### PR TITLE
ci: bump actions/download-artifact to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         key: ${{ runner.os }}-e2e-fits-${{ hashFiles('static/e2e/fixtures/manifest.json') }}
 
     - name: Download psf-guard binary
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: psf-guard-linux-x64
         path: ${{ runner.temp }}/psf-guard-bin


### PR DESCRIPTION
## Summary

Bumps the only remaining `actions/download-artifact@v6` step (in the
Playwright e2e job) to `@v7`. Every other artifact step in this
workflow is already on v7, so this just brings the last one in line.

The deprecation notice that surfaced during the multi-DB PR's CI run:

> Node.js 20 actions are deprecated. The following actions are running
> on Node.js 20 and may not work as expected: actions/download-artifact@v6.

GitHub will force Node 24 by default in June 2026 and remove Node 20
from runners in September 2026, so this only buys us a few months of
runway if left as-is.

No behavior change; the e2e job downloads the same Linux binary
artifact the same way.

## Test plan
- [x] CI Playwright e2e job runs against this branch
🤖 Generated with [Claude Code](https://claude.com/claude-code)