### PR TITLE
Add sequence quality analysis for cloud/obstruction detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,11 @@ jobs:
         npm ci
         npm run build
 
+    - name: Run frontend tests
+      run: |
+        cd static
+        npx vitest run
+
     - name: Check formatting
       run: cargo fmt -- --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,16 @@ jobs:
         echo "OPENCV_LINK_DIRS=C:\vcpkg\installed\x64-windows-static-md\lib" >> $env:GITHUB_ENV
       shell: pwsh
 
+    - name: Read Rust toolchain
+      id: rust-toolchain
+      run: echo "channel=$(grep 'channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain-file: rust-toolchain.toml
+        toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+        components: rustfmt, clippy
     - name: Cache cargo registry
       uses: actions/cache@v5
       continue-on-error: true
@@ -266,10 +272,16 @@ jobs:
 
       shell: pwsh
 
+    - name: Read Rust toolchain
+      id: rust-toolchain
+      run: echo "channel=$(grep 'channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain-file: rust-toolchain.toml
+        toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+        components: rustfmt, clippy
 
     - name: Cache cargo registry
       uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           librsvg2-dev \
           libpng-dev \
           patchelf
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc" >> $GITHUB_ENV
+        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png" >> $GITHUB_ENV
 
 
     - name: Import Apple Developer Certificate (macOS)
@@ -239,7 +239,7 @@ jobs:
         else
           echo "DYLD_FALLBACK_LIBRARY_PATH=$(xcode-select --print-path)/usr/lib/" >> $GITHUB_ENV
         fi
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc" >> $GITHUB_ENV
+        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png" >> $GITHUB_ENV
 
 
     - name: Cache vcpkg (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.89.0
-        components: rustfmt, clippy
+        toolchain-file: rust-toolchain.toml
     - name: Cache cargo registry
       uses: actions/cache@v5
       continue-on-error: true
@@ -270,7 +269,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.89.0
+        toolchain-file: rust-toolchain.toml
 
     - name: Cache cargo registry
       uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,6 @@ jobs:
           librsvg2-dev \
           libpng-dev \
           patchelf
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png,jpeg,tiff,z" >> $GITHUB_ENV
 
 
     - name: Import Apple Developer Certificate (macOS)
@@ -239,7 +238,6 @@ jobs:
         else
           echo "DYLD_FALLBACK_LIBRARY_PATH=$(xcode-select --print-path)/usr/lib/" >> $GITHUB_ENV
         fi
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png,jpeg,tiff,z" >> $GITHUB_ENV
 
 
     - name: Cache vcpkg (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           libwebkit2gtk-4.1-dev \
           libappindicator3-dev \
           librsvg2-dev \
+          libpng-dev \
           patchelf
 
     - name: Install OpenCV dependencies (macOS)
@@ -195,6 +196,7 @@ jobs:
           libwebkit2gtk-4.1-dev \
           libappindicator3-dev \
           librsvg2-dev \
+          libpng-dev \
           patchelf
         echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           librsvg2-dev \
           libpng-dev \
           patchelf
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png" >> $GITHUB_ENV
+        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png,jpeg,tiff,z" >> $GITHUB_ENV
 
 
     - name: Import Apple Developer Certificate (macOS)
@@ -239,7 +239,7 @@ jobs:
         else
           echo "DYLD_FALLBACK_LIBRARY_PATH=$(xcode-select --print-path)/usr/lib/" >> $GITHUB_ENV
         fi
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png" >> $GITHUB_ENV
+        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png,jpeg,tiff,z" >> $GITHUB_ENV
 
 
     - name: Cache vcpkg (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
           libpng-dev \
           patchelf
 
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png,jpeg,tiff,z" >> $GITHUB_ENV
-
 
     - name: Import Apple Developer Certificate (macOS)
       if: matrix.os == 'macos-latest'
@@ -84,8 +82,6 @@ jobs:
         else
           echo "DYLD_FALLBACK_LIBRARY_PATH=$(xcode-select --print-path)/usr/lib/" >> $GITHUB_ENV
         fi
-
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png,jpeg,tiff,z" >> $GITHUB_ENV
 
 
     - name: Cache vcpkg (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.89.0
+        toolchain-file: rust-toolchain.toml
 
     - name: Install Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           libwebkit2gtk-4.1-dev \
           libappindicator3-dev \
           librsvg2-dev \
+          libpng-dev \
           patchelf
 
         echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,10 +119,16 @@ jobs:
 
       shell: pwsh
 
+    - name: Read Rust toolchain
+      id: rust-toolchain
+      run: echo "channel=$(grep 'channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain-file: rust-toolchain.toml
+        toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+        components: rustfmt, clippy
 
     - name: Install Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           libpng-dev \
           patchelf
 
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png" >> $GITHUB_ENV
+        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png,jpeg,tiff,z" >> $GITHUB_ENV
 
 
     - name: Import Apple Developer Certificate (macOS)
@@ -85,7 +85,7 @@ jobs:
           echo "DYLD_FALLBACK_LIBRARY_PATH=$(xcode-select --print-path)/usr/lib/" >> $GITHUB_ENV
         fi
 
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png" >> $GITHUB_ENV
+        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png,jpeg,tiff,z" >> $GITHUB_ENV
 
 
     - name: Cache vcpkg (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           libpng-dev \
           patchelf
 
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc" >> $GITHUB_ENV
+        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png" >> $GITHUB_ENV
 
 
     - name: Import Apple Developer Certificate (macOS)
@@ -85,7 +85,7 @@ jobs:
           echo "DYLD_FALLBACK_LIBRARY_PATH=$(xcode-select --print-path)/usr/lib/" >> $GITHUB_ENV
         fi
 
-        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc" >> $GITHUB_ENV
+        echo "OPENCV_LINK_LIBS=static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc,png" >> $GITHUB_ENV
 
 
     - name: Cache vcpkg (Windows)

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain-file: rust-toolchain.toml
       
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -18,10 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       
+      - name: Read Rust toolchain
+        id: rust-toolchain
+        run: echo "channel=$(grep 'channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain-file: rust-toolchain.toml
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
       
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,9 +2744,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -4951,29 +4951,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,6 +3513,7 @@ dependencies = [
  "clap",
  "dirs",
  "fitrs",
+ "http-body-util",
  "humantime",
  "image",
  "imageproc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ dirs = { version = "6.0", optional = true }
 
 [dev-dependencies]
 tempfile = "3.23"
+http-body-util = "0.1"
 
 [features]
 default = ["opencv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
-FROM rust:latest AS builder
+# Version should match rust-toolchain.toml
+FROM rust:1.89.0 AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/docs/cloud-detection-design.md
+++ b/docs/cloud-detection-design.md
@@ -1,0 +1,661 @@
+# Cloud Detection and Image Quality Scoring -- Design Document
+
+## 1. Overview
+
+This document describes a multi-metric quality scoring system for PSF Guard that
+detects cloud-affected frames, classifies quality issues, and produces a relative
+quality score for every image in an acquisition sequence. The system builds on
+metrics already computed by the codebase (HFR, FWHM, star count, background,
+SNR, eccentricity, MAD) and requires no new image processing for v1.
+
+### Goals
+
+- Score each image 0.0--1.0 relative to the best frame in its sequence
+  (same target + filter within a contiguous session).
+- Detect cloud passages from sudden temporal changes in multiple metrics.
+- Classify issues: clouds, obstruction, focus drift, tracking error.
+- Expose analysis through a REST API for the web UI.
+- Provide sensible defaults that work without per-user tuning.
+
+### Non-Goals (v1)
+
+- Per-pixel spatial analysis (background gradient maps, quadrant comparison).
+- Machine-learning classifiers.
+- Absolute quality thresholds (everything is relative to the session).
+
+---
+
+## 2. Available Metrics
+
+These metrics are already computed per image and stored in the `acquiredimage`
+metadata JSON or obtainable from FITS headers at analysis time.
+
+| Metric | Source | Unit | Notes |
+|--------|--------|------|-------|
+| `DetectedStars` | HocusFocus / N.I.N.A. star detection | count | Primary cloud indicator |
+| `HFR` | Star detection | pixels | Increases with clouds/defocus |
+| `FWHM` | PSF fitting or HFR approximation | pixels | Correlated with HFR |
+| `Eccentricity` | PSF fitting (sigma_x / sigma_y) | 0.0--1.0 | Tracking/guiding quality |
+| `Mean` | Image statistics | ADU | Overall brightness |
+| `Median` | Image statistics | ADU | Background level (robust) |
+| `StdDev` | Image statistics | ADU | Contrast/noise |
+| `MAD` | Image statistics | ADU | Robust noise estimate |
+| `SNR` | Star detection (signal/noise) | ratio | Per-star average SNR |
+| `Temperature` | FITS header CCD-TEMP | celsius | Thermal noise baseline |
+| `Background` | Star detection (background_mean) | ADU | Sky background level |
+
+### Metadata JSON Fields (from N.I.N.A. Target Scheduler)
+
+The `acquiredimage.metadata` JSON already contains:
+
+```json
+{
+  "FileName": "...",
+  "FilterName": "Ha",
+  "HFR": 2.5,
+  "DetectedStars": 342,
+  "ExposureStartTime": "2023-08-27T10:00:00Z"
+}
+```
+
+For v1, the system uses `HFR`, `DetectedStars`, and `ExposureStartTime` from
+metadata. Additional metrics (Median, MAD, SNR, eccentricity) can be computed
+on demand from the FITS file when the file cache has resolved a path for the
+image, or pre-computed and stored during a cache refresh.
+
+---
+
+## 3. Sequence Definition
+
+A **sequence** is a contiguous group of images sharing the same:
+
+- `target_id` (same astronomical target)
+- `filter_name` (same narrowband/broadband filter)
+- Session continuity: no gap > 60 minutes between consecutive exposures
+
+Images are ordered by `ExposureStartTime` (or `acquireddate` from the database).
+A gap exceeding 60 minutes splits the group into separate sequences. This
+prevents comparing images from different nights or sessions where conditions may
+be entirely different.
+
+### Why Relative Scoring
+
+Absolute thresholds fail because conditions vary enormously between setups:
+
+- A Bortle 2 site has background 500 ADU; Bortle 7 has 8000 ADU.
+- Fast optics (f/2) produce HFR 1.5; slow optics (f/10) produce HFR 4.0.
+- Narrowband filters detect fewer stars than broadband.
+
+By scoring each image relative to the best in its sequence, the system
+automatically adapts to any equipment, site, and filter combination.
+
+---
+
+## 4. Temporal Analysis
+
+### 4.1 Cloud Passage Detection
+
+Clouds produce a characteristic multi-metric signature when they pass through
+the field of view:
+
+| Metric | Cloud Effect | Typical Magnitude |
+|--------|-------------|-------------------|
+| Star count | Drops sharply | 30--90% reduction |
+| Background (Median) | Rises (light scatter) | 10--50% increase |
+| HFR | Increases (scattering) | 15--40% increase |
+| SNR | Drops | 20--60% reduction |
+| Eccentricity | Unchanged | No effect |
+
+The key insight is that clouds affect **star count, background, HFR, and SNR
+simultaneously**, while other issues only affect a subset:
+
+- Focus drift: HFR increases gradually, star count drops slowly, background
+  unchanged.
+- Tracking error: eccentricity increases, star count unchanged, HFR may
+  increase slightly.
+- Dew/frost: similar to clouds but onset is gradual rather than sudden.
+
+### 4.2 Rolling Baseline
+
+Instead of the current fixed-window baseline in `grading.rs`, use an
+**exponentially weighted moving average (EWMA)** for each metric:
+
+```
+baseline[i] = alpha * value[i-1] + (1 - alpha) * baseline[i-1]
+```
+
+Where `alpha = 0.3` provides a ~5-frame effective window. EWMA is superior to
+the current fixed-window approach because:
+
+1. It adapts smoothly to gradual changes (temperature drift, altitude change).
+2. It does not require a fixed `cloud_baseline_count` parameter.
+3. It is cheap to compute (O(1) per frame vs O(n) for rolling median).
+
+For the very first frame, initialize baseline to the frame's own value.
+
+### 4.3 Temporal Deviation Score
+
+For each metric at each time step, compute the deviation from the EWMA
+baseline:
+
+```
+deviation[metric][i] = (value[i] - baseline[i]) / baseline[i]
+```
+
+For star count, invert the sign (a drop is bad):
+
+```
+star_deviation[i] = (baseline[i] - star_count[i]) / baseline[i]
+```
+
+A **temporal anomaly** is flagged when multiple metrics deviate simultaneously:
+
+```
+temporal_score[i] = w_stars * max(0, star_deviation[i])
+                  + w_bg    * max(0, bg_deviation[i])
+                  + w_hfr   * max(0, hfr_deviation[i])
+                  + w_snr   * max(0, -snr_deviation[i])
+```
+
+Default weights: `w_stars = 0.40, w_bg = 0.25, w_hfr = 0.20, w_snr = 0.15`
+
+Star count is weighted highest because it is the most reliable cloud indicator:
+thin clouds reduce star count before they noticeably affect background or HFR.
+
+---
+
+## 5. Quality Scoring Formula
+
+### 5.1 Per-Metric Normalization
+
+For each metric in a sequence, normalize to [0, 1] relative to the best and
+worst values observed:
+
+```
+normalized[metric][i] = (value[i] - worst) / (best - worst)
+```
+
+Where "best" and "worst" are defined per metric:
+
+| Metric | Best = | Worst = |
+|--------|--------|---------|
+| Star count | max in sequence | min in sequence |
+| HFR | min in sequence | max in sequence |
+| FWHM | min in sequence | max in sequence |
+| Eccentricity | min in sequence | max in sequence |
+| SNR | max in sequence | min in sequence |
+| Background | min in sequence | max in sequence |
+
+If best == worst (all values identical), normalized = 1.0 for all frames.
+
+### 5.2 Robust Normalization
+
+To prevent a single extreme outlier from compressing the entire scale, use
+the 5th and 95th percentiles as the normalization bounds instead of raw
+min/max:
+
+```
+best_robust  = percentile(values, 5)   // for "lower is better" metrics
+worst_robust = percentile(values, 95)  // for "lower is better" metrics
+```
+
+Values beyond these bounds are clamped to 0.0 or 1.0.
+
+### 5.3 Composite Quality Score
+
+Combine normalized metrics using a weighted sum, inspired by the PixInsight
+SubframeSelector approach:
+
+```
+quality_score[i] = w_stars * norm_stars[i]
+                 + w_hfr   * norm_hfr[i]
+                 + w_ecc   * norm_eccentricity[i]
+                 + w_snr   * norm_snr[i]
+                 + w_bg    * norm_background[i]
+```
+
+**Default weights:**
+
+| Weight | Value | Rationale |
+|--------|-------|-----------|
+| `w_stars` | 0.30 | Most reliable cloud/obstruction indicator |
+| `w_hfr` | 0.25 | Focus and atmospheric seeing quality |
+| `w_ecc` | 0.10 | Tracking/guiding quality |
+| `w_snr` | 0.25 | Overall signal quality |
+| `w_bg` | 0.10 | Sky conditions (light pollution, clouds) |
+
+These weights are designed for general deep-sky imaging. The API will accept
+optional weight overrides for specific target types (similar to PixInsight's
+per-target-type formulas).
+
+### 5.4 Penalty for Temporal Anomalies
+
+Apply a multiplicative penalty when temporal analysis flags an anomaly:
+
+```
+final_score[i] = quality_score[i] * (1.0 - clamp(temporal_score[i], 0, 0.5))
+```
+
+This ensures that even if a cloud-affected frame happens to have acceptable
+absolute metrics (thin clouds), the sudden change from baseline still reduces
+its score.
+
+### 5.5 Score Interpretation
+
+| Score Range | Interpretation |
+|-------------|----------------|
+| 0.90 -- 1.00 | Excellent -- among the best in the sequence |
+| 0.70 -- 0.89 | Good -- minor quality reduction |
+| 0.50 -- 0.69 | Fair -- noticeable degradation |
+| 0.30 -- 0.49 | Poor -- significant issues detected |
+| 0.00 -- 0.29 | Bad -- likely unusable |
+
+---
+
+## 6. Issue Classification
+
+After scoring, classify the likely cause based on which metrics deviated and
+how the deviation evolved over time.
+
+### 6.1 Classification Rules
+
+```
+IF star_count drops > 25% AND background rises > 10%:
+    category = "likely_clouds"
+
+ELSE IF star_count drops > 25% AND background stable:
+    category = "possible_obstruction"
+    (tree branch, dome slit, dew cap)
+
+ELSE IF hfr increases gradually over 3+ frames AND eccentricity stable:
+    category = "focus_drift"
+
+ELSE IF eccentricity increases > 0.15 AND star_count stable:
+    category = "tracking_error"
+
+ELSE IF hfr increases AND star_count drops AND eccentricity increases:
+    category = "wind_shake"
+    (guiding + seeing both degraded)
+
+ELSE IF background rises gradually AND star_count stable:
+    category = "sky_brightening"
+    (dawn, moon rise, light pollution event)
+
+ELSE IF all metrics degraded simultaneously and suddenly:
+    category = "likely_clouds"
+    (thick cloud event)
+
+ELSE IF score < 0.5 but no clear pattern:
+    category = "unknown_degradation"
+```
+
+### 6.2 Gradual vs Sudden Detection
+
+To distinguish "focus_drift" from "clouds", measure the rate of change:
+
+```
+rate_of_change[metric][i] = abs(value[i] - value[i-1]) / value[i-1]
+```
+
+- **Sudden**: rate > 15% in a single frame (clouds, obstruction)
+- **Gradual**: rate < 5% per frame over 3+ consecutive frames (drift, thermal)
+
+### 6.3 Classification Data Structure
+
+```rust
+pub enum IssueCategory {
+    LikelyClouds,
+    PossibleObstruction,
+    FocusDrift,
+    TrackingError,
+    WindShake,
+    SkyBrightening,
+    UnknownDegradation,
+}
+
+pub struct ImageQualityResult {
+    pub image_id: i32,
+    pub quality_score: f64,          // 0.0 to 1.0
+    pub temporal_anomaly_score: f64, // 0.0 to 1.0
+    pub category: Option<IssueCategory>,
+    pub metrics: NormalizedMetrics,
+    pub details: String,             // Human-readable explanation
+}
+
+pub struct NormalizedMetrics {
+    pub star_count: Option<f64>,     // normalized 0-1
+    pub hfr: Option<f64>,
+    pub eccentricity: Option<f64>,
+    pub snr: Option<f64>,
+    pub background: Option<f64>,
+}
+```
+
+---
+
+## 7. API Design
+
+### 7.1 Sequence Analysis Endpoint
+
+```
+POST /api/analysis/sequence
+```
+
+**Request Body:**
+
+```json
+{
+  "target_id": 5,
+  "filter_name": "Ha",
+  "session_gap_minutes": 60,
+  "weights": {
+    "star_count": 0.30,
+    "hfr": 0.25,
+    "eccentricity": 0.10,
+    "snr": 0.25,
+    "background": 0.10
+  }
+}
+```
+
+All fields except `target_id` are optional. If `filter_name` is omitted,
+analyze all filters for the target (returning separate sequences per filter).
+If `weights` is omitted, use defaults.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "sequences": [
+      {
+        "target_id": 5,
+        "target_name": "M42",
+        "filter_name": "Ha",
+        "session_start": "2024-01-15T22:00:00Z",
+        "session_end": "2024-01-16T03:30:00Z",
+        "image_count": 45,
+        "reference_values": {
+          "best_star_count": 342,
+          "best_hfr": 2.1,
+          "best_eccentricity": 0.35,
+          "best_snr": 48.2,
+          "best_background": 1250.0
+        },
+        "images": [
+          {
+            "image_id": 1001,
+            "quality_score": 0.95,
+            "temporal_anomaly_score": 0.0,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.98,
+              "hfr": 0.92,
+              "eccentricity": 0.90,
+              "snr": 0.96,
+              "background": 0.97
+            },
+            "details": null
+          },
+          {
+            "image_id": 1015,
+            "quality_score": 0.32,
+            "temporal_anomaly_score": 0.45,
+            "category": "likely_clouds",
+            "normalized_metrics": {
+              "star_count": 0.15,
+              "hfr": 0.40,
+              "eccentricity": 0.88,
+              "snr": 0.30,
+              "background": 0.25
+            },
+            "details": "Star count dropped 72% from baseline while background increased 35%. Pattern consistent with cloud passage."
+          }
+        ],
+        "summary": {
+          "excellent_count": 30,
+          "good_count": 8,
+          "fair_count": 3,
+          "poor_count": 2,
+          "bad_count": 2,
+          "cloud_events_detected": 1,
+          "focus_drift_detected": false,
+          "tracking_issues_detected": false
+        }
+      }
+    ]
+  }
+}
+```
+
+### 7.2 Batch Scoring Endpoint
+
+For scoring all images in a project at once:
+
+```
+POST /api/analysis/project/{project_id}
+```
+
+**Request Body:**
+
+```json
+{
+  "session_gap_minutes": 60,
+  "weights": null,
+  "auto_reject_threshold": 0.3,
+  "dry_run": true
+}
+```
+
+When `dry_run` is false and `auto_reject_threshold` is set, images scoring
+below the threshold are automatically marked as rejected with the reason
+set to the detected `category`.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "sequences_analyzed": 12,
+    "total_images": 450,
+    "images_below_threshold": 23,
+    "rejections_applied": 0,
+    "dry_run": true,
+    "breakdown_by_category": {
+      "likely_clouds": 15,
+      "focus_drift": 4,
+      "tracking_error": 2,
+      "unknown_degradation": 2
+    }
+  }
+}
+```
+
+### 7.3 Single Image Score Endpoint
+
+For getting the quality context of a specific image:
+
+```
+GET /api/analysis/image/{image_id}
+```
+
+Returns the image's score along with its sequence context (what sequence it
+belongs to, reference values, surrounding frame scores).
+
+### 7.4 Score Distribution Endpoint
+
+For the UI to render histograms:
+
+```
+GET /api/analysis/distribution?target_id=5&filter_name=Ha
+```
+
+Returns score histogram buckets and metric time series for charting.
+
+---
+
+## 8. Threshold Recommendations
+
+### 8.1 Auto-Reject Thresholds
+
+| Threshold | Value | Use Case |
+|-----------|-------|----------|
+| Conservative | 0.20 | Only reject clearly ruined frames |
+| Moderate | 0.35 | Good default for most users |
+| Aggressive | 0.50 | Maximize quality, discard more |
+
+### 8.2 Cloud Detection Thresholds
+
+These apply to the temporal anomaly detection (Section 4):
+
+| Parameter | Default | Range | Description |
+|-----------|---------|-------|-------------|
+| `star_drop_threshold` | 0.25 | 0.10 -- 0.50 | Minimum fractional star count drop to flag |
+| `bg_rise_threshold` | 0.10 | 0.05 -- 0.30 | Minimum fractional background increase |
+| `hfr_rise_threshold` | 0.15 | 0.10 -- 0.40 | Minimum fractional HFR increase |
+| `ewma_alpha` | 0.30 | 0.10 -- 0.50 | Smoothing factor (higher = more responsive) |
+| `sudden_change_rate` | 0.15 | 0.05 -- 0.30 | Rate threshold for sudden vs gradual |
+| `session_gap_minutes` | 60 | 15 -- 180 | Gap to split sequences |
+| `min_sequence_length` | 5 | 3 -- 10 | Minimum frames for analysis |
+
+### 8.3 Per-Metric Rejection Thresholds
+
+For users who want simple per-metric rejection (like the existing `grading.rs`
+approach), express thresholds in terms of sigma from the sequence median:
+
+| Metric | Default Sigma | Description |
+|--------|--------------|-------------|
+| HFR | 2.5 sigma | Reject if HFR > median + 2.5 * MAD |
+| Star count | 2.5 sigma | Reject if stars < median - 2.5 * MAD |
+| Eccentricity | 3.0 sigma | Reject if ecc > median + 3.0 * MAD |
+| Background | 2.0 sigma | Reject if bg > median + 2.0 * MAD |
+
+Use MAD (Median Absolute Deviation) * 1.4826 as the robust sigma estimator,
+which is already computed in the codebase.
+
+---
+
+## 9. Implementation Plan
+
+### Phase 1: Core Scoring (Backend)
+
+1. Define the `SequenceAnalyzer` struct in a new `src/sequence_analysis.rs`.
+2. Implement sequence grouping (target + filter + session gap).
+3. Implement per-metric normalization with robust percentile bounds.
+4. Implement EWMA temporal baseline and deviation scoring.
+5. Implement composite quality score with configurable weights.
+6. Implement issue classification rules.
+7. Add the `POST /api/analysis/sequence` endpoint.
+
+### Phase 2: Integration with Existing Grading
+
+8. Wire `SequenceAnalyzer` into the existing `StatisticalGrader` as an
+   optional enhancement (the current grader continues to work standalone).
+9. Add the project-level batch scoring endpoint.
+10. Add the single-image and distribution endpoints.
+
+### Phase 3: Frontend (Web UI)
+
+11. Sequence selector in the UI (pick target + filter to analyze).
+12. Time-series chart showing metrics + score over the sequence.
+13. Color-coded quality indicators on image thumbnails.
+14. Batch reject/accept controls based on score threshold slider.
+
+---
+
+## 10. Relationship to Existing Code
+
+### Current `grading.rs`
+
+The existing `StatisticalGrader` uses:
+
+- HFR z-score outlier detection (symmetric, flags both high and low)
+- Star count z-score outlier detection
+- MAD-based distribution analysis for skewed data
+- Rolling median cloud detection on HFR and star count (sequential, either/or)
+
+**Limitations addressed by this design:**
+
+1. **Single-metric cloud detection**: Current code checks HFR first, then
+   star count only if no HFR rejections found. The new system combines
+   all metrics simultaneously.
+2. **Fixed baseline window**: Current code requires `cloud_baseline_count`
+   images before establishing a baseline. EWMA starts from frame 1.
+3. **No scoring**: Current code is binary (reject/accept). The new system
+   produces a continuous score enabling threshold-based decisions.
+4. **No classification**: Current code labels everything as "Cloud Detection"
+   or "Statistical HFR". The new system classifies the likely cause.
+5. **No temporal analysis**: Current code treats HFR outliers the same
+   whether they occur gradually or suddenly.
+
+### Compatibility
+
+The new `SequenceAnalyzer` does not replace `StatisticalGrader`. The
+existing grader continues to provide its current functionality. The sequence
+analyzer is a separate, more sophisticated analysis available via the API
+that produces scores and classifications rather than binary rejections.
+
+In a future version, the grader could optionally delegate to the sequence
+analyzer, but for v1 they coexist independently.
+
+---
+
+## 11. Data Flow
+
+```
+Database (acquiredimage table)
+    |
+    v
+Query images by target_id + filter
+    |
+    v
+Sort by ExposureStartTime
+    |
+    v
+Split into sequences (60-min gap)
+    |
+    v
+For each sequence:
+    |
+    +-- Extract metrics from metadata JSON
+    |     (HFR, DetectedStars, background)
+    |
+    +-- Optionally compute additional metrics from FITS
+    |     (eccentricity, SNR, MAD -- if file available)
+    |
+    +-- Normalize each metric (robust percentile)
+    |
+    +-- Compute EWMA baseline + temporal deviation
+    |
+    +-- Compute composite quality score
+    |
+    +-- Classify issues
+    |
+    v
+Return scored + classified sequence
+```
+
+---
+
+## 12. References
+
+- PixInsight SubframeSelector: weighted quality formula using FWHM,
+  eccentricity, and SNR with per-target-type weights.
+  Source: https://chaoticnebula.com/pixinsight-subframe-selector/
+
+- PixInsight PSFSignalWeight: combined quality metric synthesizing
+  FWHM, noise, eccentricity, and SNR into a single score.
+  Source: https://stirlingastrophoto.com/posts/subframeselector-quality-metrics/
+
+- Cloud detection via star photometry and extinction measurement
+  in all-sky camera data.
+  Source: https://ui.adsabs.harvard.edu/abs/2024PASP..136c5002Z/abstract
+
+- Machine learning cloud identification achieving 95% accuracy with
+  gradient-boosted trees on all-sky camera features.
+  Source: https://arxiv.org/abs/2003.11109
+
+- N.I.N.A. HFR and star count monitoring for real-time session quality.
+  Source: https://nighttime-imaging.eu/docs/master/site/tabs/imaging/

--- a/docs/integration-test-plan.md
+++ b/docs/integration-test-plan.md
@@ -1,0 +1,547 @@
+# Integration Test Plan: Sequence Analysis API
+
+## Approach Decision
+
+### Strategy: In-Process Router Testing with `tower::ServiceExt`
+
+We will use Axum's built-in support for testing via `tower::ServiceExt` to send HTTP
+requests directly to the `Router` without binding to a TCP port. This approach:
+
+- Requires no real HTTP server or port allocation
+- Tests the full middleware stack (CORS, tracing layers)
+- Validates JSON serialization/deserialization end-to-end
+- Uses an in-memory SQLite database with test fixtures
+- Runs as standard `cargo test` (no external dependencies)
+
+**Why not E2E/Playwright?** The sequence analysis endpoints return JSON data with no
+browser interaction. In-process testing is faster, deterministic, and sufficient.
+
+**Why not snapshot testing?** The quality scores are floating-point values sensitive to
+algorithm tuning. Snapshot tests would be brittle. Instead we test structural correctness
+and behavioral invariants.
+
+### Key Technical Details
+
+- **axum 0.8** with `tower 0.5` -- use `tower::ServiceExt::oneshot` to send requests
+- **rusqlite** with `:memory:` -- in-memory SQLite for test fixtures, no file I/O
+- **AppState construction** -- `AppState::new()` validates that the database file and
+  image directories exist on disk. For integration tests, we need a test helper that
+  bypasses these checks and accepts a pre-opened `Connection` directly. We will add a
+  `#[cfg(test)]` constructor `AppState::new_for_test(conn, cache_dir)`.
+- **No image directory needed** -- sequence analysis endpoints only read from the database
+  (metadata JSON), not from FITS files on disk.
+- **tempfile crate** -- already in `[dev-dependencies]`, used for temporary cache directories.
+
+## Test Fixture Schema
+
+### Database Setup
+
+Create an in-memory SQLite database with the N.I.N.A. Target Scheduler schema:
+
+```sql
+CREATE TABLE project (
+    Id INTEGER PRIMARY KEY,
+    profileId TEXT,
+    name TEXT NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE target (
+    Id INTEGER PRIMARY KEY,
+    projectId INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 1,
+    ra REAL,
+    dec REAL,
+    FOREIGN KEY (projectId) REFERENCES project(Id)
+);
+
+CREATE TABLE acquiredimage (
+    Id INTEGER PRIMARY KEY,
+    projectId INTEGER NOT NULL,
+    targetId INTEGER NOT NULL,
+    acquireddate INTEGER,
+    filtername TEXT NOT NULL,
+    gradingStatus INTEGER NOT NULL DEFAULT 0,
+    metadata TEXT NOT NULL DEFAULT '{}',
+    rejectreason TEXT,
+    profileId TEXT,
+    FOREIGN KEY (projectId) REFERENCES project(Id),
+    FOREIGN KEY (targetId) REFERENCES target(Id)
+);
+```
+
+Note: This is the "old schema" without `guid` columns. The `SchemaCapabilities::detect()`
+will correctly report `has_*_guid = false` and queries will work without guid columns.
+
+### Fixture Data Sets
+
+#### Fixture 1: Normal Sequence (10 images, mixed quality)
+
+- Project: "Test Project" (id=1), Target: "M42" (id=1), Filter: "L"
+- 10 images spaced 5 minutes apart (300s)
+- Star counts: 300-350 range (normal variation)
+- HFR: 2.3-2.7 range
+- All with DetectedStars, HFR in metadata JSON
+- Some with SNR and Eccentricity, some without (tests missing metrics)
+
+#### Fixture 2: Cloud Passage Event
+
+- Project: "Test Project" (id=1), Target: "M42" (id=1), Filter: "Ha"
+- 8 images with 2 cloud-affected frames
+- Cloud frames: DetectedStars drops to ~100 (from ~300), background rises from 1200 to 1800
+- Tests that cloud detection works through the full API path
+
+#### Fixture 3: Session Gap (Two Sessions)
+
+- Same target, same filter
+- 5 images in session 1, then 2+ hour gap, then 5 images in session 2
+- Tests session splitting via the API
+
+#### Fixture 4: Short Sequence (< min_sequence_length)
+
+- 2 images only
+- Should return quality_score = 1.0 for all images
+
+#### Fixture 5: Missing Metrics
+
+- Images with only DetectedStars (no HFR, no SNR, no Eccentricity, no Background)
+- Tests graceful handling of sparse metadata
+
+#### Fixture 6: Empty Target
+
+- Target with no images at all
+- Should return empty sequences array
+
+### Metadata JSON Format
+
+Each `acquiredimage.metadata` field is a JSON string like:
+
+```json
+{
+    "FileName": "2024-01-15\\M42\\Light\\L\\M42_L_300s_001.fits",
+    "FilterName": "L",
+    "HFR": 2.5,
+    "DetectedStars": 342,
+    "Eccentricity": 0.35,
+    "SNR": 45.2,
+    "Background": 1200.5,
+    "ExposureStartTime": "2024-01-15T22:00:00Z"
+}
+```
+
+## Test Cases
+
+### File: `tests/integration_sequence_analysis.rs`
+
+All tests share a common test harness module.
+
+---
+
+### Test 1: `test_analyze_sequence_normal`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=1&filter_name=L`
+
+**Setup:** Fixture 1 (10 normal images)
+
+**Assertions:**
+- Response status 200
+- `success == true`
+- `data.sequences` has exactly 1 sequence (single session)
+- `sequences[0].target_id == 1`
+- `sequences[0].target_name == "M42"`
+- `sequences[0].filter_name == "L"`
+- `sequences[0].image_count == 10`
+- `sequences[0].session_start` and `session_end` are present
+- `sequences[0].reference_values` has `best_star_count`, `best_hfr` populated
+- All `sequences[0].images[*].quality_score` are between 0.0 and 1.0
+- Summary counts sum to `image_count`
+
+---
+
+### Test 2: `test_analyze_sequence_cloud_detection`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=1&filter_name=Ha`
+
+**Setup:** Fixture 2 (cloud passage)
+
+**Assertions:**
+- Cloud-affected frames have lower `quality_score` than good frames
+- At least one image has `category == "likely_clouds"`
+- `summary.cloud_events_detected >= 1`
+- Good frames have `quality_score > 0.5`
+
+---
+
+### Test 3: `test_analyze_sequence_session_split`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=1`
+
+**Setup:** Fixture 3 (two sessions with gap)
+
+**Assertions:**
+- `sequences` has 2 entries
+- Each sequence has `image_count == 5`
+- Session 1 ends before session 2 starts
+- Gap between `session_end` of seq[0] and `session_start` of seq[1] > 60 minutes
+
+---
+
+### Test 4: `test_analyze_sequence_short`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=X` (target with 2 images)
+
+**Setup:** Fixture 4
+
+**Assertions:**
+- Single sequence returned
+- `image_count == 2`
+- All images have `quality_score == 1.0` (short sequence default)
+- `summary.excellent_count == 2`
+
+---
+
+### Test 5: `test_analyze_sequence_missing_metrics`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=X`
+
+**Setup:** Fixture 5
+
+**Assertions:**
+- Does not error (200 OK)
+- `normalized_metrics` fields that had no data are `null`
+- `quality_score` is still computed using available metrics
+
+---
+
+### Test 6: `test_analyze_sequence_empty_target`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=X` (target with no images)
+
+**Setup:** Fixture 6
+
+**Assertions:**
+- 200 OK
+- `sequences` is an empty array
+
+---
+
+### Test 7: `test_analyze_sequence_nonexistent_target`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=9999`
+
+**Assertions:**
+- Returns 400 Bad Request (target not found)
+- `success == false`
+- `error` message contains "not found"
+
+---
+
+### Test 8: `test_image_quality_context`
+
+**Endpoint:** `GET /api/analysis/image/{image_id}`
+
+**Setup:** Fixture 1
+
+**Assertions:**
+- 200 OK
+- `image_id` matches request
+- `quality` is present with `quality_score` between 0.0 and 1.0
+- `sequence_target_id == 1`
+- `sequence_filter_name == "L"`
+- `sequence_image_count >= 3`
+- `reference_values` has populated fields
+
+---
+
+### Test 9: `test_image_quality_nonexistent_image`
+
+**Endpoint:** `GET /api/analysis/image/99999`
+
+**Assertions:**
+- Returns 404 Not Found
+
+---
+
+### Test 10: `test_analyze_sequence_custom_weights`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=1&filter_name=L&weight_star_count=1.0&weight_hfr=0.0&weight_eccentricity=0.0&weight_snr=0.0&weight_background=0.0`
+
+**Setup:** Fixture 1
+
+**Assertions:**
+- 200 OK
+- Scores exist and are between 0.0 and 1.0
+- With star_count as the only weight, images with higher star counts should score higher
+
+---
+
+### Test 11: `test_analyze_sequence_custom_session_gap`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=1&session_gap_minutes=5`
+
+**Setup:** Fixture 3 (two sessions with 2hr gap; images 5 min apart)
+
+**Assertions:**
+- With a 5-minute gap threshold, each 5-minute-spaced image becomes its own session
+  OR sequences split more aggressively
+- More sequences than the default (2)
+
+---
+
+### Test 12: `test_json_contract_structure`
+
+**Endpoint:** `GET /api/analysis/sequence?target_id=1&filter_name=L`
+
+**Purpose:** Validate JSON structure matches TypeScript interfaces
+
+**Assertions:**
+- Response deserializes into the expected Rust types (proving serde works)
+- Additionally, parse raw JSON and verify:
+  - `sequences[0].images[0]` has keys: `image_id`, `quality_score`, `temporal_anomaly_score`, `category`, `normalized_metrics`, `details`
+  - `normalized_metrics` has keys: `star_count`, `hfr`, `eccentricity`, `snr`, `background`
+  - `summary` has keys: `excellent_count`, `good_count`, `fair_count`, `poor_count`, `bad_count`, `cloud_events_detected`, `focus_drift_detected`, `tracking_issues_detected`
+  - `reference_values` has keys: `best_star_count`, `best_hfr`, `best_eccentricity`, `best_snr`, `best_background`
+  - Enum values use snake_case (e.g., `"likely_clouds"` not `"LikelyClouds"`)
+
+---
+
+### Test 13: `test_api_response_wrapper_structure`
+
+**Endpoint:** Any analysis endpoint
+
+**Purpose:** Validate the `ApiResponse<T>` wrapper
+
+**Assertions:**
+- Top-level JSON has keys: `success`, `data`, `error`, `status`
+- `status` is `"ready"` for successful responses
+- Error responses have `success == false` and `error` populated
+
+## Code Structure
+
+### New Test Helper: `AppState::new_for_test`
+
+Add to `src/server/state.rs` inside a `#[cfg(test)]` block:
+
+```rust
+#[cfg(test)]
+impl AppState {
+    /// Create an AppState for integration testing with a pre-opened database connection.
+    /// Skips file system validation (no image dirs or cache dir needed).
+    pub fn new_for_test(conn: Connection) -> Self {
+        Self {
+            database_path: ":memory:".to_string(),
+            image_dirs: vec![],
+            cache_dir: "/tmp/psf-guard-test".to_string(),
+            image_dir_paths: vec![],
+            cache_dir_path: std::path::PathBuf::from("/tmp/psf-guard-test"),
+            db_connection: Arc::new(Mutex::new(conn)),
+            file_check_cache: Arc::new(RwLock::new(FileCheckCache::new())),
+            directory_tree_cache: Arc::new(RwLock::new(None)),
+            refresh_mutex: Arc::new(TokioMutex::new(())),
+            pregeneration_config: crate::cli::PregenerationConfig::default(),
+        }
+    }
+}
+```
+
+### Integration Test File: `tests/integration_sequence_analysis.rs`
+
+```rust
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use http_body_util::BodyExt;
+use rusqlite::Connection;
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ---- Test Harness ----
+
+fn create_test_schema(conn: &Connection) {
+    conn.execute_batch(
+        "CREATE TABLE project (
+            Id INTEGER PRIMARY KEY,
+            profileId TEXT,
+            name TEXT NOT NULL,
+            description TEXT
+        );
+        CREATE TABLE target (
+            Id INTEGER PRIMARY KEY,
+            projectId INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1,
+            ra REAL,
+            dec REAL
+        );
+        CREATE TABLE acquiredimage (
+            Id INTEGER PRIMARY KEY,
+            projectId INTEGER NOT NULL,
+            targetId INTEGER NOT NULL,
+            acquireddate INTEGER,
+            filtername TEXT NOT NULL,
+            gradingStatus INTEGER NOT NULL DEFAULT 0,
+            metadata TEXT NOT NULL DEFAULT '{}',
+            rejectreason TEXT,
+            profileId TEXT
+        );"
+    ).unwrap();
+}
+
+fn insert_project(conn: &Connection, id: i32, name: &str) {
+    conn.execute(
+        "INSERT INTO project (Id, profileId, name) VALUES (?1, 'default', ?2)",
+        rusqlite::params![id, name],
+    ).unwrap();
+}
+
+fn insert_target(conn: &Connection, id: i32, project_id: i32, name: &str) {
+    conn.execute(
+        "INSERT INTO target (Id, projectId, name, active) VALUES (?1, ?2, ?3, 1)",
+        rusqlite::params![id, project_id, name],
+    ).unwrap();
+}
+
+fn insert_image(
+    conn: &Connection,
+    id: i32,
+    project_id: i32,
+    target_id: i32,
+    timestamp: i64,
+    filter: &str,
+    metadata: &serde_json::Value,
+) {
+    conn.execute(
+        "INSERT INTO acquiredimage (Id, projectId, targetId, acquireddate, filtername, metadata)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![id, project_id, target_id, timestamp, filter,
+                          serde_json::to_string(metadata).unwrap()],
+    ).unwrap();
+}
+
+fn build_metadata(stars: f64, hfr: f64, bg: Option<f64>, snr: Option<f64>, ecc: Option<f64>) -> Value {
+    let mut m = serde_json::json!({
+        "FileName": "test.fits",
+        "DetectedStars": stars,
+        "HFR": hfr
+    });
+    if let Some(v) = bg { m["Background"] = serde_json::json!(v); }
+    if let Some(v) = snr { m["SNR"] = serde_json::json!(v); }
+    if let Some(v) = ecc { m["Eccentricity"] = serde_json::json!(v); }
+    m
+}
+
+fn create_test_app(conn: Connection) -> Router {
+    use axum::routing::get;
+    use psf_guard::server::handlers;
+    use psf_guard::server::state::AppState;
+
+    let state = Arc::new(AppState::new_for_test(conn));
+
+    Router::new()
+        .route("/api/analysis/sequence", get(handlers::analyze_sequence))
+        .route("/api/analysis/image/{image_id}", get(handlers::get_image_quality))
+        .with_state(state)
+}
+
+async fn get_json(app: Router, uri: &str) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    (status, json)
+}
+
+// ---- Fixture Loaders ----
+
+fn load_normal_sequence(conn: &Connection) { /* Fixture 1 */ }
+fn load_cloud_passage(conn: &Connection) { /* Fixture 2 */ }
+fn load_session_gap(conn: &Connection) { /* Fixture 3 */ }
+fn load_short_sequence(conn: &Connection) { /* Fixture 4 */ }
+fn load_missing_metrics(conn: &Connection) { /* Fixture 5 */ }
+fn load_empty_target(conn: &Connection) { /* Fixture 6 */ }
+
+// ---- Tests ----
+
+#[tokio::test]
+async fn test_analyze_sequence_normal() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_normal_sequence(&conn);
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/analysis/sequence?target_id=1&filter_name=L").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+    // ... detailed assertions
+}
+
+// ... remaining tests follow the same pattern
+```
+
+### Required Changes to Production Code
+
+1. **`src/server/state.rs`**: Add `#[cfg(test)] pub fn new_for_test(conn: Connection)` method
+2. **`Cargo.toml`**: Add `http-body-util` to `[dev-dependencies]` for response body collection
+3. **No other production code changes needed**
+
+### Dev Dependencies to Add
+
+```toml
+[dev-dependencies]
+tempfile = "3.23"           # Already present
+http-body-util = "0.1"     # For collecting response bodies in tests
+tower = { version = "0.5", features = ["util"] }  # For ServiceExt::oneshot
+```
+
+Note: `tower` is already in `[dependencies]` with `features = ["util"]`, so `ServiceExt`
+is available. We only need `http-body-util` as an additional dev dependency.
+
+## How to Run the Tests
+
+```bash
+# Run all integration tests
+cargo test --test integration_sequence_analysis
+
+# Run a specific test
+cargo test --test integration_sequence_analysis test_analyze_sequence_cloud_detection
+
+# Run with output visible
+cargo test --test integration_sequence_analysis -- --nocapture
+
+# Run integration tests alongside unit tests
+cargo test
+```
+
+## Contract Validation Strategy
+
+Rather than generating JSON schemas, we validate contracts pragmatically:
+
+1. **Rust-side**: Deserialize API responses back into the same response types
+   (`SequenceAnalysisResponse`, `ImageQualityContextResponse`) to prove round-trip
+   serialization works.
+
+2. **Field presence**: Parse as raw `serde_json::Value` and assert that all fields
+   expected by the TypeScript interfaces exist with the correct types.
+
+3. **Enum serialization**: Verify that `IssueCategory` variants serialize as snake_case
+   strings (e.g., `"likely_clouds"`, `"focus_drift"`) matching the TypeScript string
+   union type.
+
+4. **Optional field behavior**: Verify that `None` values serialize as JSON `null`
+   (matching TypeScript's `?: type` optional fields).
+
+## Summary
+
+| Component | Count |
+|---|---|
+| Test fixtures | 6 data sets |
+| Test cases | 13 tests |
+| Production code changes | 1 file (state.rs: test constructor) |
+| New dev dependencies | 1 (http-body-util) |
+| New files | 1 (tests/integration_sequence_analysis.rs) |

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -11,7 +11,7 @@ fi
 
 echo "Using DYLD_FALLBACK_LIBRARY_PATH: $DYLD_FALLBACK_LIBRARY_PATH"
 
-export OPENCV_LINK_LIBS="static=opencv_core,static=opencv_imgproc,static=opencv_imgcodecs,static=opencv_ximgproc"
-
 # Run the build with all arguments passed through
+# Note: We rely on pkg-config for OpenCV link flags rather than
+# OPENCV_LINK_LIBS static overrides, which miss transitive deps.
 cargo "$@"

--- a/src/db.rs
+++ b/src/db.rs
@@ -28,11 +28,9 @@ impl SchemaCapabilities {
         let query = format!("PRAGMA table_info({})", table);
         if let Ok(mut stmt) = conn.prepare(&query) {
             if let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(1)) {
-                for col_result in rows {
-                    if let Ok(col_name) = col_result {
-                        if col_name.eq_ignore_ascii_case(column) {
-                            return true;
-                        }
+                for col_name in rows.flatten() {
+                    if col_name.eq_ignore_ascii_case(column) {
+                        return true;
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod opencv_morphology;
 pub mod opencv_utils;
 pub mod opencv_wavelets;
 pub mod psf_fitting;
+pub mod sequence_analysis;
 pub mod server;
 pub mod utils;
 

--- a/src/sequence_analysis.rs
+++ b/src/sequence_analysis.rs
@@ -1,0 +1,1451 @@
+use serde::{Deserialize, Serialize};
+
+/// Issue categories for quality problems detected in image sequences.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueCategory {
+    LikelyClouds,
+    PossibleObstruction,
+    FocusDrift,
+    TrackingError,
+    WindShake,
+    SkyBrightening,
+    UnknownDegradation,
+}
+
+/// Per-image normalized metric values (0.0 = worst in sequence, 1.0 = best).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NormalizedMetrics {
+    pub star_count: Option<f64>,
+    pub hfr: Option<f64>,
+    pub eccentricity: Option<f64>,
+    pub snr: Option<f64>,
+    pub background: Option<f64>,
+}
+
+/// Quality analysis result for a single image within its sequence context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageQualityResult {
+    pub image_id: i32,
+    pub quality_score: f64,
+    pub temporal_anomaly_score: f64,
+    pub category: Option<IssueCategory>,
+    pub normalized_metrics: NormalizedMetrics,
+    pub details: Option<String>,
+}
+
+/// Reference values representing the best metrics observed in a sequence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReferenceValues {
+    pub best_star_count: Option<f64>,
+    pub best_hfr: Option<f64>,
+    pub best_eccentricity: Option<f64>,
+    pub best_snr: Option<f64>,
+    pub best_background: Option<f64>,
+}
+
+/// Summary statistics for a scored sequence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SequenceSummary {
+    pub excellent_count: usize,
+    pub good_count: usize,
+    pub fair_count: usize,
+    pub poor_count: usize,
+    pub bad_count: usize,
+    pub cloud_events_detected: usize,
+    pub focus_drift_detected: bool,
+    pub tracking_issues_detected: bool,
+}
+
+/// A scored sequence of images sharing the same target, filter, and session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScoredSequence {
+    pub target_id: i32,
+    pub target_name: String,
+    pub filter_name: String,
+    pub session_start: Option<i64>,
+    pub session_end: Option<i64>,
+    pub image_count: usize,
+    pub reference_values: ReferenceValues,
+    pub images: Vec<ImageQualityResult>,
+    pub summary: SequenceSummary,
+}
+
+/// Raw metric values extracted from an image's metadata for analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageMetrics {
+    pub image_id: i32,
+    pub timestamp: Option<i64>,
+    pub star_count: Option<f64>,
+    pub hfr: Option<f64>,
+    pub eccentricity: Option<f64>,
+    pub snr: Option<f64>,
+    pub background: Option<f64>,
+}
+
+/// Configurable weights for composite quality scoring.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QualityWeights {
+    pub star_count: f64,
+    pub hfr: f64,
+    pub eccentricity: f64,
+    pub snr: f64,
+    pub background: f64,
+}
+
+impl Default for QualityWeights {
+    fn default() -> Self {
+        Self {
+            star_count: 0.30,
+            hfr: 0.25,
+            eccentricity: 0.10,
+            snr: 0.25,
+            background: 0.10,
+        }
+    }
+}
+
+impl QualityWeights {
+    /// Normalize weights so they sum to 1.0. If all weights are zero, returns defaults.
+    pub fn normalized(self) -> Self {
+        let sum = self.star_count + self.hfr + self.eccentricity + self.snr + self.background;
+        if sum < 1e-10 {
+            return Self::default();
+        }
+        if (sum - 1.0).abs() < 1e-10 {
+            return self;
+        }
+        Self {
+            star_count: self.star_count / sum,
+            hfr: self.hfr / sum,
+            eccentricity: self.eccentricity / sum,
+            snr: self.snr / sum,
+            background: self.background / sum,
+        }
+    }
+}
+
+/// Configurable weights for temporal anomaly detection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TemporalWeights {
+    pub star_count: f64,
+    pub background: f64,
+    pub hfr: f64,
+    pub snr: f64,
+}
+
+impl Default for TemporalWeights {
+    fn default() -> Self {
+        Self {
+            star_count: 0.40,
+            background: 0.25,
+            hfr: 0.20,
+            snr: 0.15,
+        }
+    }
+}
+
+/// Configuration for the sequence analyzer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SequenceAnalyzerConfig {
+    pub session_gap_minutes: u64,
+    pub min_sequence_length: usize,
+    pub ewma_alpha: f64,
+    pub quality_weights: QualityWeights,
+    pub temporal_weights: TemporalWeights,
+    pub star_drop_threshold: f64,
+    pub bg_rise_threshold: f64,
+    pub hfr_rise_threshold: f64,
+    pub sudden_change_rate: f64,
+}
+
+impl Default for SequenceAnalyzerConfig {
+    fn default() -> Self {
+        Self {
+            session_gap_minutes: 60,
+            min_sequence_length: 3,
+            ewma_alpha: 0.3,
+            quality_weights: QualityWeights::default(),
+            temporal_weights: TemporalWeights::default(),
+            star_drop_threshold: 0.25,
+            bg_rise_threshold: 0.10,
+            hfr_rise_threshold: 0.15,
+            sudden_change_rate: 0.15,
+        }
+    }
+}
+
+/// Analyzer that scores image quality within acquisition sequences.
+pub struct SequenceAnalyzer {
+    config: SequenceAnalyzerConfig,
+}
+
+impl SequenceAnalyzer {
+    pub fn new(mut config: SequenceAnalyzerConfig) -> Self {
+        config.quality_weights = config.quality_weights.normalized();
+        Self { config }
+    }
+
+    /// Analyze a set of images, grouping them into sequences and scoring each.
+    /// All images should share the same target and filter.
+    pub fn analyze(
+        &self,
+        images: &[ImageMetrics],
+        target_id: i32,
+        target_name: &str,
+        filter_name: &str,
+    ) -> Vec<ScoredSequence> {
+        let sequences = self.split_into_sequences(images);
+
+        sequences
+            .into_iter()
+            .map(|seq| self.score_sequence(seq, target_id, target_name, filter_name))
+            .collect()
+    }
+
+    /// Split a time-ordered list of images into contiguous sessions.
+    fn split_into_sequences(&self, images: &[ImageMetrics]) -> Vec<Vec<ImageMetrics>> {
+        if images.is_empty() {
+            return vec![];
+        }
+
+        let mut sorted: Vec<ImageMetrics> = images.to_vec();
+        sorted.sort_by_key(|img| img.timestamp.unwrap_or(0));
+
+        let gap_seconds = (self.config.session_gap_minutes * 60) as i64;
+        let mut sequences: Vec<Vec<ImageMetrics>> = Vec::new();
+        let mut current_seq: Vec<ImageMetrics> = vec![sorted[0].clone()];
+
+        for img in sorted.iter().skip(1) {
+            let prev_ts = current_seq
+                .last()
+                .and_then(|prev| prev.timestamp)
+                .unwrap_or(0);
+            let curr_ts = img.timestamp.unwrap_or(0);
+
+            if curr_ts - prev_ts > gap_seconds {
+                sequences.push(std::mem::take(&mut current_seq));
+            }
+            current_seq.push(img.clone());
+        }
+        if !current_seq.is_empty() {
+            sequences.push(current_seq);
+        }
+
+        sequences
+    }
+
+    /// Score a single sequence of images.
+    fn score_sequence(
+        &self,
+        images: Vec<ImageMetrics>,
+        target_id: i32,
+        target_name: &str,
+        filter_name: &str,
+    ) -> ScoredSequence {
+        let image_count = images.len();
+
+        let session_start = images.first().and_then(|i| i.timestamp);
+        let session_end = images.last().and_then(|i| i.timestamp);
+
+        // If sequence is too short, return with score 1.0 for all images
+        if image_count < self.config.min_sequence_length {
+            let results: Vec<ImageQualityResult> = images
+                .iter()
+                .map(|img| ImageQualityResult {
+                    image_id: img.image_id,
+                    quality_score: 1.0,
+                    temporal_anomaly_score: 0.0,
+                    category: None,
+                    normalized_metrics: NormalizedMetrics {
+                        star_count: Some(1.0),
+                        hfr: Some(1.0),
+                        eccentricity: Some(1.0),
+                        snr: Some(1.0),
+                        background: Some(1.0),
+                    },
+                    details: None,
+                })
+                .collect();
+
+            return ScoredSequence {
+                target_id,
+                target_name: target_name.to_string(),
+                filter_name: filter_name.to_string(),
+                session_start,
+                session_end,
+                image_count,
+                reference_values: ReferenceValues {
+                    best_star_count: None,
+                    best_hfr: None,
+                    best_eccentricity: None,
+                    best_snr: None,
+                    best_background: None,
+                },
+                images: results,
+                summary: SequenceSummary {
+                    excellent_count: image_count,
+                    good_count: 0,
+                    fair_count: 0,
+                    poor_count: 0,
+                    bad_count: 0,
+                    cloud_events_detected: 0,
+                    focus_drift_detected: false,
+                    tracking_issues_detected: false,
+                },
+            };
+        }
+
+        // Normalize each metric
+        let norm_stars = self.normalize_metric_higher_better(
+            &images.iter().map(|i| i.star_count).collect::<Vec<_>>(),
+        );
+        let norm_hfr =
+            self.normalize_metric_lower_better(&images.iter().map(|i| i.hfr).collect::<Vec<_>>());
+        let norm_ecc = self.normalize_metric_lower_better(
+            &images.iter().map(|i| i.eccentricity).collect::<Vec<_>>(),
+        );
+        let norm_snr =
+            self.normalize_metric_higher_better(&images.iter().map(|i| i.snr).collect::<Vec<_>>());
+        let norm_bg = self.normalize_metric_lower_better(
+            &images.iter().map(|i| i.background).collect::<Vec<_>>(),
+        );
+
+        // Compute EWMA temporal deviation scores
+        let temporal_scores = self.compute_temporal_scores(&images);
+
+        // Compute composite quality scores
+        let w = &self.config.quality_weights;
+        let mut results: Vec<ImageQualityResult> = Vec::with_capacity(image_count);
+
+        for i in 0..image_count {
+            let ns = norm_stars[i];
+            let nh = norm_hfr[i];
+            let ne = norm_ecc[i];
+            let nsn = norm_snr[i];
+            let nb = norm_bg[i];
+
+            // Weighted sum using available metrics
+            let (score, total_weight) = weighted_sum_available(&[
+                (ns, w.star_count),
+                (nh, w.hfr),
+                (ne, w.eccentricity),
+                (nsn, w.snr),
+                (nb, w.background),
+            ]);
+
+            let quality_score = if total_weight > 0.0 {
+                score / total_weight
+            } else {
+                1.0
+            };
+
+            // Apply temporal penalty
+            let temporal = temporal_scores[i];
+            let penalty = 1.0 - temporal.min(0.5);
+            let final_score = (quality_score * penalty).clamp(0.0, 1.0);
+
+            results.push(ImageQualityResult {
+                image_id: images[i].image_id,
+                quality_score: final_score,
+                temporal_anomaly_score: temporal,
+                category: None, // Classified below
+                normalized_metrics: NormalizedMetrics {
+                    star_count: ns,
+                    hfr: nh,
+                    eccentricity: ne,
+                    snr: nsn,
+                    background: nb,
+                },
+                details: None,
+            });
+        }
+
+        // Classify issues
+        self.classify_issues(&mut results, &images);
+
+        // Build reference values
+        let reference_values = ReferenceValues {
+            best_star_count: best_value(&images, |i| i.star_count, true),
+            best_hfr: best_value(&images, |i| i.hfr, false),
+            best_eccentricity: best_value(&images, |i| i.eccentricity, false),
+            best_snr: best_value(&images, |i| i.snr, true),
+            best_background: best_value(&images, |i| i.background, false),
+        };
+
+        // Build summary
+        let summary = self.build_summary(&results);
+
+        ScoredSequence {
+            target_id,
+            target_name: target_name.to_string(),
+            filter_name: filter_name.to_string(),
+            session_start,
+            session_end,
+            image_count,
+            reference_values,
+            images: results,
+            summary,
+        }
+    }
+
+    /// Normalize values where higher is better (e.g. star count, SNR).
+    /// Uses 5th/95th percentile bounds for robustness.
+    fn normalize_metric_higher_better(&self, values: &[Option<f64>]) -> Vec<Option<f64>> {
+        let valid: Vec<f64> = values.iter().filter_map(|v| *v).collect();
+        if valid.is_empty() {
+            return values.iter().map(|_| None).collect();
+        }
+
+        let (p5, p95) = percentile_bounds(&valid);
+        if (p95 - p5).abs() < f64::EPSILON {
+            return values.iter().map(|v| v.map(|_| 1.0)).collect();
+        }
+
+        values
+            .iter()
+            .map(|v| v.map(|val| ((val - p5) / (p95 - p5)).clamp(0.0, 1.0)))
+            .collect()
+    }
+
+    /// Normalize values where lower is better (e.g. HFR, background).
+    /// Uses 5th/95th percentile bounds for robustness.
+    fn normalize_metric_lower_better(&self, values: &[Option<f64>]) -> Vec<Option<f64>> {
+        let valid: Vec<f64> = values.iter().filter_map(|v| *v).collect();
+        if valid.is_empty() {
+            return values.iter().map(|_| None).collect();
+        }
+
+        let (p5, p95) = percentile_bounds(&valid);
+        if (p95 - p5).abs() < f64::EPSILON {
+            return values.iter().map(|v| v.map(|_| 1.0)).collect();
+        }
+
+        values
+            .iter()
+            .map(|v| v.map(|val| ((p95 - val) / (p95 - p5)).clamp(0.0, 1.0)))
+            .collect()
+    }
+
+    /// Compute EWMA-based temporal deviation scores for the sequence.
+    fn compute_temporal_scores(&self, images: &[ImageMetrics]) -> Vec<f64> {
+        let alpha = self.config.ewma_alpha;
+        let tw = &self.config.temporal_weights;
+        let n = images.len();
+        let mut scores = vec![0.0f64; n];
+
+        // EWMA baselines for each metric
+        let mut bl_stars: Option<f64> = None;
+        let mut bl_bg: Option<f64> = None;
+        let mut bl_hfr: Option<f64> = None;
+        let mut bl_snr: Option<f64> = None;
+
+        for i in 0..n {
+            let img = &images[i];
+
+            const EPSILON: f64 = 1e-10;
+
+            // Star count deviation (drop is bad)
+            let star_dev = if let (Some(val), Some(bl)) = (img.star_count, bl_stars) {
+                if bl.abs() > EPSILON {
+                    ((bl - val) / bl).max(0.0)
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            };
+
+            // Background deviation (rise is bad)
+            let bg_dev = if let (Some(val), Some(bl)) = (img.background, bl_bg) {
+                if bl.abs() > EPSILON {
+                    ((val - bl) / bl).max(0.0)
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            };
+
+            // HFR deviation (rise is bad)
+            let hfr_dev = if let (Some(val), Some(bl)) = (img.hfr, bl_hfr) {
+                if bl.abs() > EPSILON {
+                    ((val - bl) / bl).max(0.0)
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            };
+
+            // SNR deviation (drop is bad, so negate)
+            let snr_dev = if let (Some(val), Some(bl)) = (img.snr, bl_snr) {
+                if bl.abs() > EPSILON {
+                    ((bl - val) / bl).max(0.0)
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            };
+
+            scores[i] = tw.star_count * star_dev
+                + tw.background * bg_dev
+                + tw.hfr * hfr_dev
+                + tw.snr * snr_dev;
+
+            // Update EWMA baselines
+            if let Some(val) = img.star_count {
+                bl_stars = Some(match bl_stars {
+                    Some(bl) => alpha * val + (1.0 - alpha) * bl,
+                    None => val,
+                });
+            }
+            if let Some(val) = img.background {
+                bl_bg = Some(match bl_bg {
+                    Some(bl) => alpha * val + (1.0 - alpha) * bl,
+                    None => val,
+                });
+            }
+            if let Some(val) = img.hfr {
+                bl_hfr = Some(match bl_hfr {
+                    Some(bl) => alpha * val + (1.0 - alpha) * bl,
+                    None => val,
+                });
+            }
+            if let Some(val) = img.snr {
+                bl_snr = Some(match bl_snr {
+                    Some(bl) => alpha * val + (1.0 - alpha) * bl,
+                    None => val,
+                });
+            }
+        }
+
+        scores
+    }
+
+    /// Classify issues for each image based on metric deviations.
+    fn classify_issues(&self, results: &mut [ImageQualityResult], images: &[ImageMetrics]) {
+        let n = images.len();
+        if n < 2 {
+            return;
+        }
+
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..n {
+            if results[i].quality_score >= 0.7 {
+                continue; // No classification needed for good frames
+            }
+
+            let star_drop = self.compute_fractional_drop(images, i, |m| m.star_count);
+            let bg_rise = self.compute_fractional_rise(images, i, |m| m.background);
+            let hfr_rise = self.compute_fractional_rise(images, i, |m| m.hfr);
+            let ecc_rise = self.compute_fractional_rise(images, i, |m| m.eccentricity);
+
+            let is_gradual_hfr = self.is_gradual_change(images, i, |m| m.hfr, 3);
+            let is_gradual_bg = self.is_gradual_change(images, i, |m| m.background, 3);
+
+            let star_stable = star_drop < self.config.star_drop_threshold;
+            let bg_stable = bg_rise < self.config.bg_rise_threshold;
+            let ecc_stable = ecc_rise < 0.15;
+
+            // Classification rules from the design document
+            let (category, details) = if star_drop > self.config.star_drop_threshold
+                && bg_rise > self.config.bg_rise_threshold
+            {
+                (
+                    Some(IssueCategory::LikelyClouds),
+                    Some(format!(
+                        "Star count dropped {:.0}% from baseline while background increased {:.0}%. Pattern consistent with cloud passage.",
+                        star_drop * 100.0,
+                        bg_rise * 100.0
+                    )),
+                )
+            } else if star_drop > self.config.star_drop_threshold && bg_stable {
+                (
+                    Some(IssueCategory::PossibleObstruction),
+                    Some(format!(
+                        "Star count dropped {:.0}% with stable background. Possible obstruction (tree, dome slit, dew cap).",
+                        star_drop * 100.0
+                    )),
+                )
+            } else if hfr_rise > self.config.hfr_rise_threshold && is_gradual_hfr && ecc_stable {
+                (
+                    Some(IssueCategory::FocusDrift),
+                    Some(format!(
+                        "HFR increased {:.0}% gradually over multiple frames with stable eccentricity. Consistent with focus drift.",
+                        hfr_rise * 100.0
+                    )),
+                )
+            } else if ecc_rise > 0.15 && star_stable {
+                (
+                    Some(IssueCategory::TrackingError),
+                    Some(format!(
+                        "Eccentricity increased by {:.2} with stable star count. Consistent with tracking/guiding error.",
+                        ecc_rise
+                    )),
+                )
+            } else if hfr_rise > self.config.hfr_rise_threshold
+                && star_drop > self.config.star_drop_threshold
+                && !ecc_stable
+            {
+                (
+                    Some(IssueCategory::WindShake),
+                    Some("HFR increased, star count dropped, and eccentricity changed. Consistent with wind shake affecting guiding and seeing.".to_string()),
+                )
+            } else if bg_rise > self.config.bg_rise_threshold && is_gradual_bg && star_stable {
+                (
+                    Some(IssueCategory::SkyBrightening),
+                    Some(format!(
+                        "Background increased {:.0}% gradually with stable star count. Consistent with sky brightening (dawn, moon rise).",
+                        bg_rise * 100.0
+                    )),
+                )
+            } else if results[i].quality_score < 0.5 {
+                (
+                    Some(IssueCategory::UnknownDegradation),
+                    Some(
+                        "Quality degraded but no clear pattern matches known issue types."
+                            .to_string(),
+                    ),
+                )
+            } else {
+                (None, None)
+            };
+
+            results[i].category = category;
+            results[i].details = details;
+        }
+    }
+
+    /// Compute fractional drop relative to a local baseline (preceding frames).
+    fn compute_fractional_drop(
+        &self,
+        images: &[ImageMetrics],
+        idx: usize,
+        f: impl Fn(&ImageMetrics) -> Option<f64>,
+    ) -> f64 {
+        let current = match f(&images[idx]) {
+            Some(v) => v,
+            None => return 0.0,
+        };
+
+        let baseline = self.local_baseline(images, idx, &f);
+        if baseline.abs() < 1e-10 {
+            return 0.0;
+        }
+        ((baseline - current) / baseline).max(0.0)
+    }
+
+    /// Compute fractional rise relative to a local baseline (preceding frames).
+    fn compute_fractional_rise(
+        &self,
+        images: &[ImageMetrics],
+        idx: usize,
+        f: impl Fn(&ImageMetrics) -> Option<f64>,
+    ) -> f64 {
+        let current = match f(&images[idx]) {
+            Some(v) => v,
+            None => return 0.0,
+        };
+
+        let baseline = self.local_baseline(images, idx, &f);
+        if baseline.abs() < 1e-10 {
+            return 0.0;
+        }
+        ((current - baseline) / baseline).max(0.0)
+    }
+
+    /// Compute local baseline as median of up to 5 preceding frames.
+    fn local_baseline(
+        &self,
+        images: &[ImageMetrics],
+        idx: usize,
+        f: &impl Fn(&ImageMetrics) -> Option<f64>,
+    ) -> f64 {
+        let start = idx.saturating_sub(5);
+        let mut vals: Vec<f64> = (start..idx).filter_map(|j| f(&images[j])).collect();
+        if vals.is_empty() {
+            return f(&images[idx]).unwrap_or(0.0);
+        }
+        vals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        vals[vals.len() / 2]
+    }
+
+    /// Check if a metric changed gradually over the last `window` frames.
+    fn is_gradual_change(
+        &self,
+        images: &[ImageMetrics],
+        idx: usize,
+        f: impl Fn(&ImageMetrics) -> Option<f64>,
+        window: usize,
+    ) -> bool {
+        if idx < window {
+            return false;
+        }
+
+        let mut consecutive_small = 0;
+        for j in (idx - window + 1)..=idx {
+            let prev = match f(&images[j - 1]) {
+                Some(v) if v > 0.0 => v,
+                _ => continue,
+            };
+            let curr = match f(&images[j]) {
+                Some(v) => v,
+                None => continue,
+            };
+            let rate = ((curr - prev) / prev).abs();
+            if rate < self.config.sudden_change_rate {
+                consecutive_small += 1;
+            }
+        }
+
+        consecutive_small >= window - 1
+    }
+
+    /// Build summary from scored results.
+    fn build_summary(&self, results: &[ImageQualityResult]) -> SequenceSummary {
+        let mut summary = SequenceSummary {
+            excellent_count: 0,
+            good_count: 0,
+            fair_count: 0,
+            poor_count: 0,
+            bad_count: 0,
+            cloud_events_detected: 0,
+            focus_drift_detected: false,
+            tracking_issues_detected: false,
+        };
+
+        for r in results {
+            match r.quality_score {
+                s if s >= 0.90 => summary.excellent_count += 1,
+                s if s >= 0.70 => summary.good_count += 1,
+                s if s >= 0.50 => summary.fair_count += 1,
+                s if s >= 0.30 => summary.poor_count += 1,
+                _ => summary.bad_count += 1,
+            }
+
+            match &r.category {
+                Some(IssueCategory::LikelyClouds) => summary.cloud_events_detected += 1,
+                Some(IssueCategory::FocusDrift) => summary.focus_drift_detected = true,
+                Some(IssueCategory::TrackingError) => summary.tracking_issues_detected = true,
+                _ => {}
+            }
+        }
+
+        summary
+    }
+}
+
+/// Compute the 5th and 95th percentile values from a slice.
+fn percentile_bounds(values: &[f64]) -> (f64, f64) {
+    if values.is_empty() {
+        return (0.0, 0.0);
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = sorted.len();
+    let p5_idx = ((n as f64 * 0.05).floor() as usize).min(n - 1);
+    let p95_idx = ((n as f64 * 0.95).ceil() as usize).min(n - 1);
+    (sorted[p5_idx], sorted[p95_idx])
+}
+
+/// Weighted sum of available (non-None) metric values.
+fn weighted_sum_available(items: &[(Option<f64>, f64)]) -> (f64, f64) {
+    let mut sum = 0.0;
+    let mut total_weight = 0.0;
+    for (value, weight) in items {
+        if let Some(v) = value {
+            sum += v * weight;
+            total_weight += weight;
+        }
+    }
+    (sum, total_weight)
+}
+
+/// Find the best value for a metric across images (max if higher_better, min otherwise).
+fn best_value(
+    images: &[ImageMetrics],
+    f: impl Fn(&ImageMetrics) -> Option<f64>,
+    higher_better: bool,
+) -> Option<f64> {
+    let vals: Vec<f64> = images.iter().filter_map(&f).collect();
+    if vals.is_empty() {
+        return None;
+    }
+    if higher_better {
+        vals.into_iter()
+            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+    } else {
+        vals.into_iter()
+            .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+    }
+}
+
+/// Parse image metrics from an AcquiredImage's metadata JSON.
+pub fn extract_metrics_from_metadata(
+    image_id: i32,
+    metadata_json: &str,
+    acquired_date: Option<i64>,
+) -> ImageMetrics {
+    let metadata: serde_json::Value =
+        serde_json::from_str(metadata_json).unwrap_or(serde_json::Value::Null);
+
+    // Use acquireddate (i64 from DB) as primary sort key; fall back to parsing
+    // ExposureStartTime from metadata JSON if acquireddate is NULL
+    let timestamp = acquired_date.or_else(|| {
+        metadata["ExposureStartTime"]
+            .as_str()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.timestamp())
+    });
+
+    let star_count = metadata["DetectedStars"]
+        .as_f64()
+        .or_else(|| metadata["DetectedStars"].as_i64().map(|v| v as f64));
+
+    let hfr = metadata["HFR"].as_f64();
+
+    let eccentricity = metadata["Eccentricity"].as_f64();
+    let snr = metadata["SNR"].as_f64();
+
+    // Background can be stored under several keys
+    let background = metadata["Background"]
+        .as_f64()
+        .or_else(|| metadata["Median"].as_f64());
+
+    ImageMetrics {
+        image_id,
+        timestamp,
+        star_count,
+        hfr,
+        eccentricity,
+        snr,
+        background,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_image(id: i32, ts: i64, stars: f64, hfr: f64) -> ImageMetrics {
+        ImageMetrics {
+            image_id: id,
+            timestamp: Some(ts),
+            star_count: Some(stars),
+            hfr: Some(hfr),
+            eccentricity: None,
+            snr: None,
+            background: None,
+        }
+    }
+
+    fn make_full_image(
+        id: i32,
+        ts: i64,
+        stars: f64,
+        hfr: f64,
+        bg: f64,
+        snr: f64,
+        ecc: f64,
+    ) -> ImageMetrics {
+        ImageMetrics {
+            image_id: id,
+            timestamp: Some(ts),
+            star_count: Some(stars),
+            hfr: Some(hfr),
+            eccentricity: Some(ecc),
+            snr: Some(snr),
+            background: Some(bg),
+        }
+    }
+
+    #[test]
+    fn test_percentile_bounds_basic() {
+        let values: Vec<f64> = (1..=100).map(|x| x as f64).collect();
+        let (p5, p95) = percentile_bounds(&values);
+        assert!(p5 <= 6.0, "p5 should be around 5: got {}", p5);
+        assert!(p95 >= 95.0, "p95 should be around 95: got {}", p95);
+    }
+
+    #[test]
+    fn test_percentile_bounds_identical() {
+        let values = vec![5.0, 5.0, 5.0, 5.0];
+        let (p5, p95) = percentile_bounds(&values);
+        assert_eq!(p5, 5.0);
+        assert_eq!(p95, 5.0);
+    }
+
+    #[test]
+    fn test_percentile_bounds_empty() {
+        let values: Vec<f64> = vec![];
+        let (p5, p95) = percentile_bounds(&values);
+        assert_eq!(p5, 0.0);
+        assert_eq!(p95, 0.0);
+    }
+
+    #[test]
+    fn test_normalize_higher_better() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let values = vec![
+            Some(100.0),
+            Some(200.0),
+            Some(300.0),
+            Some(400.0),
+            Some(500.0),
+        ];
+        let normalized = analyzer.normalize_metric_higher_better(&values);
+
+        // 500 should be the best (1.0), 100 the worst (0.0)
+        assert!(normalized[4].unwrap() > normalized[0].unwrap());
+        // The best value should be close to 1.0
+        assert!(normalized[4].unwrap() >= 0.9);
+    }
+
+    #[test]
+    fn test_normalize_lower_better() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let values = vec![Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)];
+        let normalized = analyzer.normalize_metric_lower_better(&values);
+
+        // 1.0 should be the best (close to 1.0), 5.0 the worst (close to 0.0)
+        assert!(normalized[0].unwrap() > normalized[4].unwrap());
+        assert!(normalized[0].unwrap() >= 0.9);
+    }
+
+    #[test]
+    fn test_normalize_all_identical() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let values = vec![Some(3.0), Some(3.0), Some(3.0)];
+        let normalized = analyzer.normalize_metric_higher_better(&values);
+        for v in &normalized {
+            assert_eq!(v.unwrap(), 1.0);
+        }
+    }
+
+    #[test]
+    fn test_normalize_with_nones() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let values = vec![Some(100.0), None, Some(300.0), None, Some(500.0)];
+        let normalized = analyzer.normalize_metric_higher_better(&values);
+
+        assert!(normalized[0].is_some());
+        assert!(normalized[1].is_none());
+        assert!(normalized[2].is_some());
+        assert!(normalized[3].is_none());
+        assert!(normalized[4].is_some());
+    }
+
+    #[test]
+    fn test_ewma_temporal_scores_stable() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let images: Vec<ImageMetrics> = (0..10)
+            .map(|i| make_image(i, i as i64 * 300, 300.0, 2.5))
+            .collect();
+
+        let scores = analyzer.compute_temporal_scores(&images);
+        // All frames are identical, so temporal scores should be 0
+        for s in &scores {
+            assert!(
+                *s < 0.01,
+                "Stable sequence should have near-zero temporal score: {}",
+                s
+            );
+        }
+    }
+
+    #[test]
+    fn test_ewma_temporal_scores_cloud_event() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let mut images: Vec<ImageMetrics> = (0..10)
+            .map(|i| make_image(i, i as i64 * 300, 300.0, 2.5))
+            .collect();
+
+        // Simulate cloud event at frame 7: star count drops 50%, HFR rises 30%
+        images[7].star_count = Some(150.0);
+        images[7].hfr = Some(3.25);
+
+        let scores = analyzer.compute_temporal_scores(&images);
+        // Frame 7 should have a significantly higher temporal score
+        assert!(
+            scores[7] > scores[5],
+            "Cloud event frame should have higher temporal score: {} vs {}",
+            scores[7],
+            scores[5]
+        );
+        assert!(
+            scores[7] > 0.1,
+            "Cloud event should produce notable temporal score: {}",
+            scores[7]
+        );
+    }
+
+    #[test]
+    fn test_sequence_splitting_single_session() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let images: Vec<ImageMetrics> = (0..10)
+            .map(|i| make_image(i, 1000 + i as i64 * 300, 300.0, 2.5)) // 5-min gaps
+            .collect();
+
+        let sequences = analyzer.split_into_sequences(&images);
+        assert_eq!(sequences.len(), 1, "Should be a single session");
+        assert_eq!(sequences[0].len(), 10);
+    }
+
+    #[test]
+    fn test_sequence_splitting_two_sessions() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let mut images: Vec<ImageMetrics> = (0..5)
+            .map(|i| make_image(i, 1000 + i as i64 * 300, 300.0, 2.5))
+            .collect();
+
+        // Second session 2 hours later
+        for i in 5..10 {
+            images.push(make_image(
+                i,
+                1000 + 5 * 300 + 7200 + (i as i64 - 5) * 300,
+                300.0,
+                2.5,
+            ));
+        }
+
+        let sequences = analyzer.split_into_sequences(&images);
+        assert_eq!(sequences.len(), 2, "Should split into two sessions");
+        assert_eq!(sequences[0].len(), 5);
+        assert_eq!(sequences[1].len(), 5);
+    }
+
+    #[test]
+    fn test_scoring_good_sequence() {
+        let config = SequenceAnalyzerConfig {
+            min_sequence_length: 3,
+            ..Default::default()
+        };
+        let analyzer = SequenceAnalyzer::new(config);
+
+        // All good frames clustered tightly around the same values
+        let images: Vec<ImageMetrics> = (0..10)
+            .map(|i| {
+                // Small oscillation around center values
+                let offset = if i % 2 == 0 { 1.0 } else { -1.0 };
+                make_full_image(
+                    i,
+                    i as i64 * 300,
+                    300.0 + offset * 3.0,  // Tight star count variation
+                    2.5 + offset * 0.02,   // Tight HFR variation
+                    1200.0 + offset * 5.0, // Tight background variation
+                    45.0 + offset * 0.3,   // Tight SNR variation
+                    0.35,                  // Constant eccentricity
+                )
+            })
+            .collect();
+
+        let results = analyzer.analyze(&images, 1, "M42", "L");
+        assert_eq!(results.len(), 1);
+        let seq = &results[0];
+        assert_eq!(seq.image_count, 10);
+
+        // All frames should score reasonably since they're all similar
+        // With tight clustering, even after normalization scores should not be extremely low
+        let above_fair = seq.images.iter().filter(|r| r.quality_score >= 0.3).count();
+        assert!(
+            above_fair >= 8,
+            "Most frames in a tight sequence should score above fair: {} out of 10",
+            above_fair
+        );
+    }
+
+    #[test]
+    fn test_scoring_with_cloud_event() {
+        let config = SequenceAnalyzerConfig {
+            min_sequence_length: 3,
+            ..Default::default()
+        };
+        let analyzer = SequenceAnalyzer::new(config);
+
+        let mut images: Vec<ImageMetrics> = (0..10)
+            .map(|i| make_full_image(i, i as i64 * 300, 300.0, 2.5, 1200.0, 45.0, 0.35))
+            .collect();
+
+        // Cloud event at frame 7
+        images[7] = make_full_image(7, 7 * 300, 100.0, 4.0, 1800.0, 15.0, 0.35);
+        // Another cloud frame
+        images[8] = make_full_image(8, 8 * 300, 80.0, 4.5, 2000.0, 10.0, 0.35);
+
+        let results = analyzer.analyze(&images, 1, "M42", "L");
+        assert_eq!(results.len(), 1);
+        let seq = &results[0];
+
+        // Cloud-affected frames should score worse than good frames
+        let good_score = seq.images[3].quality_score;
+        let cloud_score = seq.images[7].quality_score;
+        assert!(
+            cloud_score < good_score,
+            "Cloud frame should score worse: {} vs {}",
+            cloud_score,
+            good_score
+        );
+
+        // Cloud frame should be classified
+        assert!(
+            seq.images[7].category.is_some(),
+            "Cloud frame should have a category"
+        );
+    }
+
+    #[test]
+    fn test_classify_likely_clouds() {
+        let config = SequenceAnalyzerConfig {
+            min_sequence_length: 3,
+            ..Default::default()
+        };
+        let analyzer = SequenceAnalyzer::new(config);
+
+        let mut images: Vec<ImageMetrics> = (0..8)
+            .map(|i| make_full_image(i, i as i64 * 300, 300.0, 2.5, 1200.0, 45.0, 0.35))
+            .collect();
+
+        // Frame 6: star drop + background rise = likely clouds
+        images[6] = make_full_image(6, 6 * 300, 100.0, 3.5, 1800.0, 15.0, 0.35);
+
+        let results = analyzer.analyze(&images, 1, "test", "L");
+        let seq = &results[0];
+
+        let cloud_frame = &seq.images[6];
+        assert_eq!(
+            cloud_frame.category,
+            Some(IssueCategory::LikelyClouds),
+            "Should classify as LikelyClouds, got {:?}",
+            cloud_frame.category
+        );
+    }
+
+    #[test]
+    fn test_classify_possible_obstruction() {
+        let config = SequenceAnalyzerConfig {
+            min_sequence_length: 3,
+            ..Default::default()
+        };
+        let analyzer = SequenceAnalyzer::new(config);
+
+        let mut images: Vec<ImageMetrics> = (0..8)
+            .map(|i| make_full_image(i, i as i64 * 300, 300.0, 2.5, 1200.0, 45.0, 0.35))
+            .collect();
+
+        // Frame 6: star drop but stable background = obstruction
+        images[6] = make_full_image(6, 6 * 300, 100.0, 2.6, 1200.0, 40.0, 0.35);
+
+        let results = analyzer.analyze(&images, 1, "test", "L");
+        let seq = &results[0];
+
+        let obst_frame = &seq.images[6];
+        assert_eq!(
+            obst_frame.category,
+            Some(IssueCategory::PossibleObstruction),
+            "Should classify as PossibleObstruction, got {:?}",
+            obst_frame.category
+        );
+    }
+
+    #[test]
+    fn test_short_sequence_returns_perfect_scores() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        // 2 images is below min_sequence_length of 3
+        let images: Vec<ImageMetrics> = (0..2)
+            .map(|i| make_image(i, i as i64 * 300, 300.0, 2.5))
+            .collect();
+
+        let results = analyzer.analyze(&images, 1, "test", "L");
+        assert_eq!(results.len(), 1);
+
+        for img in &results[0].images {
+            assert_eq!(
+                img.quality_score, 1.0,
+                "Short sequence images should get 1.0"
+            );
+        }
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let images: Vec<ImageMetrics> = vec![];
+        let results = analyzer.analyze(&images, 1, "test", "L");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_weighted_sum_available() {
+        let items = [
+            (Some(0.8), 0.3),
+            (None, 0.25),
+            (Some(0.6), 0.10),
+            (None, 0.25),
+            (Some(0.9), 0.10),
+        ];
+        let (sum, weight) = weighted_sum_available(&items);
+        let expected_sum = 0.8 * 0.3 + 0.6 * 0.10 + 0.9 * 0.10;
+        let expected_weight = 0.3 + 0.10 + 0.10;
+        assert!((sum - expected_sum).abs() < 1e-10);
+        assert!((weight - expected_weight).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_extract_metrics_from_metadata() {
+        let json = r#"{
+            "FileName": "test.fits",
+            "FilterName": "Ha",
+            "HFR": 2.5,
+            "DetectedStars": 342,
+            "ExposureStartTime": "2024-01-15T22:00:00Z"
+        }"#;
+
+        let metrics = extract_metrics_from_metadata(1, json, None);
+        assert_eq!(metrics.image_id, 1);
+        assert_eq!(metrics.star_count, Some(342.0));
+        assert_eq!(metrics.hfr, Some(2.5));
+        assert!(metrics.timestamp.is_some());
+        assert!(metrics.eccentricity.is_none());
+        assert!(metrics.snr.is_none());
+        assert!(metrics.background.is_none());
+    }
+
+    #[test]
+    fn test_extract_metrics_acquireddate_preferred_over_exposure_start() {
+        // When both acquireddate and ExposureStartTime exist, acquireddate takes priority
+        let json = r#"{
+            "FileName": "test.fits",
+            "ExposureStartTime": "2024-01-15T22:00:00Z"
+        }"#;
+        let acquired_ts = 1705400000_i64; // Different from ExposureStartTime
+        let metrics = extract_metrics_from_metadata(1, json, Some(acquired_ts));
+        assert_eq!(metrics.timestamp, Some(acquired_ts));
+    }
+
+    #[test]
+    fn test_extract_metrics_fallback_to_exposure_start_time() {
+        // When acquireddate is NULL, fall back to ExposureStartTime
+        let json = r#"{
+            "FileName": "test.fits",
+            "ExposureStartTime": "2024-01-15T22:00:00Z"
+        }"#;
+        let metrics = extract_metrics_from_metadata(1, json, None);
+        assert!(metrics.timestamp.is_some());
+    }
+
+    #[test]
+    fn test_extract_metrics_no_timestamp_sources() {
+        let json = r#"{"FileName": "test.fits", "FilterName": "Ha"}"#;
+        let metrics = extract_metrics_from_metadata(1, json, None);
+        assert_eq!(metrics.timestamp, None);
+    }
+
+    #[test]
+    fn test_extract_metrics_invalid_json() {
+        let metrics = extract_metrics_from_metadata(1, "not json", Some(123));
+        assert_eq!(metrics.image_id, 1);
+        assert_eq!(metrics.timestamp, Some(123));
+        assert!(metrics.star_count.is_none());
+        assert!(metrics.hfr.is_none());
+    }
+
+    #[test]
+    fn test_summary_counts() {
+        let results = vec![
+            ImageQualityResult {
+                image_id: 1,
+                quality_score: 0.95,
+                temporal_anomaly_score: 0.0,
+                category: None,
+                normalized_metrics: NormalizedMetrics {
+                    star_count: Some(1.0),
+                    hfr: Some(1.0),
+                    eccentricity: None,
+                    snr: None,
+                    background: None,
+                },
+                details: None,
+            },
+            ImageQualityResult {
+                image_id: 2,
+                quality_score: 0.75,
+                temporal_anomaly_score: 0.0,
+                category: None,
+                normalized_metrics: NormalizedMetrics {
+                    star_count: Some(0.8),
+                    hfr: Some(0.7),
+                    eccentricity: None,
+                    snr: None,
+                    background: None,
+                },
+                details: None,
+            },
+            ImageQualityResult {
+                image_id: 3,
+                quality_score: 0.25,
+                temporal_anomaly_score: 0.4,
+                category: Some(IssueCategory::LikelyClouds),
+                normalized_metrics: NormalizedMetrics {
+                    star_count: Some(0.1),
+                    hfr: Some(0.3),
+                    eccentricity: None,
+                    snr: None,
+                    background: None,
+                },
+                details: Some("Cloud".to_string()),
+            },
+        ];
+
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let summary = analyzer.build_summary(&results);
+
+        assert_eq!(summary.excellent_count, 1);
+        assert_eq!(summary.good_count, 1);
+        assert_eq!(summary.bad_count, 1);
+        assert_eq!(summary.cloud_events_detected, 1);
+    }
+
+    #[test]
+    fn test_custom_weights() {
+        let config = SequenceAnalyzerConfig {
+            min_sequence_length: 3,
+            quality_weights: QualityWeights {
+                star_count: 0.5,
+                hfr: 0.5,
+                eccentricity: 0.0,
+                snr: 0.0,
+                background: 0.0,
+            },
+            ..Default::default()
+        };
+
+        let analyzer = SequenceAnalyzer::new(config);
+        let images: Vec<ImageMetrics> = (0..6)
+            .map(|i| {
+                make_image(
+                    i,
+                    i as i64 * 300,
+                    300.0 - i as f64 * 30.0,
+                    2.5 + i as f64 * 0.2,
+                )
+            })
+            .collect();
+
+        let results = analyzer.analyze(&images, 1, "test", "L");
+        assert_eq!(results.len(), 1);
+
+        // First frame should score better than last (more stars, lower HFR)
+        assert!(
+            results[0].images[0].quality_score >= results[0].images[5].quality_score,
+            "First frame should score >= last: {} vs {}",
+            results[0].images[0].quality_score,
+            results[0].images[5].quality_score,
+        );
+    }
+
+    #[test]
+    fn test_weight_normalization() {
+        let weights = QualityWeights {
+            star_count: 2.0,
+            hfr: 2.0,
+            eccentricity: 1.0,
+            snr: 0.0,
+            background: 0.0,
+        };
+        let normalized = weights.normalized();
+        let sum = normalized.star_count
+            + normalized.hfr
+            + normalized.eccentricity
+            + normalized.snr
+            + normalized.background;
+        assert!(
+            (sum - 1.0).abs() < 1e-10,
+            "Normalized weights should sum to 1.0, got {}",
+            sum
+        );
+        assert!((normalized.star_count - 0.4).abs() < 1e-10);
+        assert!((normalized.hfr - 0.4).abs() < 1e-10);
+        assert!((normalized.eccentricity - 0.2).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_weight_normalization_already_normalized() {
+        let weights = QualityWeights::default();
+        let normalized = weights.normalized();
+        assert!((normalized.star_count - 0.30).abs() < 1e-10);
+        assert!((normalized.hfr - 0.25).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_weight_normalization_all_zero_returns_defaults() {
+        let weights = QualityWeights {
+            star_count: 0.0,
+            hfr: 0.0,
+            eccentricity: 0.0,
+            snr: 0.0,
+            background: 0.0,
+        };
+        let normalized = weights.normalized();
+        let defaults = QualityWeights::default();
+        assert!((normalized.star_count - defaults.star_count).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_weight_redistribution_with_missing_metrics() {
+        // When some metrics are None, weighted_sum_available divides by total
+        // available weight, effectively redistributing proportionally
+        let items_all = [
+            (Some(0.8), 0.3),
+            (Some(0.7), 0.25),
+            (Some(0.6), 0.10),
+            (Some(0.9), 0.25),
+            (Some(0.5), 0.10),
+        ];
+        let (sum_all, weight_all) = weighted_sum_available(&items_all);
+        let score_all = sum_all / weight_all;
+
+        // With two metrics missing
+        let items_partial = [
+            (Some(0.8), 0.3),
+            (Some(0.7), 0.25),
+            (None, 0.10),
+            (None, 0.25),
+            (Some(0.5), 0.10),
+        ];
+        let (sum_partial, weight_partial) = weighted_sum_available(&items_partial);
+        let score_partial = sum_partial / weight_partial;
+
+        // Both should produce a score between 0.0 and 1.0
+        assert!(score_all >= 0.0 && score_all <= 1.0);
+        assert!(score_partial >= 0.0 && score_partial <= 1.0);
+        // Weight redistribution means remaining weights are scaled up proportionally
+        assert!(
+            (weight_partial - 0.65).abs() < 1e-10,
+            "Available weight should be 0.3+0.25+0.10=0.65, got {}",
+            weight_partial
+        );
+    }
+
+    #[test]
+    fn test_best_value_higher_better() {
+        let images = vec![
+            make_image(1, 100, 200.0, 2.5),
+            make_image(2, 200, 350.0, 2.3),
+            make_image(3, 300, 100.0, 2.8),
+        ];
+        let best = best_value(&images, |i| i.star_count, true);
+        assert_eq!(best, Some(350.0));
+    }
+
+    #[test]
+    fn test_best_value_lower_better() {
+        let images = vec![
+            make_image(1, 100, 200.0, 2.5),
+            make_image(2, 200, 350.0, 2.3),
+            make_image(3, 300, 100.0, 2.8),
+        ];
+        let best = best_value(&images, |i| i.hfr, false);
+        assert_eq!(best, Some(2.3));
+    }
+}

--- a/src/sequence_analysis.rs
+++ b/src/sequence_analysis.rs
@@ -1417,8 +1417,8 @@ mod tests {
         let score_partial = sum_partial / weight_partial;
 
         // Both should produce a score between 0.0 and 1.0
-        assert!(score_all >= 0.0 && score_all <= 1.0);
-        assert!(score_partial >= 0.0 && score_partial <= 1.0);
+        assert!((0.0..=1.0).contains(&score_all));
+        assert!((0.0..=1.0).contains(&score_partial));
         // Weight redistribution means remaining weights are scaled up proportionally
         assert!(
             (weight_partial - 0.65).abs() < 1e-10,

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -1,3 +1,4 @@
+use crate::sequence_analysis::{ImageQualityResult, ReferenceValues, SequenceSummary};
 use crate::server::state::RefreshStatus;
 use serde::{Deserialize, Serialize};
 
@@ -299,4 +300,46 @@ pub struct FileStatusResponse {
     pub missing_files: Vec<MissingFileInfo>,
     pub cache_hit_rate: u32,
     pub optimistic_assumption: bool, // true if we assumed files exist due to low hit rate
+}
+
+// Sequence analysis request/response types
+
+#[derive(Debug, Deserialize)]
+pub struct SequenceAnalysisQuery {
+    pub target_id: i32,
+    pub filter_name: Option<String>,
+    pub session_gap_minutes: Option<u64>,
+    pub weight_star_count: Option<f64>,
+    pub weight_hfr: Option<f64>,
+    pub weight_eccentricity: Option<f64>,
+    pub weight_snr: Option<f64>,
+    pub weight_background: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SequenceAnalysisResponse {
+    pub sequences: Vec<ScoredSequenceResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScoredSequenceResponse {
+    pub target_id: i32,
+    pub target_name: String,
+    pub filter_name: String,
+    pub session_start: Option<i64>,
+    pub session_end: Option<i64>,
+    pub image_count: usize,
+    pub reference_values: ReferenceValues,
+    pub images: Vec<ImageQualityResult>,
+    pub summary: SequenceSummary,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ImageQualityContextResponse {
+    pub image_id: i32,
+    pub quality: Option<ImageQualityResult>,
+    pub sequence_target_id: Option<i32>,
+    pub sequence_filter_name: Option<String>,
+    pub sequence_image_count: Option<usize>,
+    pub reference_values: Option<ReferenceValues>,
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -186,6 +186,11 @@ async fn run_server_internal(
             "/images/{image_id}/grade",
             put(handlers::update_image_grade),
         )
+        .route("/analysis/sequence", get(handlers::analyze_sequence))
+        .route(
+            "/analysis/image/{image_id}",
+            get(handlers::get_image_quality),
+        )
         .with_state(state);
 
     // Create main app with either embedded or filesystem static serving

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -902,6 +902,26 @@ impl AppState {
     }
 }
 
+impl AppState {
+    /// Create an AppState for integration testing with a pre-opened database connection.
+    /// Skips file system validation (no image dirs or cache dir needed).
+    #[doc(hidden)]
+    pub fn new_for_test(conn: Connection) -> Self {
+        Self {
+            database_path: ":memory:".to_string(),
+            image_dirs: vec![],
+            cache_dir: "/tmp/psf-guard-test".to_string(),
+            image_dir_paths: vec![],
+            cache_dir_path: std::path::PathBuf::from("/tmp/psf-guard-test"),
+            db_connection: Arc::new(Mutex::new(conn)),
+            file_check_cache: Arc::new(RwLock::new(FileCheckCache::new())),
+            directory_tree_cache: Arc::new(RwLock::new(None)),
+            refresh_mutex: Arc::new(TokioMutex::new(())),
+            pregeneration_config: crate::cli::PregenerationConfig::default(),
+        }
+    }
+}
+
 impl Clone for AppState {
     fn clone(&self) -> Self {
         Self {

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -1755,9 +1755,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz",
-      "integrity": "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -21,6 +21,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@types/react-window": "^1.8.8",
@@ -29,10 +32,27 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "jsdom": "^28.0.0",
+        "msw": "^2.12.9",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.1",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -47,6 +67,61 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.8",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.8.tgz",
+      "integrity": "sha512-stisC1nULNc9oH5lakAj8MH88ZxeGxzyWNDfbdCxvJSJIvDsHNZqYvscGTgy/ysgXWLJPt6K/4t0/GjvtKcFJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -337,6 +412,138 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.0.0.tgz",
+      "integrity": "sha512-q4d82GTl8BIlh/dTnVsWmxnbWJeb3kiU8eUH71UxlxnS+WIaALmtzTL8gR15PkYOexMQYVk0CO4qIG93C1IvPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -935,6 +1142,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
+      "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1001,6 +1226,94 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1040,6 +1353,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.2.tgz",
+      "integrity": "sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1077,6 +1408,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.34",
@@ -1365,6 +1721,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.85.5",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.5.tgz",
@@ -1400,6 +1763,104 @@
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1445,6 +1906,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1515,6 +1994,13 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.41.0",
@@ -1808,6 +2294,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1831,6 +2428,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1846,6 +2453,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1871,6 +2488,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1894,6 +2531,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -1996,6 +2643,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2011,6 +2668,49 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -2087,11 +2787,72 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2111,6 +2872,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2126,6 +2894,24 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2148,6 +2934,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2165,6 +2971,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2426,6 +3239,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2434,6 +3257,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2631,6 +3464,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2713,6 +3556,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
+      "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2762,6 +3615,54 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2799,6 +3700,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2807,6 +3718,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2822,6 +3743,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2831,6 +3759,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2857,6 +3792,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
+      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^5.3.7",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.20.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -2963,6 +3938,27 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2971,6 +3967,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -3023,6 +4026,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3042,6 +4055,61 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.12.9",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.9.tgz",
+      "integrity": "sha512-NYbi51C6M3dujGmcmuGemu68jy12KqQPoVWGeroKToLGsBgrwG5ErM8WctoIIg49/EV49SEvYM9WSqO4G7kNeQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.10.1",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3076,6 +4144,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3093,6 +4172,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -3139,6 +4225,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3158,6 +4257,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3216,6 +4329,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/proxy-from-env": {
@@ -3304,6 +4447,14 @@
         }
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3369,6 +4520,40 @@
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3378,6 +4563,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
+      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -3454,6 +4646,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -3499,6 +4704,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3507,6 +4732,78 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3533,6 +4830,43 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -3583,6 +4917,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
+      "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.22"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3594,6 +4958,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3620,6 +5010,22 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.3.tgz",
+      "integrity": "sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -3658,6 +5064,26 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
+      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -3807,6 +5233,145 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3823,6 +5388,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3833,12 +5415,83 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -3848,6 +5501,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/static/package.json
+++ b/static/package.json
@@ -8,14 +8,16 @@
     "build": "tsc -b && vite build",
     "build:prod": "npm run build && cp -r dist/* ../dist/static/",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "preview": "vite preview",
     "tauri:dev": "cd .. && cargo tauri dev",
     "tauri:build": "cd .. && cargo tauri build"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.85.5",
-    "@types/react-router-dom": "^5.3.3",
     "@tauri-apps/api": "^2.8",
+    "@types/react-router-dom": "^5.3.3",
     "axios": "^1.12.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
@@ -26,6 +28,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@types/react-window": "^1.8.8",
@@ -34,8 +39,11 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jsdom": "^28.0.0",
+    "msw": "^2.12.9",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.0.18"
   }
 }

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -2809,3 +2809,375 @@
   height: 100%;
   object-fit: contain;
 }
+
+/* Quality dot on ImageCard */
+.quality-dot {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid rgba(0, 0, 0, 0.5);
+  z-index: 5;
+  pointer-events: none;
+}
+
+/* ============================================ */
+/* Sequence View                                 */
+/* ============================================ */
+.sequence-view {
+  width: 100%;
+  padding: 0;
+}
+
+.sequence-header {
+  padding: 1.5rem;
+}
+
+.sequence-header h2 {
+  margin: 0;
+  color: var(--color-primary);
+  font-size: 1.3rem;
+}
+
+.sequence-target-list {
+  padding: 0 1.5rem 1.5rem;
+}
+
+.sequence-target-list h3 {
+  color: var(--color-primary);
+  margin: 0 0 1rem 0;
+}
+
+.target-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.target-card-btn {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-bg-quaternary);
+  border-radius: 6px;
+  padding: 0.75rem 1.25rem;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  transition: all 0.2s;
+}
+
+.target-card-btn:hover {
+  border-color: var(--color-primary);
+  background: var(--color-bg-elevated);
+}
+
+.target-card-name {
+  font-weight: 500;
+  color: var(--color-primary);
+}
+
+.target-card-count {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+/* Sequence Controls */
+.sequence-controls {
+  background: var(--color-bg-secondary);
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-bg-tertiary);
+}
+
+.sequence-controls.sticky {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.sequence-controls-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.sequence-controls-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.sequence-controls-left h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-primary);
+  white-space: nowrap;
+}
+
+.sequence-controls-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.threshold-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.threshold-control label {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.threshold-control input[type="range"] {
+  width: 100px;
+  height: 4px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--color-bg-tertiary);
+  border-radius: 3px;
+  outline: none;
+  cursor: pointer;
+}
+
+.threshold-control input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  background: var(--color-warning);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.threshold-control input[type="range"]::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  background: var(--color-warning);
+  border-radius: 50%;
+  cursor: pointer;
+  border: none;
+}
+
+.threshold-value {
+  color: var(--color-warning);
+  font-weight: 500;
+  font-size: 0.85rem;
+  min-width: 30px;
+}
+
+/* Sequence error */
+.sequence-error {
+  background: var(--color-error-alpha-10);
+  border: 1px solid var(--color-error);
+  border-radius: 6px;
+  padding: 1rem 1.5rem;
+  margin: 1rem;
+  color: var(--color-error-light);
+}
+
+/* Sequence tabs */
+.sequence-tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem 0;
+}
+
+.sequence-tab {
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-bg-quaternary);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  transition: all 0.2s;
+}
+
+.sequence-tab.active {
+  background: var(--color-bg-secondary);
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.sequence-tab:hover:not(.active) {
+  background: var(--color-bg-quaternary);
+}
+
+/* Summary bar */
+.sequence-summary-bar {
+  background: var(--color-bg-secondary);
+  padding: 0.75rem 1rem;
+  margin: 0.5rem 1rem 0;
+  border-radius: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.summary-stats {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.85rem;
+}
+
+.summary-item {
+  font-weight: 500;
+}
+
+.summary-item.excellent { color: var(--color-success); }
+.summary-item.good { color: var(--color-success-light); }
+.summary-item.fair { color: var(--color-warning); }
+.summary-item.poor { color: var(--color-warning-light); }
+.summary-item.bad { color: var(--color-error); }
+
+.summary-issues {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.issue-badge {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  font-weight: 500;
+}
+
+.issue-badge.clouds {
+  background: var(--color-error-alpha-20);
+  color: var(--color-error-light);
+}
+
+.issue-badge.focus {
+  background: var(--color-warning-alpha-20);
+  color: var(--color-warning-light);
+}
+
+.issue-badge.tracking {
+  background: var(--color-primary-alpha-20);
+  color: var(--color-primary);
+}
+
+/* Timeline */
+.sequence-timeline {
+  margin: 0.5rem 1rem;
+  background: var(--color-bg-secondary);
+  border-radius: 6px;
+  padding: 0.5rem;
+  overflow-x: auto;
+}
+
+/* Image strip */
+.sequence-strip {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  align-items: flex-start;
+}
+
+.sequence-image-card {
+  flex-shrink: 0;
+  width: 160px;
+  background: var(--color-bg-secondary);
+  border: 2px solid var(--color-bg-tertiary);
+  border-radius: 6px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.sequence-image-card:hover {
+  border-color: var(--color-bg-quaternary);
+  transform: translateY(-2px);
+}
+
+.sequence-image-card.selected {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha-30);
+}
+
+.sequence-image-card.below-threshold {
+  opacity: 0.7;
+}
+
+.sequence-image-card.below-threshold:not(.selected) {
+  border-color: var(--color-error);
+}
+
+.sequence-image-preview {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: var(--color-bg-primary);
+  overflow: hidden;
+}
+
+.sequence-image-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* Quality badge on sequence cards */
+.quality-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  padding: 2px 6px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  z-index: 5;
+}
+
+/* Category label on sequence cards */
+.category-label {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  right: 4px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: white;
+  background: rgba(244, 67, 54, 0.8);
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  z-index: 5;
+}
+
+.sequence-image-info {
+  padding: 0.35rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.sequence-image-time {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.sequence-image-details {
+  font-size: 0.7rem;
+  color: var(--color-text-hint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/static/src/App.tsx
+++ b/static/src/App.tsx
@@ -57,6 +57,7 @@ function App() {
   
   const isOnOverview = location.pathname === '/' || location.pathname === '/overview';
   const isOnGrid = location.pathname === '/grid';
+  const isOnSequence = location.pathname === '/sequence';
 
   return (
     <div className="app">
@@ -85,6 +86,11 @@ function App() {
           {!isOnGrid && (
             <button onClick={() => navigate('/grid')} className="header-button">
               Images
+            </button>
+          )}
+          {!isOnSequence && (
+            <button onClick={() => navigate('/sequence')} className="header-button">
+              Sequence
             </button>
           )}
           {!isOnOverview && (

--- a/static/src/__fixtures__/image-quality-context.json
+++ b/static/src/__fixtures__/image-quality-context.json
@@ -1,0 +1,32 @@
+{
+  "success": true,
+  "data": {
+    "image_id": 5,
+    "quality": {
+      "image_id": 5,
+      "quality_score": 0.70,
+      "temporal_anomaly_score": 0.10,
+      "category": null,
+      "normalized_metrics": {
+        "star_count": 0.65,
+        "hfr": 0.72,
+        "eccentricity": 0.70,
+        "snr": 0.74,
+        "background": 0.94
+      },
+      "details": "Slightly elevated HFR"
+    },
+    "sequence_target_id": 1,
+    "sequence_filter_name": "L",
+    "sequence_image_count": 10,
+    "reference_values": {
+      "best_star_count": 1.0,
+      "best_hfr": 1.0,
+      "best_eccentricity": 1.0,
+      "best_snr": 0.95,
+      "best_background": 0.98
+    }
+  },
+  "error": null,
+  "status": "ready"
+}

--- a/static/src/__fixtures__/sequence-analysis-clouds.json
+++ b/static/src/__fixtures__/sequence-analysis-clouds.json
@@ -1,0 +1,148 @@
+{
+  "success": true,
+  "data": {
+    "sequences": [
+      {
+        "target_id": 1,
+        "target_name": "M42",
+        "filter_name": "Ha",
+        "session_start": 1705356000,
+        "session_end": 1705358100,
+        "image_count": 8,
+        "reference_values": {
+          "best_star_count": 1.0,
+          "best_hfr": 1.0,
+          "best_eccentricity": 1.0,
+          "best_snr": 0.96,
+          "best_background": 0.98
+        },
+        "images": [
+          {
+            "image_id": 101,
+            "quality_score": 0.88,
+            "temporal_anomaly_score": 0.03,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.90,
+              "hfr": 0.88,
+              "eccentricity": 0.85,
+              "snr": 0.92,
+              "background": 0.95
+            },
+            "details": null
+          },
+          {
+            "image_id": 102,
+            "quality_score": 0.85,
+            "temporal_anomaly_score": 0.04,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.86,
+              "hfr": 0.85,
+              "eccentricity": 0.83,
+              "snr": 0.88,
+              "background": 0.93
+            },
+            "details": null
+          },
+          {
+            "image_id": 103,
+            "quality_score": 0.90,
+            "temporal_anomaly_score": 0.02,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.92,
+              "hfr": 0.91,
+              "eccentricity": 0.88,
+              "snr": 0.94,
+              "background": 0.96
+            },
+            "details": null
+          },
+          {
+            "image_id": 104,
+            "quality_score": 0.18,
+            "temporal_anomaly_score": 0.85,
+            "category": "likely_clouds",
+            "normalized_metrics": {
+              "star_count": 0.15,
+              "hfr": 0.20,
+              "eccentricity": 0.45,
+              "snr": 0.12,
+              "background": 0.25
+            },
+            "details": "Star count dropped 70%, background rose 40%"
+          },
+          {
+            "image_id": 105,
+            "quality_score": 0.14,
+            "temporal_anomaly_score": 0.90,
+            "category": "likely_clouds",
+            "normalized_metrics": {
+              "star_count": 0.12,
+              "hfr": 0.15,
+              "eccentricity": 0.40,
+              "snr": 0.10,
+              "background": 0.20
+            },
+            "details": "Severe cloud passage, star count minimal"
+          },
+          {
+            "image_id": 106,
+            "quality_score": 0.82,
+            "temporal_anomaly_score": 0.05,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.84,
+              "hfr": 0.82,
+              "eccentricity": 0.80,
+              "snr": 0.86,
+              "background": 0.90
+            },
+            "details": null
+          },
+          {
+            "image_id": 107,
+            "quality_score": 0.86,
+            "temporal_anomaly_score": 0.03,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.88,
+              "hfr": 0.87,
+              "eccentricity": 0.84,
+              "snr": 0.90,
+              "background": 0.94
+            },
+            "details": null
+          },
+          {
+            "image_id": 108,
+            "quality_score": 0.89,
+            "temporal_anomaly_score": 0.02,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.91,
+              "hfr": 0.90,
+              "eccentricity": 0.87,
+              "snr": 0.93,
+              "background": 0.95
+            },
+            "details": null
+          }
+        ],
+        "summary": {
+          "excellent_count": 2,
+          "good_count": 4,
+          "fair_count": 0,
+          "poor_count": 0,
+          "bad_count": 2,
+          "cloud_events_detected": 1,
+          "focus_drift_detected": false,
+          "tracking_issues_detected": false
+        }
+      }
+    ]
+  },
+  "error": null,
+  "status": "ready"
+}

--- a/static/src/__fixtures__/sequence-analysis-empty.json
+++ b/static/src/__fixtures__/sequence-analysis-empty.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "data": {
+    "sequences": []
+  },
+  "error": null,
+  "status": "ready"
+}

--- a/static/src/__fixtures__/sequence-analysis-multi-session.json
+++ b/static/src/__fixtures__/sequence-analysis-multi-session.json
@@ -1,0 +1,203 @@
+{
+  "success": true,
+  "data": {
+    "sequences": [
+      {
+        "target_id": 2,
+        "target_name": "NGC7000",
+        "filter_name": "L",
+        "session_start": 1705352400,
+        "session_end": 1705353600,
+        "image_count": 5,
+        "reference_values": {
+          "best_star_count": 1.0,
+          "best_hfr": 0.95,
+          "best_eccentricity": 0.92,
+          "best_snr": 0.90,
+          "best_background": 0.96
+        },
+        "images": [
+          {
+            "image_id": 201,
+            "quality_score": 0.78,
+            "temporal_anomaly_score": 0.06,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.75,
+              "hfr": 0.80,
+              "eccentricity": 0.82,
+              "snr": 0.78,
+              "background": 0.88
+            },
+            "details": null
+          },
+          {
+            "image_id": 202,
+            "quality_score": 0.82,
+            "temporal_anomaly_score": 0.04,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.80,
+              "hfr": 0.84,
+              "eccentricity": 0.85,
+              "snr": 0.81,
+              "background": 0.90
+            },
+            "details": null
+          },
+          {
+            "image_id": 203,
+            "quality_score": 0.86,
+            "temporal_anomaly_score": 0.03,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.85,
+              "hfr": 0.88,
+              "eccentricity": 0.88,
+              "snr": 0.85,
+              "background": 0.92
+            },
+            "details": null
+          },
+          {
+            "image_id": 204,
+            "quality_score": 0.90,
+            "temporal_anomaly_score": 0.01,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.92,
+              "hfr": 0.92,
+              "eccentricity": 0.90,
+              "snr": 0.88,
+              "background": 0.94
+            },
+            "details": null
+          },
+          {
+            "image_id": 205,
+            "quality_score": 0.94,
+            "temporal_anomaly_score": 0.01,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.96,
+              "hfr": 0.95,
+              "eccentricity": 0.92,
+              "snr": 0.90,
+              "background": 0.96
+            },
+            "details": null
+          }
+        ],
+        "summary": {
+          "excellent_count": 2,
+          "good_count": 2,
+          "fair_count": 1,
+          "poor_count": 0,
+          "bad_count": 0,
+          "cloud_events_detected": 0,
+          "focus_drift_detected": false,
+          "tracking_issues_detected": false
+        }
+      },
+      {
+        "target_id": 2,
+        "target_name": "NGC7000",
+        "filter_name": "L",
+        "session_start": 1705361400,
+        "session_end": 1705362600,
+        "image_count": 5,
+        "reference_values": {
+          "best_star_count": 0.98,
+          "best_hfr": 0.96,
+          "best_eccentricity": 0.94,
+          "best_snr": 0.92,
+          "best_background": 0.95
+        },
+        "images": [
+          {
+            "image_id": 211,
+            "quality_score": 0.80,
+            "temporal_anomaly_score": 0.05,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.78,
+              "hfr": 0.82,
+              "eccentricity": 0.84,
+              "snr": 0.80,
+              "background": 0.86
+            },
+            "details": null
+          },
+          {
+            "image_id": 212,
+            "quality_score": 0.84,
+            "temporal_anomaly_score": 0.03,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.83,
+              "hfr": 0.86,
+              "eccentricity": 0.87,
+              "snr": 0.84,
+              "background": 0.88
+            },
+            "details": null
+          },
+          {
+            "image_id": 213,
+            "quality_score": 0.88,
+            "temporal_anomaly_score": 0.02,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.88,
+              "hfr": 0.90,
+              "eccentricity": 0.90,
+              "snr": 0.87,
+              "background": 0.91
+            },
+            "details": null
+          },
+          {
+            "image_id": 214,
+            "quality_score": 0.92,
+            "temporal_anomaly_score": 0.01,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.94,
+              "hfr": 0.94,
+              "eccentricity": 0.93,
+              "snr": 0.90,
+              "background": 0.93
+            },
+            "details": null
+          },
+          {
+            "image_id": 215,
+            "quality_score": 0.95,
+            "temporal_anomaly_score": 0.01,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.98,
+              "hfr": 0.96,
+              "eccentricity": 0.94,
+              "snr": 0.92,
+              "background": 0.95
+            },
+            "details": null
+          }
+        ],
+        "summary": {
+          "excellent_count": 2,
+          "good_count": 2,
+          "fair_count": 1,
+          "poor_count": 0,
+          "bad_count": 0,
+          "cloud_events_detected": 0,
+          "focus_drift_detected": false,
+          "tracking_issues_detected": false
+        }
+      }
+    ]
+  },
+  "error": null,
+  "status": "ready"
+}

--- a/static/src/__fixtures__/sequence-analysis-normal.json
+++ b/static/src/__fixtures__/sequence-analysis-normal.json
@@ -1,0 +1,176 @@
+{
+  "success": true,
+  "data": {
+    "sequences": [
+      {
+        "target_id": 1,
+        "target_name": "M42",
+        "filter_name": "L",
+        "session_start": 1705352400,
+        "session_end": 1705355100,
+        "image_count": 10,
+        "reference_values": {
+          "best_star_count": 1.0,
+          "best_hfr": 1.0,
+          "best_eccentricity": 1.0,
+          "best_snr": 0.95,
+          "best_background": 0.98
+        },
+        "images": [
+          {
+            "image_id": 1,
+            "quality_score": 0.82,
+            "temporal_anomaly_score": 0.05,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.80,
+              "hfr": 0.85,
+              "eccentricity": 0.78,
+              "snr": 0.82,
+              "background": 0.90
+            },
+            "details": null
+          },
+          {
+            "image_id": 2,
+            "quality_score": 0.88,
+            "temporal_anomaly_score": 0.02,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.90,
+              "hfr": 0.90,
+              "eccentricity": 0.82,
+              "snr": 0.85,
+              "background": 0.88
+            },
+            "details": null
+          },
+          {
+            "image_id": 3,
+            "quality_score": 0.75,
+            "temporal_anomaly_score": 0.08,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.72,
+              "hfr": 0.78,
+              "eccentricity": 0.74,
+              "snr": 0.78,
+              "background": 0.92
+            },
+            "details": null
+          },
+          {
+            "image_id": 4,
+            "quality_score": 0.91,
+            "temporal_anomaly_score": 0.01,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.95,
+              "hfr": 0.92,
+              "eccentricity": 0.88,
+              "snr": 0.90,
+              "background": 0.86
+            },
+            "details": null
+          },
+          {
+            "image_id": 5,
+            "quality_score": 0.70,
+            "temporal_anomaly_score": 0.10,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.65,
+              "hfr": 0.72,
+              "eccentricity": 0.70,
+              "snr": 0.74,
+              "background": 0.94
+            },
+            "details": null
+          },
+          {
+            "image_id": 6,
+            "quality_score": 0.85,
+            "temporal_anomaly_score": 0.03,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.85,
+              "hfr": 0.88,
+              "eccentricity": 0.80,
+              "snr": 0.84,
+              "background": 0.89
+            },
+            "details": null
+          },
+          {
+            "image_id": 7,
+            "quality_score": 0.77,
+            "temporal_anomaly_score": 0.06,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.75,
+              "hfr": 0.76,
+              "eccentricity": 0.76,
+              "snr": 0.80,
+              "background": 0.91
+            },
+            "details": null
+          },
+          {
+            "image_id": 8,
+            "quality_score": 0.90,
+            "temporal_anomaly_score": 0.01,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.92,
+              "hfr": 0.93,
+              "eccentricity": 0.86,
+              "snr": 0.88,
+              "background": 0.87
+            },
+            "details": null
+          },
+          {
+            "image_id": 9,
+            "quality_score": 0.83,
+            "temporal_anomaly_score": 0.04,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.82,
+              "hfr": 0.85,
+              "eccentricity": 0.80,
+              "snr": 0.83,
+              "background": 0.90
+            },
+            "details": null
+          },
+          {
+            "image_id": 10,
+            "quality_score": 0.72,
+            "temporal_anomaly_score": 0.09,
+            "category": null,
+            "normalized_metrics": {
+              "star_count": 0.70,
+              "hfr": 0.68,
+              "eccentricity": 0.72,
+              "snr": null,
+              "background": 0.93
+            },
+            "details": "Slightly elevated HFR"
+          }
+        ],
+        "summary": {
+          "excellent_count": 3,
+          "good_count": 4,
+          "fair_count": 3,
+          "poor_count": 0,
+          "bad_count": 0,
+          "cloud_events_detected": 0,
+          "focus_drift_detected": false,
+          "tracking_issues_detected": false
+        }
+      }
+    ]
+  },
+  "error": null,
+  "status": "ready"
+}

--- a/static/src/api/__tests__/client.test.ts
+++ b/static/src/api/__tests__/client.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import { apiClient } from '../client';
+import normalFixture from '../../__fixtures__/sequence-analysis-normal.json';
+import cloudsFixture from '../../__fixtures__/sequence-analysis-clouds.json';
+import imageQualityFixture from '../../__fixtures__/image-quality-context.json';
+
+// Reset the API client's lazy initialization between tests
+// by clearing the cached instance so each test starts fresh
+beforeEach(() => {
+  // The apiClient module caches its axios instance; since we're using
+  // MSW to intercept at the network level, this works fine as-is.
+});
+
+describe('apiClient.analyzeSequence', () => {
+  it('returns sequence analysis data for a target', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(normalFixture);
+      }),
+    );
+
+    const result = await apiClient.analyzeSequence({ target_id: 1, filter_name: 'L' });
+
+    expect(result.sequences).toHaveLength(1);
+    expect(result.sequences[0].target_id).toBe(1);
+    expect(result.sequences[0].target_name).toBe('M42');
+    expect(result.sequences[0].filter_name).toBe('L');
+    expect(result.sequences[0].image_count).toBe(10);
+    expect(result.sequences[0].images).toHaveLength(10);
+  });
+
+  it('returns cloud-affected sequence data', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(cloudsFixture);
+      }),
+    );
+
+    const result = await apiClient.analyzeSequence({ target_id: 1, filter_name: 'Ha' });
+
+    expect(result.sequences).toHaveLength(1);
+    expect(result.sequences[0].image_count).toBe(8);
+    expect(result.sequences[0].summary.cloud_events_detected).toBe(1);
+
+    // Cloud frames should have low scores
+    const cloudImages = result.sequences[0].images.filter(img => img.category === 'likely_clouds');
+    expect(cloudImages).toHaveLength(2);
+    cloudImages.forEach(img => {
+      expect(img.quality_score).toBeLessThan(0.3);
+    });
+  });
+
+  it('sends query parameters correctly', async () => {
+    let capturedUrl: URL | null = null;
+
+    server.use(
+      http.get('/api/analysis/sequence', ({ request }) => {
+        capturedUrl = new URL(request.url);
+        return HttpResponse.json(normalFixture);
+      }),
+    );
+
+    await apiClient.analyzeSequence({
+      target_id: 1,
+      filter_name: 'Ha',
+      session_gap_minutes: 90,
+      weight_star_count: 0.5,
+    });
+
+    expect(capturedUrl).not.toBeNull();
+    expect(capturedUrl!.searchParams.get('target_id')).toBe('1');
+    expect(capturedUrl!.searchParams.get('filter_name')).toBe('Ha');
+    expect(capturedUrl!.searchParams.get('session_gap_minutes')).toBe('90');
+    expect(capturedUrl!.searchParams.get('weight_star_count')).toBe('0.5');
+  });
+
+  it('throws when data is null', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json({
+          success: true,
+          data: null,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    await expect(apiClient.analyzeSequence({ target_id: 1 })).rejects.toThrow('Sequence analysis failed');
+  });
+});
+
+describe('apiClient.getImageQuality', () => {
+  it('returns image quality context', async () => {
+    server.use(
+      http.get('/api/analysis/image/:imageId', () => {
+        return HttpResponse.json(imageQualityFixture);
+      }),
+    );
+
+    const result = await apiClient.getImageQuality(5);
+
+    expect(result.image_id).toBe(5);
+    expect(result.quality).toBeDefined();
+    expect(result.quality!.quality_score).toBe(0.70);
+    expect(result.sequence_target_id).toBe(1);
+    expect(result.sequence_filter_name).toBe('L');
+    expect(result.sequence_image_count).toBe(10);
+    expect(result.reference_values).toBeDefined();
+    expect(result.reference_values!.best_star_count).toBe(1.0);
+  });
+
+  it('throws when data is null', async () => {
+    server.use(
+      http.get('/api/analysis/image/:imageId', () => {
+        return HttpResponse.json({
+          success: false,
+          data: null,
+          error: 'Image not found',
+          status: null,
+        }, { status: 404 });
+      }),
+    );
+
+    await expect(apiClient.getImageQuality(99999)).rejects.toThrow();
+  });
+});

--- a/static/src/api/__tests__/contract.test.ts
+++ b/static/src/api/__tests__/contract.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import normalFixture from '../../__fixtures__/sequence-analysis-normal.json';
+import cloudsFixture from '../../__fixtures__/sequence-analysis-clouds.json';
+import multiSessionFixture from '../../__fixtures__/sequence-analysis-multi-session.json';
+import imageQualityFixture from '../../__fixtures__/image-quality-context.json';
+import emptyFixture from '../../__fixtures__/sequence-analysis-empty.json';
+import type {
+  SequenceAnalysisResponse,
+  ImageQualityResponse,
+  ScoredSequence,
+  ImageQualityResult,
+  ReferenceValues,
+  SequenceSummary,
+} from '../types';
+
+// Helper to check ApiResponse wrapper structure
+function assertApiResponseWrapper(fixture: Record<string, unknown>) {
+  expect(fixture).toHaveProperty('success');
+  expect(fixture).toHaveProperty('data');
+  expect(fixture).toHaveProperty('error');
+  expect(fixture).toHaveProperty('status');
+  expect(typeof fixture.success).toBe('boolean');
+}
+
+// Helper to validate a ScoredSequence object has all expected fields
+function assertScoredSequence(seq: ScoredSequence) {
+  expect(typeof seq.target_id).toBe('number');
+  expect(typeof seq.target_name).toBe('string');
+  expect(typeof seq.filter_name).toBe('string');
+  expect(typeof seq.image_count).toBe('number');
+  expect(seq).toHaveProperty('session_start');
+  expect(seq).toHaveProperty('session_end');
+  expect(seq).toHaveProperty('reference_values');
+  expect(seq).toHaveProperty('images');
+  expect(seq).toHaveProperty('summary');
+  expect(Array.isArray(seq.images)).toBe(true);
+}
+
+// Helper to validate ImageQualityResult fields
+function assertImageQualityResult(img: ImageQualityResult) {
+  expect(typeof img.image_id).toBe('number');
+  expect(typeof img.quality_score).toBe('number');
+  expect(img.quality_score).toBeGreaterThanOrEqual(0);
+  expect(img.quality_score).toBeLessThanOrEqual(1);
+  expect(typeof img.temporal_anomaly_score).toBe('number');
+  expect(img).toHaveProperty('category');
+  expect(img).toHaveProperty('normalized_metrics');
+  expect(img).toHaveProperty('details');
+
+  // Validate normalized_metrics has all expected keys
+  const nm = img.normalized_metrics;
+  expect(nm).toHaveProperty('star_count');
+  expect(nm).toHaveProperty('hfr');
+  expect(nm).toHaveProperty('eccentricity');
+  expect(nm).toHaveProperty('snr');
+  expect(nm).toHaveProperty('background');
+}
+
+// Helper to validate ReferenceValues fields
+function assertReferenceValues(refs: ReferenceValues) {
+  expect(refs).toHaveProperty('best_star_count');
+  expect(refs).toHaveProperty('best_hfr');
+  expect(refs).toHaveProperty('best_eccentricity');
+  expect(refs).toHaveProperty('best_snr');
+  expect(refs).toHaveProperty('best_background');
+}
+
+// Helper to validate SequenceSummary fields
+function assertSequenceSummary(summary: SequenceSummary) {
+  expect(typeof summary.excellent_count).toBe('number');
+  expect(typeof summary.good_count).toBe('number');
+  expect(typeof summary.fair_count).toBe('number');
+  expect(typeof summary.poor_count).toBe('number');
+  expect(typeof summary.bad_count).toBe('number');
+  expect(typeof summary.cloud_events_detected).toBe('number');
+  expect(typeof summary.focus_drift_detected).toBe('boolean');
+  expect(typeof summary.tracking_issues_detected).toBe('boolean');
+}
+
+describe('API contract: ApiResponse wrapper', () => {
+  it.each([
+    ['normal', normalFixture],
+    ['clouds', cloudsFixture],
+    ['multi-session', multiSessionFixture],
+    ['image-quality', imageQualityFixture],
+    ['empty', emptyFixture],
+  ])('%s fixture has correct wrapper structure', (_name, fixture) => {
+    assertApiResponseWrapper(fixture);
+  });
+
+  it('successful responses have success=true and null error', () => {
+    expect(normalFixture.success).toBe(true);
+    expect(normalFixture.error).toBeNull();
+    expect(normalFixture.status).toBe('ready');
+  });
+});
+
+describe('API contract: SequenceAnalysisResponse', () => {
+  it('normal fixture matches SequenceAnalysisResponse shape', () => {
+    const data = normalFixture.data as SequenceAnalysisResponse;
+    expect(data).toHaveProperty('sequences');
+    expect(Array.isArray(data.sequences)).toBe(true);
+    expect(data.sequences).toHaveLength(1);
+
+    const seq = data.sequences[0];
+    assertScoredSequence(seq);
+    assertReferenceValues(seq.reference_values);
+    assertSequenceSummary(seq.summary);
+    seq.images.forEach(assertImageQualityResult);
+  });
+
+  it('summary counts sum to image_count', () => {
+    const seq = normalFixture.data.sequences[0];
+    const { excellent_count, good_count, fair_count, poor_count, bad_count } = seq.summary;
+    const total = excellent_count + good_count + fair_count + poor_count + bad_count;
+    expect(total).toBe(seq.image_count);
+  });
+
+  it('images array length matches image_count', () => {
+    const seq = normalFixture.data.sequences[0];
+    expect(seq.images).toHaveLength(seq.image_count);
+  });
+});
+
+describe('API contract: cloud detection', () => {
+  it('clouds fixture has likely_clouds category values', () => {
+    const seq = cloudsFixture.data.sequences[0];
+    const cloudImages = seq.images.filter(
+      (img: ImageQualityResult) => img.category === 'likely_clouds',
+    );
+    expect(cloudImages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('category values use snake_case', () => {
+    const seq = cloudsFixture.data.sequences[0];
+    seq.images.forEach((img: ImageQualityResult) => {
+      if (img.category !== null) {
+        expect(img.category).toMatch(/^[a-z][a-z0-9_]*$/);
+      }
+    });
+  });
+
+  it('cloud-affected images have quality_score < 0.3', () => {
+    const seq = cloudsFixture.data.sequences[0];
+    const cloudImages = seq.images.filter(
+      (img: ImageQualityResult) => img.category === 'likely_clouds',
+    );
+    cloudImages.forEach((img: ImageQualityResult) => {
+      expect(img.quality_score).toBeLessThan(0.3);
+    });
+  });
+
+  it('summary reports cloud events', () => {
+    const seq = cloudsFixture.data.sequences[0];
+    expect(seq.summary.cloud_events_detected).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('API contract: multi-session', () => {
+  it('multi-session fixture has 2 sequences', () => {
+    const data = multiSessionFixture.data as SequenceAnalysisResponse;
+    expect(data.sequences).toHaveLength(2);
+  });
+
+  it('session 1 ends before session 2 starts', () => {
+    const [seq1, seq2] = multiSessionFixture.data.sequences;
+    expect(seq1.session_end).toBeDefined();
+    expect(seq2.session_start).toBeDefined();
+    expect(seq1.session_end!).toBeLessThan(seq2.session_start!);
+  });
+
+  it('both sequences share the same target', () => {
+    const [seq1, seq2] = multiSessionFixture.data.sequences;
+    expect(seq1.target_id).toBe(seq2.target_id);
+    expect(seq1.target_name).toBe(seq2.target_name);
+  });
+
+  it('each sequence has correct image_count', () => {
+    multiSessionFixture.data.sequences.forEach((seq) => {
+      assertScoredSequence(seq as ScoredSequence);
+      expect(seq.images).toHaveLength(seq.image_count);
+    });
+  });
+});
+
+describe('API contract: ImageQualityResponse', () => {
+  it('image quality fixture matches ImageQualityResponse shape', () => {
+    const data = imageQualityFixture.data as ImageQualityResponse;
+    expect(typeof data.image_id).toBe('number');
+    expect(data).toHaveProperty('quality');
+    expect(data).toHaveProperty('sequence_target_id');
+    expect(data).toHaveProperty('sequence_filter_name');
+    expect(data).toHaveProperty('sequence_image_count');
+    expect(data).toHaveProperty('reference_values');
+  });
+
+  it('quality field contains valid ImageQualityResult', () => {
+    const data = imageQualityFixture.data as ImageQualityResponse;
+    expect(data.quality).toBeDefined();
+    assertImageQualityResult(data.quality!);
+  });
+
+  it('reference_values contains all expected fields', () => {
+    const data = imageQualityFixture.data as ImageQualityResponse;
+    expect(data.reference_values).toBeDefined();
+    assertReferenceValues(data.reference_values!);
+  });
+});
+
+describe('API contract: empty response', () => {
+  it('empty fixture has empty sequences array', () => {
+    const data = emptyFixture.data as SequenceAnalysisResponse;
+    expect(data.sequences).toHaveLength(0);
+  });
+
+  it('empty fixture still has valid wrapper', () => {
+    assertApiResponseWrapper(emptyFixture);
+    expect(emptyFixture.success).toBe(true);
+  });
+});
+
+describe('API contract: normalized metric values', () => {
+  it('numeric normalized metrics are between 0 and 1', () => {
+    normalFixture.data.sequences[0].images.forEach((img: ImageQualityResult) => {
+      const nm = img.normalized_metrics;
+      for (const [, value] of Object.entries(nm)) {
+        if (value !== null && value !== undefined) {
+          expect(value).toBeGreaterThanOrEqual(0);
+          expect(value).toBeLessThanOrEqual(1);
+        }
+      }
+    });
+  });
+
+  it('nullable metrics can be null', () => {
+    // Image 10 in the normal fixture has snr: null
+    const img10 = normalFixture.data.sequences[0].images[9];
+    expect(img10.normalized_metrics.snr).toBeNull();
+  });
+});

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -16,6 +16,9 @@ import type {
   TargetOverview,
   OverallStats,
   CacheRefreshProgress,
+  SequenceAnalysisRequest,
+  SequenceAnalysisResponse,
+  ImageQualityResponse,
 } from './types';
 
 // Default API instance (used as fallback)
@@ -210,6 +213,21 @@ export const apiClient = {
     const apiInstance = await getApi();
     const { data } = await apiInstance.get<ApiResponse<CacheRefreshProgress>>('/cache-progress');
     if (!data.data) throw new Error('Failed to get cache progress');
+    return data.data;
+  },
+
+  // Sequence analysis
+  analyzeSequence: async (request: SequenceAnalysisRequest): Promise<SequenceAnalysisResponse> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<SequenceAnalysisResponse>>('/analysis/sequence', { params: request });
+    if (!data.data) throw new Error('Sequence analysis failed');
+    return data.data;
+  },
+
+  getImageQuality: async (imageId: number): Promise<ImageQualityResponse> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<ImageQualityResponse>>(`/analysis/image/${imageId}`);
+    if (!data.data) throw new Error('Image quality data not found');
     return data.data;
   },
 };

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -231,15 +231,15 @@ export interface ImageQualityResult {
   image_id: number;
   quality_score: number;
   temporal_anomaly_score: number;
-  category?: string;
+  category: string | null;
   normalized_metrics: {
-    star_count?: number;
-    hfr?: number;
-    eccentricity?: number;
-    snr?: number;
-    background?: number;
+    star_count: number | null;
+    hfr: number | null;
+    eccentricity: number | null;
+    snr: number | null;
+    background: number | null;
   };
-  details?: string;
+  details: string | null;
 }
 
 export interface SequenceSummary {

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -198,3 +198,74 @@ export interface CacheRefreshProgress {
   files_found: number;
   files_missing: number;
 }
+
+// Sequence analysis types
+export interface SequenceAnalysisRequest {
+  target_id: number;
+  filter_name?: string;
+  session_gap_minutes?: number;
+  weight_star_count?: number;
+  weight_hfr?: number;
+  weight_eccentricity?: number;
+  weight_snr?: number;
+  weight_background?: number;
+}
+
+export interface SequenceAnalysisResponse {
+  sequences: ScoredSequence[];
+}
+
+export interface ScoredSequence {
+  target_id: number;
+  target_name: string;
+  filter_name: string;
+  session_start?: number;
+  session_end?: number;
+  image_count: number;
+  reference_values: ReferenceValues;
+  images: ImageQualityResult[];
+  summary: SequenceSummary;
+}
+
+export interface ImageQualityResult {
+  image_id: number;
+  quality_score: number;
+  temporal_anomaly_score: number;
+  category?: string;
+  normalized_metrics: {
+    star_count?: number;
+    hfr?: number;
+    eccentricity?: number;
+    snr?: number;
+    background?: number;
+  };
+  details?: string;
+}
+
+export interface SequenceSummary {
+  excellent_count: number;
+  good_count: number;
+  fair_count: number;
+  poor_count: number;
+  bad_count: number;
+  cloud_events_detected: number;
+  focus_drift_detected: boolean;
+  tracking_issues_detected: boolean;
+}
+
+export interface ReferenceValues {
+  best_star_count?: number;
+  best_hfr?: number;
+  best_eccentricity?: number;
+  best_snr?: number;
+  best_background?: number;
+}
+
+export interface ImageQualityResponse {
+  image_id: number;
+  quality?: ImageQualityResult;
+  sequence_target_id?: number;
+  sequence_filter_name?: string;
+  sequence_image_count?: number;
+  reference_values?: ReferenceValues;
+}

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -8,9 +8,10 @@ interface ImageCardProps {
   isSelected: boolean;
   onClick: (event: React.MouseEvent) => void;
   onDoubleClick: () => void;
+  qualityScore?: number;
 }
 
-export default function ImageCard({ image, isSelected, onClick, onDoubleClick }: ImageCardProps) {
+export default function ImageCard({ image, isSelected, onClick, onDoubleClick, qualityScore }: ImageCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
   const [imageError, setImageError] = useState(false);
@@ -110,6 +111,15 @@ export default function ImageCard({ image, isSelected, onClick, onDoubleClick }:
             alt={`${image.target_name} - ${image.filter_name || 'No filter'}`}
             loading="lazy"
             onError={() => setImageError(true)}
+          />
+        )}
+        {qualityScore !== undefined && (
+          <div
+            className="quality-dot"
+            style={{
+              backgroundColor: qualityScore >= 0.7 ? 'var(--color-success)' : qualityScore >= 0.5 ? 'var(--color-warning)' : 'var(--color-error)',
+            }}
+            title={`Quality: ${(qualityScore * 100).toFixed(0)}%`}
           />
         )}
       </div>

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -1,0 +1,510 @@
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import { useSequenceAnalysis } from '../hooks/useSequenceAnalysis';
+import { useGrading } from '../hooks/useGrading';
+import { useProjectTarget } from '../hooks/useUrlState';
+import UndoRedoToolbar from './UndoRedoToolbar';
+import type { ScoredSequence, ImageQualityResult } from '../api/types';
+
+function formatCategory(category: string): string {
+  return category
+    .split('_')
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function qualityColor(score: number): string {
+  if (score >= 0.7) return 'var(--color-success)';
+  if (score >= 0.5) return 'var(--color-warning)';
+  return 'var(--color-error)';
+}
+
+function qualityLabel(score: number): string {
+  if (score >= 0.85) return 'Excellent';
+  if (score >= 0.7) return 'Good';
+  if (score >= 0.5) return 'Fair';
+  if (score >= 0.3) return 'Poor';
+  return 'Bad';
+}
+
+export default function SequenceView() {
+  const { projectId, targetId } = useProjectTarget();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const grading = useGrading();
+  const { analyze, data: analysisData, isLoading: isAnalyzing, error: analysisError } = useSequenceAnalysis();
+
+  const filterName = searchParams.get('filterName') || undefined;
+  const [threshold, setThreshold] = useState(0.5);
+  const [selectedImages, setSelectedImages] = useState<Set<number>>(new Set());
+  const [activeSequenceIndex, setActiveSequenceIndex] = useState(0);
+
+  // Fetch targets for the project to allow selection
+  const { data: targets = [] } = useQuery({
+    queryKey: ['targets', projectId],
+    queryFn: () => apiClient.getTargets(projectId!),
+    enabled: !!projectId,
+  });
+
+  // Fetch images for the target (for preview URLs)
+  const { data: images = [] } = useQuery({
+    queryKey: ['all-images', projectId, targetId],
+    queryFn: () => apiClient.getImages({
+      project_id: projectId || undefined,
+      target_id: targetId || undefined,
+      limit: 10000,
+    }),
+    enabled: projectId !== undefined,
+  });
+
+  // Build image lookup map
+  const imageMap = useMemo(() => {
+    const map = new Map<number, typeof images[0]>();
+    images.forEach(img => map.set(img.id, img));
+    return map;
+  }, [images]);
+
+  // Auto-analyze when target is selected
+  useEffect(() => {
+    if (targetId) {
+      analyze({ target_id: targetId, filter_name: filterName });
+    }
+  }, [targetId, filterName, analyze]);
+
+  const sequences = analysisData?.sequences || [];
+  const activeSequence: ScoredSequence | undefined = sequences[activeSequenceIndex];
+
+  // Get unique filter names from available targets
+  const availableFilters = useMemo(() => {
+    const filters = new Set<string>();
+    images.forEach(img => {
+      if (img.filter_name) filters.add(img.filter_name);
+    });
+    return Array.from(filters).sort();
+  }, [images]);
+
+  // Select all images below threshold
+  const selectBelowThreshold = useCallback(() => {
+    if (!activeSequence) return;
+    const ids = new Set<number>();
+    activeSequence.images.forEach(img => {
+      if (img.quality_score < threshold) {
+        ids.add(img.image_id);
+      }
+    });
+    setSelectedImages(ids);
+  }, [activeSequence, threshold]);
+
+  // Select contiguous runs of clouded/bad images
+  const selectCloudedSequence = useCallback(() => {
+    if (!activeSequence) return;
+    const ids = new Set<number>();
+    let inRun = false;
+    const runBuffer: number[] = [];
+
+    for (const img of activeSequence.images) {
+      const isBad = img.category === 'likely_clouds' || img.quality_score < 0.3;
+      if (isBad) {
+        inRun = true;
+        runBuffer.push(img.image_id);
+      } else {
+        if (inRun && runBuffer.length >= 2) {
+          runBuffer.forEach(id => ids.add(id));
+        }
+        inRun = false;
+        runBuffer.length = 0;
+      }
+    }
+    // Flush trailing run
+    if (inRun && runBuffer.length >= 2) {
+      runBuffer.forEach(id => ids.add(id));
+    }
+    setSelectedImages(ids);
+  }, [activeSequence]);
+
+  // Batch reject selected
+  const rejectSelected = useCallback(async () => {
+    if (selectedImages.size === 0) return;
+    await grading.gradeBatch(Array.from(selectedImages), 'rejected', 'Quality analysis');
+    setSelectedImages(new Set());
+  }, [selectedImages, grading]);
+
+  // Toggle individual image selection
+  const toggleImage = useCallback((imageId: number) => {
+    setSelectedImages(prev => {
+      const next = new Set(prev);
+      if (next.has(imageId)) {
+        next.delete(imageId);
+      } else {
+        next.add(imageId);
+      }
+      return next;
+    });
+  }, []);
+
+  if (!projectId) {
+    return (
+      <div className="empty-state">
+        Select a project to analyze image sequences
+      </div>
+    );
+  }
+
+  if (!targetId) {
+    return (
+      <div className="sequence-view">
+        <div className="sequence-header">
+          <h2>Sequence Analysis</h2>
+          <p style={{ color: 'var(--color-text-muted)', marginTop: '0.5rem' }}>
+            Select a target from the header to analyze its image sequences.
+          </p>
+        </div>
+        {targets.length > 0 && (
+          <div className="sequence-target-list">
+            <h3>Available Targets</h3>
+            <div className="target-cards">
+              {targets.map(t => (
+                <button
+                  key={t.id}
+                  className="target-card-btn"
+                  onClick={() => navigate(`/sequence?project=${projectId}&target=${t.id}`)}
+                >
+                  <span className="target-card-name">{t.name}</span>
+                  <span className="target-card-count">{t.image_count} images</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="sequence-view">
+      {/* Controls bar */}
+      <div className="sequence-controls sticky">
+        <div className="sequence-controls-row">
+          <div className="sequence-controls-left">
+            <h2>Sequence Analysis</h2>
+            {availableFilters.length > 1 && (
+              <div className="filter-input-group">
+                <label>Filter:</label>
+                <select
+                  value={filterName || 'all'}
+                  onChange={(e) => {
+                    const val = e.target.value === 'all' ? undefined : e.target.value;
+                    const params = new URLSearchParams(searchParams);
+                    if (val) {
+                      params.set('filterName', val);
+                    } else {
+                      params.delete('filterName');
+                    }
+                    navigate(`/sequence?${params.toString()}`);
+                  }}
+                >
+                  <option value="all">All Filters</option>
+                  {availableFilters.map(f => (
+                    <option key={f} value={f}>{f}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+            <button
+              className="header-button"
+              onClick={() => analyze({ target_id: targetId, filter_name: filterName })}
+              disabled={isAnalyzing}
+            >
+              {isAnalyzing ? 'Analyzing...' : 'Re-analyze'}
+            </button>
+          </div>
+
+          <div className="sequence-controls-right">
+            <div className="threshold-control">
+              <label>Threshold:</label>
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.05"
+                value={threshold}
+                onChange={(e) => setThreshold(parseFloat(e.target.value))}
+              />
+              <span className="threshold-value">{threshold.toFixed(2)}</span>
+            </div>
+            <button className="header-button" onClick={selectBelowThreshold}>
+              Select Below Threshold
+            </button>
+            <button className="header-button" onClick={selectCloudedSequence}>
+              Select Clouded
+            </button>
+            {selectedImages.size > 0 && (
+              <>
+                <button
+                  className="action-button reject"
+                  style={{ padding: '0.4rem 0.8rem', fontSize: '0.85rem' }}
+                  onClick={rejectSelected}
+                >
+                  Reject Selected ({selectedImages.size})
+                </button>
+                <button
+                  className="header-button"
+                  onClick={() => setSelectedImages(new Set())}
+                >
+                  Clear
+                </button>
+              </>
+            )}
+            <UndoRedoToolbar
+              canUndo={grading.canUndo}
+              canRedo={grading.canRedo}
+              isProcessing={grading.isLoading}
+              undoStackSize={grading.undoStackSize}
+              redoStackSize={grading.redoStackSize}
+              onUndo={grading.undo}
+              onRedo={grading.redo}
+              getLastAction={grading.getLastAction}
+              getNextRedoAction={grading.getNextRedoAction}
+              className="compact"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Error state */}
+      {analysisError && (
+        <div className="sequence-error">
+          Failed to analyze sequence: {(analysisError as Error).message}
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isAnalyzing && (
+        <div className="loading">Analyzing image sequences...</div>
+      )}
+
+      {/* Results */}
+      {!isAnalyzing && sequences.length > 0 && (
+        <>
+          {/* Sequence tabs (if multiple) */}
+          {sequences.length > 1 && (
+            <div className="sequence-tabs">
+              {sequences.map((seq, i) => (
+                <button
+                  key={i}
+                  className={`sequence-tab ${i === activeSequenceIndex ? 'active' : ''}`}
+                  onClick={() => setActiveSequenceIndex(i)}
+                >
+                  {seq.filter_name} ({seq.image_count})
+                </button>
+              ))}
+            </div>
+          )}
+
+          {activeSequence && (
+            <>
+              {/* Summary bar */}
+              <div className="sequence-summary-bar">
+                <div className="summary-stats">
+                  <span className="summary-item excellent">{activeSequence.summary.excellent_count} excellent</span>
+                  <span className="summary-item good">{activeSequence.summary.good_count} good</span>
+                  <span className="summary-item fair">{activeSequence.summary.fair_count} fair</span>
+                  <span className="summary-item poor">{activeSequence.summary.poor_count} poor</span>
+                  <span className="summary-item bad">{activeSequence.summary.bad_count} bad</span>
+                </div>
+                <div className="summary-issues">
+                  {activeSequence.summary.cloud_events_detected > 0 && (
+                    <span className="issue-badge clouds">{activeSequence.summary.cloud_events_detected} cloud events</span>
+                  )}
+                  {activeSequence.summary.focus_drift_detected && (
+                    <span className="issue-badge focus">Focus drift</span>
+                  )}
+                  {activeSequence.summary.tracking_issues_detected && (
+                    <span className="issue-badge tracking">Tracking issues</span>
+                  )}
+                </div>
+              </div>
+
+              {/* Timeline chart */}
+              <SequenceTimeline
+                images={activeSequence.images}
+                threshold={threshold}
+                selectedImages={selectedImages}
+                onToggle={toggleImage}
+              />
+
+              {/* Image strip */}
+              <div className="sequence-strip">
+                {activeSequence.images.map((qr) => {
+                  const img = imageMap.get(qr.image_id);
+                  const isSelected = selectedImages.has(qr.image_id);
+                  return (
+                    <SequenceImageCard
+                      key={qr.image_id}
+                      quality={qr}
+                      image={img}
+                      isSelected={isSelected}
+                      isBelowThreshold={qr.quality_score < threshold}
+                      onClick={() => toggleImage(qr.image_id)}
+                      onDoubleClick={() => {
+                        const params = searchParams.toString();
+                        navigate(`/detail/${qr.image_id}?${params}`);
+                      }}
+                    />
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {/* No results */}
+      {!isAnalyzing && !analysisError && sequences.length === 0 && analysisData && (
+        <div className="empty-state">
+          No sequences found for this target. Make sure images have been captured.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Timeline visualization component
+function SequenceTimeline({
+  images,
+  threshold,
+  selectedImages,
+  onToggle,
+}: {
+  images: ImageQualityResult[];
+  threshold: number;
+  selectedImages: Set<number>;
+  onToggle: (id: number) => void;
+}) {
+  if (images.length === 0) return null;
+
+  const chartWidth = Math.max(images.length * 12, 400);
+  const chartHeight = 120;
+  const padding = { top: 10, right: 10, bottom: 20, left: 30 };
+  const innerWidth = chartWidth - padding.left - padding.right;
+  const innerHeight = chartHeight - padding.top - padding.bottom;
+
+  const barWidth = Math.max(2, Math.min(10, (innerWidth / images.length) - 1));
+
+  return (
+    <div className="sequence-timeline">
+      <svg
+        width="100%"
+        height={chartHeight}
+        viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+        preserveAspectRatio="none"
+        style={{ display: 'block' }}
+      >
+        {/* Threshold line */}
+        <line
+          x1={padding.left}
+          y1={padding.top + innerHeight * (1 - threshold)}
+          x2={chartWidth - padding.right}
+          y2={padding.top + innerHeight * (1 - threshold)}
+          stroke="var(--color-warning)"
+          strokeWidth="1"
+          strokeDasharray="4,4"
+          opacity="0.6"
+        />
+
+        {/* Y-axis labels */}
+        <text x={padding.left - 4} y={padding.top + 4} fontSize="9" fill="var(--color-text-muted)" textAnchor="end">1.0</text>
+        <text x={padding.left - 4} y={padding.top + innerHeight / 2 + 3} fontSize="9" fill="var(--color-text-muted)" textAnchor="end">0.5</text>
+        <text x={padding.left - 4} y={padding.top + innerHeight + 3} fontSize="9" fill="var(--color-text-muted)" textAnchor="end">0.0</text>
+
+        {/* Bars */}
+        {images.map((img, i) => {
+          const x = padding.left + (i / images.length) * innerWidth;
+          const barHeight = img.quality_score * innerHeight;
+          const y = padding.top + innerHeight - barHeight;
+          const isSelected = selectedImages.has(img.image_id);
+
+          return (
+            <rect
+              key={img.image_id}
+              x={x}
+              y={y}
+              width={barWidth}
+              height={Math.max(1, barHeight)}
+              fill={qualityColor(img.quality_score)}
+              opacity={isSelected ? 1 : 0.7}
+              stroke={isSelected ? 'var(--color-primary)' : 'none'}
+              strokeWidth={isSelected ? 1 : 0}
+              style={{ cursor: 'pointer' }}
+              onClick={() => onToggle(img.image_id)}
+            >
+              <title>Score: {img.quality_score.toFixed(2)}{img.category ? ` (${formatCategory(img.category)})` : ''}</title>
+            </rect>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+// Individual image card in the sequence strip
+function SequenceImageCard({
+  quality,
+  image,
+  isSelected,
+  isBelowThreshold,
+  onClick,
+  onDoubleClick,
+}: {
+  quality: ImageQualityResult;
+  image?: { id: number; target_name: string; filter_name: string | null; acquired_date: number | null; grading_status: number };
+  isSelected: boolean;
+  isBelowThreshold: boolean;
+  onClick: () => void;
+  onDoubleClick: () => void;
+}) {
+  const formatDate = (timestamp: number | null | undefined) => {
+    if (!timestamp) return '';
+    return new Date(timestamp * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  return (
+    <div
+      className={`sequence-image-card ${isSelected ? 'selected' : ''} ${isBelowThreshold ? 'below-threshold' : ''}`}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+    >
+      <div className="sequence-image-preview">
+        <img
+          src={apiClient.getPreviewUrl(quality.image_id, { size: 'screen' })}
+          alt={`Image ${quality.image_id}`}
+          loading="lazy"
+        />
+        {/* Quality badge */}
+        <div
+          className="quality-badge"
+          style={{ backgroundColor: qualityColor(quality.quality_score) }}
+          title={`Quality: ${quality.quality_score.toFixed(2)} - ${qualityLabel(quality.quality_score)}`}
+        >
+          {(quality.quality_score * 100).toFixed(0)}
+        </div>
+        {/* Category label */}
+        {quality.category && (
+          <div className="category-label">
+            {formatCategory(quality.category)}
+          </div>
+        )}
+      </div>
+      <div className="sequence-image-info">
+        <span className="sequence-image-time">{formatDate(image?.acquired_date)}</span>
+        {quality.details && (
+          <span className="sequence-image-details" title={quality.details}>
+            {quality.details}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -1,0 +1,642 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import SequenceView from '../SequenceView';
+import normalFixture from '../../__fixtures__/sequence-analysis-normal.json';
+import cloudsFixture from '../../__fixtures__/sequence-analysis-clouds.json';
+import multiSessionFixture from '../../__fixtures__/sequence-analysis-multi-session.json';
+import emptyFixture from '../../__fixtures__/sequence-analysis-empty.json';
+
+// Mock images data that aligns with the normal fixture's image IDs
+const mockImages = normalFixture.data.sequences[0].images.map((img, i) => ({
+  id: img.image_id,
+  project_id: 1,
+  project_name: 'Test Project',
+  project_display_name: 'Test Project',
+  target_id: 1,
+  target_name: 'M42',
+  acquired_date: 1705352400 + i * 300,
+  filter_name: 'L',
+  grading_status: 0,
+  reject_reason: null,
+  metadata: { FileName: `image_${img.image_id}.fits` },
+  filesystem_path: `/images/image_${img.image_id}.fits`,
+}));
+
+const mockTargets = [
+  { id: 1, name: 'M42', ra: 83.82, dec: -5.39, active: true, image_count: 10, accepted_count: 5, rejected_count: 0, has_files: true },
+  { id: 2, name: 'NGC7000', ra: 314.0, dec: 44.0, active: true, image_count: 10, accepted_count: 8, rejected_count: 0, has_files: true },
+];
+
+function createWrapper(initialRoute = '/sequence?project=1&target=1') {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialRoute]}>
+          {children}
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function setupDefaultHandlers() {
+  server.use(
+    http.get('/api/analysis/sequence', () => {
+      return HttpResponse.json(normalFixture);
+    }),
+    http.get('/api/projects/:projectId/targets', () => {
+      return HttpResponse.json({
+        success: true,
+        data: mockTargets,
+        error: null,
+        status: 'ready',
+      });
+    }),
+    http.get('/api/images', () => {
+      return HttpResponse.json({
+        success: true,
+        data: mockImages,
+        error: null,
+        status: 'ready',
+      });
+    }),
+    http.get('/api/images/:imageId', () => {
+      return HttpResponse.json({
+        success: true,
+        data: mockImages[0],
+        error: null,
+        status: 'ready',
+      });
+    }),
+    http.put('/api/images/:imageId/grade', () => {
+      return HttpResponse.json({
+        success: true,
+        data: null,
+        error: null,
+        status: 'ready',
+      });
+    }),
+  );
+}
+
+describe('SequenceView: rendering states', () => {
+  it('shows empty state when no project is selected', () => {
+    render(<SequenceView />, { wrapper: createWrapper('/sequence') });
+    expect(screen.getByText('Select a project to analyze image sequences')).toBeInTheDocument();
+  });
+
+  it('shows target selection when project is selected but no target', () => {
+    server.use(
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: [],
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1') });
+    expect(screen.getByText('Sequence Analysis')).toBeInTheDocument();
+    expect(screen.getByText(/Select a target/)).toBeInTheDocument();
+  });
+
+  it('shows available targets as buttons', async () => {
+    server.use(
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: [],
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText('M42')).toBeInTheDocument();
+    });
+    expect(screen.getByText('NGC7000')).toBeInTheDocument();
+  });
+
+  it('shows loading state while analyzing', async () => {
+    // Use a delayed response to catch the loading state
+    server.use(
+      http.get('/api/analysis/sequence', async () => {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        return HttpResponse.json(normalFixture);
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    expect(screen.getByText('Analyzing image sequences...')).toBeInTheDocument();
+  });
+
+  it('shows error state on analysis failure', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(
+          { success: false, data: null, error: 'Target not found', status: null },
+          { status: 400 },
+        );
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to analyze sequence/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no sequences found', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(emptyFixture);
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No sequences found/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SequenceView: quality display', () => {
+  it('renders summary bar with quality counts', async () => {
+    setupDefaultHandlers();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText(/3 excellent/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/4 good/)).toBeInTheDocument();
+    expect(screen.getByText(/3 fair/)).toBeInTheDocument();
+  });
+
+  it('renders image cards with quality badges', async () => {
+    setupDefaultHandlers();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      // Quality badges show percentage (e.g., "82" for 0.82)
+      expect(screen.getByText('82')).toBeInTheDocument();
+    });
+  });
+
+  it('shows cloud event badges when clouds are detected', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(cloudsFixture);
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText(/cloud event/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows category labels on cloud-affected images', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(cloudsFixture);
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      // formatCategory converts "likely_clouds" to "Likely Clouds"
+      const labels = screen.getAllByText('Likely Clouds');
+      expect(labels.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});
+
+describe('SequenceView: interactions', () => {
+  it('toggles image selection on click', async () => {
+    setupDefaultHandlers();
+    const user = userEvent.setup();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText('82')).toBeInTheDocument();
+    });
+
+    // Find image cards and click one
+    const cards = document.querySelectorAll('.sequence-image-card');
+    expect(cards.length).toBeGreaterThan(0);
+
+    await user.click(cards[0]);
+
+    // After clicking, the card should have the 'selected' class
+    expect(cards[0].classList.contains('selected')).toBe(true);
+
+    // Click again to deselect
+    await user.click(cards[0]);
+    expect(cards[0].classList.contains('selected')).toBe(false);
+  });
+
+  it('selects images below threshold', async () => {
+    setupDefaultHandlers();
+    const user = userEvent.setup();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText('Select Below Threshold')).toBeInTheDocument();
+    });
+
+    // Default threshold is 0.50. With the normal fixture, images below 0.50 would be none.
+    // Instead, test with the default threshold -- just click the button and verify behavior.
+    // The default threshold of 0.50 won't select any normal fixture images (all are >= 0.70),
+    // so let's use fireEvent to set the threshold to 0.80.
+    const slider = screen.getByRole('slider');
+    // fireEvent is more reliable for range inputs than userEvent
+    const { fireEvent } = await import('@testing-library/react');
+    fireEvent.change(slider, { target: { value: '0.80' } });
+
+    await user.click(screen.getByText('Select Below Threshold'));
+
+    // Images with quality_score < 0.80: IDs 3 (0.75), 5 (0.70), 7 (0.77), 10 (0.72)
+    // After selecting, the "Reject Selected" button should appear with count
+    await waitFor(() => {
+      const rejectButton = screen.queryByText(/Reject Selected/);
+      expect(rejectButton).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Select Clouded" button and selects cloud runs', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(cloudsFixture);
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText('Select Clouded')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Select Clouded'));
+
+    // The cloud fixture has 2 consecutive cloud images (IDs 104, 105)
+    // selectCloudedSequence selects runs of >= 2 bad images
+    await waitFor(() => {
+      const rejectButton = screen.getByText(/Reject Selected \(2\)/);
+      expect(rejectButton).toBeInTheDocument();
+    });
+  });
+
+  it('clears selection when Clear button is clicked', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(cloudsFixture);
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText('Select Clouded')).toBeInTheDocument();
+    });
+
+    // Select clouded images first
+    await user.click(screen.getByText('Select Clouded'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Reject Selected/)).toBeInTheDocument();
+    });
+
+    // Click Clear
+    await user.click(screen.getByText('Clear'));
+
+    // Reject button should disappear after clearing
+    await waitFor(() => {
+      expect(screen.queryByText(/Reject Selected/)).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('SequenceView: multi-session', () => {
+  it('renders sequence tabs for multiple sessions', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(multiSessionFixture);
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: [],
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=2') });
+
+    await waitFor(() => {
+      // Each tab shows "filter_name (image_count)"
+      const tabs = screen.getAllByText(/L \(5\)/);
+      expect(tabs).toHaveLength(2);
+    });
+  });
+
+  it('switches between sequences when tabs are clicked', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(multiSessionFixture);
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: [],
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=2') });
+
+    await waitFor(() => {
+      const tabs = screen.getAllByText(/L \(5\)/);
+      expect(tabs).toHaveLength(2);
+    });
+
+    const tabs = screen.getAllByText(/L \(5\)/);
+
+    // First tab should be active by default
+    expect(tabs[0].classList.contains('active')).toBe(true);
+
+    // Click second tab
+    await user.click(tabs[1]);
+
+    // Second tab should now be active
+    expect(tabs[1].classList.contains('active')).toBe(true);
+    expect(tabs[0].classList.contains('active')).toBe(false);
+  });
+});
+
+describe('SequenceView: batch operations', () => {
+  it('calls grade API when rejecting selected images', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(cloudsFixture);
+      }),
+      http.get('/api/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/images/:imageId', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages[0],
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    const gradeRequests: Array<{ imageId: string; body: unknown }> = [];
+    server.use(
+      http.put('/api/images/:imageId/grade', async ({ params, request }) => {
+        const body = await request.json();
+        gradeRequests.push({ imageId: params.imageId as string, body });
+        return HttpResponse.json({
+          success: true,
+          data: null,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText('Select Clouded')).toBeInTheDocument();
+    });
+
+    // Select clouded images
+    await user.click(screen.getByText('Select Clouded'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Reject Selected \(2\)/)).toBeInTheDocument();
+    });
+
+    // Click reject
+    await user.click(screen.getByText(/Reject Selected \(2\)/));
+
+    // Wait for the grade API calls to be made
+    await waitFor(() => {
+      expect(gradeRequests.length).toBe(2);
+    });
+
+    // Verify the grade requests were for rejection
+    gradeRequests.forEach(req => {
+      expect((req.body as Record<string, unknown>).status).toBe('rejected');
+    });
+  });
+
+  it('shows Re-analyze button', async () => {
+    setupDefaultHandlers();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?project=1&target=1') });
+
+    await waitFor(() => {
+      expect(screen.getByText('Re-analyze')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -254,10 +254,10 @@ describe('SequenceView: quality display', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/3 excellent/)).toBeInTheDocument();
-    });
+    }, { timeout: 3000 });
     expect(screen.getByText(/4 good/)).toBeInTheDocument();
     expect(screen.getByText(/3 fair/)).toBeInTheDocument();
-  });
+  }, 10000);
 
   it('renders image cards with quality badges', async () => {
     setupDefaultHandlers();

--- a/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
+++ b/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import { useSequenceAnalysis, useImageQuality } from '../useSequenceAnalysis';
+import normalFixture from '../../__fixtures__/sequence-analysis-normal.json';
+import imageQualityFixture from '../../__fixtures__/image-quality-context.json';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useSequenceAnalysis', () => {
+  it('starts with no data and not loading', () => {
+    const { result } = renderHook(() => useSequenceAnalysis(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetches data after analyze() is called', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(normalFixture);
+      }),
+    );
+
+    const { result } = renderHook(() => useSequenceAnalysis(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.analyze({ target_id: 1, filter_name: 'L' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+
+    expect(result.current.data!.sequences).toHaveLength(1);
+    expect(result.current.data!.sequences[0].target_name).toBe('M42');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('resets state when reset() is called', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(normalFixture);
+      }),
+    );
+
+    const { result } = renderHook(() => useSequenceAnalysis(), {
+      wrapper: createWrapper(),
+    });
+
+    // Trigger analysis
+    act(() => {
+      result.current.analyze({ target_id: 1 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+
+    // Reset
+    act(() => {
+      result.current.reset();
+    });
+
+    // After reset, query is disabled (no target_id), so data becomes undefined
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('handles server errors', async () => {
+    server.use(
+      http.get('/api/analysis/sequence', () => {
+        return HttpResponse.json(
+          { success: false, data: null, error: 'Target not found', status: null },
+          { status: 400 },
+        );
+      }),
+    );
+
+    const { result } = renderHook(() => useSequenceAnalysis(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.analyze({ target_id: 9999 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+  });
+});
+
+describe('useImageQuality', () => {
+  it('does not fetch when imageId is undefined', () => {
+    const { result } = renderHook(() => useImageQuality(undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('fetches image quality when imageId is provided', async () => {
+    server.use(
+      http.get('/api/analysis/image/:imageId', () => {
+        return HttpResponse.json(imageQualityFixture);
+      }),
+    );
+
+    const { result } = renderHook(() => useImageQuality(5), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBeDefined();
+    });
+
+    expect(result.current.data!.image_id).toBe(5);
+    expect(result.current.data!.quality).toBeDefined();
+    expect(result.current.data!.quality!.quality_score).toBe(0.70);
+    expect(result.current.data!.sequence_filter_name).toBe('L');
+  });
+});

--- a/static/src/hooks/useSequenceAnalysis.ts
+++ b/static/src/hooks/useSequenceAnalysis.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import type { SequenceAnalysisRequest } from '../api/types';
+import { useState, useCallback } from 'react';
+
+export function useSequenceAnalysis() {
+  const [request, setRequest] = useState<SequenceAnalysisRequest | null>(null);
+
+  const query = useQuery({
+    queryKey: ['sequence-analysis', request?.target_id, request?.filter_name],
+    queryFn: () => apiClient.analyzeSequence(request!),
+    enabled: !!request?.target_id,
+    staleTime: 60000,
+  });
+
+  const analyze = useCallback((req: SequenceAnalysisRequest) => {
+    setRequest(req);
+  }, []);
+
+  return {
+    analyze,
+    data: query.data,
+    isLoading: query.isLoading && !!request,
+    error: query.error,
+    reset: () => setRequest(null),
+  };
+}
+
+export function useImageQuality(imageId: number | undefined) {
+  return useQuery({
+    queryKey: ['image-quality', imageId],
+    queryFn: () => apiClient.getImageQuality(imageId!),
+    enabled: !!imageId,
+    staleTime: 60000,
+  });
+}

--- a/static/src/router/index.tsx
+++ b/static/src/router/index.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from '../App';
 import MainView from '../components/MainView';
 import Overview from '../components/Overview';
+import SequenceView from '../components/SequenceView';
 
 // Create React Query client
 const queryClient = new QueryClient({
@@ -39,6 +40,10 @@ const router = createHashRouter([
       {
         path: "compare/:leftImageId/:rightImageId",
         element: <MainView />
+      },
+      {
+        path: "sequence",
+        element: <SequenceView />
       }
     ]
   }

--- a/static/src/test/__tests__/smoke.test.ts
+++ b/static/src/test/__tests__/smoke.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+
+describe('Test infrastructure', () => {
+  it('vitest runs correctly', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  it('jsdom environment is active', () => {
+    expect(typeof document).toBe('object');
+    expect(typeof window).toBe('object');
+  });
+
+  it('MSW server is running (setup.ts loaded)', async () => {
+    // If MSW setup failed, this would throw due to onUnhandledRequest: 'error'
+    const response = await fetch('/api/projects');
+    expect(response.ok).toBe(true);
+    const json = await response.json();
+    expect(json.success).toBe(true);
+  });
+});

--- a/static/src/test/msw-handlers.ts
+++ b/static/src/test/msw-handlers.ts
@@ -1,0 +1,68 @@
+import { http, HttpResponse } from 'msw';
+
+// Default empty responses for handlers
+const emptySequenceAnalysis = {
+  success: true,
+  data: { sequences: [] },
+  error: null,
+  status: 'ready',
+};
+
+const notFoundImageQuality = {
+  success: false,
+  data: null,
+  error: 'Image not found',
+  status: null,
+};
+
+export const handlers = [
+  // Sequence analysis endpoint
+  http.get('/api/analysis/sequence', () => {
+    return HttpResponse.json(emptySequenceAnalysis);
+  }),
+
+  // Image quality endpoint
+  http.get('/api/analysis/image/:imageId', () => {
+    return HttpResponse.json(notFoundImageQuality, { status: 404 });
+  }),
+
+  // Projects endpoint (needed for SequenceView)
+  http.get('/api/projects', () => {
+    return HttpResponse.json({
+      success: true,
+      data: [],
+      error: null,
+      status: 'ready',
+    });
+  }),
+
+  // Targets for project
+  http.get('/api/projects/:projectId/targets', () => {
+    return HttpResponse.json({
+      success: true,
+      data: [],
+      error: null,
+      status: 'ready',
+    });
+  }),
+
+  // Images list
+  http.get('/api/images', () => {
+    return HttpResponse.json({
+      success: true,
+      data: [],
+      error: null,
+      status: 'ready',
+    });
+  }),
+
+  // Grade update
+  http.put('/api/images/:imageId/grade', () => {
+    return HttpResponse.json({
+      success: true,
+      data: null,
+      error: null,
+      status: 'ready',
+    });
+  }),
+];

--- a/static/src/test/msw-server.ts
+++ b/static/src/test/msw-server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './msw-handlers';
+
+export const server = setupServer(...handlers);

--- a/static/src/test/setup.ts
+++ b/static/src/test/setup.ts
@@ -1,0 +1,16 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, afterAll, beforeAll } from 'vitest';
+import { server } from './msw-server';
+
+// Start MSW server before all tests
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+
+// Reset handlers after each test
+afterEach(() => {
+  cleanup();
+  server.resetHandlers();
+});
+
+// Close server after all tests
+afterAll(() => server.close());

--- a/static/vite.config.ts
+++ b/static/vite.config.ts
@@ -1,9 +1,15 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    globals: true,
+  },
   server: {
     proxy: {
       '/api': {

--- a/tests/integration_sequence_analysis.rs
+++ b/tests/integration_sequence_analysis.rs
@@ -1,0 +1,818 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use http_body_util::BodyExt;
+use rusqlite::Connection;
+use serde_json::Value;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ---- Test Harness ----
+
+fn create_test_schema(conn: &Connection) {
+    conn.execute_batch(
+        "CREATE TABLE project (
+            Id INTEGER PRIMARY KEY,
+            profileId TEXT,
+            name TEXT NOT NULL,
+            description TEXT
+        );
+        CREATE TABLE target (
+            Id INTEGER PRIMARY KEY,
+            projectId INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1,
+            ra REAL,
+            dec REAL
+        );
+        CREATE TABLE acquiredimage (
+            Id INTEGER PRIMARY KEY,
+            projectId INTEGER NOT NULL,
+            targetId INTEGER NOT NULL,
+            acquireddate INTEGER,
+            filtername TEXT NOT NULL,
+            gradingStatus INTEGER NOT NULL DEFAULT 0,
+            metadata TEXT NOT NULL DEFAULT '{}',
+            rejectreason TEXT,
+            profileId TEXT
+        );",
+    )
+    .unwrap();
+}
+
+fn insert_project(conn: &Connection, id: i32, name: &str) {
+    conn.execute(
+        "INSERT INTO project (Id, profileId, name) VALUES (?1, 'default', ?2)",
+        rusqlite::params![id, name],
+    )
+    .unwrap();
+}
+
+fn insert_target(conn: &Connection, id: i32, project_id: i32, name: &str) {
+    conn.execute(
+        "INSERT INTO target (Id, projectId, name, active) VALUES (?1, ?2, ?3, 1)",
+        rusqlite::params![id, project_id, name],
+    )
+    .unwrap();
+}
+
+fn insert_image(
+    conn: &Connection,
+    id: i32,
+    project_id: i32,
+    target_id: i32,
+    timestamp: i64,
+    filter: &str,
+    metadata: &Value,
+) {
+    conn.execute(
+        "INSERT INTO acquiredimage (Id, projectId, targetId, acquireddate, filtername, metadata)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![
+            id,
+            project_id,
+            target_id,
+            timestamp,
+            filter,
+            serde_json::to_string(metadata).unwrap()
+        ],
+    )
+    .unwrap();
+}
+
+fn build_metadata(
+    stars: f64,
+    hfr: f64,
+    bg: Option<f64>,
+    snr: Option<f64>,
+    ecc: Option<f64>,
+) -> Value {
+    let mut m = serde_json::json!({
+        "FileName": "test.fits",
+        "DetectedStars": stars,
+        "HFR": hfr
+    });
+    if let Some(v) = bg {
+        m["Background"] = serde_json::json!(v);
+    }
+    if let Some(v) = snr {
+        m["SNR"] = serde_json::json!(v);
+    }
+    if let Some(v) = ecc {
+        m["Eccentricity"] = serde_json::json!(v);
+    }
+    m
+}
+
+fn create_test_app(conn: Connection) -> Router {
+    use axum::routing::get;
+    use psf_guard::server::handlers;
+    use psf_guard::server::state::AppState;
+
+    let state = Arc::new(AppState::new_for_test(conn));
+
+    Router::new()
+        .route(
+            "/api/analysis/sequence",
+            get(handlers::analyze_sequence),
+        )
+        .route(
+            "/api/analysis/image/{image_id}",
+            get(handlers::get_image_quality),
+        )
+        .with_state(state)
+}
+
+async fn get_json(app: Router, uri: &str) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    (status, json)
+}
+
+// ---- Fixture Loaders ----
+
+/// Fixture 1: Normal sequence - 10 images, mixed quality, L filter
+/// Jan 15, 2024 starting at 22:00 UTC, 5 min apart
+fn load_normal_sequence(conn: &Connection) {
+    insert_project(conn, 1, "Test Project");
+    insert_target(conn, 1, 1, "M42");
+
+    let base_ts: i64 = 1705352400; // 2024-01-15T22:00:00Z
+    let stars = [320.0, 335.0, 310.0, 345.0, 300.0, 330.0, 315.0, 340.0, 325.0, 350.0];
+    let hfrs = [2.4, 2.3, 2.5, 2.35, 2.6, 2.45, 2.55, 2.3, 2.4, 2.7];
+    let bgs = [1200.0, 1210.0, 1195.0, 1205.0, 1215.0, 1200.0, 1190.0, 1208.0, 1202.0, 1198.0];
+
+    for i in 0..10 {
+        let ts = base_ts + i as i64 * 300;
+        // Some images have SNR and eccentricity, some don't (tests missing metrics)
+        let snr = if i < 7 { Some(45.0 + (i as f64 - 3.0) * 1.5) } else { None };
+        let ecc = if i < 8 { Some(0.35 + (i as f64 - 4.0) * 0.01) } else { None };
+        let meta = build_metadata(stars[i], hfrs[i], Some(bgs[i]), snr, ecc);
+        insert_image(conn, (i + 1) as i32, 1, 1, ts, "L", &meta);
+    }
+}
+
+/// Fixture 2: Cloud passage event - 8 Ha images
+/// 3 good, 2 cloud-affected, 3 good
+fn load_cloud_passage(conn: &Connection) {
+    // Re-use project/target from fixture 1 if present, or create new
+    let has_project: bool = conn
+        .query_row("SELECT COUNT(*) FROM project WHERE Id = 1", [], |row| {
+            row.get::<_, i32>(0)
+        })
+        .unwrap()
+        > 0;
+    if !has_project {
+        insert_project(conn, 1, "Test Project");
+        insert_target(conn, 1, 1, "M42");
+    }
+
+    let base_ts: i64 = 1705356000; // 2024-01-15T23:00:00Z (after L sequence)
+
+    // Good frames: stars ~300, bg ~1200, snr ~45, hfr ~2.5
+    // Cloud frames: stars drop to ~90 (70% drop), bg rises to ~1680 (40% rise)
+    let data: [(f64, f64, f64, f64); 8] = [
+        (310.0, 2.45, 1200.0, 46.0), // good
+        (305.0, 2.50, 1210.0, 44.5), // good
+        (315.0, 2.40, 1195.0, 47.0), // good
+        (90.0, 3.80, 1680.0, 12.0),  // cloud
+        (85.0, 4.00, 1700.0, 10.0),  // cloud
+        (300.0, 2.55, 1220.0, 43.0), // good (recovery)
+        (308.0, 2.48, 1205.0, 45.5), // good
+        (312.0, 2.42, 1198.0, 46.5), // good
+    ];
+
+    for (i, (stars, hfr, bg, snr)) in data.iter().enumerate() {
+        let ts = base_ts + i as i64 * 300;
+        let meta = build_metadata(*stars, *hfr, Some(*bg), Some(*snr), Some(0.35));
+        insert_image(conn, 100 + (i + 1) as i32, 1, 1, ts, "Ha", &meta);
+    }
+}
+
+/// Fixture 3: Session gap - two sessions with 2+ hour gap, L filter, same target
+fn load_session_gap(conn: &Connection) {
+    insert_project(conn, 2, "Session Gap Project");
+    insert_target(conn, 2, 2, "NGC7000");
+
+    let base_ts1: i64 = 1705352400; // Session 1: 2024-01-15T22:00:00Z
+    let base_ts2: i64 = base_ts1 + 5 * 300 + 7200; // Session 2: ~2h20m after session 1 start
+
+    // Session 1: 5 images
+    for i in 0i32..5 {
+        let ts = base_ts1 + i as i64 * 300;
+        let meta = build_metadata(280.0 + i as f64 * 5.0, 2.6, Some(1100.0), Some(40.0), Some(0.30));
+        insert_image(conn, 200 + i + 1, 2, 2, ts, "L", &meta);
+    }
+
+    // Session 2: 5 images
+    for i in 0i32..5 {
+        let ts = base_ts2 + i as i64 * 300;
+        let meta = build_metadata(290.0 + i as f64 * 3.0, 2.55, Some(1120.0), Some(42.0), Some(0.32));
+        insert_image(conn, 210 + i + 1, 2, 2, ts, "L", &meta);
+    }
+}
+
+/// Fixture 4: Short sequence - only 2 images (below min_sequence_length)
+fn load_short_sequence(conn: &Connection) {
+    insert_project(conn, 3, "Short Sequence Project");
+    insert_target(conn, 3, 3, "IC1396");
+
+    let base_ts: i64 = 1705352400;
+    for i in 0i32..2 {
+        let ts = base_ts + i as i64 * 300;
+        let meta = build_metadata(250.0 + i as f64 * 10.0, 2.8, Some(1300.0), Some(38.0), Some(0.40));
+        insert_image(conn, 300 + i + 1, 3, 3, ts, "L", &meta);
+    }
+}
+
+/// Fixture 5: Missing metrics - images with only DetectedStars (no HFR, no SNR, etc.)
+fn load_missing_metrics(conn: &Connection) {
+    insert_project(conn, 4, "Missing Metrics Project");
+    insert_target(conn, 4, 4, "M31");
+
+    let base_ts: i64 = 1705352400;
+    for i in 0i32..5 {
+        let ts = base_ts + i as i64 * 300;
+        // Only DetectedStars, no HFR, no SNR, no Eccentricity, no Background
+        let meta = serde_json::json!({
+            "FileName": "test.fits",
+            "DetectedStars": 200.0 + i as f64 * 20.0,
+        });
+        insert_image(conn, 400 + i + 1, 4, 4, ts, "L", &meta);
+    }
+}
+
+/// Fixture 6: Empty target - target with no images
+fn load_empty_target(conn: &Connection) {
+    insert_project(conn, 5, "Empty Target Project");
+    insert_target(conn, 5, 5, "EmptyTarget");
+    // No images inserted
+}
+
+// ---- Tests ----
+
+/// Test 1: Normal sequence analysis
+#[tokio::test]
+async fn test_analyze_sequence_normal() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_normal_sequence(&conn);
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/analysis/sequence?target_id=1&filter_name=L").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    assert_eq!(sequences.len(), 1, "Should have exactly 1 sequence (single session)");
+
+    let seq = &sequences[0];
+    assert_eq!(seq["target_id"], 1);
+    assert_eq!(seq["target_name"], "M42");
+    assert_eq!(seq["filter_name"], "L");
+    assert_eq!(seq["image_count"], 10);
+    assert!(seq["session_start"].is_number());
+    assert!(seq["session_end"].is_number());
+
+    // Reference values should be populated
+    let refs = &seq["reference_values"];
+    assert!(refs["best_star_count"].is_number(), "best_star_count should be populated");
+    assert!(refs["best_hfr"].is_number(), "best_hfr should be populated");
+
+    // All quality scores should be between 0.0 and 1.0
+    let images = seq["images"].as_array().unwrap();
+    assert_eq!(images.len(), 10);
+    for img in images {
+        let score = img["quality_score"].as_f64().unwrap();
+        assert!(
+            (0.0..=1.0).contains(&score),
+            "quality_score should be between 0.0 and 1.0, got {}",
+            score
+        );
+    }
+
+    // Summary counts should sum to image_count
+    let summary = &seq["summary"];
+    let total_summary = summary["excellent_count"].as_u64().unwrap()
+        + summary["good_count"].as_u64().unwrap()
+        + summary["fair_count"].as_u64().unwrap()
+        + summary["poor_count"].as_u64().unwrap()
+        + summary["bad_count"].as_u64().unwrap();
+    assert_eq!(total_summary, 10, "Summary counts should sum to image_count");
+}
+
+/// Test 2: Cloud detection through the full API path
+#[tokio::test]
+async fn test_analyze_sequence_cloud_detection() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_cloud_passage(&conn);
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/analysis/sequence?target_id=1&filter_name=Ha").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    assert_eq!(sequences.len(), 1);
+
+    let seq = &sequences[0];
+    let images = seq["images"].as_array().unwrap();
+    assert_eq!(images.len(), 8);
+
+    // Cloud-affected frames (indices 3, 4) should have lower quality_score than good frames
+    let good_score = images[0]["quality_score"].as_f64().unwrap();
+    let cloud_score_1 = images[3]["quality_score"].as_f64().unwrap();
+    let cloud_score_2 = images[4]["quality_score"].as_f64().unwrap();
+
+    assert!(
+        cloud_score_1 < good_score,
+        "Cloud frame should score worse than good frame: {} vs {}",
+        cloud_score_1,
+        good_score
+    );
+    assert!(
+        cloud_score_2 < good_score,
+        "Cloud frame should score worse than good frame: {} vs {}",
+        cloud_score_2,
+        good_score
+    );
+
+    // At least one image should be classified as likely_clouds
+    let has_cloud_category = images.iter().any(|img| {
+        img["category"].as_str() == Some("likely_clouds")
+    });
+    assert!(has_cloud_category, "At least one image should have category 'likely_clouds'");
+
+    // Summary should detect cloud events
+    let summary = &seq["summary"];
+    assert!(
+        summary["cloud_events_detected"].as_u64().unwrap() >= 1,
+        "Should detect at least 1 cloud event"
+    );
+
+    // Good frames should score above 0.5
+    assert!(good_score > 0.5, "Good frames should score above 0.5, got {}", good_score);
+}
+
+/// Test 3: Session splitting with 2+ hour gap
+#[tokio::test]
+async fn test_analyze_sequence_session_split() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_session_gap(&conn);
+    let app = create_test_app(conn);
+
+    // No filter_name to get all filters for the target
+    let (status, json) = get_json(app, "/api/analysis/sequence?target_id=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    assert_eq!(sequences.len(), 2, "Should split into 2 sessions");
+
+    // Each sequence should have 5 images
+    assert_eq!(sequences[0]["image_count"], 5);
+    assert_eq!(sequences[1]["image_count"], 5);
+
+    // Session 1 should end before session 2 starts
+    let seq0_end = sequences[0]["session_end"].as_i64().unwrap();
+    let seq1_start = sequences[1]["session_start"].as_i64().unwrap();
+
+    assert!(
+        seq0_end < seq1_start,
+        "Session 1 should end before session 2 starts"
+    );
+
+    // Gap should be > 60 minutes (3600 seconds)
+    let gap = seq1_start - seq0_end;
+    assert!(
+        gap > 3600,
+        "Gap between sessions should be > 60 minutes (3600s), got {}s",
+        gap
+    );
+}
+
+/// Test 4: Short sequence (below min_sequence_length) returns perfect scores
+#[tokio::test]
+async fn test_analyze_sequence_short() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_short_sequence(&conn);
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/analysis/sequence?target_id=3").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    assert_eq!(sequences.len(), 1, "Should have 1 sequence");
+
+    let seq = &sequences[0];
+    assert_eq!(seq["image_count"], 2);
+
+    // All images should have quality_score == 1.0 (short sequence default)
+    let images = seq["images"].as_array().unwrap();
+    for img in images {
+        let score = img["quality_score"].as_f64().unwrap();
+        assert_eq!(
+            score, 1.0,
+            "Short sequence images should get quality_score 1.0, got {}",
+            score
+        );
+    }
+
+    // Summary should count all as excellent
+    let summary = &seq["summary"];
+    assert_eq!(summary["excellent_count"], 2);
+}
+
+/// Test 5: Missing metrics - images with sparse metadata
+#[tokio::test]
+async fn test_analyze_sequence_missing_metrics() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_missing_metrics(&conn);
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/analysis/sequence?target_id=4").await;
+
+    assert_eq!(status, StatusCode::OK, "Should not error with missing metrics");
+    assert_eq!(json["success"], true);
+
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    assert_eq!(sequences.len(), 1);
+
+    let seq = &sequences[0];
+    let images = seq["images"].as_array().unwrap();
+    assert_eq!(images.len(), 5);
+
+    // Check that normalized_metrics fields that had no data are null
+    for img in images {
+        let nm = &img["normalized_metrics"];
+        // star_count should be present (we provided DetectedStars)
+        assert!(
+            nm["star_count"].is_number(),
+            "star_count should be a number since DetectedStars was provided"
+        );
+        // hfr, eccentricity, snr, background should be null (not provided)
+        assert!(nm["hfr"].is_null(), "hfr should be null when not provided in metadata");
+        assert!(
+            nm["eccentricity"].is_null(),
+            "eccentricity should be null when not provided"
+        );
+        assert!(nm["snr"].is_null(), "snr should be null when not provided");
+        assert!(
+            nm["background"].is_null(),
+            "background should be null when not provided"
+        );
+    }
+
+    // quality_score should still be computed using available metrics
+    for img in images {
+        let score = img["quality_score"].as_f64().unwrap();
+        assert!(
+            (0.0..=1.0).contains(&score),
+            "quality_score should be between 0.0 and 1.0 even with sparse data, got {}",
+            score
+        );
+    }
+}
+
+/// Test 6: Empty target - target with no images
+#[tokio::test]
+async fn test_analyze_sequence_empty_target() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_empty_target(&conn);
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/analysis/sequence?target_id=5").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    assert!(sequences.is_empty(), "Should return empty sequences array for target with no images");
+}
+
+/// Test 7: Nonexistent target returns 400 Bad Request
+#[tokio::test]
+async fn test_analyze_sequence_nonexistent_target() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    // No fixtures loaded - just empty schema
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/analysis/sequence?target_id=9999").await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["success"], false);
+    let error_msg = json["error"].as_str().unwrap();
+    assert!(
+        error_msg.to_lowercase().contains("not found"),
+        "Error message should contain 'not found', got: {}",
+        error_msg
+    );
+}
+
+/// Test 8: Image quality context endpoint
+#[tokio::test]
+async fn test_image_quality_context() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_normal_sequence(&conn);
+    let app = create_test_app(conn);
+
+    // Request quality context for image 5 (in the middle of the normal sequence)
+    let (status, json) = get_json(app, "/api/analysis/image/5").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+
+    let data = &json["data"];
+    assert_eq!(data["image_id"], 5);
+
+    // Quality should be present with a valid score
+    let quality = &data["quality"];
+    assert!(!quality.is_null(), "quality should be present");
+    let score = quality["quality_score"].as_f64().unwrap();
+    assert!(
+        (0.0..=1.0).contains(&score),
+        "quality_score should be between 0.0 and 1.0, got {}",
+        score
+    );
+
+    assert_eq!(data["sequence_target_id"], 1);
+    assert_eq!(data["sequence_filter_name"], "L");
+    assert!(
+        data["sequence_image_count"].as_u64().unwrap() >= 3,
+        "sequence_image_count should be >= 3"
+    );
+
+    // Reference values should be populated
+    let refs = &data["reference_values"];
+    assert!(!refs.is_null(), "reference_values should be present");
+    assert!(refs["best_star_count"].is_number());
+    assert!(refs["best_hfr"].is_number());
+}
+
+/// Test 9: Nonexistent image returns 404
+#[tokio::test]
+async fn test_image_quality_nonexistent_image() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    let app = create_test_app(conn);
+
+    let (status, _json) = get_json(app, "/api/analysis/image/99999").await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// Test 10: Custom weights change scoring behavior
+#[tokio::test]
+async fn test_analyze_sequence_custom_weights() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_normal_sequence(&conn);
+    let app = create_test_app(conn);
+
+    let uri = "/api/analysis/sequence?target_id=1&filter_name=L\
+        &weight_star_count=1.0&weight_hfr=0.0&weight_eccentricity=0.0\
+        &weight_snr=0.0&weight_background=0.0";
+
+    let (status, json) = get_json(app, uri).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["success"], true);
+
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    assert_eq!(sequences.len(), 1);
+
+    let images = sequences[0]["images"].as_array().unwrap();
+
+    // All scores should be between 0.0 and 1.0
+    for img in images {
+        let score = img["quality_score"].as_f64().unwrap();
+        assert!(
+            (0.0..=1.0).contains(&score),
+            "quality_score should be between 0.0 and 1.0 with custom weights, got {}",
+            score
+        );
+    }
+
+    // With star_count as the only weight, images with higher star counts should score higher
+    // Image with most stars (id=10, stars=350) should score >= image with fewest (id=5, stars=300)
+    let img_highest_stars = images.iter().find(|i| i["image_id"] == 10).unwrap();
+    let img_lowest_stars = images.iter().find(|i| i["image_id"] == 5).unwrap();
+    let score_high = img_highest_stars["quality_score"].as_f64().unwrap();
+    let score_low = img_lowest_stars["quality_score"].as_f64().unwrap();
+    assert!(
+        score_high >= score_low,
+        "Image with most stars should score >= image with fewest: {} vs {}",
+        score_high,
+        score_low
+    );
+}
+
+/// Test 11: Custom session gap threshold splits sessions more aggressively
+#[tokio::test]
+async fn test_analyze_sequence_custom_session_gap() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_session_gap(&conn);
+
+    // First verify default behavior produces 2 sequences
+    let conn1 = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn1);
+    load_session_gap(&conn1);
+    let app1 = create_test_app(conn1);
+    let (_, json_default) = get_json(app1, "/api/analysis/sequence?target_id=2").await;
+    let default_count = json_default["data"]["sequences"].as_array().unwrap().len();
+    assert_eq!(default_count, 2, "Default should produce 2 sequences");
+
+    // Now test with a very small gap (5 minutes)
+    let conn2 = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn2);
+    load_session_gap(&conn2);
+    let app2 = create_test_app(conn2);
+    let (status, json) = get_json(app2, "/api/analysis/sequence?target_id=2&session_gap_minutes=5").await;
+
+    assert_eq!(status, StatusCode::OK);
+
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    // With 5-minute gap threshold and 5-minute spacing, each frame-pair gap exactly equals the
+    // threshold, so we might get more sequences than 2. At minimum it should be >= 2.
+    assert!(
+        sequences.len() >= 2,
+        "With 5-minute gap threshold, should have at least 2 sequences (same or more than default), got {}",
+        sequences.len()
+    );
+}
+
+/// Test 12: JSON contract structure matches TypeScript interfaces
+#[tokio::test]
+async fn test_json_contract_structure() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_normal_sequence(&conn);
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/analysis/sequence?target_id=1&filter_name=L").await;
+
+    assert_eq!(status, StatusCode::OK);
+
+    // Verify top-level structure
+    assert!(json.get("success").is_some(), "Missing 'success' field");
+    assert!(json.get("data").is_some(), "Missing 'data' field");
+    assert!(json.get("error").is_some(), "Missing 'error' field");
+    assert!(json.get("status").is_some(), "Missing 'status' field");
+
+    let seq = &json["data"]["sequences"][0];
+
+    // Verify sequence-level fields
+    assert!(seq.get("target_id").is_some(), "Missing 'target_id'");
+    assert!(seq.get("target_name").is_some(), "Missing 'target_name'");
+    assert!(seq.get("filter_name").is_some(), "Missing 'filter_name'");
+    assert!(seq.get("session_start").is_some(), "Missing 'session_start'");
+    assert!(seq.get("session_end").is_some(), "Missing 'session_end'");
+    assert!(seq.get("image_count").is_some(), "Missing 'image_count'");
+    assert!(seq.get("reference_values").is_some(), "Missing 'reference_values'");
+    assert!(seq.get("images").is_some(), "Missing 'images'");
+    assert!(seq.get("summary").is_some(), "Missing 'summary'");
+
+    // Verify image-level fields
+    let img = &seq["images"][0];
+    for key in &[
+        "image_id",
+        "quality_score",
+        "temporal_anomaly_score",
+        "category",
+        "normalized_metrics",
+        "details",
+    ] {
+        assert!(
+            img.get(*key).is_some(),
+            "Missing '{}' in images[0]",
+            key
+        );
+    }
+
+    // Verify normalized_metrics keys
+    let nm = &img["normalized_metrics"];
+    for key in &["star_count", "hfr", "eccentricity", "snr", "background"] {
+        assert!(
+            nm.get(*key).is_some(),
+            "Missing '{}' in normalized_metrics",
+            key
+        );
+    }
+
+    // Verify summary keys
+    let summary = &seq["summary"];
+    for key in &[
+        "excellent_count",
+        "good_count",
+        "fair_count",
+        "poor_count",
+        "bad_count",
+        "cloud_events_detected",
+        "focus_drift_detected",
+        "tracking_issues_detected",
+    ] {
+        assert!(
+            summary.get(*key).is_some(),
+            "Missing '{}' in summary",
+            key
+        );
+    }
+
+    // Verify reference_values keys
+    let refs = &seq["reference_values"];
+    for key in &[
+        "best_star_count",
+        "best_hfr",
+        "best_eccentricity",
+        "best_snr",
+        "best_background",
+    ] {
+        assert!(
+            refs.get(*key).is_some(),
+            "Missing '{}' in reference_values",
+            key
+        );
+    }
+
+    // Verify enum values use snake_case by checking cloud passage fixture
+    let conn2 = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn2);
+    load_cloud_passage(&conn2);
+    let app2 = create_test_app(conn2);
+    let (_, cloud_json) = get_json(app2, "/api/analysis/sequence?target_id=1&filter_name=Ha").await;
+
+    let cloud_images = cloud_json["data"]["sequences"][0]["images"].as_array().unwrap();
+    let categories: Vec<&str> = cloud_images
+        .iter()
+        .filter_map(|img| img["category"].as_str())
+        .collect();
+
+    // All categories should be snake_case
+    for cat in &categories {
+        assert!(
+            !cat.contains(char::is_uppercase),
+            "Category '{}' should be snake_case, not PascalCase",
+            cat
+        );
+    }
+}
+
+/// Test 13: API response wrapper structure
+#[tokio::test]
+async fn test_api_response_wrapper_structure() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_normal_sequence(&conn);
+
+    // Test successful response
+    let app = create_test_app(conn);
+    let (_, json) = get_json(app, "/api/analysis/sequence?target_id=1&filter_name=L").await;
+
+    // Top-level keys
+    assert!(json.get("success").is_some(), "Missing 'success'");
+    assert!(json.get("data").is_some(), "Missing 'data'");
+    assert!(json.get("error").is_some(), "Missing 'error'");
+    assert!(json.get("status").is_some(), "Missing 'status'");
+
+    // Successful response values
+    assert_eq!(json["success"], true);
+    assert_eq!(json["status"], "ready");
+    assert!(json["data"].is_object(), "data should be an object for success");
+    assert!(json["error"].is_null(), "error should be null for success");
+
+    // Test error response
+    let conn2 = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn2);
+    let app2 = create_test_app(conn2);
+    let (_, err_json) = get_json(app2, "/api/analysis/sequence?target_id=9999").await;
+
+    assert_eq!(err_json["success"], false);
+    assert!(
+        err_json["error"].is_string(),
+        "error should be a string for error responses"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a multi-metric quality scoring system that detects cloud-affected frames, classifies quality issues, and produces a relative quality score (0.0-1.0) for every image in an acquisition sequence
- New `SequenceAnalyzer` backend with EWMA temporal baseline, weighted composite scoring (star count, HFR, SNR, eccentricity, background), and issue classification (clouds, obstruction, focus drift, tracking error, wind shake, sky brightening)
- New `SequenceView` frontend with timeline chart, quality badges, batch selection ("Select Below Threshold" slider + "Select Clouded"), and full undo/redo integration

## Details

**Backend** (`src/sequence_analysis.rs` + API endpoints):
- Sequences defined by target + filter + 60-min session gap
- Robust percentile normalization (5th/95th) prevents outlier compression
- Graceful fallback when metrics are missing (weight redistribution)
- `GET /api/analysis/sequence?target_id=X&filter_name=Y`
- `GET /api/analysis/image/{id}` for single image quality context
- 31 new unit tests (116 total passing)

**Frontend** (`SequenceView.tsx` + hooks + types):
- SVG bar chart timeline showing quality score progression
- Color-coded quality badges (green/yellow/red)
- Category labels on flagged images
- Batch reject through existing `useGrading` hook for undo/redo support
- `useQuery`-based hook with proper caching

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean (only pre-existing db.rs warning)
- [x] `cargo test` — 116 passed, 0 failed
- [x] `tsc -b && vite build` — frontend compiles clean
- [ ] Manual: navigate to /sequence, select target, verify quality scores render
- [ ] Manual: use threshold slider + batch reject, verify undo works
- [ ] Integration tests (in progress — separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)