### PR TITLE
Out-of-tree reject archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,10 @@ test_output/
 /static/playwright-report/
 /static/blob-report/
 /static/playwright/.cache/
+
+# Local dev artifacts
+/Frameworks/
+/psf-guard
+/mise.toml
+/TAURI_TODOS.md
+/scripts/__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,29 @@ the platform config location (`<config>/psf-guard/config.json` by default).
 
 Implementation tracker and design rationale: [MULTI_DB_PLAN.md](./MULTI_DB_PLAN.md).
 
+### Out-of-tree reject archive (2026-05)
+- **Command**: `psf-guard move-rejects --db <slug>` (multi-DB-aware via the
+  registry). Moves files marked `gradingStatus = 2` to
+  `<image_dir>/<P>/REJECT/<rest>` by default, plus same-stem sidecars
+  (`.xisf`, `.json`, `.txt` by default). Idempotent across re-runs.
+- **State**: a `psf_guard_archive` sibling table in the same SQLite file
+  records each move, keyed on `acquiredimage.guid` (TS plugin migration
+  22). The plan deliberately avoids stamping the upstream `metadata`
+  JSON column (TS's `ImageMetadata` DTO drops unknown keys on
+  round-trip, see plan §3). Each archive root also gets a redundant
+  `.psf-guard-manifest.json` for disaster recovery.
+- **Config precedence**: CLI flags > per-DB `reject_archive` block in
+  the registry (`segment_name`, `depth`, `sidecar_exts`) > compiled-in
+  defaults (`REJECT`, `1`, `[.xisf, .json, .txt]`).
+- **Schema requirement**: TS plugin schema v22+ (the `guid` column).
+  Older DBs are refused with an actionable error pointing at the
+  legacy `filter-rejected` command.
+- **Legacy**: `psf-guard filter-rejected <db> <base>` still works
+  (still useful for its `--stat-*` statistical-regrading flags) but
+  prints a deprecation banner pointing at `move-rejects`.
+
+Design, phases, tracker: [REJECT_ARCHIVE_PLAN.md](./REJECT_ARCHIVE_PLAN.md).
+
 ### Smart Binary Mode Selection
 - **Single binary** `psf-guard` with intelligent mode detection
 - **GUI mode**: When tauri feature is enabled and no arguments passed → Desktop app launches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,13 +67,24 @@ Implementation tracker and design rationale: [MULTI_DB_PLAN.md](./MULTI_DB_PLAN.
 - **Command**: `psf-guard move-rejects --db <slug>` (multi-DB-aware via the
   registry). Moves files marked `gradingStatus = 2` to
   `<image_dir>/<P>/REJECT/<rest>` by default, plus same-stem sidecars
-  (`.xisf`, `.json`, `.txt` by default). Idempotent across re-runs.
+  (`.xisf`, `.json`, `.txt` by default). Idempotent across re-runs. Files
+  stay findable in the web UI — the directory tree indexes the REJECT
+  subtree and resolves previews by basename. `--dry-run` performs no DB
+  writes (the `psf_guard_archive` table is not even created).
+- **Restore**: `psf-guard restore-rejects --db <slug>` reverses a move. By
+  default restores only rows whose current grade is no longer `Rejected`
+  (un-rejected in the UI, to Accepted *or* Pending); `--all` /
+  `--image-id` / `--guid` override that. Never overwrites — restores
+  beside an occupant with a `.restored[.N]` suffix. Deletes the archive
+  row and prunes emptied REJECT dirs (a dir still holding the manifest is
+  kept).
 - **State**: a `psf_guard_archive` sibling table in the same SQLite file
   records each move, keyed on `acquiredimage.guid` (TS plugin migration
   22). The plan deliberately avoids stamping the upstream `metadata`
   JSON column (TS's `ImageMetadata` DTO drops unknown keys on
-  round-trip, see plan §3). Each archive root also gets a redundant
-  `.psf-guard-manifest.json` for disaster recovery.
+  round-trip, see plan §3). Each archive root
+  (`<image_dir>/<P>/REJECT/.psf-guard-manifest.json`, one per tree — not
+  per leaf) also gets a redundant manifest for disaster recovery.
 - **Config precedence**: CLI flags > per-DB `reject_archive` block in
   the registry (`segment_name`, `depth`, `sidecar_exts`) > compiled-in
   defaults (`REJECT`, `1`, `[.xisf, .json, .txt]`).

--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ psf-guard move-rejects --db <slug> [--dry-run]
                        [--sidecar-exts ".xisf,.json,.txt"]
                        [--project NAME] [--target NAME]
 
+# Move archived rejects back into the tree. By default restores only files
+# you've un-rejected in the UI (grade no longer Rejected); --all restores
+# everything. Never overwrites — restores beside an occupant with a
+# `.restored` suffix. Removes the archive row and prunes emptied dirs.
+psf-guard restore-rejects --db <slug> [--all]
+                          [--image-id N] [--guid X] [--dry-run]
+
 # Legacy: in-place rename `LIGHT/` → `LIGHT_REJECT/` as a sibling folder
 # under the same project root. Deprecated — files stay in the same tree
 # PixInsight loads. Still works for the statistical-regrading flags

--- a/README.md
+++ b/README.md
@@ -274,7 +274,18 @@ psf-guard server --registry /tmp/scratch.json <database> <image-dirs...>
 # from the registry)
 psf-guard server --config psf-guard.toml [--port 8080]  # CLI overrides config
 
-# Move rejected images  
+# Archive rejected images out of the directory tree PixInsight scans
+# (default: <image_dir>/<Project>/REJECT/<rest> with same-stem sidecars).
+# Idempotent and reversible — see REJECT_ARCHIVE_PLAN.md for the design.
+psf-guard move-rejects --db <slug> [--dry-run]
+                       [--reject-segment NAME] [--reject-depth N]
+                       [--sidecar-exts ".xisf,.json,.txt"]
+                       [--project NAME] [--target NAME]
+
+# Legacy: in-place rename `LIGHT/` → `LIGHT_REJECT/` as a sibling folder
+# under the same project root. Deprecated — files stay in the same tree
+# PixInsight loads. Still works for the statistical-regrading flags
+# (`--stat-*`) that `move-rejects` doesn't duplicate.
 psf-guard filter-rejected <database> <image-dir> [--dry-run] [--project NAME]
 
 # Star detection analysis

--- a/REJECT_ARCHIVE_PLAN.md
+++ b/REJECT_ARCHIVE_PLAN.md
@@ -339,7 +339,7 @@ mergeable commit.
 ### Implementation
 - [x] **A1** Schema bootstrap (`psf_guard_archive` table) + version check
 - [x] **A2** Per-DB `reject_archive` registry field (additive)
-- [ ] **A3** `archive_path_for` pure function + tests
+- [x] **A3** `archive_path_for` pure function + tests
 - [ ] **A4** `find_sidecars` discovery + tests
 - [ ] **A5** `psf-guard move-rejects` CLI command (multi-DB-aware) with transactional move + DB row + manifest entry
 - [ ] **A6** Deprecation shim for `filter-rejected`

--- a/REJECT_ARCHIVE_PLAN.md
+++ b/REJECT_ARCHIVE_PLAN.md
@@ -341,7 +341,7 @@ mergeable commit.
 - [x] **A2** Per-DB `reject_archive` registry field (additive)
 - [x] **A3** `archive_path_for` pure function + tests
 - [x] **A4** `find_sidecars` discovery + tests
-- [ ] **A5** `psf-guard move-rejects` CLI command (multi-DB-aware) with transactional move + DB row + manifest entry
+- [x] **A5** `psf-guard move-rejects` CLI command (multi-DB-aware) with transactional move + DB row + manifest entry
 - [ ] **A6** Deprecation shim for `filter-rejected`
 - [ ] **A7** Integration test against a synthesized NINA-style tempdir
 

--- a/REJECT_ARCHIVE_PLAN.md
+++ b/REJECT_ARCHIVE_PLAN.md
@@ -1,0 +1,359 @@
+# Out-of-Tree Reject Archive — Design & Implementation Plan
+
+Status: **Draft / not started**
+Owner: TBD
+Last updated: 2026-05-20
+
+## 1. Goal
+
+Move user-rejected FITS files (DB `gradingStatus = 2`) out of the directory
+tree that PixInsight loads in bulk, while keeping them findable per-project.
+Today's `psf-guard filter-rejected` only renames `LIGHT/` → `LIGHT_REJECT/` as
+a sibling directory under the same project root — PixInsight users who point
+their session loader at the project still see the rejects unless they
+manually exclude that folder. We want a true out-of-tree archive that's
+discoverable per-project, configurable per-rig, and reversible.
+
+### Concrete outcomes
+
+- Rejected files (plus same-basename sidecars) land at:
+  `<image_dir>/<P>/REJECT/<original-subpath>/<file>` by default, where
+  `<P>` is the depth-1 segment under the configured image dir.
+- The CLI is the only trigger surface (no UI button in v1). It's multi-DB
+  aware via `--db <slug>`.
+- The action is **idempotent**: re-running skips files already archived.
+- Each move is recorded in a `psf_guard_archive` table in the same SQLite
+  database, joined on `acquiredimage.guid`. A redundant JSON manifest lives
+  at the REJECT root so disaster recovery (lost DB) is still possible.
+- A future `psf-guard restore-rejects` command (out of scope for v1 but
+  designed for) reverses the move using the recorded state.
+
+### Non-goals (v1)
+- No automatic move when the user clicks "reject" in the web UI — that
+  stays a DB-only operation. Archiving is an explicit batch action.
+- No HTTP API. The CLI is the only entry point.
+- No deletion. We move files; we never `rm` them.
+- No multi-base-dir conflict resolution beyond "each image_dir evaluated
+  independently against the file's actual location."
+
+---
+
+## 2. Current state (survey, single-DB)
+
+- **CLI**: `psf-guard filter-rejected <db> <base_dir> [--dry-run] [--project] [--target]` (`src/cli.rs:47-72`, `src/cli_main.rs:36-58`). Pre-multi-DB; takes a `&Connection` directly.
+- **Core**: `src/commands/filter_rejected.rs` — queries DB for `gradingStatus = 2`, generates ~28 candidate paths per image via `get_possible_paths` (date ±1 day, several reject-folder naming conventions), falls back to `DirectoryTree::find_file_first`.
+- **Move action**: `process_file_movement:258-266` — string-substitutes `/LIGHT/` → `/LIGHT_REJECT/` in the source path, `fs::rename` to that. Sibling folder, same tree.
+- **No state tracking**: `gradingStatus = 2` means "user rejected"; no flag for "file has been physically moved." Re-runs hit not-found errors silently.
+- **No sidecar handling**: only the primary FITS file moves. `.xisf`, plate-solve `.json`, mask files stay.
+- **No undo**.
+- **Zero integration tests**.
+- **UI never invokes it**: web UI's reject button only sets `gradingStatus = 2`; users drop to a terminal afterward.
+
+---
+
+## 3. Target Scheduler schema research
+
+Done; full report in conversation thread, summary here.
+
+- `acquiredimage.metadata` is **TEXT NOT NULL** owned by the Target Scheduler
+  plugin. The C# DTO (`ImageMetadata`) deserializes with Newtonsoft defaults
+  (`MissingMemberHandling.Ignore`, no `[JsonExtensionData]`). Round-tripping
+  through the `Metadata` property pair is **lossy by design**: unknown keys
+  are silently dropped on read.
+- **Today** no upstream code path round-trips: writes on existing rows
+  (`Grading/ImageGrader.cs` `UpdateDatabase`) mutate `GradingStatus` and
+  `RejectReason` only, and EF6 sends the unchanged `metadata` string back
+  verbatim. So extra keys would survive — for now.
+- **Future risk**: any new upstream PR that does
+  `acquiredImage.Metadata = newMetadata` anywhere strips our annotations
+  silently. Detecting that requires monitoring the upstream repo.
+- **No annotation columns** (no `notes`, `comments`, `tags`, etc.) on
+  `acquiredimage`. The sibling `imagedata` table is for thumbnail BLOBs.
+- **`guid` column** (added in migration 22) is explicitly designed as a
+  cross-tool identifier; it's stable across export/reimport whereas `Id`
+  is auto-increment.
+
+**Decision**: do NOT stamp `metadata`. Use a new sibling table
+(`psf_guard_archive`) in the same SQLite file, keyed on `acquiredimage.guid`.
+Plus a JSON manifest at the REJECT root for redundancy.
+
+---
+
+## 4. Design
+
+### 4.1 Destination rule
+
+Compute the archive path from `(image_dir, source_path)`:
+
+```
+relative   = source_path.strip_prefix(image_dir)
+segments   = relative.path_components()
+if segments.len() >= depth + 1:
+    head, tail = segments[..depth], segments[depth..]
+    archive  = image_dir / head.join(/) / segment_name / tail.join(/)
+else:
+    # File lives shallower than the configured depth. Fall back to
+    # placing it directly under <image_dir>/<segment_name>/<file>.
+    archive  = image_dir / segment_name / relative
+```
+
+Defaults:
+- `segment_name = "REJECT"`
+- `depth = 1` (insert below the project folder)
+
+Example with depth=1, segment="REJECT":
+
+| Source | Archive |
+|---|---|
+| `Targets/M31/2026-04-16/B/LIGHT/img.fits` | `Targets/M31/REJECT/2026-04-16/B/LIGHT/img.fits` |
+| `Targets/M42/LIGHT/img.fits` | `Targets/M42/REJECT/LIGHT/img.fits` |
+| `Targets/img.fits` (depth-0) | `Targets/REJECT/img.fits` |
+
+### 4.2 Config precedence
+
+CLI flag > per-DB registry override > global default.
+
+- Global default: `{ segment_name: "REJECT", depth: 1, sidecar_exts: [".xisf", ".json", ".txt"] }`. Hardcoded in source.
+- Per-DB registry override: optional `reject_archive` block in each `DbEntry`. New fields on the JSON shape (additive — old configs keep working):
+  ```jsonc
+  {
+    "id": "imaging-rig",
+    "name": "Imaging Rig",
+    "db_path": "...",
+    "image_dirs": [...],
+    "reject_archive": {            // optional
+      "segment_name": "REJECT",    // optional
+      "depth": 1,                  // optional
+      "sidecar_exts": [".xisf", ".json"]  // optional
+    }
+  }
+  ```
+- CLI: `--reject-segment NAME`, `--reject-depth N`, `--sidecar-exts ".xisf,.json"` override the per-DB / global values for this invocation only.
+
+### 4.3 Sidecar handling
+
+For each rejected file, after locating the primary on disk, collect siblings
+in the same directory whose **stem matches** and whose **extension is in
+the configured `sidecar_exts` list** (case-insensitive compare on the ext).
+Move every match alongside the primary into the same archive directory.
+
+Calibration masters (`Bias_*.fits`, `Dark_*.fits`, etc.) have a different
+stem and are therefore never selected.
+
+### 4.4 State tracking — sibling table on the TS database
+
+The metadata-column stamping path is rejected (see §3). Use a sibling table:
+
+```sql
+CREATE TABLE IF NOT EXISTS psf_guard_archive (
+  acquired_image_guid TEXT PRIMARY KEY,  -- joins to acquiredimage.guid
+  acquired_image_id   INTEGER NOT NULL,  -- joins to acquiredimage.Id (current run convenience)
+  moved_at            INTEGER NOT NULL,  -- unix seconds
+  original_path       TEXT NOT NULL,
+  archive_path        TEXT NOT NULL,
+  segment_name        TEXT NOT NULL,
+  archive_depth       INTEGER NOT NULL,
+  sidecar_files       TEXT NOT NULL DEFAULT '[]',  -- JSON array of relative sidecar names
+  source_db_slug      TEXT                          -- our registry slug, for cross-DB tooling later
+);
+CREATE INDEX IF NOT EXISTS idx_psf_guard_archive_image_id ON psf_guard_archive(acquired_image_id);
+```
+
+The table is **owned by psf-guard**. It doesn't shadow the upstream
+`gradingStatus` field — `gradingStatus = 2` means "user marked rejected,"
+and presence in `psf_guard_archive` means "file has been moved."
+
+Idempotency: before moving a file, check if a row exists for that
+`acquired_image_guid` (or `acquired_image_id` if guid is missing). If yes
+and the archive path exists, skip. If yes and the archive path is missing,
+log and skip (manual intervention; we don't auto-recover).
+
+**Requires** Target Scheduler schema `user_version >= 22` for the `guid`
+column. Older DBs are detected at startup of the command — emit a clear
+error pointing the user at how to upgrade their plugin.
+
+### 4.5 Manifest at the REJECT root
+
+A redundant JSON file lives at `<image_dir>/<P>/REJECT/.psf-guard-manifest.json`
+(one per archive root). Schema:
+
+```jsonc
+{
+  "version": 1,
+  "moves": [
+    {
+      "guid": "...",
+      "image_id": 42,
+      "moved_at": 1776470400,
+      "original_path": "...",
+      "archive_path": "...",
+      "sidecar_files": ["img.xisf", "img.json"],
+      "segment_name": "REJECT",
+      "archive_depth": 1
+    }
+  ]
+}
+```
+
+Appended to atomically (write to `.tmp`, rename). Used only for disaster
+recovery if the DB is lost; the table is the authoritative source.
+
+### 4.6 CLI surface
+
+A new subcommand replaces the existing one (which becomes a deprecated
+alias):
+
+```
+psf-guard move-rejects --db <slug> [--dry-run]
+                       [--reject-segment NAME] [--reject-depth N]
+                       [--sidecar-exts ".xisf,.json,.txt"]
+                       [--registry <path>]
+                       [--project NAME] [--target NAME]
+```
+
+- `--db <slug>` — required. Looks up the entry in the shared registry.
+- Project/target filters narrow scope (same as today).
+- `--dry-run` prints the plan (source → destination, sidecars) without
+  touching disk or the DB.
+- `--registry <path>` overrides the default registry location (matches the
+  server flag from B3 of the multi-DB work, for dev/test isolation).
+
+The legacy `filter-rejected <db> <base_dir>` stays as a thin alias that
+prints a deprecation warning, looks up the DB in the registry by canonical
+path of the supplied `<db>`, and calls into the new code with default
+arguments. Removed in a future cycle once the docs and any scripts catch up.
+
+### 4.7 Restore command (future, designed-for-but-not-built)
+
+Out of scope for v1, but the shape is dictated by the state-tracking
+design:
+
+```
+psf-guard restore-rejects --db <slug> [--image-id N] [--guid X] [--dry-run]
+```
+
+Reads `psf_guard_archive`, moves each archived file (plus sidecars) back to
+`original_path`, and deletes the row. Errors on rows whose archive path no
+longer exists.
+
+---
+
+## 5. Implementation phases
+
+Each phase ends in a green build (`cargo build && cargo test`) and a
+mergeable commit.
+
+### Phase A1 — Schema bootstrap + read helpers
+- `src/db.rs`: add `ensure_psf_guard_archive_table(&Connection)` that issues
+  the `CREATE TABLE IF NOT EXISTS` + index. Called at start of any command
+  that uses it.
+- Read helper: `get_archive_record(guid_or_id) -> Option<ArchiveRecord>`.
+- Schema-version check: `assert_target_scheduler_schema(>= 22)` reads
+  `PRAGMA user_version`. Older DB → clear error with upgrade hint.
+- Unit tests against an in-memory SQLite.
+
+### Phase A2 — Per-DB registry field
+- Extend `DbEntry` in `src/db_registry.rs` with optional `reject_archive`
+  block. Default-construct when absent. Backwards-compatible: existing
+  v2 configs load unchanged.
+- Round-trip test (load → save → load).
+- Update the Tauri settings types (`static/src/utils/tauri.ts`) so future
+  settings UI can edit it. UI editor is *not* added in v1.
+
+### Phase A3 — Destination computation
+- Pure function `archive_path_for(image_dir, source_path, depth, segment)`
+  in a new `src/commands/reject_archive.rs`. No I/O.
+- Property tests over realistic NINA path shapes; explicit unit tests
+  for the depth-0 edge case and multi-`image_dir` independence.
+
+### Phase A4 — Sidecar discovery
+- `find_sidecars(primary_path, exts) -> Vec<PathBuf>`. Tested against a
+  tempdir layout including non-matching siblings and calibration masters.
+
+### Phase A5 — `move-rejects` command
+- New `Commands::MoveRejects` clap variant + handler in `src/cli_main.rs`.
+- Reuses existing `query_images` + `get_possible_paths` + `DirectoryTree`
+  fallback for source-on-disk discovery.
+- For each rejected row:
+  1. Check `psf_guard_archive` — skip if already moved.
+  2. Compute destination + sidecars.
+  3. Print plan (dry-run exits here).
+  4. `fs::create_dir_all` destination parent.
+  5. `fs::rename` primary, then each sidecar.
+  6. INSERT row into `psf_guard_archive`.
+  7. Append entry to the REJECT-root manifest.
+- Transactional behavior: if step 4 or 5 fails, rollback any moves already
+  made for this image (move them back) before failing the run. The DB
+  insert (step 6) is the commit point.
+
+### Phase A6 — Deprecation shim for `filter-rejected`
+- Keep the existing command but emit a warning and call into the new path
+  with default args. Update README + CLAUDE.md.
+
+### Phase A7 — Integration test
+- Synthesize a tiny SQLite (the test-fixture pattern from
+  `tests/integration_sequence_analysis.rs::create_test_schema`) plus a
+  tempdir with realistic NINA-style folder layout. Bump `user_version` to
+  22 and populate a `guid` column.
+- Spec: register 3 rejected images, run `move-rejects --dry-run`, assert
+  the plan; run for real, assert files moved + sidecars moved + rows
+  inserted + manifest written; re-run, assert no-op.
+
+### Phase A8 (future) — `restore-rejects`
+- Designed for in §4.7; not built in v1.
+
+---
+
+## 6. Open questions / deferred work
+
+- **Multiple image_dirs configured for the same DB**: today each is
+  scanned for the source file; archive lands relative to whichever dir
+  the file was found under. Need to confirm this matches user
+  expectation — if a file in dir B should always archive into dir A
+  (preferred archive root), we need an explicit `archive_root` per DB
+  rather than computing from `image_dir`.
+- **Cross-DB archive search** (looking up "where was this file archived?"
+  given just a filename): possible later via the `psf_guard_archive`
+  table since `original_path` is recorded.
+- **Restore command**: phase A8, after v1 ships and we have real moves
+  in the wild.
+- **Guid backfill**: if a user has a TS DB at `user_version >= 22` but
+  the `guid` column was populated only for newly-acquired images
+  (existing rows have NULL), we may need a backfill path. Need to
+  check whether TS backfills on migration or only on INSERT going
+  forward.
+- **UI trigger**: not in v1, but eventually a "Move rejected files
+  out-of-tree" button on each DB section in the merged Overview would
+  close the workflow loop. Gated behind `--allow-database-management`
+  (same gate as the existing CRUD endpoints).
+
+---
+
+## 7. Task tracker
+
+`[ ]` pending, `[~]` in progress, `[x]` done.
+
+### Research
+- [x] Verify safety of stamping `acquiredimage.metadata` (verdict: unsafe long-term; pivot to sibling table on `acquiredimage.guid`)
+
+### Implementation
+- [x] **A1** Schema bootstrap (`psf_guard_archive` table) + version check
+- [ ] **A2** Per-DB `reject_archive` registry field (additive)
+- [ ] **A3** `archive_path_for` pure function + tests
+- [ ] **A4** `find_sidecars` discovery + tests
+- [ ] **A5** `psf-guard move-rejects` CLI command (multi-DB-aware) with transactional move + DB row + manifest entry
+- [ ] **A6** Deprecation shim for `filter-rejected`
+- [ ] **A7** Integration test against a synthesized NINA-style tempdir
+
+### Docs / follow-up
+- [ ] Update `README.md` (CLI section)
+- [ ] Update `CLAUDE.md` (Architecture / Multi-database support note)
+- [ ] Watch upstream `tcpalmer/nina.plugin.targetscheduler` for any new
+      writes to `acquiredImage.Metadata` (would invalidate the residual
+      "metadata stamping is safe today" claim — we're not relying on it,
+      but a regression there could affect anyone else who is)
+
+### Deferred
+- [ ] **A8** `psf-guard restore-rejects` command
+- [ ] UI trigger (button on Overview DB section)
+- [ ] Cross-DB archive lookup helper

--- a/REJECT_ARCHIVE_PLAN.md
+++ b/REJECT_ARCHIVE_PLAN.md
@@ -1,7 +1,7 @@
 # Out-of-Tree Reject Archive — Design & Implementation Plan
 
-Status: **Draft / not started**
-Owner: TBD
+Status: **Implemented (A1–A7); A8 restore-rejects in progress**
+Owner: psf-guard maintainers
 Last updated: 2026-05-20
 
 ## 1. Goal
@@ -223,18 +223,36 @@ prints a deprecation warning, looks up the DB in the registry by canonical
 path of the supplied `<db>`, and calls into the new code with default
 arguments. Removed in a future cycle once the docs and any scripts catch up.
 
-### 4.7 Restore command (future, designed-for-but-not-built)
-
-Out of scope for v1, but the shape is dictated by the state-tracking
-design:
+### 4.7 Restore command (implemented, A8)
 
 ```
-psf-guard restore-rejects --db <slug> [--image-id N] [--guid X] [--dry-run]
+psf-guard restore-rejects --db <slug> [--all]
+                          [--image-id N] [--guid X]
+                          [--dry-run] [--registry <path>] [--verbose]
 ```
 
-Reads `psf_guard_archive`, moves each archived file (plus sidecars) back to
-`original_path`, and deletes the row. Errors on rows whose archive path no
-longer exists.
+Reads `psf_guard_archive` (LEFT JOIN to `acquiredimage` on `guid` for the
+current grade), moves each eligible archived file plus sidecars back toward
+`original_path`, deletes the row, and prunes emptied archive directories.
+
+- **Default scope:** only rows whose current `gradingStatus` is no longer
+  `Rejected` — i.e. files un-rejected in the UI, whether re-Accepted or set
+  back to Pending (the `U` undo key). This is the everyday "I changed my
+  mind, bring it back" flow and the reason the join exists.
+- `--all` restores every archived row regardless of current grade.
+- `--image-id N` / `--guid X` target a single row and restore it regardless
+  of grade (an explicit, deliberate request).
+- **Never overwrites.** If `original_path` (or a sidecar's original path) is
+  occupied by a different file, the restored file lands beside it with a
+  `.restored` suffix inserted before the extension (`img.fits` →
+  `img.restored.fits`, then `.restored.1`, … on further collision).
+- **Pruning.** After a successful restore the now-empty leaf archive dirs are
+  removed up to and including the `REJECT` segment, stopping at the first
+  non-empty directory. A `REJECT` dir that still holds the manifest (or other
+  not-yet-restored files) is kept.
+- Rows whose `archive_path` is missing on disk are reported (`missing_archive`
+  counter) and left in place so the loss stays visible.
+- `--dry-run` prints the plan without moving files or deleting rows.
 
 ---
 
@@ -349,9 +367,15 @@ mergeable commit.
 - [x] **A5** `psf-guard move-rejects` CLI command (multi-DB-aware) with transactional move + DB row + manifest entry
 - [x] **A6** Deprecation shim for `filter-rejected`
 - [x] **A7** Integration test against a synthesized NINA-style tempdir
-  (`tests/integration_reject_archive.rs`, 4 cases: dry-run, live move +
-  sidecar discrimination + manifest, idempotent re-run, legacy DB
-  refusal)
+  (`tests/integration_reject_archive.rs`: move cases — dry-run, live move +
+  sidecar discrimination + single manifest at REJECT root, idempotent
+  re-run, legacy DB refusal; restore cases — default un-rejected-only,
+  `--all` + dir pruning, never-overwrite suffix, dry-run, targeted-by-guid)
+- [x] **A8** `psf-guard restore-rejects` command — default restores files no
+  longer graded Rejected; `--all` / `--image-id` / `--guid` override the
+  grade filter; never overwrites (`.restored[.N]` suffix beside an
+  occupant); deletes the archive row and prunes emptied REJECT dirs
+  (keeping a dir that still holds the manifest)
 
 ### Docs / follow-up
 - [x] Update `README.md` (CLI section)
@@ -362,6 +386,5 @@ mergeable commit.
       but a regression there could affect anyone else who is)
 
 ### Deferred
-- [ ] **A8** `psf-guard restore-rejects` command
 - [ ] UI trigger (button on Overview DB section)
 - [ ] Cross-DB archive lookup helper

--- a/REJECT_ARCHIVE_PLAN.md
+++ b/REJECT_ARCHIVE_PLAN.md
@@ -348,7 +348,10 @@ mergeable commit.
 - [x] **A4** `find_sidecars` discovery + tests
 - [x] **A5** `psf-guard move-rejects` CLI command (multi-DB-aware) with transactional move + DB row + manifest entry
 - [x] **A6** Deprecation shim for `filter-rejected`
-- [ ] **A7** Integration test against a synthesized NINA-style tempdir
+- [x] **A7** Integration test against a synthesized NINA-style tempdir
+  (`tests/integration_reject_archive.rs`, 4 cases: dry-run, live move +
+  sidecar discrimination + manifest, idempotent re-run, legacy DB
+  refusal)
 
 ### Docs / follow-up
 - [x] Update `README.md` (CLI section)

--- a/REJECT_ARCHIVE_PLAN.md
+++ b/REJECT_ARCHIVE_PLAN.md
@@ -286,9 +286,14 @@ mergeable commit.
   made for this image (move them back) before failing the run. The DB
   insert (step 6) is the commit point.
 
-### Phase A6 — Deprecation shim for `filter-rejected`
-- Keep the existing command but emit a warning and call into the new path
-  with default args. Update README + CLAUDE.md.
+### Phase A6 — Deprecation notice on `filter-rejected`
+- Print a one-time deprecation warning at the top of the command that
+  points users at `move-rejects` for the out-of-tree archiving flow.
+- Keep the old behavior working — the existing command also runs
+  statistical analysis (`--stat-*` flags) that `move-rejects` doesn't
+  duplicate, and silently redirecting would break workflows. Removal
+  in a future cycle once the docs settle.
+- Update README + CLAUDE.md with the new command and a migration note.
 
 ### Phase A7 — Integration test
 - Synthesize a tiny SQLite (the test-fixture pattern from
@@ -342,12 +347,12 @@ mergeable commit.
 - [x] **A3** `archive_path_for` pure function + tests
 - [x] **A4** `find_sidecars` discovery + tests
 - [x] **A5** `psf-guard move-rejects` CLI command (multi-DB-aware) with transactional move + DB row + manifest entry
-- [ ] **A6** Deprecation shim for `filter-rejected`
+- [x] **A6** Deprecation shim for `filter-rejected`
 - [ ] **A7** Integration test against a synthesized NINA-style tempdir
 
 ### Docs / follow-up
-- [ ] Update `README.md` (CLI section)
-- [ ] Update `CLAUDE.md` (Architecture / Multi-database support note)
+- [x] Update `README.md` (CLI section)
+- [x] Update `CLAUDE.md` (Architecture / Multi-database support note)
 - [ ] Watch upstream `tcpalmer/nina.plugin.targetscheduler` for any new
       writes to `acquiredImage.Metadata` (would invalidate the residual
       "metadata stamping is safe today" claim — we're not relying on it,

--- a/REJECT_ARCHIVE_PLAN.md
+++ b/REJECT_ARCHIVE_PLAN.md
@@ -338,7 +338,7 @@ mergeable commit.
 
 ### Implementation
 - [x] **A1** Schema bootstrap (`psf_guard_archive` table) + version check
-- [ ] **A2** Per-DB `reject_archive` registry field (additive)
+- [x] **A2** Per-DB `reject_archive` registry field (additive)
 - [ ] **A3** `archive_path_for` pure function + tests
 - [ ] **A4** `find_sidecars` discovery + tests
 - [ ] **A5** `psf-guard move-rejects` CLI command (multi-DB-aware) with transactional move + DB row + manifest entry

--- a/REJECT_ARCHIVE_PLAN.md
+++ b/REJECT_ARCHIVE_PLAN.md
@@ -340,7 +340,7 @@ mergeable commit.
 - [x] **A1** Schema bootstrap (`psf_guard_archive` table) + version check
 - [x] **A2** Per-DB `reject_archive` registry field (additive)
 - [x] **A3** `archive_path_for` pure function + tests
-- [ ] **A4** `find_sidecars` discovery + tests
+- [x] **A4** `find_sidecars` discovery + tests
 - [ ] **A5** `psf-guard move-rejects` CLI command (multi-DB-aware) with transactional move + DB row + manifest entry
 - [ ] **A6** Deprecation shim for `filter-rejected`
 - [ ] **A7** Integration test against a synthesized NINA-style tempdir

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,7 +43,6 @@ pub enum Commands {
         project: String,
     },
 
-    /// Filter rejected files and move them to LIGHT_REJECT folders
     /// Move rejected files out of the directory tree PixInsight scans.
     ///
     /// Walks `gradingStatus = 2` images for the specified database (selected
@@ -59,7 +58,8 @@ pub enum Commands {
         #[arg(long)]
         db: String,
 
-        /// Perform a dry run (print the plan; no files moved, no DB writes)
+        /// Perform a dry run (print the plan; no files moved, no DB writes —
+        /// the `psf_guard_archive` table is not created in dry-run mode).
         #[arg(long)]
         dry_run: bool,
 
@@ -91,6 +91,46 @@ pub enum Commands {
         target: Option<String>,
 
         /// Verbose: print per-image trace including paths that didn't match.
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Move archived rejects back into the directory tree.
+    ///
+    /// Reverses `move-rejects`. By default restores only files that are no
+    /// longer graded `Rejected` (i.e. you un-rejected them in the UI — to
+    /// Accepted or Pending); use `--all` to restore everything in the
+    /// archive. Never overwrites: if the original path is occupied, the file
+    /// is restored beside it with a `.restored` suffix. On success the
+    /// `psf_guard_archive` row is removed and emptied REJECT directories are
+    /// pruned (a directory left holding only the manifest is kept).
+    RestoreRejects {
+        /// Slug of the database (from the registry) to operate on.
+        #[arg(long)]
+        db: String,
+
+        /// Restore every archived row regardless of current grade.
+        #[arg(long)]
+        all: bool,
+
+        /// Restore only this acquiredimage Id (regardless of grade).
+        #[arg(long)]
+        image_id: Option<i64>,
+
+        /// Restore only this acquiredimage guid (regardless of grade).
+        #[arg(long)]
+        guid: Option<String>,
+
+        /// Perform a dry run (print the plan; no files moved, no DB writes).
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Path to the database registry JSON file (defaults to the platform
+        /// config directory). Useful for dev/test isolation.
+        #[arg(long)]
+        registry: Option<String>,
+
+        /// Verbose: print per-image trace.
         #[arg(short, long)]
         verbose: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,57 @@ pub enum Commands {
     },
 
     /// Filter rejected files and move them to LIGHT_REJECT folders
+    /// Move rejected files out of the directory tree PixInsight scans.
+    ///
+    /// Walks `gradingStatus = 2` images for the specified database (selected
+    /// from the registry by slug), looks them up on disk under the DB's
+    /// configured image_dirs, and moves each one — plus same-stem sidecars —
+    /// to `<image_dir>/<P>/REJECT/<rest>` by default. Idempotent: re-runs
+    /// skip rows already recorded in the `psf_guard_archive` sibling table.
+    ///
+    /// See REJECT_ARCHIVE_PLAN.md for the full design. Eventually deprecates
+    /// `filter-rejected`.
+    MoveRejects {
+        /// Slug of the database (from the registry) to operate on.
+        #[arg(long)]
+        db: String,
+
+        /// Perform a dry run (print the plan; no files moved, no DB writes)
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Override the archive segment name (default `REJECT`).
+        #[arg(long)]
+        reject_segment: Option<String>,
+
+        /// Override the depth at which the segment is inserted (default 1 —
+        /// just below the project folder).
+        #[arg(long)]
+        reject_depth: Option<u32>,
+
+        /// Override the sidecar extension list (comma-separated, e.g.
+        /// `.xisf,.json,.txt`).
+        #[arg(long, value_delimiter = ',')]
+        sidecar_exts: Option<Vec<String>>,
+
+        /// Path to the database registry JSON file (defaults to the platform
+        /// config directory). Useful for dev/test isolation.
+        #[arg(long)]
+        registry: Option<String>,
+
+        /// Filter by project name (substring match)
+        #[arg(short, long)]
+        project: Option<String>,
+
+        /// Filter by target name (substring match)
+        #[arg(short, long)]
+        target: Option<String>,
+
+        /// Verbose: print per-image trace including paths that didn't match.
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
     FilterRejected {
         /// Database file to use
         database: String,

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -33,6 +33,78 @@ pub fn main() -> Result<()> {
                 .with_context(|| format!("Failed to open database: {}", cli.database))?;
             list_targets(&conn, &project)?;
         }
+        Commands::MoveRejects {
+            db,
+            dry_run,
+            reject_segment,
+            reject_depth,
+            sidecar_exts,
+            registry,
+            project,
+            target,
+            verbose,
+        } => {
+            use crate::commands::reject_archive::{
+                ensure_archive_schema, move_rejects, require_target_scheduler_guid, resolve_config,
+                MoveRejectsOptions,
+            };
+            use crate::db_registry::DbRegistry;
+            use std::path::PathBuf;
+
+            let registry_path = match registry {
+                Some(p) => PathBuf::from(p),
+                None => DbRegistry::default_path().context("resolving default registry path")?,
+            };
+            let db_registry = DbRegistry::load_or_init(&registry_path)
+                .with_context(|| format!("loading registry at {}", registry_path.display()))?;
+            let entry = db_registry
+                .find(&db)
+                .ok_or_else(|| anyhow::anyhow!(
+                    "No database with slug '{}' in {} (use `psf-guard server` once to register, or hand-edit the file).",
+                    db,
+                    registry_path.display(),
+                ))?;
+            if entry.image_dirs.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Database '{}' has no image_dirs configured in the registry; \
+                     archiving needs to know where to search for files.",
+                    db
+                ));
+            }
+
+            let conn = Connection::open(&entry.db_path)
+                .with_context(|| format!("opening database at {}", entry.db_path))?;
+            require_target_scheduler_guid(&conn)?;
+            ensure_archive_schema(&conn)?;
+
+            let resolved = resolve_config(
+                entry.reject_archive.as_ref(),
+                reject_segment.as_deref(),
+                reject_depth,
+                sidecar_exts.as_deref(),
+            )?;
+
+            let options = MoveRejectsOptions {
+                config: resolved,
+                project_filter: project,
+                target_filter: target,
+                dry_run,
+                source_db_slug: entry.id.clone(),
+                verbose,
+            };
+
+            let summary = move_rejects(&conn, &entry.image_dirs, &options)?;
+            println!(
+                "\nReject archive {}: planned={}, archived={}, already_archived={}, not_found={}, errors={}",
+                if dry_run { "(dry-run)" } else { "(live)" },
+                summary.planned,
+                summary.archived,
+                summary.already_archived,
+                summary.not_found_on_disk,
+                summary.errors,
+            );
+        }
+
         Commands::FilterRejected {
             database,
             base_dir,

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -75,7 +75,11 @@ pub fn main() -> Result<()> {
             let conn = Connection::open(&entry.db_path)
                 .with_context(|| format!("opening database at {}", entry.db_path))?;
             require_target_scheduler_guid(&conn)?;
-            ensure_archive_schema(&conn)?;
+            // Dry-run must not write to the DB — defer table creation to live
+            // runs. move_rejects tolerates a missing table in dry-run mode.
+            if !dry_run {
+                ensure_archive_schema(&conn)?;
+            }
 
             let resolved = resolve_config(
                 entry.reject_archive.as_ref(),
@@ -95,12 +99,67 @@ pub fn main() -> Result<()> {
 
             let summary = move_rejects(&conn, &entry.image_dirs, &options)?;
             println!(
-                "\nReject archive {}: planned={}, archived={}, already_archived={}, not_found={}, errors={}",
+                "\nReject archive {}: planned={}, archived={}, already_archived={}, missing_archive={}, not_found={}, errors={}",
                 if dry_run { "(dry-run)" } else { "(live)" },
                 summary.planned,
                 summary.archived,
                 summary.already_archived,
+                summary.missing_archive,
                 summary.not_found_on_disk,
+                summary.errors,
+            );
+        }
+
+        Commands::RestoreRejects {
+            db,
+            all,
+            image_id,
+            guid,
+            dry_run,
+            registry,
+            verbose,
+        } => {
+            use crate::commands::reject_archive::{
+                require_target_scheduler_guid, restore_rejects, RestoreRejectsOptions,
+            };
+            use crate::db_registry::DbRegistry;
+            use std::path::PathBuf;
+
+            let registry_path = match registry {
+                Some(p) => PathBuf::from(p),
+                None => DbRegistry::default_path().context("resolving default registry path")?,
+            };
+            let db_registry = DbRegistry::load_or_init(&registry_path)
+                .with_context(|| format!("loading registry at {}", registry_path.display()))?;
+            let entry = db_registry
+                .find(&db)
+                .ok_or_else(|| anyhow::anyhow!(
+                    "No database with slug '{}' in {} (use `psf-guard server` once to register, or hand-edit the file).",
+                    db,
+                    registry_path.display(),
+                ))?;
+
+            let conn = Connection::open(&entry.db_path)
+                .with_context(|| format!("opening database at {}", entry.db_path))?;
+            require_target_scheduler_guid(&conn)?;
+
+            let options = RestoreRejectsOptions {
+                restore_all: all,
+                image_id_filter: image_id,
+                guid_filter: guid,
+                dry_run,
+                verbose,
+            };
+
+            let summary = restore_rejects(&conn, &options)?;
+            println!(
+                "\nRestore rejects {}: planned={}, restored={} (with_suffix={}), skipped_still_rejected={}, missing_archive={}, errors={}",
+                if dry_run { "(dry-run)" } else { "(live)" },
+                summary.planned,
+                summary.restored,
+                summary.restored_with_suffix,
+                summary.skipped_still_rejected,
+                summary.missing_archive,
                 summary.errors,
             );
         }

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -114,6 +114,18 @@ pub fn main() -> Result<()> {
             verbose,
             stat_options,
         } => {
+            eprintln!(
+                "⚠️  `filter-rejected` is deprecated. It renames `LIGHT/` → \
+                 `LIGHT_REJECT/` as a sibling under the same project root, \
+                 which PixInsight's bulk-load workflows still pick up.\n   \
+                 For an out-of-tree archive with idempotency, sidecar moves, \
+                 and a future restore path, register the DB in the registry \
+                 (run `psf-guard server <db> <dirs>` once) and use:\n     \
+                 psf-guard move-rejects --db <slug>\n   See \
+                 REJECT_ARCHIVE_PLAN.md for the full design. `filter-rejected` \
+                 still works for now and retains its statistical-analysis \
+                 flags that the new command does not duplicate.\n"
+            );
             let conn = Connection::open(&database)
                 .with_context(|| format!("Failed to open database: {}", database))?;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod list_projects;
 pub mod list_targets;
 pub mod read_fits;
 pub mod regrade;
+pub mod reject_archive;
 pub mod show_images;
 pub mod stretch_to_png;
 pub mod update_grade;

--- a/src/commands/reject_archive.rs
+++ b/src/commands/reject_archive.rs
@@ -193,6 +193,65 @@ pub fn archive_path_for(
     Some(archive)
 }
 
+/// Find sidecar files in the same directory as `primary` whose stem matches
+/// the primary's and whose extension is one of `exts`. Extension comparison
+/// is case-insensitive; entries in `exts` must start with a `.` (validated
+/// upstream in `resolve_config`).
+///
+/// Returns absolute paths sorted lexicographically for deterministic
+/// dry-run output and stable archive-record contents. Returns an empty
+/// vec — never errors — if the directory can't be read; the move
+/// orchestrator handles missing primaries earlier.
+///
+/// Calibration masters (`Bias_master.fits`, `Dark_*.fits`, etc.) have a
+/// different stem and are therefore never selected, even if their
+/// extension is in the list.
+pub fn find_sidecars(primary: &std::path::Path, exts: &[String]) -> Vec<std::path::PathBuf> {
+    let Some(parent) = primary.parent() else {
+        return Vec::new();
+    };
+    let Some(stem) = primary.file_stem() else {
+        return Vec::new();
+    };
+    let primary_filename = primary.file_name();
+
+    // Normalize the configured extensions once for the membership check.
+    let lc_exts: Vec<String> = exts
+        .iter()
+        .map(|e| e.trim_start_matches('.').to_ascii_lowercase())
+        .collect();
+
+    let entries = match std::fs::read_dir(parent) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut out: Vec<std::path::PathBuf> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if entry.file_type().map(|t| !t.is_file()).unwrap_or(true) {
+            continue;
+        }
+        // Don't list the primary as its own sidecar.
+        if primary_filename.is_some() && path.file_name() == primary_filename {
+            continue;
+        }
+        if path.file_stem() != Some(stem) {
+            continue;
+        }
+        let ext_lc = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase());
+        let Some(ext_lc) = ext_lc else { continue };
+        if lc_exts.iter().any(|want| *want == ext_lc) {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
 fn validate_sidecar_ext(ext: &str) -> Result<()> {
     if !ext.starts_with('.') {
         return Err(anyhow::anyhow!(
@@ -628,6 +687,84 @@ mod tests {
         )
         .unwrap();
         assert_eq!(archive, p("targets/M31/REJECT/2026-04-16/LIGHT/img.fits"));
+    }
+
+    #[test]
+    fn find_sidecars_picks_same_stem_only() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let primary = dir.path().join("img_0028.fits");
+        fs::write(&primary, b"").unwrap();
+
+        // Sidecars (should be picked up):
+        fs::write(dir.path().join("img_0028.xisf"), b"").unwrap();
+        fs::write(dir.path().join("img_0028.json"), b"").unwrap();
+        fs::write(dir.path().join("img_0028.txt"), b"").unwrap();
+
+        // Same stem but extension not in the list:
+        fs::write(dir.path().join("img_0028.log"), b"").unwrap();
+
+        // Different stem — typical calibration-master shape:
+        fs::write(dir.path().join("Bias_master.fits"), b"").unwrap();
+        fs::write(dir.path().join("Dark_60s.xisf"), b"").unwrap();
+
+        // Subdirectory should not be descended into:
+        let sub = dir.path().join("nested");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("img_0028.xisf"), b"").unwrap();
+
+        let exts: Vec<String> = [".xisf", ".json", ".txt"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let found = find_sidecars(&primary, &exts);
+
+        let expected = vec![
+            dir.path().join("img_0028.json"),
+            dir.path().join("img_0028.txt"),
+            dir.path().join("img_0028.xisf"),
+        ];
+        assert_eq!(found, expected);
+    }
+
+    #[test]
+    fn find_sidecars_extension_match_is_case_insensitive() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let primary = dir.path().join("img.fits");
+        fs::write(&primary, b"").unwrap();
+        fs::write(dir.path().join("img.XISF"), b"").unwrap();
+        fs::write(dir.path().join("img.Json"), b"").unwrap();
+
+        let exts: Vec<String> = [".xisf", ".json"].iter().map(|s| s.to_string()).collect();
+        let mut found = find_sidecars(&primary, &exts);
+        found.sort();
+        assert_eq!(found.len(), 2);
+        assert!(found.iter().any(|p| p.file_name().unwrap() == "img.XISF"));
+        assert!(found.iter().any(|p| p.file_name().unwrap() == "img.Json"));
+    }
+
+    #[test]
+    fn find_sidecars_returns_empty_when_parent_missing() {
+        let found = find_sidecars(
+            &std::path::Path::new("/no/such/dir/img.fits"),
+            &[".xisf".to_string()],
+        );
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn find_sidecars_excludes_the_primary_itself() {
+        // If exts somehow listed `.fits` (caller bug), the primary file
+        // itself should still not be returned as its own sidecar.
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let primary = dir.path().join("img.fits");
+        fs::write(&primary, b"").unwrap();
+
+        let exts = vec![".fits".to_string()];
+        let found = find_sidecars(&primary, &exts);
+        assert!(found.is_empty());
     }
 
     #[test]

--- a/src/commands/reject_archive.rs
+++ b/src/commands/reject_archive.rs
@@ -197,6 +197,53 @@ pub fn archive_path_for(
     Some(archive)
 }
 
+/// Compute the archive *root* directory for a rejected file: the path up to
+/// and including the inserted `segment_name`. This is where the single
+/// per-archive `.psf-guard-manifest.json` lives — one manifest per REJECT
+/// tree, not one per leaf directory.
+///
+/// ```text
+/// image_dir = /data
+/// source    = /data/M31/2026-04-16/LIGHT/img.fits   (depth=1, segment=REJECT)
+/// root      = /data/M31/REJECT
+/// ```
+///
+/// Returns `None` under exactly the same conditions as
+/// [`archive_path_for`] (source not under `image_dir`, or source == image_dir),
+/// so callers can compute both and treat a `Some`/`None` from one as
+/// authoritative for the other.
+pub fn archive_root_for(
+    image_dir: &std::path::Path,
+    source_path: &std::path::Path,
+    depth: u32,
+    segment_name: &str,
+) -> Option<std::path::PathBuf> {
+    use std::path::{Component, PathBuf};
+
+    let relative = source_path.strip_prefix(image_dir).ok()?;
+    let segments: Vec<&std::ffi::OsStr> = relative
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(s) => Some(s),
+            _ => None,
+        })
+        .collect();
+
+    if segments.is_empty() {
+        return None;
+    }
+
+    let depth = depth as usize;
+    let mut root = PathBuf::from(image_dir);
+    if depth != 0 && segments.len() > depth {
+        for seg in &segments[..depth] {
+            root.push(seg);
+        }
+    }
+    root.push(segment_name);
+    Some(root)
+}
+
 /// Find sidecar files in the same directory as `primary` whose stem matches
 /// the primary's and whose extension is one of `exts`. Extension comparison
 /// is case-insensitive; entries in `exts` must start with a `.` (validated
@@ -332,6 +379,20 @@ pub fn ensure_archive_schema(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Whether the `psf_guard_archive` table exists yet. Used by dry-run paths
+/// that must not create it: a missing table simply means "nothing archived
+/// yet," so callers treat every image as not-yet-archived.
+pub fn archive_table_exists(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'psf_guard_archive'",
+        [],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|o| o.is_some())
+    .unwrap_or(false)
+}
+
 /// Refuse to operate against a Target Scheduler database that pre-dates the
 /// `acquiredimage.guid` column (migration 22). Without `guid`, we have no
 /// stable cross-export key to anchor archive rows against; falling back to
@@ -390,6 +451,17 @@ pub fn get_archive_record_by_image_id(
     .context("querying psf_guard_archive by image_id")
 }
 
+/// Delete the archive record for a guid. Called by `restore-rejects` once a
+/// file is back at (near) its original location.
+pub fn delete_archive_record_by_guid(conn: &Connection, guid: &str) -> Result<()> {
+    conn.execute(
+        "DELETE FROM psf_guard_archive WHERE acquired_image_guid = ?1",
+        params![guid],
+    )
+    .with_context(|| format!("deleting psf_guard_archive row for guid {}", guid))?;
+    Ok(())
+}
+
 fn row_to_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArchiveRecord> {
     let sidecar_raw: String = row.get("sidecar_files")?;
     let sidecar_files = serde_json::from_str::<Vec<String>>(&sidecar_raw).unwrap_or_default();
@@ -430,6 +502,10 @@ pub struct MoveRejectsSummary {
     pub planned: usize,
     pub archived: usize,
     pub already_archived: usize,
+    /// Rows whose `psf_guard_archive` record exists but whose `archive_path`
+    /// is no longer on disk. Surfaced for manual intervention rather than
+    /// silently counted as `already_archived`.
+    pub missing_archive: usize,
     pub not_found_on_disk: usize,
     pub errors: usize,
 }
@@ -444,15 +520,19 @@ pub struct MoveRejectsSummary {
 /// one bad row still archives the other 99.
 ///
 /// The function assumes:
-/// - `ensure_archive_schema(conn)` has already been called (caller does).
 /// - `require_target_scheduler_guid(conn)` has passed (caller does).
 /// - `options.config` is valid (resolved through `resolve_config`).
+/// - For live runs, `ensure_archive_schema(conn)` has been called. In
+///   `--dry-run` mode the table may not exist yet (we deliberately don't
+///   create it); the prior-archive lookup is skipped in that case and every
+///   image is treated as not-yet-archived for planning purposes.
 pub fn move_rejects(
     conn: &Connection,
     image_dirs: &[String],
     options: &MoveRejectsOptions,
 ) -> Result<MoveRejectsSummary> {
     let db = Database::new(conn);
+    let archive_table_known = archive_table_exists(conn);
 
     let images = db
         .query_images(
@@ -468,21 +548,26 @@ pub fn move_rejects(
         ..Default::default()
     };
 
-    // Build a directory tree per image_dir (lazily). Each tree caches the
-    // first-hit basename → absolute-path mapping that powers the fallback
-    // lookup when the date-aware path heuristics miss.
-    let mut trees: Vec<DirectoryTree> = Vec::with_capacity(image_dirs.len());
-    for dir in image_dirs {
-        match DirectoryTree::build_multiple(&[std::path::Path::new(dir)]) {
-            Ok(t) => trees.push(t),
-            Err(e) => {
-                eprintln!(
-                    "⚠️  Could not index image directory {} ({}); continuing without it",
-                    dir, e
-                );
-            }
-        }
-    }
+    // Build a directory tree per image_dir. Each tree caches the first-hit
+    // basename → absolute-path mapping that powers the fallback lookup when
+    // the date-aware path heuristics miss. The vec is kept index-aligned with
+    // `image_dirs` (a failed build becomes `None`) so `trees[dir_idx]` always
+    // refers to the correct directory.
+    let trees: Vec<Option<DirectoryTree>> = image_dirs
+        .iter()
+        .map(
+            |dir| match DirectoryTree::build_multiple(&[std::path::Path::new(dir)]) {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    eprintln!(
+                        "⚠️  Could not index image directory {} ({}); continuing without it",
+                        dir, e
+                    );
+                    None
+                }
+            },
+        )
+        .collect();
 
     for (image, _project_name, target_name) in images {
         let Some(guid) = image.guid.as_deref() else {
@@ -497,13 +582,28 @@ pub fn move_rejects(
             continue;
         };
 
-        // Already archived? Skip silently (idempotent re-runs).
-        if let Some(prior) = get_archive_record_by_guid(conn, guid)? {
-            if options.verbose {
-                println!("⏭️  {} already archived at {}", guid, prior.archive_path);
+        // Already archived? Skip (idempotent re-runs). If the recorded
+        // archive_path has gone missing, surface it for manual intervention
+        // rather than masking a broken archive as a clean skip.
+        if archive_table_known {
+            if let Some(prior) = get_archive_record_by_guid(conn, guid)? {
+                if std::path::Path::new(&prior.archive_path).exists() {
+                    if options.verbose {
+                        println!("⏭️  {} already archived at {}", guid, prior.archive_path);
+                    }
+                    summary.already_archived += 1;
+                } else {
+                    eprintln!(
+                        "⚠️  Image id={} guid={} has a psf_guard_archive row pointing at \
+                         {} but that file is missing. Leaving the DB row in place; \
+                         resolve manually (restore from backup, or delete the row to \
+                         re-archive).",
+                        image.id, guid, prior.archive_path
+                    );
+                    summary.missing_archive += 1;
+                }
+                continue;
             }
-            summary.already_archived += 1;
-            continue;
         }
 
         // Extract filename from the metadata JSON.
@@ -535,7 +635,7 @@ pub fn move_rejects(
                 }
             }
             if located.is_none() {
-                if let Some(tree) = trees.get(dir_idx) {
+                if let Some(Some(tree)) = trees.get(dir_idx) {
                     if let Some(path) = tree.find_file_first(&filename) {
                         if path.exists() {
                             located = Some((dir.clone(), path.clone()));
@@ -559,7 +659,7 @@ pub fn move_rejects(
             continue;
         };
 
-        // Compute destination.
+        // Compute destination + the archive root that owns the manifest.
         let archive_path = match archive_path_for(
             Path::new(&image_dir),
             &source_path,
@@ -577,6 +677,13 @@ pub fn move_rejects(
                 continue;
             }
         };
+        let archive_root = archive_root_for(
+            Path::new(&image_dir),
+            &source_path,
+            options.config.depth,
+            &options.config.segment_name,
+        )
+        .expect("archive_root_for succeeds whenever archive_path_for did");
 
         let sidecars = find_sidecars(&source_path, &options.config.sidecar_exts);
 
@@ -604,6 +711,7 @@ pub fn move_rejects(
             image_id: image.id,
             source_path: &source_path,
             archive_path: &archive_path,
+            archive_root: &archive_root,
             sidecars: &sidecars,
             config: &options.config,
             source_db_slug: &options.source_db_slug,
@@ -640,6 +748,10 @@ struct MoveContext<'a> {
     image_id: i32,
     source_path: &'a Path,
     archive_path: &'a Path,
+    /// Directory up to and including the inserted segment (e.g.
+    /// `<image_dir>/<P>/REJECT`). The single per-archive manifest lives here,
+    /// not in the leaf directory that holds the moved file.
+    archive_root: &'a Path,
     sidecars: &'a [PathBuf],
     config: &'a RejectArchiveConfig,
     source_db_slug: &'a str,
@@ -651,6 +763,7 @@ fn execute_one_move(conn: &Connection, ctx: &MoveContext<'_>) -> Result<()> {
         image_id,
         source_path,
         archive_path,
+        archive_root,
         sidecars,
         config,
         source_db_slug,
@@ -724,8 +837,8 @@ fn execute_one_move(conn: &Connection, ctx: &MoveContext<'_>) -> Result<()> {
         return Err(anyhow::Error::new(e).context("inserting psf_guard_archive row"));
     }
 
-    // Manifest at the archive root (best-effort; if it fails, we log but
-    // don't roll back — the DB row is the authoritative source).
+    // Single manifest at the archive root (best-effort; if it fails, we log
+    // but don't roll back — the DB row is the authoritative source).
     let manifest_ctx = ManifestEntryInput {
         guid,
         image_id,
@@ -735,10 +848,10 @@ fn execute_one_move(conn: &Connection, ctx: &MoveContext<'_>) -> Result<()> {
         sidecar_files: &sidecar_names,
         config,
     };
-    if let Err(e) = append_to_manifest(archive_parent, &manifest_ctx) {
+    if let Err(e) = append_to_manifest(archive_root, &manifest_ctx) {
         eprintln!(
             "⚠️  Wrote DB row but could not append manifest at {}: {:#}",
-            archive_parent.display(),
+            archive_root.display(),
             e
         );
     }
@@ -762,6 +875,305 @@ fn rollback(moved: &[(PathBuf, PathBuf)]) {
 impl RejectArchiveConfig {
     fn archive_depth_as_i64(&self) -> i64 {
         self.depth as i64
+    }
+}
+
+// ── Restore ────────────────────────────────────────────────────────────────
+
+/// Options for `restore-rejects`. Mirrors the CLI flags.
+#[derive(Debug, Clone, Default)]
+pub struct RestoreRejectsOptions {
+    /// Restore every archived row regardless of the image's current grade.
+    /// When false (the default), only rows whose current `gradingStatus` is
+    /// no longer `Rejected` are restored — i.e. files the user un-rejected in
+    /// the UI (to Accepted *or* Pending).
+    pub restore_all: bool,
+    /// Restore only the row for this `acquiredimage.Id`. Implies "regardless
+    /// of grade" for that one row (an explicit, targeted request).
+    pub image_id_filter: Option<i64>,
+    /// Restore only the row for this guid. Same "regardless of grade" rule.
+    pub guid_filter: Option<String>,
+    pub dry_run: bool,
+    pub verbose: bool,
+}
+
+/// Summary counters for a `restore-rejects` run.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RestoreRejectsSummary {
+    /// Rows considered (after the grade/id/guid filtering).
+    pub planned: usize,
+    pub restored: usize,
+    /// Rows skipped because the image is still graded `Rejected` and no
+    /// targeted filter / `--all` overrode that.
+    pub skipped_still_rejected: usize,
+    /// Rows whose `archive_path` is no longer on disk — can't restore.
+    pub missing_archive: usize,
+    /// Files restored next to (not over) an occupant via a `.restored`
+    /// suffix. Counted in `restored` too; this is just a heads-up tally.
+    pub restored_with_suffix: usize,
+    pub errors: usize,
+}
+
+/// One archive row joined with the image's current grade (None if no
+/// `acquiredimage` row matches the stored guid — e.g. after a DB reimport).
+struct RestoreCandidate {
+    record: ArchiveRecord,
+    current_grade: Option<i32>,
+}
+
+/// Run the restore pipeline. Reads `psf_guard_archive`, optionally filtered to
+/// a single id/guid, and for each eligible row moves the archived primary
+/// (plus its sidecars) back toward `original_path`, deletes the row, and
+/// prunes now-empty archive directories.
+///
+/// Assumes `require_target_scheduler_guid(conn)` has passed. If the archive
+/// table doesn't exist yet, there's nothing to restore — returns an empty
+/// summary.
+pub fn restore_rejects(
+    conn: &Connection,
+    options: &RestoreRejectsOptions,
+) -> Result<RestoreRejectsSummary> {
+    let mut summary = RestoreRejectsSummary::default();
+    if !archive_table_exists(conn) {
+        return Ok(summary);
+    }
+
+    let candidates = load_restore_candidates(conn, options)?;
+
+    // A targeted id/guid request, or --all, restores regardless of grade.
+    let targeted = options.image_id_filter.is_some() || options.guid_filter.is_some();
+    let ignore_grade = options.restore_all || targeted;
+
+    for cand in candidates {
+        let eligible = ignore_grade || cand.current_grade != Some(GradingStatus::Rejected as i32);
+        if !eligible {
+            summary.skipped_still_rejected += 1;
+            if options.verbose {
+                println!(
+                    "⏭️  {} still Rejected; leaving archived (use --all to override)",
+                    cand.record.acquired_image_guid
+                );
+            }
+            continue;
+        }
+        summary.planned += 1;
+
+        let archive_path = PathBuf::from(&cand.record.archive_path);
+        if !archive_path.exists() {
+            eprintln!(
+                "⚠️  Archived file missing for guid={}: {} — cannot restore. \
+                 Leaving the DB row so the loss stays visible.",
+                cand.record.acquired_image_guid, cand.record.archive_path
+            );
+            summary.missing_archive += 1;
+            continue;
+        }
+
+        match restore_one(conn, &cand.record, options, &mut summary) {
+            Ok(()) => summary.restored += 1,
+            Err(e) => {
+                eprintln!(
+                    "❌ Failed to restore guid={}: {:#}",
+                    cand.record.acquired_image_guid, e
+                );
+                summary.errors += 1;
+            }
+        }
+    }
+
+    Ok(summary)
+}
+
+fn load_restore_candidates(
+    conn: &Connection,
+    options: &RestoreRejectsOptions,
+) -> Result<Vec<RestoreCandidate>> {
+    // LEFT JOIN so rows survive even if no acquiredimage matches the guid
+    // (current_grade becomes NULL); the default filter treats unknown grade
+    // as "not confirmed un-rejected" and skips it unless --all/targeted.
+    let mut sql = String::from(
+        "SELECT a.acquired_image_guid, a.acquired_image_id, a.moved_at,
+                a.original_path, a.archive_path, a.segment_name, a.archive_depth,
+                a.sidecar_files, a.source_db_slug, ai.gradingStatus
+         FROM psf_guard_archive a
+         LEFT JOIN acquiredimage ai ON ai.guid = a.acquired_image_guid
+         WHERE 1=1",
+    );
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    if let Some(id) = options.image_id_filter {
+        sql.push_str(" AND a.acquired_image_id = ?");
+        params.push(Box::new(id));
+    }
+    if let Some(ref g) = options.guid_filter {
+        sql.push_str(" AND a.acquired_image_guid = ?");
+        params.push(Box::new(g.clone()));
+    }
+    sql.push_str(" ORDER BY a.moved_at ASC");
+
+    let mut stmt = conn.prepare(&sql)?;
+    let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+    let rows = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            let record = row_to_record(row)?;
+            let current_grade: Option<i32> = row.get("gradingStatus")?;
+            Ok(RestoreCandidate {
+                record,
+                current_grade,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// Move one archived file (and sidecars) back toward its original location.
+/// Never overwrites: if the original path is occupied by a different file,
+/// the restored file lands beside it with a `.restored[.N]` suffix. Deletes
+/// the DB row on success and prunes emptied archive directories.
+fn restore_one(
+    conn: &Connection,
+    record: &ArchiveRecord,
+    options: &RestoreRejectsOptions,
+    summary: &mut RestoreRejectsSummary,
+) -> Result<()> {
+    let archive_path = PathBuf::from(&record.archive_path);
+    let archive_dir = archive_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("archive_path has no parent: {}", record.archive_path))?
+        .to_path_buf();
+    let original_path = PathBuf::from(&record.original_path);
+    let original_dir = original_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("original_path has no parent: {}", record.original_path))?
+        .to_path_buf();
+
+    // Plan the primary destination (collision-safe).
+    let primary_dest = unique_restore_dest(&original_path);
+    let suffixed = primary_dest != original_path;
+
+    // Plan sidecar destinations: each sidecar moves from the archive dir back
+    // to the original dir, also collision-safe and independently uniquified.
+    let mut plan: Vec<(PathBuf, PathBuf)> = vec![(archive_path.clone(), primary_dest.clone())];
+    for name in &record.sidecar_files {
+        let src = archive_dir.join(name);
+        if !src.exists() {
+            eprintln!(
+                "⚠️  Sidecar {} missing in archive for guid={}; skipping it",
+                src.display(),
+                record.acquired_image_guid
+            );
+            continue;
+        }
+        let desired = original_dir.join(name);
+        plan.push((src, unique_restore_dest(&desired)));
+    }
+
+    let kind = if options.dry_run { "PLAN" } else { "RESTORE" };
+    for (src, dest) in &plan {
+        println!("{}  {} → {}", kind, src.display(), dest.display());
+    }
+    if suffixed {
+        summary.restored_with_suffix += 1;
+        if options.verbose {
+            println!(
+                "       (original {} occupied; restored beside it)",
+                original_path.display()
+            );
+        }
+    }
+
+    if options.dry_run {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&original_dir)
+        .with_context(|| format!("creating original dir {}", original_dir.display()))?;
+
+    // Move everything, tracking for rollback.
+    let mut moved: Vec<(PathBuf, PathBuf)> = Vec::new();
+    for (src, dest) in &plan {
+        if let Err(e) = std::fs::rename(src, dest) {
+            rollback(&moved);
+            return Err(anyhow::Error::new(e).context(format!(
+                "restoring {} → {}",
+                src.display(),
+                dest.display()
+            )));
+        }
+        moved.push((src.clone(), dest.clone()));
+    }
+
+    // Delete the DB row. If this fails, roll the files back so on-disk state
+    // matches the still-present DB row.
+    if let Err(e) = delete_archive_record_by_guid(conn, &record.acquired_image_guid) {
+        rollback(&moved);
+        return Err(e.context("deleting archive row after restore"));
+    }
+
+    prune_empty_dirs(&archive_dir, &record.segment_name);
+    Ok(())
+}
+
+/// Return `desired` if nothing is there, otherwise a sibling path with
+/// `.restored` (then `.restored.1`, `.restored.2`, …) inserted before the
+/// extension. Guarantees the returned path does not currently exist, so a
+/// rename into it never overwrites.
+fn unique_restore_dest(desired: &Path) -> PathBuf {
+    if !desired.exists() {
+        return desired.to_path_buf();
+    }
+    let dir = desired.parent().unwrap_or_else(|| Path::new("."));
+    let stem = desired
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let ext = desired
+        .extension()
+        .map(|e| e.to_string_lossy().into_owned());
+    for n in 0u32.. {
+        let base = if n == 0 {
+            format!("{}.restored", stem)
+        } else {
+            format!("{}.restored.{}", stem, n)
+        };
+        let name = match &ext {
+            Some(e) => format!("{}.{}", base, e),
+            None => base,
+        };
+        let candidate = dir.join(name);
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    unreachable!("u32 range exhausted finding a free restore path")
+}
+
+/// Remove `archive_dir` and any parent directories up to (and including) the
+/// inserted `segment_name` directory, stopping at the first non-empty one.
+/// A directory containing only the manifest is considered non-empty so the
+/// recovery breadcrumb survives. Best-effort: errors are ignored.
+fn prune_empty_dirs(archive_dir: &Path, segment_name: &str) {
+    let mut dir = archive_dir.to_path_buf();
+    loop {
+        if dir_is_empty(&dir) {
+            if std::fs::remove_dir(&dir).is_err() {
+                return;
+            }
+        } else {
+            return;
+        }
+        // Stop after we've removed the segment directory itself.
+        let was_segment = dir.file_name().map(|n| n == segment_name).unwrap_or(false);
+        match dir.parent() {
+            Some(p) if !was_segment => dir = p.to_path_buf(),
+            _ => return,
+        }
+    }
+}
+
+fn dir_is_empty(dir: &Path) -> bool {
+    match std::fs::read_dir(dir) {
+        Ok(mut entries) => entries.next().is_none(),
+        Err(_) => false,
     }
 }
 
@@ -1113,6 +1525,84 @@ mod tests {
         assert_eq!(
             archive,
             p("/data/M31/PSF-Guard-Rejects/2026-04-16/LIGHT/img.fits")
+        );
+    }
+
+    #[test]
+    fn archive_root_for_is_path_up_to_segment() {
+        let root = archive_root_for(
+            &p("/data"),
+            &p("/data/M31/2026-04-16/LIGHT/img.fits"),
+            1,
+            "REJECT",
+        )
+        .unwrap();
+        assert_eq!(root, p("/data/M31/REJECT"));
+    }
+
+    #[test]
+    fn archive_root_for_depth_zero_and_shallow_collapse_to_top() {
+        // depth 0: single bucket directly under image_dir.
+        let root = archive_root_for(
+            &p("/data"),
+            &p("/data/M31/2026-04-16/LIGHT/img.fits"),
+            0,
+            "REJECT",
+        )
+        .unwrap();
+        assert_eq!(root, p("/data/REJECT"));
+        // shallow fallback (file directly under image_dir) also lands at top.
+        let root2 = archive_root_for(&p("/data"), &p("/data/img.fits"), 1, "REJECT").unwrap();
+        assert_eq!(root2, p("/data/REJECT"));
+    }
+
+    #[test]
+    fn archive_root_for_matches_archive_path_prefix() {
+        // The archive root must be a prefix of the computed archive path so
+        // the manifest sits above every leaf move in its tree.
+        let img = p("/data/M31/2026-04-16/LIGHT/img.fits");
+        let path = archive_path_for(&p("/data"), &img, 1, "REJECT").unwrap();
+        let root = archive_root_for(&p("/data"), &img, 1, "REJECT").unwrap();
+        assert!(
+            path.starts_with(&root),
+            "{path:?} should start with {root:?}"
+        );
+    }
+
+    #[test]
+    fn archive_root_for_returns_none_outside_image_dir() {
+        assert!(archive_root_for(&p("/data"), &p("/other/img.fits"), 1, "REJECT").is_none());
+    }
+
+    #[test]
+    fn unique_restore_dest_returns_input_when_free() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("img_0028.fits");
+        assert_eq!(unique_restore_dest(&target), target);
+    }
+
+    #[test]
+    fn unique_restore_dest_inserts_suffix_on_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("img_0028.fits");
+        std::fs::write(&target, b"occupied").unwrap();
+        let alt = unique_restore_dest(&target);
+        assert_eq!(alt, dir.path().join("img_0028.restored.fits"));
+
+        // Occupy the .restored slot too → numeric bump.
+        std::fs::write(&alt, b"also occupied").unwrap();
+        let alt2 = unique_restore_dest(&target);
+        assert_eq!(alt2, dir.path().join("img_0028.restored.1.fits"));
+    }
+
+    #[test]
+    fn unique_restore_dest_handles_extensionless_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("README");
+        std::fs::write(&target, b"x").unwrap();
+        assert_eq!(
+            unique_restore_dest(&target),
+            dir.path().join("README.restored")
         );
     }
 

--- a/src/commands/reject_archive.rs
+++ b/src/commands/reject_archive.rs
@@ -112,6 +112,87 @@ fn validate_segment_name(s: &str) -> Result<()> {
     Ok(())
 }
 
+/// Compute the archive destination path for a single rejected file.
+///
+/// Returns `None` if `source_path` doesn't lie underneath `image_dir`, in
+/// which case the caller should fall back to a different `image_dir` or
+/// skip the file. Returns `Some(path)` otherwise; the path is purely
+/// computed — no I/O, no parent-directory creation — so this function is
+/// trivial to unit-test.
+///
+/// The rule: walk the source path's segments relative to `image_dir` and
+/// insert `segment_name` after `depth` segments. With `depth = 1` and
+/// `segment_name = "REJECT"` (the defaults):
+///
+/// ```text
+/// image_dir = /Volumes/Astro/Targets
+/// source    = /Volumes/Astro/Targets/M31/2026-04-16/B/LIGHT/img.fits
+///                                    └── depth-1 anchor
+/// archive   = /Volumes/Astro/Targets/M31/REJECT/2026-04-16/B/LIGHT/img.fits
+/// ```
+///
+/// Edge cases:
+/// - File is shallower than `depth` (e.g. depth=1 but the file lives
+///   directly under `image_dir`): falls back to
+///   `<image_dir>/<segment>/<filename>`.
+/// - File is `image_dir` itself (no relative path): returns `None`.
+/// - `depth = 0`: equivalent to the shallow-fallback case for every file.
+///
+/// Validation of `segment_name` happens in `resolve_config`; this function
+/// assumes the caller already passed a valid name. Path separators in
+/// `segment_name` would produce a path that crosses out of `image_dir`,
+/// which is exactly what the validator prevents.
+pub fn archive_path_for(
+    image_dir: &std::path::Path,
+    source_path: &std::path::Path,
+    depth: u32,
+    segment_name: &str,
+) -> Option<std::path::PathBuf> {
+    use std::path::{Component, PathBuf};
+
+    let relative = source_path.strip_prefix(image_dir).ok()?;
+
+    // Only `Normal` segments count for depth math. A relative path stripped
+    // from an absolute prefix typically yields all-Normal components, but
+    // be defensive about `..` / `.` that could appear in pathological
+    // inputs.
+    let segments: Vec<&std::ffi::OsStr> = relative
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(s) => Some(s),
+            _ => None,
+        })
+        .collect();
+
+    if segments.is_empty() {
+        // source_path == image_dir; not a file we can archive.
+        return None;
+    }
+
+    let depth = depth as usize;
+    let mut archive = PathBuf::from(image_dir);
+
+    if depth == 0 || segments.len() <= depth {
+        // Either explicitly "drop into a single REJECT bucket per image_dir"
+        // or the file is too shallow to honor the requested depth — both
+        // collapse to the same shape: <image_dir>/<segment>/<relative>.
+        archive.push(segment_name);
+        for seg in &segments {
+            archive.push(seg);
+        }
+    } else {
+        for seg in &segments[..depth] {
+            archive.push(seg);
+        }
+        archive.push(segment_name);
+        for seg in &segments[depth..] {
+            archive.push(seg);
+        }
+    }
+
+    Some(archive)
+}
+
 fn validate_sidecar_ext(ext: &str) -> Result<()> {
     if !ext.starts_with('.') {
         return Err(anyhow::anyhow!(
@@ -432,6 +513,121 @@ mod tests {
         let bad_exts: Vec<String> = vec!["xisf".into()]; // missing dot
         let err = resolve_config(None, None, None, Some(&bad_exts)).unwrap_err();
         assert!(format!("{err}").contains("sidecar_exts"));
+    }
+
+    fn p(s: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(s)
+    }
+
+    #[test]
+    fn archive_path_for_inserts_at_depth_1_by_default() {
+        let archive = archive_path_for(
+            &p("/Volumes/Astro/Targets"),
+            &p("/Volumes/Astro/Targets/M31/2026-04-16/B/LIGHT/img.fits"),
+            1,
+            "REJECT",
+        )
+        .unwrap();
+        assert_eq!(
+            archive,
+            p("/Volumes/Astro/Targets/M31/REJECT/2026-04-16/B/LIGHT/img.fits")
+        );
+    }
+
+    #[test]
+    fn archive_path_for_handles_depth_2() {
+        let archive = archive_path_for(
+            &p("/data"),
+            &p("/data/M31/2026-04-16/LIGHT/img.fits"),
+            2,
+            "REJECT",
+        )
+        .unwrap();
+        assert_eq!(archive, p("/data/M31/2026-04-16/REJECT/LIGHT/img.fits"));
+    }
+
+    #[test]
+    fn archive_path_for_treats_project_plus_file_as_in_tree() {
+        // segments = ["M31", "img.fits"], depth = 1 → head=[M31], tail=[img.fits].
+        // REJECT lands inside the project, NOT above it — keeps per-project
+        // discoverability ("everything under M31 belongs to M31, including
+        // its rejects").
+        let archive = archive_path_for(&p("/data"), &p("/data/M31/img.fits"), 1, "REJECT").unwrap();
+        assert_eq!(archive, p("/data/M31/REJECT/img.fits"));
+    }
+
+    #[test]
+    fn archive_path_for_falls_back_when_file_is_at_image_dir_root() {
+        // Only one segment under image_dir (just the file); depth=1 needs
+        // depth+1=2 segments → fallback to image_dir/segment/file.
+        let archive = archive_path_for(&p("/data"), &p("/data/img.fits"), 1, "REJECT").unwrap();
+        assert_eq!(archive, p("/data/REJECT/img.fits"));
+    }
+
+    #[test]
+    fn archive_path_for_falls_back_when_depth_exceeds_available_segments() {
+        // Three segments under image_dir; depth=3 needs depth+1=4 → fallback.
+        let archive = archive_path_for(
+            &p("/data"),
+            &p("/data/M31/2026-04-16/img.fits"),
+            3,
+            "REJECT",
+        )
+        .unwrap();
+        assert_eq!(archive, p("/data/REJECT/M31/2026-04-16/img.fits"));
+    }
+
+    #[test]
+    fn archive_path_for_depth_zero_drops_into_single_bucket() {
+        let archive = archive_path_for(
+            &p("/data"),
+            &p("/data/M31/2026-04-16/LIGHT/img.fits"),
+            0,
+            "REJECT",
+        )
+        .unwrap();
+        assert_eq!(archive, p("/data/REJECT/M31/2026-04-16/LIGHT/img.fits"));
+    }
+
+    #[test]
+    fn archive_path_for_returns_none_when_source_outside_image_dir() {
+        let archive = archive_path_for(&p("/data"), &p("/other/M31/img.fits"), 1, "REJECT");
+        assert!(archive.is_none());
+    }
+
+    #[test]
+    fn archive_path_for_returns_none_when_source_is_image_dir_itself() {
+        let archive = archive_path_for(&p("/data"), &p("/data"), 1, "REJECT");
+        assert!(archive.is_none());
+    }
+
+    #[test]
+    fn archive_path_for_honors_custom_segment_name() {
+        let archive = archive_path_for(
+            &p("/data"),
+            &p("/data/M31/2026-04-16/LIGHT/img.fits"),
+            1,
+            "PSF-Guard-Rejects",
+        )
+        .unwrap();
+        assert_eq!(
+            archive,
+            p("/data/M31/PSF-Guard-Rejects/2026-04-16/LIGHT/img.fits")
+        );
+    }
+
+    #[test]
+    fn archive_path_for_handles_relative_paths_when_consistent() {
+        // Both paths relative — practical for tests that work inside a
+        // tempdir without needing absolute paths.
+        let archive = archive_path_for(
+            &p("targets"),
+            &p("targets/M31/2026-04-16/LIGHT/img.fits"),
+            1,
+            "REJECT",
+        )
+        .unwrap();
+        assert_eq!(archive, p("targets/M31/REJECT/2026-04-16/LIGHT/img.fits"));
     }
 
     #[test]

--- a/src/commands/reject_archive.rs
+++ b/src/commands/reject_archive.rs
@@ -14,9 +14,13 @@
 
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
+use std::path::{Path, PathBuf};
 
-use crate::db::SchemaCapabilities;
+use crate::commands::filter_rejected::get_possible_paths;
+use crate::db::{Database, SchemaCapabilities};
 use crate::db_registry::RejectArchiveOverrides;
+use crate::directory_tree::DirectoryTree;
+use crate::models::GradingStatus;
 
 /// Compiled-in defaults for the reject-archive feature. Overridden by
 /// per-DB registry fields (`DbEntry.reject_archive`), then by per-invocation
@@ -244,7 +248,7 @@ pub fn find_sidecars(primary: &std::path::Path, exts: &[String]) -> Vec<std::pat
             .and_then(|e| e.to_str())
             .map(|e| e.to_ascii_lowercase());
         let Some(ext_lc) = ext_lc else { continue };
-        if lc_exts.iter().any(|want| *want == ext_lc) {
+        if lc_exts.contains(&ext_lc) {
             out.push(path);
         }
     }
@@ -400,6 +404,443 @@ fn row_to_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArchiveRecord> {
         sidecar_files,
         source_db_slug: row.get("source_db_slug")?,
     })
+}
+
+// ── Orchestration ─────────────────────────────────────────────────────────────
+
+/// Options bag for `move_rejects`. Mirrors the CLI flags + per-DB context
+/// the handler in `cli_main.rs` collects.
+#[derive(Debug, Clone)]
+pub struct MoveRejectsOptions {
+    pub config: RejectArchiveConfig,
+    pub project_filter: Option<String>,
+    pub target_filter: Option<String>,
+    pub dry_run: bool,
+    /// Registry slug for the DB being operated on. Stored in each archive
+    /// row so cross-DB tooling can later identify which rig produced a move.
+    pub source_db_slug: String,
+    /// Verbose: print per-image "tried this path, then that path" trace.
+    pub verbose: bool,
+}
+
+/// Summary counters returned from a `move_rejects` run. The CLI prints them
+/// at the end; tests assert on them directly.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MoveRejectsSummary {
+    pub planned: usize,
+    pub archived: usize,
+    pub already_archived: usize,
+    pub not_found_on_disk: usize,
+    pub errors: usize,
+}
+
+/// Run the move-rejects pipeline. Locates each rejected image on disk under
+/// one of `image_dirs`, computes the archive path, moves the primary plus
+/// any matching sidecars, then records the move both in the
+/// `psf_guard_archive` table and in a per-archive-root JSON manifest.
+///
+/// Returns a summary of what happened. Does not panic on per-image errors —
+/// it counts them in `summary.errors` and moves on, so a batch of 100 with
+/// one bad row still archives the other 99.
+///
+/// The function assumes:
+/// - `ensure_archive_schema(conn)` has already been called (caller does).
+/// - `require_target_scheduler_guid(conn)` has passed (caller does).
+/// - `options.config` is valid (resolved through `resolve_config`).
+pub fn move_rejects(
+    conn: &Connection,
+    image_dirs: &[String],
+    options: &MoveRejectsOptions,
+) -> Result<MoveRejectsSummary> {
+    let db = Database::new(conn);
+
+    let images = db
+        .query_images(
+            Some(GradingStatus::Rejected),
+            options.project_filter.as_deref(),
+            options.target_filter.as_deref(),
+            None,
+        )
+        .context("querying rejected images")?;
+
+    let mut summary = MoveRejectsSummary {
+        planned: images.len(),
+        ..Default::default()
+    };
+
+    // Build a directory tree per image_dir (lazily). Each tree caches the
+    // first-hit basename → absolute-path mapping that powers the fallback
+    // lookup when the date-aware path heuristics miss.
+    let mut trees: Vec<DirectoryTree> = Vec::with_capacity(image_dirs.len());
+    for dir in image_dirs {
+        match DirectoryTree::build_multiple(&[std::path::Path::new(dir)]) {
+            Ok(t) => trees.push(t),
+            Err(e) => {
+                eprintln!(
+                    "⚠️  Could not index image directory {} ({}); continuing without it",
+                    dir, e
+                );
+            }
+        }
+    }
+
+    for (image, _project_name, target_name) in images {
+        let Some(guid) = image.guid.as_deref() else {
+            eprintln!(
+                "⚠️  Skipping image id={} (rejected={}): no guid on row; \
+                 cannot archive without a stable key. Upgrade the TS plugin \
+                 to populate guid, or set the image to pending and re-grade.",
+                image.id,
+                image.reject_reason.as_deref().unwrap_or("")
+            );
+            summary.errors += 1;
+            continue;
+        };
+
+        // Already archived? Skip silently (idempotent re-runs).
+        if let Some(prior) = get_archive_record_by_guid(conn, guid)? {
+            if options.verbose {
+                println!("⏭️  {} already archived at {}", guid, prior.archive_path);
+            }
+            summary.already_archived += 1;
+            continue;
+        }
+
+        // Extract filename from the metadata JSON.
+        let filename = match parse_filename_from_metadata(&image.metadata) {
+            Some(name) => name,
+            None => {
+                eprintln!(
+                    "⚠️  Image id={} (guid={}) has no FileName in metadata; skipping",
+                    image.id, guid
+                );
+                summary.errors += 1;
+                continue;
+            }
+        };
+
+        // Locate on disk. Try each image_dir's get_possible_paths first,
+        // then fall back to the directory tree.
+        let mut located: Option<(String, PathBuf)> = None;
+        let date_str = image
+            .acquired_date
+            .and_then(|d| chrono::DateTime::from_timestamp(d, 0))
+            .map(|dt| dt.format("%Y-%m-%d").to_string())
+            .unwrap_or_default();
+        for (dir_idx, dir) in image_dirs.iter().enumerate() {
+            for candidate in get_possible_paths(dir, &date_str, &target_name, &filename) {
+                if candidate.exists() {
+                    located = Some((dir.clone(), candidate));
+                    break;
+                }
+            }
+            if located.is_none() {
+                if let Some(tree) = trees.get(dir_idx) {
+                    if let Some(path) = tree.find_file_first(&filename) {
+                        if path.exists() {
+                            located = Some((dir.clone(), path.clone()));
+                        }
+                    }
+                }
+            }
+            if located.is_some() {
+                break;
+            }
+        }
+
+        let Some((image_dir, source_path)) = located else {
+            if options.verbose {
+                eprintln!(
+                    "⚠️  Not found on disk: id={} guid={} filename={}",
+                    image.id, guid, filename
+                );
+            }
+            summary.not_found_on_disk += 1;
+            continue;
+        };
+
+        // Compute destination.
+        let archive_path = match archive_path_for(
+            Path::new(&image_dir),
+            &source_path,
+            options.config.depth,
+            &options.config.segment_name,
+        ) {
+            Some(p) => p,
+            None => {
+                eprintln!(
+                    "⚠️  Cannot compute archive path for {}: source not under image_dir {}",
+                    source_path.display(),
+                    image_dir
+                );
+                summary.errors += 1;
+                continue;
+            }
+        };
+
+        let sidecars = find_sidecars(&source_path, &options.config.sidecar_exts);
+
+        // Print plan line whether dry-run or not (always; users want to see
+        // what we did, not just what we will do).
+        let kind = if options.dry_run { "PLAN" } else { "MOVE" };
+        println!(
+            "{}  {} → {}",
+            kind,
+            source_path.display(),
+            archive_path.display()
+        );
+        for sc in &sidecars {
+            println!("       + sidecar {}", sc.display());
+        }
+
+        if options.dry_run {
+            continue;
+        }
+
+        // Execute. Roll back any partial moves for this image if anything
+        // mid-sequence fails.
+        let ctx = MoveContext {
+            guid,
+            image_id: image.id,
+            source_path: &source_path,
+            archive_path: &archive_path,
+            sidecars: &sidecars,
+            config: &options.config,
+            source_db_slug: &options.source_db_slug,
+        };
+        match execute_one_move(conn, &ctx) {
+            Ok(()) => summary.archived += 1,
+            Err(e) => {
+                eprintln!(
+                    "❌ Failed to archive id={} guid={}: {:#}",
+                    image.id, guid, e
+                );
+                summary.errors += 1;
+            }
+        }
+    }
+
+    Ok(summary)
+}
+
+fn parse_filename_from_metadata(metadata_json: &str) -> Option<String> {
+    let v = serde_json::from_str::<serde_json::Value>(metadata_json).ok()?;
+    let raw = v.get("FileName")?.as_str()?;
+    // FileName values can be full paths from NINA; we only want the basename
+    // (matches what `filter_rejected` does today).
+    let basename = raw.split(&['\\', '/'][..]).next_back().unwrap_or(raw);
+    Some(basename.to_string())
+}
+
+/// Per-image move context — kept as a struct rather than positional args so
+/// `execute_one_move` and `append_to_manifest` stay below clippy's
+/// too-many-arguments threshold and the call sites can't get fields mixed up.
+struct MoveContext<'a> {
+    guid: &'a str,
+    image_id: i32,
+    source_path: &'a Path,
+    archive_path: &'a Path,
+    sidecars: &'a [PathBuf],
+    config: &'a RejectArchiveConfig,
+    source_db_slug: &'a str,
+}
+
+fn execute_one_move(conn: &Connection, ctx: &MoveContext<'_>) -> Result<()> {
+    let MoveContext {
+        guid,
+        image_id,
+        source_path,
+        archive_path,
+        sidecars,
+        config,
+        source_db_slug,
+    } = *ctx;
+    let archive_parent = archive_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("archive_path has no parent: {:?}", archive_path))?;
+    std::fs::create_dir_all(archive_parent)
+        .with_context(|| format!("creating archive parent {}", archive_parent.display()))?;
+
+    // Track what we moved so we can undo on later failure.
+    let mut moved: Vec<(PathBuf, PathBuf)> = Vec::new();
+
+    // Move the primary first.
+    std::fs::rename(source_path, archive_path).with_context(|| {
+        format!(
+            "renaming primary {} → {}",
+            source_path.display(),
+            archive_path.display()
+        )
+    })?;
+    moved.push((source_path.to_path_buf(), archive_path.to_path_buf()));
+
+    // Sidecars next. Each lands beside the primary in the archive dir.
+    let mut sidecar_names: Vec<String> = Vec::with_capacity(sidecars.len());
+    for src in sidecars {
+        let Some(name) = src.file_name() else {
+            // Shouldn't happen (we got these from a read_dir), but bail out.
+            rollback(&moved);
+            return Err(anyhow::anyhow!(
+                "sidecar path has no filename: {}",
+                src.display()
+            ));
+        };
+        let dest = archive_parent.join(name);
+        if let Err(e) = std::fs::rename(src, &dest) {
+            rollback(&moved);
+            return Err(anyhow::Error::new(e).context(format!(
+                "renaming sidecar {} → {}",
+                src.display(),
+                dest.display()
+            )));
+        }
+        sidecar_names.push(name.to_string_lossy().into_owned());
+        moved.push((src.clone(), dest));
+    }
+
+    // Record in the DB. If this insert fails (e.g. constraint violation),
+    // also roll the moves back so the on-disk state matches the DB.
+    let sidecar_json = serde_json::to_string(&sidecar_names).unwrap_or_else(|_| "[]".to_string());
+    let now = chrono::Utc::now().timestamp();
+    if let Err(e) = conn.execute(
+        "INSERT INTO psf_guard_archive
+         (acquired_image_guid, acquired_image_id, moved_at,
+          original_path, archive_path, segment_name, archive_depth,
+          sidecar_files, source_db_slug)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            guid,
+            image_id,
+            now,
+            source_path.to_string_lossy().as_ref(),
+            archive_path.to_string_lossy().as_ref(),
+            &config.segment_name,
+            config.archive_depth_as_i64(),
+            sidecar_json,
+            source_db_slug,
+        ],
+    ) {
+        rollback(&moved);
+        return Err(anyhow::Error::new(e).context("inserting psf_guard_archive row"));
+    }
+
+    // Manifest at the archive root (best-effort; if it fails, we log but
+    // don't roll back — the DB row is the authoritative source).
+    let manifest_ctx = ManifestEntryInput {
+        guid,
+        image_id,
+        moved_at: now,
+        original_path: source_path,
+        archive_path,
+        sidecar_files: &sidecar_names,
+        config,
+    };
+    if let Err(e) = append_to_manifest(archive_parent, &manifest_ctx) {
+        eprintln!(
+            "⚠️  Wrote DB row but could not append manifest at {}: {:#}",
+            archive_parent.display(),
+            e
+        );
+    }
+
+    Ok(())
+}
+
+fn rollback(moved: &[(PathBuf, PathBuf)]) {
+    for (src, dest) in moved.iter().rev() {
+        if let Err(e) = std::fs::rename(dest, src) {
+            eprintln!(
+                "❌ Rollback also failed: could not restore {} ← {}: {}",
+                src.display(),
+                dest.display(),
+                e
+            );
+        }
+    }
+}
+
+impl RejectArchiveConfig {
+    fn archive_depth_as_i64(&self) -> i64 {
+        self.depth as i64
+    }
+}
+
+// ── Manifest helper ──────────────────────────────────────────────────────────
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Default)]
+struct ManifestFile {
+    #[serde(default = "manifest_version_default")]
+    version: u32,
+    #[serde(default)]
+    moves: Vec<ManifestEntry>,
+}
+
+fn manifest_version_default() -> u32 {
+    1
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct ManifestEntry {
+    guid: String,
+    image_id: i32,
+    moved_at: i64,
+    original_path: String,
+    archive_path: String,
+    sidecar_files: Vec<String>,
+    segment_name: String,
+    archive_depth: u32,
+}
+
+struct ManifestEntryInput<'a> {
+    guid: &'a str,
+    image_id: i32,
+    moved_at: i64,
+    original_path: &'a Path,
+    archive_path: &'a Path,
+    sidecar_files: &'a [String],
+    config: &'a RejectArchiveConfig,
+}
+
+/// Atomically append one entry to the manifest at the archive root. Reads
+/// the existing file (if any), appends, writes to `.tmp`, then renames.
+fn append_to_manifest(archive_root: &Path, entry: &ManifestEntryInput<'_>) -> Result<()> {
+    let ManifestEntryInput {
+        guid,
+        image_id,
+        moved_at,
+        original_path,
+        archive_path,
+        sidecar_files,
+        config,
+    } = *entry;
+
+    let manifest_path = archive_root.join(".psf-guard-manifest.json");
+    let mut manifest: ManifestFile = if manifest_path.exists() {
+        let body = std::fs::read_to_string(&manifest_path)
+            .with_context(|| format!("reading {}", manifest_path.display()))?;
+        serde_json::from_str(&body).unwrap_or_default()
+    } else {
+        ManifestFile {
+            version: 1,
+            moves: Vec::new(),
+        }
+    };
+    manifest.moves.push(ManifestEntry {
+        guid: guid.to_string(),
+        image_id,
+        moved_at,
+        original_path: original_path.to_string_lossy().into_owned(),
+        archive_path: archive_path.to_string_lossy().into_owned(),
+        sidecar_files: sidecar_files.to_vec(),
+        segment_name: config.segment_name.clone(),
+        archive_depth: config.depth,
+    });
+
+    let tmp = manifest_path.with_extension("json.tmp");
+    let body = serde_json::to_string_pretty(&manifest).context("serializing manifest")?;
+    std::fs::write(&tmp, body).with_context(|| format!("writing {}", tmp.display()))?;
+    std::fs::rename(&tmp, &manifest_path).context("renaming manifest tmp into place")?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -747,7 +1188,7 @@ mod tests {
     #[test]
     fn find_sidecars_returns_empty_when_parent_missing() {
         let found = find_sidecars(
-            &std::path::Path::new("/no/such/dir/img.fits"),
+            std::path::Path::new("/no/such/dir/img.fits"),
             &[".xisf".to_string()],
         );
         assert!(found.is_empty());

--- a/src/commands/reject_archive.rs
+++ b/src/commands/reject_archive.rs
@@ -16,6 +16,124 @@ use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::db::SchemaCapabilities;
+use crate::db_registry::RejectArchiveOverrides;
+
+/// Compiled-in defaults for the reject-archive feature. Overridden by
+/// per-DB registry fields (`DbEntry.reject_archive`), then by per-invocation
+/// CLI flags. See REJECT_ARCHIVE_PLAN.md §4.2 for the precedence rules.
+pub const DEFAULT_SEGMENT_NAME: &str = "REJECT";
+pub const DEFAULT_DEPTH: u32 = 1;
+pub const DEFAULT_SIDECAR_EXTS: &[&str] = &[".xisf", ".json", ".txt"];
+
+/// Resolved (CLI ∪ per-DB ∪ defaults) configuration used at command time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejectArchiveConfig {
+    pub segment_name: String,
+    pub depth: u32,
+    pub sidecar_exts: Vec<String>,
+}
+
+impl Default for RejectArchiveConfig {
+    fn default() -> Self {
+        Self {
+            segment_name: DEFAULT_SEGMENT_NAME.to_string(),
+            depth: DEFAULT_DEPTH,
+            sidecar_exts: DEFAULT_SIDECAR_EXTS
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        }
+    }
+}
+
+/// Compose the effective archive config. CLI overrides win, then per-DB
+/// registry block, then compiled-in defaults. Each field resolves
+/// independently — e.g. a CLI segment override doesn't reset the per-DB
+/// sidecar list.
+///
+/// Validates the resolved `segment_name` is non-empty and contains no
+/// path separators (we use it as a literal path component). Validates
+/// `sidecar_exts` are non-empty and dot-prefixed. Depth has no upper
+/// bound — extreme values just degrade to "deeper anchor than the file
+/// has segments," which `archive_path_for` handles by falling back to
+/// the depth-0 case (A3).
+pub fn resolve_config(
+    per_db: Option<&RejectArchiveOverrides>,
+    cli_segment: Option<&str>,
+    cli_depth: Option<u32>,
+    cli_sidecar_exts: Option<&[String]>,
+) -> Result<RejectArchiveConfig> {
+    let defaults = RejectArchiveConfig::default();
+
+    let segment_name = cli_segment
+        .map(|s| s.to_string())
+        .or_else(|| per_db.and_then(|o| o.segment_name.clone()))
+        .unwrap_or(defaults.segment_name);
+    validate_segment_name(&segment_name)?;
+
+    let depth = cli_depth
+        .or_else(|| per_db.and_then(|o| o.depth))
+        .unwrap_or(defaults.depth);
+
+    let sidecar_exts = cli_sidecar_exts
+        .map(|s| s.to_vec())
+        .or_else(|| per_db.and_then(|o| o.sidecar_exts.clone()))
+        .unwrap_or(defaults.sidecar_exts);
+    for ext in &sidecar_exts {
+        validate_sidecar_ext(ext)?;
+    }
+
+    Ok(RejectArchiveConfig {
+        segment_name,
+        depth,
+        sidecar_exts,
+    })
+}
+
+fn validate_segment_name(s: &str) -> Result<()> {
+    if s.is_empty() {
+        return Err(anyhow::anyhow!(
+            "reject_archive.segment_name cannot be empty"
+        ));
+    }
+    if s.contains('/') || s.contains('\\') {
+        return Err(anyhow::anyhow!(
+            "reject_archive.segment_name '{}' contains a path separator; \
+             it must be a single directory name",
+            s
+        ));
+    }
+    if s == "." || s == ".." {
+        return Err(anyhow::anyhow!(
+            "reject_archive.segment_name '{}' is a special directory name",
+            s
+        ));
+    }
+    Ok(())
+}
+
+fn validate_sidecar_ext(ext: &str) -> Result<()> {
+    if !ext.starts_with('.') {
+        return Err(anyhow::anyhow!(
+            "reject_archive.sidecar_exts entry '{}' must start with a dot \
+             (e.g. \".xisf\")",
+            ext
+        ));
+    }
+    if ext.len() < 2 {
+        return Err(anyhow::anyhow!(
+            "reject_archive.sidecar_exts entry '{}' is too short",
+            ext
+        ));
+    }
+    if ext.contains('/') || ext.contains('\\') {
+        return Err(anyhow::anyhow!(
+            "reject_archive.sidecar_exts entry '{}' contains a path separator",
+            ext
+        ));
+    }
+    Ok(())
+}
 
 /// `psf-guard`'s view of a single archived rejected image. One row per
 /// `acquired_image_guid` (upstream's stable cross-tool join key).
@@ -251,6 +369,69 @@ mod tests {
 
         let by_id = get_archive_record_by_image_id(&conn, 42).unwrap().unwrap();
         assert_eq!(by_id, by_guid);
+    }
+
+    #[test]
+    fn resolve_config_uses_defaults_when_nothing_overrides() {
+        let cfg = resolve_config(None, None, None, None).unwrap();
+        assert_eq!(cfg.segment_name, "REJECT");
+        assert_eq!(cfg.depth, 1);
+        assert_eq!(cfg.sidecar_exts, vec![".xisf", ".json", ".txt"]);
+    }
+
+    #[test]
+    fn resolve_config_per_db_overrides_defaults() {
+        let per_db = RejectArchiveOverrides {
+            segment_name: Some("BAD".into()),
+            depth: Some(2),
+            sidecar_exts: Some(vec![".xisf".into()]),
+        };
+        let cfg = resolve_config(Some(&per_db), None, None, None).unwrap();
+        assert_eq!(cfg.segment_name, "BAD");
+        assert_eq!(cfg.depth, 2);
+        assert_eq!(cfg.sidecar_exts, vec![".xisf"]);
+    }
+
+    #[test]
+    fn resolve_config_cli_wins_over_per_db_per_field() {
+        // CLI provides segment only; depth + sidecars fall through to per-DB.
+        let per_db = RejectArchiveOverrides {
+            segment_name: Some("BAD".into()),
+            depth: Some(2),
+            sidecar_exts: Some(vec![".xisf".into()]),
+        };
+        let cli_exts: Option<&[String]> = None;
+        let cfg = resolve_config(Some(&per_db), Some("KEPT-AWAY"), None, cli_exts).unwrap();
+        assert_eq!(cfg.segment_name, "KEPT-AWAY", "CLI segment wins");
+        assert_eq!(
+            cfg.depth, 2,
+            "per-DB depth wins when CLI doesn't supply one"
+        );
+        assert_eq!(
+            cfg.sidecar_exts,
+            vec![".xisf"],
+            "per-DB exts win when CLI doesn't supply"
+        );
+    }
+
+    #[test]
+    fn resolve_config_rejects_invalid_segment() {
+        for bad in ["", "has/slash", "has\\backslash", ".", ".."] {
+            let err = resolve_config(None, Some(bad), None, None).unwrap_err();
+            let msg = format!("{err}");
+            assert!(
+                msg.contains("segment_name"),
+                "error for {:?} should name the field: {msg}",
+                bad
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_config_rejects_invalid_sidecar_exts() {
+        let bad_exts: Vec<String> = vec!["xisf".into()]; // missing dot
+        let err = resolve_config(None, None, None, Some(&bad_exts)).unwrap_err();
+        assert!(format!("{err}").contains("sidecar_exts"));
     }
 
     #[test]

--- a/src/commands/reject_archive.rs
+++ b/src/commands/reject_archive.rs
@@ -1,0 +1,272 @@
+//! Out-of-tree reject archive support.
+//!
+//! Owns the `psf_guard_archive` sibling table inside the Target Scheduler
+//! database. Each row records that psf-guard moved a rejected FITS file
+//! (and its same-stem sidecars) out of the tree PixInsight loads in bulk,
+//! keyed on the upstream `acquiredimage.guid` so it stays joinable across
+//! TS exports/reimports.
+//!
+//! The plan, history, and design rationale live in
+//! [REJECT_ARCHIVE_PLAN.md](../../../REJECT_ARCHIVE_PLAN.md). Phase A1 is
+//! this module: schema bootstrap + read helpers + a schema-version guard.
+//! Subsequent phases add destination computation (A3), sidecar discovery
+//! (A4), the `move-rejects` CLI handler (A5), and an integration test (A7).
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+
+use crate::db::SchemaCapabilities;
+
+/// `psf-guard`'s view of a single archived rejected image. One row per
+/// `acquired_image_guid` (upstream's stable cross-tool join key).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArchiveRecord {
+    pub acquired_image_guid: String,
+    pub acquired_image_id: i64,
+    /// Unix seconds (UTC) at which the move was committed to the DB.
+    pub moved_at: i64,
+    pub original_path: String,
+    pub archive_path: String,
+    /// Folder segment inserted between project and the rest of the path.
+    /// Recorded so a future `restore-rejects` can rebuild the move plan
+    /// even if the per-DB config changed since the move ran.
+    pub segment_name: String,
+    /// Depth at which `segment_name` was inserted. Same rationale.
+    pub archive_depth: u32,
+    /// Sidecar filenames (basename only, relative to the archive directory)
+    /// that travelled alongside the primary. Serialized as a JSON array of
+    /// strings in storage; deserialized eagerly here for ergonomics.
+    pub sidecar_files: Vec<String>,
+    /// Which registry slug owns this DB at the time of the move. Optional
+    /// for forward-compatibility with non-multi-DB callers; in practice
+    /// the v1 CLI always populates it.
+    pub source_db_slug: Option<String>,
+}
+
+/// Create the archive table + index if they don't already exist.
+///
+/// Safe to call repeatedly — the statements are `IF NOT EXISTS`. Schema is
+/// owned by psf-guard; no migrations from upstream Target Scheduler touch
+/// it. See REJECT_ARCHIVE_PLAN.md §4.4 for the rationale.
+pub fn ensure_archive_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS psf_guard_archive (
+            acquired_image_guid TEXT PRIMARY KEY,
+            acquired_image_id   INTEGER NOT NULL,
+            moved_at            INTEGER NOT NULL,
+            original_path       TEXT NOT NULL,
+            archive_path        TEXT NOT NULL,
+            segment_name        TEXT NOT NULL,
+            archive_depth       INTEGER NOT NULL,
+            sidecar_files       TEXT NOT NULL DEFAULT '[]',
+            source_db_slug      TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_psf_guard_archive_image_id
+            ON psf_guard_archive(acquired_image_id);
+        "#,
+    )
+    .context("creating psf_guard_archive table")?;
+    Ok(())
+}
+
+/// Refuse to operate against a Target Scheduler database that pre-dates the
+/// `acquiredimage.guid` column (migration 22). Without `guid`, we have no
+/// stable cross-export key to anchor archive rows against; falling back to
+/// `Id` would silently desync after any TS DB export/reimport.
+///
+/// The error message is user-facing — keep it actionable.
+pub fn require_target_scheduler_guid(conn: &Connection) -> Result<()> {
+    let caps = SchemaCapabilities::detect(conn);
+    if !caps.has_acquiredimage_guid {
+        return Err(anyhow::anyhow!(
+            "This Target Scheduler database is too old: it lacks the \
+             `acquiredimage.guid` column (added in plugin schema v22) which \
+             psf-guard's reject-archive feature uses to track moves across \
+             DB exports/reimports.\n\nUpgrade by opening the database in a \
+             recent N.I.N.A. + Target Scheduler version, or run earlier \
+             psf-guard commands (`filter-rejected`) that don't need it."
+        ));
+    }
+    Ok(())
+}
+
+/// Look up the archive record for an image by its TS guid. Returns
+/// `Ok(None)` if the image was never archived by psf-guard.
+pub fn get_archive_record_by_guid(conn: &Connection, guid: &str) -> Result<Option<ArchiveRecord>> {
+    conn.query_row(
+        "SELECT acquired_image_guid, acquired_image_id, moved_at,
+                original_path, archive_path, segment_name, archive_depth,
+                sidecar_files, source_db_slug
+         FROM psf_guard_archive
+         WHERE acquired_image_guid = ?1",
+        params![guid],
+        row_to_record,
+    )
+    .optional()
+    .context("querying psf_guard_archive by guid")
+}
+
+/// Look up the archive record by the TS internal `acquiredimage.Id`. Slightly
+/// less stable than guid (auto-increment IDs renumber on export/reimport)
+/// but useful for in-process callers that already have the row id from a
+/// query.
+pub fn get_archive_record_by_image_id(
+    conn: &Connection,
+    image_id: i64,
+) -> Result<Option<ArchiveRecord>> {
+    conn.query_row(
+        "SELECT acquired_image_guid, acquired_image_id, moved_at,
+                original_path, archive_path, segment_name, archive_depth,
+                sidecar_files, source_db_slug
+         FROM psf_guard_archive
+         WHERE acquired_image_id = ?1",
+        params![image_id],
+        row_to_record,
+    )
+    .optional()
+    .context("querying psf_guard_archive by image_id")
+}
+
+fn row_to_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArchiveRecord> {
+    let sidecar_raw: String = row.get("sidecar_files")?;
+    let sidecar_files = serde_json::from_str::<Vec<String>>(&sidecar_raw).unwrap_or_default();
+    Ok(ArchiveRecord {
+        acquired_image_guid: row.get("acquired_image_guid")?,
+        acquired_image_id: row.get("acquired_image_id")?,
+        moved_at: row.get("moved_at")?,
+        original_path: row.get("original_path")?,
+        archive_path: row.get("archive_path")?,
+        segment_name: row.get("segment_name")?,
+        archive_depth: row.get::<_, i64>("archive_depth")? as u32,
+        sidecar_files,
+        source_db_slug: row.get("source_db_slug")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_with_acquiredimage(guid: bool) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        let guid_col = if guid { ", guid TEXT" } else { "" };
+        conn.execute_batch(&format!(
+            "CREATE TABLE acquiredimage (
+                Id INTEGER PRIMARY KEY,
+                projectId INTEGER NOT NULL,
+                targetId INTEGER NOT NULL,
+                gradingStatus INTEGER NOT NULL DEFAULT 0,
+                metadata TEXT NOT NULL DEFAULT '{{}}'{guid_col}
+            );",
+        ))
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn ensure_archive_schema_is_idempotent_and_creates_index() {
+        let conn = open_with_acquiredimage(true);
+        // Call twice; second call must not error.
+        ensure_archive_schema(&conn).unwrap();
+        ensure_archive_schema(&conn).unwrap();
+
+        // Table exists.
+        let table_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='table' AND name='psf_guard_archive'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(table_count, 1);
+
+        // Index exists.
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='index' AND name='idx_psf_guard_archive_image_id'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(idx_count, 1);
+    }
+
+    #[test]
+    fn require_target_scheduler_guid_errors_without_column() {
+        let conn = open_with_acquiredimage(false);
+        let err = require_target_scheduler_guid(&conn).unwrap_err();
+        let msg = format!("{err}");
+        // Both keywords appear in the message so users grepping logs can find it.
+        assert!(msg.contains("guid"), "msg should mention guid: {msg}");
+        assert!(
+            msg.contains("v22") || msg.contains("22"),
+            "msg should mention schema version: {msg}"
+        );
+    }
+
+    #[test]
+    fn require_target_scheduler_guid_passes_with_column() {
+        let conn = open_with_acquiredimage(true);
+        require_target_scheduler_guid(&conn).unwrap();
+    }
+
+    #[test]
+    fn lookup_returns_none_when_no_row() {
+        let conn = open_with_acquiredimage(true);
+        ensure_archive_schema(&conn).unwrap();
+        assert!(get_archive_record_by_guid(&conn, "nope").unwrap().is_none());
+        assert!(get_archive_record_by_image_id(&conn, 999)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn lookup_returns_record_after_insert() {
+        let conn = open_with_acquiredimage(true);
+        ensure_archive_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO psf_guard_archive
+             (acquired_image_guid, acquired_image_id, moved_at,
+              original_path, archive_path, segment_name, archive_depth,
+              sidecar_files, source_db_slug)
+             VALUES ('abc', 42, 1700000000,
+                     '/src/img.fits', '/src/REJECT/img.fits',
+                     'REJECT', 1, '[\"img.xisf\"]', 'imaging-rig')",
+            [],
+        )
+        .unwrap();
+
+        let by_guid = get_archive_record_by_guid(&conn, "abc").unwrap().unwrap();
+        assert_eq!(by_guid.acquired_image_id, 42);
+        assert_eq!(by_guid.moved_at, 1700000000);
+        assert_eq!(by_guid.original_path, "/src/img.fits");
+        assert_eq!(by_guid.archive_path, "/src/REJECT/img.fits");
+        assert_eq!(by_guid.segment_name, "REJECT");
+        assert_eq!(by_guid.archive_depth, 1);
+        assert_eq!(by_guid.sidecar_files, vec!["img.xisf"]);
+        assert_eq!(by_guid.source_db_slug.as_deref(), Some("imaging-rig"));
+
+        let by_id = get_archive_record_by_image_id(&conn, 42).unwrap().unwrap();
+        assert_eq!(by_id, by_guid);
+    }
+
+    #[test]
+    fn corrupt_sidecar_json_falls_back_to_empty() {
+        let conn = open_with_acquiredimage(true);
+        ensure_archive_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO psf_guard_archive
+             (acquired_image_guid, acquired_image_id, moved_at,
+              original_path, archive_path, segment_name, archive_depth,
+              sidecar_files)
+             VALUES ('x', 1, 0, '/o', '/a', 'REJECT', 1, 'not-json')",
+            [],
+        )
+        .unwrap();
+        let r = get_archive_record_by_guid(&conn, "x").unwrap().unwrap();
+        assert!(r.sidecar_files.is_empty());
+    }
+}

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -28,6 +28,38 @@ pub struct DbEntry {
     pub db_path: String,
     #[serde(default)]
     pub image_dirs: Vec<String>,
+    /// Per-DB overrides for the out-of-tree reject-archive feature (see
+    /// REJECT_ARCHIVE_PLAN.md). All fields optional; absent values fall
+    /// back to the CLI flag, then the compiled-in defaults
+    /// (`segment_name = "REJECT"`, `depth = 1`,
+    /// `sidecar_exts = [".xisf", ".json", ".txt"]`).
+    ///
+    /// The block itself is also optional; absent in older configs means
+    /// "no per-DB overrides — use CLI flags or defaults entirely."
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reject_archive: Option<RejectArchiveOverrides>,
+}
+
+/// Persisted per-DB override block for the reject archive. All fields are
+/// optional so users can set just the knobs they care about (e.g. only the
+/// segment name) without re-specifying every default.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct RejectArchiveOverrides {
+    /// Folder name inserted into the archive path. Default `"REJECT"`.
+    /// Validated (URL-safe-ish, no path separators) at command time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub segment_name: Option<String>,
+    /// How many path segments below `image_dir` to descend before
+    /// inserting `segment_name`. Default `1` (right under the project
+    /// folder); set to `0` to drop everything into a single per-image-dir
+    /// REJECT bucket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub depth: Option<u32>,
+    /// Extensions of sibling files that move alongside the primary FITS.
+    /// Defaults to `.xisf`, `.json`, `.txt` (set via the resolver in the
+    /// CLI command — this slot is only the override).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sidecar_exts: Option<Vec<String>>,
 }
 
 /// Persisted shape of the database registry on disk (v2+).
@@ -122,6 +154,7 @@ impl DbRegistry {
                 name,
                 db_path,
                 image_dirs: v1.image_directories,
+                reject_archive: None,
             });
         }
         reg.save(path)?;
@@ -188,6 +221,7 @@ impl DbRegistry {
             name,
             db_path,
             image_dirs,
+            reject_archive: None,
         });
         Ok(self.databases.last().unwrap())
     }
@@ -364,6 +398,57 @@ mod tests {
         reg.save(&path).unwrap();
         let reloaded = DbRegistry::load_or_init(&path).unwrap();
         assert_eq!(reloaded.databases, reg.databases);
+    }
+
+    #[test]
+    fn loads_v2_config_without_reject_archive_block() {
+        // Configs written before A2 don't have the `reject_archive` key.
+        // Older configs must keep loading; the field defaults to None.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let body = serde_json::json!({
+            "schema_version": 2,
+            "databases": [
+                {"id": "a", "name": "A", "db_path": "/tmp/a.sqlite", "image_dirs": []}
+            ],
+        });
+        write(&path, &body.to_string());
+        let reg = DbRegistry::load_or_init(&path).unwrap();
+        assert_eq!(reg.databases.len(), 1);
+        assert!(reg.databases[0].reject_archive.is_none());
+    }
+
+    #[test]
+    fn round_trips_reject_archive_overrides() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let mut reg = DbRegistry::default();
+        reg.add(
+            "Imaging Rig".into(),
+            "/tmp/imaging.sqlite".into(),
+            vec!["/tmp/imgs".into()],
+            Some("imaging-rig".into()),
+        )
+        .unwrap();
+        reg.databases[0].reject_archive = Some(RejectArchiveOverrides {
+            segment_name: Some("BAD".into()),
+            depth: Some(2),
+            sidecar_exts: Some(vec![".xisf".into(), ".json".into()]),
+        });
+        reg.save(&path).unwrap();
+        let reloaded = DbRegistry::load_or_init(&path).unwrap();
+        assert_eq!(reloaded.databases, reg.databases);
+
+        // The serialized JSON should NOT include the block when it's None,
+        // so older psf-guards skip it cleanly (forward-compat sanity).
+        let mut bare = DbRegistry::default();
+        bare.add("X".into(), "/tmp/x.sqlite".into(), vec![], Some("x".into()))
+            .unwrap();
+        let json = serde_json::to_string(&bare).unwrap();
+        assert!(
+            !json.contains("reject_archive"),
+            "default config should not write the key: {json}"
+        );
     }
 
     #[test]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -342,6 +342,7 @@ impl AppState {
                 name,
                 db_path,
                 image_dirs,
+                reject_archive: None,
             }],
             cache_dir,
             pregeneration_config,

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -43,12 +43,23 @@ export const initializeApiBaseUrl = async (): Promise<string> => {
   return serverUrl ? `${serverUrl}/api` : '/api';
 };
 
+// Per-DB overrides for the reject-archive feature (mirrors
+// `RejectArchiveOverrides` in src/db_registry.rs). All fields optional;
+// missing keys fall through to the CLI flag, then the compiled-in defaults
+// (`REJECT`, depth 1, `.xisf` / `.json` / `.txt`).
+export interface RejectArchiveOverrides {
+  segment_name?: string;
+  depth?: number;
+  sidecar_exts?: string[];
+}
+
 // One configured database entry (mirrors `DbEntry` in the Rust db_registry module).
 export interface DbEntry {
   id: string;
   name: string;
   db_path: string;
   image_dirs: string[];
+  reject_archive?: RejectArchiveOverrides;
 }
 
 // Persisted registry of all configured databases (mirrors `DbRegistry`).

--- a/tests/integration_reject_archive.rs
+++ b/tests/integration_reject_archive.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 
 use psf_guard::commands::reject_archive::{
     ensure_archive_schema, move_rejects, require_target_scheduler_guid, resolve_config,
-    MoveRejectsOptions,
+    restore_rejects, MoveRejectsOptions, RestoreRejectsOptions, RestoreRejectsSummary,
 };
 use rusqlite::{params, Connection};
 use tempfile::tempdir;
@@ -190,6 +190,21 @@ fn run_archive(
     move_rejects(&conn, &dirs, &options).unwrap()
 }
 
+fn run_restore(fixture: &Fixture, options: RestoreRejectsOptions) -> RestoreRejectsSummary {
+    let conn = open_conn(&fixture.db_path);
+    require_target_scheduler_guid(&conn).unwrap();
+    restore_rejects(&conn, &options).unwrap()
+}
+
+fn set_grade(fixture: &Fixture, image_id: i64, grade: i32) {
+    let conn = open_conn(&fixture.db_path);
+    conn.execute(
+        "UPDATE acquiredimage SET gradingStatus = ?1 WHERE Id = ?2",
+        params![grade, image_id],
+    )
+    .unwrap();
+}
+
 #[test]
 fn dry_run_leaves_filesystem_and_db_alone() {
     let fixture = build_fixture();
@@ -285,9 +300,18 @@ fn live_run_moves_primary_plus_matching_sidecars_only() {
     sidecars_sorted.sort();
     assert_eq!(sidecars_sorted, vec!["img_0028.json", "img_0028.xisf"]);
 
-    // Manifest file appended.
-    let manifest = archive_dir.join(".psf-guard-manifest.json");
-    assert!(manifest.exists());
+    // Manifest lives at the REJECT root (<image_dir>/M31/REJECT), not in the
+    // leaf archive directory — one manifest per archive tree.
+    let manifest = fixture
+        .image_dir
+        .join("M31")
+        .join("REJECT")
+        .join(".psf-guard-manifest.json");
+    assert!(manifest.exists(), "manifest should live at the REJECT root");
+    assert!(
+        !archive_dir.join(".psf-guard-manifest.json").exists(),
+        "no manifest should be written in the leaf archive dir"
+    );
     let body: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&manifest).unwrap()).unwrap();
     let moves = body["moves"].as_array().unwrap();
@@ -334,4 +358,136 @@ fn legacy_db_without_guid_column_is_refused() {
         msg.contains("filter-rejected"),
         "msg should point at the legacy command: {msg}"
     );
+}
+
+fn archive_count(fixture: &Fixture) -> i64 {
+    let conn = open_conn(&fixture.db_path);
+    conn.query_row("SELECT COUNT(*) FROM psf_guard_archive", [], |r| r.get(0))
+        .unwrap()
+}
+
+#[test]
+fn restore_default_only_moves_un_rejected() {
+    let fixture = build_fixture();
+    run_archive(&fixture, false);
+    assert_eq!(archive_count(&fixture), 2);
+
+    // Un-reject img1 (id=1) to Accepted; leave img2 (id=2) Rejected.
+    set_grade(&fixture, 1, 1);
+
+    let summary = run_restore(&fixture, RestoreRejectsOptions::default());
+    assert_eq!(summary.planned, 1);
+    assert_eq!(summary.restored, 1);
+    assert_eq!(summary.skipped_still_rejected, 1);
+    assert_eq!(summary.errors, 0);
+
+    // img1 primary + sidecars are back at their original paths.
+    assert!(fixture.img1_src.exists(), "primary 28 restored");
+    let orig_dir = fixture.img1_src.parent().unwrap();
+    assert!(orig_dir.join("img_0028.xisf").exists());
+    assert!(orig_dir.join("img_0028.json").exists());
+
+    // img2 is still archived (still Rejected); its row remains.
+    assert_eq!(archive_count(&fixture), 1);
+    assert!(!fixture.img2_src.exists(), "img2 still archived on disk");
+}
+
+#[test]
+fn restore_all_moves_everything_and_prunes() {
+    let fixture = build_fixture();
+    run_archive(&fixture, false);
+
+    // Both still Rejected; --all overrides the grade filter.
+    let summary = run_restore(
+        &fixture,
+        RestoreRejectsOptions {
+            restore_all: true,
+            ..Default::default()
+        },
+    );
+    assert_eq!(summary.planned, 2);
+    assert_eq!(summary.restored, 2);
+    assert_eq!(summary.skipped_still_rejected, 0);
+    assert_eq!(archive_count(&fixture), 0);
+
+    assert!(fixture.img1_src.exists());
+    assert!(fixture.img2_src.exists());
+
+    // The emptied leaf archive dirs are pruned; the REJECT root survives
+    // because it still holds the manifest.
+    let reject_root = fixture.image_dir.join("M31").join("REJECT");
+    assert!(
+        reject_root.join(".psf-guard-manifest.json").exists(),
+        "manifest kept at REJECT root"
+    );
+    assert!(
+        !reject_root.join("2026-04-16").exists(),
+        "emptied date dir should be pruned"
+    );
+}
+
+#[test]
+fn restore_never_overwrites_uses_suffix() {
+    let fixture = build_fixture();
+    run_archive(&fixture, false);
+    set_grade(&fixture, 1, 1); // un-reject img1
+
+    // A *different* file now occupies img1's original path.
+    let orig = &fixture.img1_src;
+    fs::write(orig, b"a different newer capture").unwrap();
+
+    let summary = run_restore(&fixture, RestoreRejectsOptions::default());
+    assert_eq!(summary.restored, 1);
+    assert_eq!(summary.restored_with_suffix, 1);
+    assert_eq!(summary.errors, 0);
+
+    // The occupant is untouched.
+    assert_eq!(
+        fs::read_to_string(orig).unwrap(),
+        "a different newer capture"
+    );
+    // The archived primary landed beside it with a .restored suffix.
+    let restored = orig.parent().unwrap().join("img_0028.restored.fits");
+    assert!(restored.exists(), "restored beside the occupant");
+    assert_eq!(fs::read_to_string(&restored).unwrap(), "primary 28");
+}
+
+#[test]
+fn restore_dry_run_changes_nothing() {
+    let fixture = build_fixture();
+    run_archive(&fixture, false);
+    set_grade(&fixture, 1, 1);
+    set_grade(&fixture, 2, 1);
+
+    let summary = run_restore(
+        &fixture,
+        RestoreRejectsOptions {
+            dry_run: true,
+            ..Default::default()
+        },
+    );
+    assert_eq!(summary.planned, 2);
+    assert_eq!(summary.restored, 2); // counted as planned-and-would-restore
+    assert_eq!(archive_count(&fixture), 2, "rows untouched in dry-run");
+    assert!(!fixture.img1_src.exists(), "files not moved in dry-run");
+}
+
+#[test]
+fn restore_targeted_by_guid_ignores_grade() {
+    let fixture = build_fixture();
+    run_archive(&fixture, false);
+    // Both still Rejected. Target img2's guid explicitly.
+    let summary = run_restore(
+        &fixture,
+        RestoreRejectsOptions {
+            guid_filter: Some("guid-img-29".into()),
+            ..Default::default()
+        },
+    );
+    assert_eq!(summary.planned, 1);
+    assert_eq!(summary.restored, 1);
+    assert_eq!(summary.skipped_still_rejected, 0);
+    assert!(fixture.img2_src.exists(), "targeted img2 restored");
+    assert!(!fixture.img1_src.exists(), "img1 left archived");
+    assert_eq!(archive_count(&fixture), 1);
 }

--- a/tests/integration_reject_archive.rs
+++ b/tests/integration_reject_archive.rs
@@ -1,0 +1,337 @@
+//! End-to-end test for the out-of-tree reject archive (A7).
+//!
+//! Builds a tempdir with a NINA-style layout, a SQLite DB containing the
+//! Target Scheduler tables (including the v22 `guid` column required by
+//! the archive feature), rejects three images, then exercises the
+//! `move_rejects` orchestrator. Verifies the move plan, the on-disk
+//! result, the `psf_guard_archive` row, the manifest file, and
+//! idempotent re-runs.
+
+use std::fs;
+use std::path::PathBuf;
+
+use psf_guard::commands::reject_archive::{
+    ensure_archive_schema, move_rejects, require_target_scheduler_guid, resolve_config,
+    MoveRejectsOptions,
+};
+use rusqlite::{params, Connection};
+use tempfile::tempdir;
+
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    image_dir: PathBuf,
+    db_path: PathBuf,
+    // Per-image absolute source paths so the test can assert their move/non-move.
+    img1_src: PathBuf, // rejected, has sidecars
+    img2_src: PathBuf, // rejected, no sidecars
+    img3_src: PathBuf, // accepted, must NOT move
+}
+
+/// Build a self-contained NINA-style layout:
+///
+/// ```
+/// images/
+///   M31/
+///     2026-04-16/
+///       LIGHT/
+///         img_0028.fits          (rejected) + .xisf + .json sidecars
+///         img_0029.fits          (rejected, no sidecars)
+///         img_0030.fits          (accepted)
+///   M42/
+///     2026-04-17/
+///       LIGHT/
+///         (calibration master that must not be touched)
+///         Bias_master.fits
+/// ```
+fn build_fixture() -> Fixture {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let image_dir = root.join("images");
+    let m31_light = image_dir.join("M31").join("2026-04-16").join("LIGHT");
+    let m42_light = image_dir.join("M42").join("2026-04-17").join("LIGHT");
+    fs::create_dir_all(&m31_light).unwrap();
+    fs::create_dir_all(&m42_light).unwrap();
+
+    let img1_src = m31_light.join("img_0028.fits");
+    fs::write(&img1_src, b"primary 28").unwrap();
+    fs::write(m31_light.join("img_0028.xisf"), b"xisf 28").unwrap();
+    fs::write(m31_light.join("img_0028.json"), b"json 28").unwrap();
+    // Non-matching extension; should NOT move.
+    fs::write(m31_light.join("img_0028.log"), b"log 28").unwrap();
+
+    let img2_src = m31_light.join("img_0029.fits");
+    fs::write(&img2_src, b"primary 29").unwrap();
+
+    let img3_src = m31_light.join("img_0030.fits");
+    fs::write(&img3_src, b"primary 30 accepted").unwrap();
+
+    // Calibration master in a different folder — same .fits ext but
+    // different stem from any LIGHT, never touched.
+    fs::write(m42_light.join("Bias_master.fits"), b"bias").unwrap();
+
+    let db_path = root.join("scheduler.sqlite");
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE project (
+            Id INTEGER PRIMARY KEY,
+            profileId TEXT,
+            name TEXT NOT NULL,
+            description TEXT
+        );
+        CREATE TABLE target (
+            Id INTEGER PRIMARY KEY,
+            projectId INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1,
+            ra REAL,
+            dec REAL
+        );
+        CREATE TABLE acquiredimage (
+            Id INTEGER PRIMARY KEY,
+            projectId INTEGER NOT NULL,
+            targetId INTEGER NOT NULL,
+            acquireddate INTEGER,
+            filtername TEXT NOT NULL,
+            gradingStatus INTEGER NOT NULL DEFAULT 0,
+            metadata TEXT NOT NULL DEFAULT '{}',
+            rejectreason TEXT,
+            profileId TEXT,
+            guid TEXT
+        );
+
+        INSERT INTO project (Id, profileId, name) VALUES (1, 'default', 'M31');
+        INSERT INTO target (Id, projectId, name) VALUES (1, 1, 'M31');
+    "#,
+    )
+    .unwrap();
+
+    // 1700000000 = 2023-11-14 UTC; date doesn't matter for the archive
+    // logic — we go through directory_tree fallback. The metadata FileName
+    // is what matters for source-on-disk discovery.
+    let insert = "INSERT INTO acquiredimage
+        (Id, projectId, targetId, acquireddate, filtername, gradingStatus, metadata, guid)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+    conn.execute(
+        insert,
+        params![
+            1,
+            1,
+            1,
+            1700000000i64,
+            "L",
+            2, // Rejected
+            r#"{"FileName": "img_0028.fits"}"#,
+            "guid-img-28",
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        insert,
+        params![
+            2,
+            1,
+            1,
+            1700000100i64,
+            "L",
+            2,
+            r#"{"FileName": "img_0029.fits"}"#,
+            "guid-img-29",
+        ],
+    )
+    .unwrap();
+    conn.execute(
+        insert,
+        params![
+            3,
+            1,
+            1,
+            1700000200i64,
+            "L",
+            1, // Accepted — must NOT move
+            r#"{"FileName": "img_0030.fits"}"#,
+            "guid-img-30",
+        ],
+    )
+    .unwrap();
+
+    Fixture {
+        _tmp: tmp,
+        image_dir,
+        db_path,
+        img1_src,
+        img2_src,
+        img3_src,
+    }
+}
+
+fn open_conn(path: &std::path::Path) -> Connection {
+    Connection::open(path).unwrap()
+}
+
+fn run_archive(
+    fixture: &Fixture,
+    dry_run: bool,
+) -> psf_guard::commands::reject_archive::MoveRejectsSummary {
+    let conn = open_conn(&fixture.db_path);
+    require_target_scheduler_guid(&conn).unwrap();
+    ensure_archive_schema(&conn).unwrap();
+
+    let config = resolve_config(None, None, None, None).unwrap();
+    let options = MoveRejectsOptions {
+        config,
+        project_filter: None,
+        target_filter: None,
+        dry_run,
+        source_db_slug: "test-rig".into(),
+        verbose: false,
+    };
+    let dirs = vec![fixture.image_dir.to_string_lossy().into_owned()];
+    move_rejects(&conn, &dirs, &options).unwrap()
+}
+
+#[test]
+fn dry_run_leaves_filesystem_and_db_alone() {
+    let fixture = build_fixture();
+    let summary = run_archive(&fixture, true);
+
+    assert_eq!(summary.planned, 2, "two rejected rows expected");
+    assert_eq!(summary.archived, 0);
+    assert_eq!(summary.already_archived, 0);
+    assert_eq!(summary.errors, 0);
+
+    // Files still at their source paths.
+    assert!(fixture.img1_src.exists());
+    assert!(fixture.img2_src.exists());
+    assert!(fixture.img3_src.exists());
+
+    // No archive table rows were inserted.
+    let conn = open_conn(&fixture.db_path);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM psf_guard_archive", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn live_run_moves_primary_plus_matching_sidecars_only() {
+    let fixture = build_fixture();
+    let summary = run_archive(&fixture, false);
+
+    assert_eq!(summary.archived, 2);
+    assert_eq!(summary.errors, 0);
+
+    // Primary should have moved to <image_dir>/M31/REJECT/2026-04-16/LIGHT/.
+    // (Date string in get_possible_paths comes from acquireddate; but the
+    // directory_tree fallback works regardless. We just check the new
+    // location matches the depth-1 rule against image_dir.)
+    let archive_dir = fixture
+        .image_dir
+        .join("M31")
+        .join("REJECT")
+        .join("2026-04-16")
+        .join("LIGHT");
+    assert!(
+        archive_dir.join("img_0028.fits").exists(),
+        "primary 28 should have moved"
+    );
+    assert!(
+        archive_dir.join("img_0028.xisf").exists(),
+        "matching .xisf sidecar should have moved"
+    );
+    assert!(
+        archive_dir.join("img_0028.json").exists(),
+        "matching .json sidecar should have moved"
+    );
+    assert!(
+        !archive_dir.join("img_0028.log").exists(),
+        "non-matching extension should NOT have moved"
+    );
+
+    // The .log file stays where the primary was.
+    let orig_dir = fixture.img1_src.parent().unwrap();
+    assert!(orig_dir.join("img_0028.log").exists());
+    // The accepted image stays put.
+    assert!(fixture.img3_src.exists());
+
+    // Archive table records both moves keyed on guid.
+    let conn = open_conn(&fixture.db_path);
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM psf_guard_archive", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 2);
+
+    let (orig, arch, segment, depth, sidecar_json): (String, String, String, i64, String) = conn
+        .query_row(
+            "SELECT original_path, archive_path, segment_name, archive_depth, sidecar_files
+             FROM psf_guard_archive WHERE acquired_image_guid = 'guid-img-28'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )
+        .unwrap();
+    assert!(orig.contains("img_0028.fits"));
+    assert!(arch.ends_with(
+        std::path::PathBuf::from("REJECT")
+            .join("2026-04-16")
+            .join("LIGHT")
+            .join("img_0028.fits")
+            .to_string_lossy()
+            .as_ref()
+    ));
+    assert_eq!(segment, "REJECT");
+    assert_eq!(depth, 1);
+    let sidecars: Vec<String> = serde_json::from_str(&sidecar_json).unwrap();
+    let mut sidecars_sorted = sidecars.clone();
+    sidecars_sorted.sort();
+    assert_eq!(sidecars_sorted, vec!["img_0028.json", "img_0028.xisf"]);
+
+    // Manifest file appended.
+    let manifest = archive_dir.join(".psf-guard-manifest.json");
+    assert!(manifest.exists());
+    let body: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest).unwrap()).unwrap();
+    let moves = body["moves"].as_array().unwrap();
+    assert_eq!(moves.len(), 2, "manifest should have both moves");
+}
+
+#[test]
+fn re_run_is_idempotent_and_reports_already_archived() {
+    let fixture = build_fixture();
+    let _first = run_archive(&fixture, false);
+    let second = run_archive(&fixture, false);
+
+    assert_eq!(second.archived, 0, "second run should archive nothing");
+    assert_eq!(
+        second.already_archived, 2,
+        "both prior moves should be counted as already_archived"
+    );
+    assert_eq!(second.errors, 0);
+}
+
+#[test]
+fn legacy_db_without_guid_column_is_refused() {
+    // Same layout as build_fixture, but drop the `guid` column on
+    // acquiredimage. The schema guard should refuse the run with a
+    // clear message.
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("legacy.sqlite");
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE acquiredimage (
+            Id INTEGER PRIMARY KEY,
+            projectId INTEGER NOT NULL,
+            targetId INTEGER NOT NULL,
+            gradingStatus INTEGER NOT NULL DEFAULT 0,
+            metadata TEXT NOT NULL DEFAULT '{}'
+        );",
+    )
+    .unwrap();
+
+    let err = require_target_scheduler_guid(&conn).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("guid"), "msg should mention guid: {msg}");
+    assert!(
+        msg.contains("filter-rejected"),
+        "msg should point at the legacy command: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Replaces `psf-guard filter-rejected`'s "rename LIGHT/ to LIGHT_REJECT/ as a sibling" behavior with a genuine out-of-tree archive: rejected FITS files (plus same-stem sidecars) move to `<image_dir>/<Project>/REJECT/<rest>`, configurable depth/segment via per-DB registry fields and CLI overrides. Idempotent and reversible via a sibling `psf_guard_archive` table in the TS database (keyed on `acquiredimage.guid`) plus a manifest at the REJECT root.

**Status: all implementation phases (A1–A8) complete and pushed. Ready for review.** All seven Copilot review comments have been addressed (see the `A8 + review` commit). Remaining work is deferred by design (UI trigger button, cross-DB archive lookup — see plan §6).

Full design and tracker: [REJECT_ARCHIVE_PLAN.md](../blob/reject-archive-a1/REJECT_ARCHIVE_PLAN.md).

## Why a sibling table, not extending TS's `metadata` column

Research (see plan §3): the TS `ImageMetadata` C# DTO uses Newtonsoft defaults with no `[JsonExtensionData]`. Round-tripping through the `AcquiredImage.Metadata` property pair is lossy by design — unknown keys are silently dropped on read. No upstream code path currently round-trips on existing rows, but any future TS PR doing `acquiredImage.Metadata = ...` would silently wipe annotations. Sibling table on `guid` (TS migration 22, designed as a cross-tool join key) sidesteps the risk entirely.

## What's included

- **`move-rejects` command** (`psf-guard move-rejects --db <slug>`): multi-DB-aware via the registry, finds each rejected image on disk, moves the primary + matching sidecars out of tree, records each move in `psf_guard_archive` and a `.psf-guard-manifest.json` at the archive root. `--dry-run`, `--project`, `--target`, `--verbose`, plus `--reject-segment` / `--reject-depth` / `--sidecar-exts` overrides.
- **Config precedence**: CLI flag > per-DB `reject_archive` registry block (`segment_name`, `depth`, `sidecar_exts`) > compiled-in defaults (`REJECT`, depth `1`, `[.xisf, .json, .txt]`), resolved field-by-field.
- **Schema guard**: refuses pre-v22 DBs (no `guid` column) with an actionable error pointing at the legacy command.
- **Idempotency**: re-runs skip already-archived guids; partial per-image failures roll back and are counted, not fatal.
- **`filter-rejected` deprecation**: prints a one-time banner pointing at `move-rejects`, but still runs to completion — it retains the statistical-regrading `--stat-*` flags the new command doesn't duplicate.

## Phases (each a separate commit)

- [x] **A1** Schema bootstrap + version check
- [x] **A2** Per-DB `reject_archive` registry field + resolver
- [x] **A3** `archive_path_for` pure function + unit tests
- [x] **A4** `find_sidecars` same-stem discovery + unit tests
- [x] **A5** `psf-guard move-rejects` CLI handler
- [x] **A6** Deprecation banner for `filter-rejected` + README/CLAUDE.md docs
- [x] **A7** Integration test (`tests/integration_reject_archive.rs`)
- [x] **A8** `restore-rejects` — implemented (default restores un-rejected files; `--all`/`--image-id`/`--guid`; never overwrites; prunes emptied dirs)



## Addressed review comments (Copilot)

- **Tree index desync** (`reject_archive.rs`): a failed `DirectoryTree` build dropped an entry and shifted later indices. Now `Vec<Option<DirectoryTree>>` aligned to `image_dirs`.
- **Stale already-archived rows**: a row whose `archive_path` is missing on disk is now reported via a new `missing_archive` counter, not silently counted as a clean skip.
- **Manifest location**: now a single manifest at the REJECT root (`archive_root_for`), not one per leaf dir. Test assertion updated.
- **Dry-run did DDL**: `move-rejects --dry-run` no longer creates the `psf_guard_archive` table; lookups tolerate a missing table.
- **Stale doc comment / help text** on `MoveRejects`; **plan header** no longer says "Draft / not started".

## restore-rejects (A8)

Reverses `move-rejects`. Default restores only files no longer graded Rejected (un-rejected in the UI — Accepted *or* Pending); `--all` / `--image-id` / `--guid` override the grade filter. Never overwrites (`.restored[.N]` suffix beside an occupant). Deletes the archive row and prunes emptied REJECT dirs (keeping a dir that still holds the manifest).

## Test plan

- `cargo test` — green: 155 unit + 4 new reject-archive integration + 13 sequence integration + 5 (others)
- A7 integration test covers: dry-run (no fs/db mutation), live move (primary + matching sidecars move, non-matching `.log` and accepted images stay put, archive row + manifest written), idempotent re-run (`already_archived` counts), and legacy-DB-without-guid refusal
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- Manual smoke against a real TS DB on v22+ recommended before merge

## Note on history

An earlier commit on this branch accidentally swept in local build artifacts (`Frameworks/*.dylib`, `mise.toml`, etc.) via `git add -A`. It was replaced with a clean commit via force-push-with-lease, and `.gitignore` now covers those paths so it can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

