### PR TITLE
feat: two-DB sync between scheduler DBs (`sync grades` push + `sync pull` mirror)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,31 @@ Implementation tracker and design rationale: [MULTI_DB_PLAN.md](./MULTI_DB_PLAN.
 
 Design, phases, tracker: [REJECT_ARCHIVE_PLAN.md](./REJECT_ARCHIVE_PLAN.md).
 
+### Two-DB grade sync (2026-06)
+- **Command**: `psf-guard sync grades --from <slug|path> --to <slug|path>`
+  (`src/commands/sync.rs`). Pushes grading state (`gradingStatus` +
+  `rejectreason`) one-way from a source DB into a destination DB. Source
+  always wins; run it both ways for a crude bidirectional reconcile.
+- **Match key**: exact `acquiredimage.guid` (TS schema v22+, enforced on both
+  sides via `require_target_scheduler_guid`). Assumes same-lineage DBs (one a
+  copy/export of the other) so guids line up 1:1. No filename/fuzzy matching.
+- **DB scope**: `--from`/`--to` accept *either* a registry slug *or* a raw
+  `.sqlite` path, so you can sync into an unmanaged live N.I.N.A. DB. Registry
+  is loaded only when a side isn't already a file (so syncing two plain paths
+  creates no config). Source opened READ_ONLY, destination READ_WRITE; refuses
+  same-path source/dest.
+- **Filters / safety**: `--status pending|accepted|rejected` scopes which
+  source rows are pushed; `--project` / `--target` substring filters;
+  `--dry-run` computes the plan with zero writes; `--verbose` traces each
+  transition. Destination writes go through one transaction
+  (`batch_update_grading_status`). Reuses `query_images` for both sides.
+- **Reporting**: summarizes considered / matched / changed / unchanged /
+  unmatched-source / dest-only, with a per-transition breakdown. Rows with
+  NULL/empty guid and guids duplicated within a DB are skipped (counted, not
+  fatal).
+- **Extensibility**: structured as `sync <kind>` (only `grades` today) so
+  future sync kinds (targets, project config) slot in without breaking the CLI.
+
 ### Smart Binary Mode Selection
 - **Single binary** `psf-guard` with intelligent mode detection
 - **GUI mode**: When tauri feature is enabled and no arguments passed → Desktop app launches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,8 @@ READ_WRITE, refuse same-path source/dest, and have `--dry-run` + `--verbose`.
 
 **`sync pull --from <telescope> --to <our>`** — pull structure + captures.
 - Mirrors `exposuretemplate`, `project`, `ruleweight`, `target`, `exposureplan`,
-  `acquiredimage` (and `imagedata` blobs with `--with-image-data`) into our DB.
+  `acquiredimage`, and `imagedata` blobs (copied by default; `--no-image-data`
+  to skip) into our DB.
   Processed in FK order, building `src_guid → dest_Id` maps so child FKs
   (target→project, plan→target+template, image→project+target+exposureId,
   ruleweight→project) are remapped onto the destination's local autoincrement

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,30 +97,42 @@ Implementation tracker and design rationale: [MULTI_DB_PLAN.md](./MULTI_DB_PLAN.
 
 Design, phases, tracker: [REJECT_ARCHIVE_PLAN.md](./REJECT_ARCHIVE_PLAN.md).
 
-### Two-DB grade sync (2026-06)
-- **Command**: `psf-guard sync grades --from <slug|path> --to <slug|path>`
-  (`src/commands/sync.rs`). Pushes grading state (`gradingStatus` +
-  `rejectreason`) one-way from a source DB into a destination DB. Source
-  always wins; run it both ways for a crude bidirectional reconcile.
-- **Match key**: exact `acquiredimage.guid` (TS schema v22+, enforced on both
-  sides via `require_target_scheduler_guid`). Assumes same-lineage DBs (one a
-  copy/export of the other) so guids line up 1:1. No filename/fuzzy matching.
-- **DB scope**: `--from`/`--to` accept *either* a registry slug *or* a raw
-  `.sqlite` path, so you can sync into an unmanaged live N.I.N.A. DB. Registry
-  is loaded only when a side isn't already a file (so syncing two plain paths
-  creates no config). Source opened READ_ONLY, destination READ_WRITE; refuses
-  same-path source/dest.
-- **Filters / safety**: `--status pending|accepted|rejected` scopes which
-  source rows are pushed; `--project` / `--target` substring filters;
-  `--dry-run` computes the plan with zero writes; `--verbose` traces each
-  transition. Destination writes go through one transaction
-  (`batch_update_grading_status`). Reuses `query_images` for both sides.
-- **Reporting**: summarizes considered / matched / changed / unchanged /
-  unmatched-source / dest-only, with a per-transition breakdown. Rows with
-  NULL/empty guid and guids duplicated within a DB are skipped (counted, not
-  fatal).
-- **Extensibility**: structured as `sync <kind>` (only `grades` today) so
-  future sync kinds (targets, project config) slot in without breaking the CLI.
+### Two-DB sync (2026-06)
+Lives in `src/commands/sync/` (`mod.rs` shared helpers + `grades.rs` + `pull.rs`).
+Two complementary single-direction kinds, structured as `sync <kind>` so more
+kinds slot in without breaking the CLI. Both match by `guid` (TS schema v22+),
+accept a registry slug *or* a raw `.sqlite` path for `--from`/`--to` (registry
+loaded only when a side isn't already a file), open source READ_ONLY / dest
+READ_WRITE, refuse same-path source/dest, and have `--dry-run` + `--verbose`.
+
+**`sync grades --from <our> --to <telescope>`** — push grading state.
+- Pushes `gradingStatus` + `rejectreason` one-way; source wins. Match by
+  `acquiredimage.guid`, guard via `require_target_scheduler_guid`.
+- `--status pending|accepted|rejected` scopes source rows; `--project` /
+  `--target` substring filters. One transaction (`batch_update_grading_status`),
+  reuses `query_images` for both sides.
+- Reports considered / matched / changed / unchanged / unmatched-source /
+  dest-only + per-transition breakdown. NULL/empty and within-DB-duplicate guids
+  skipped (counted, not fatal).
+
+**`sync pull --from <telescope> --to <our>`** — pull structure + captures.
+- Mirrors `exposuretemplate`, `project`, `ruleweight`, `target`, `exposureplan`,
+  `acquiredimage` (and `imagedata` blobs with `--with-image-data`) into our DB.
+  Processed in FK order, building `src_guid → dest_Id` maps so child FKs
+  (target→project, plan→target+template, image→project+target+exposureId,
+  ruleweight→project) are remapped onto the destination's local autoincrement
+  Ids. Generic guid-keyed upsert reads all columns via `pragma_table_info` so it
+  survives TS schema additions; `ruleweight` (no guid) matches by
+  `(projectId, name)`; `imagedata` is insert-only.
+- **Telescope wins for structure** (upsert: insert new, update changed fields —
+  project state, plan desired/acquired counts, coordinates). **Local grading is
+  preserved**: a new image takes the telescope grade; an existing image keeps
+  its grade unless still Pending (0), in which case it adopts the telescope's
+  grade. Guard via `require_pull_capable` (guid on all 5 core tables).
+- `--project <substr>` scopes the pull (cascades to that project's targets,
+  plans, images; templates always synced so plan FKs resolve). Whole pull runs
+  in one transaction, rolled back on `--dry-run`.
+- Reports per-table inserted/updated/unchanged plus grades filled/preserved.
 
 ### Smart Binary Mode Selection
 - **Single binary** `psf-guard` with intelligent mode detection

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -416,6 +416,18 @@ pub enum Commands {
         verbose: bool,
     },
 
+    /// Sync state between two Target Scheduler databases.
+    ///
+    /// Currently supports pushing grading state (accept/reject/pending plus the
+    /// reject reason) one-way from a source DB into a destination DB, matched
+    /// by the stable `acquiredimage.guid` (TS plugin schema v22+). The two DBs
+    /// are assumed same-lineage (one a copy/export of the other). The source
+    /// always wins — run it both ways for a crude bidirectional reconcile.
+    Sync {
+        #[command(subcommand)]
+        kind: SyncKind,
+    },
+
     /// Start the web server for API access and static file serving
     Server {
         /// Path to TOML configuration file
@@ -482,6 +494,45 @@ pub enum Commands {
         /// trusted interface (e.g. localhost). Tauri mode always enables it.
         #[arg(long)]
         allow_database_management: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum SyncKind {
+    /// Push grading state from one database into another (one-way, by guid).
+    Grades {
+        /// Source database (read-only): a registry slug or a path to a .sqlite file.
+        #[arg(long)]
+        from: String,
+
+        /// Destination database (written): a registry slug or a path to a .sqlite file.
+        #[arg(long)]
+        to: String,
+
+        /// Print the plan without writing to the destination.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Only push rows whose SOURCE grade is this (pending|accepted|rejected).
+        #[arg(long)]
+        status: Option<String>,
+
+        /// Restrict to source rows whose project name matches (substring).
+        #[arg(short, long)]
+        project: Option<String>,
+
+        /// Restrict to source rows whose target name matches (substring).
+        #[arg(short, long)]
+        target: Option<String>,
+
+        /// Path to the database registry JSON file (only consulted when
+        /// --from/--to is a slug; defaults to the platform config directory).
+        #[arg(long)]
+        registry: Option<String>,
+
+        /// Verbose: print a per-image trace of each grade transition.
+        #[arg(short, long)]
+        verbose: bool,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -534,6 +534,46 @@ pub enum SyncKind {
         #[arg(short, long)]
         verbose: bool,
     },
+
+    /// Pull structure + captured images FROM a telescope DB INTO our local DB.
+    ///
+    /// Mirrors projects, targets (coordinates), exposure templates/plans, rule
+    /// weights, and acquired images, matched by `guid` (TS schema v22+) with
+    /// foreign keys remapped onto the destination's local Ids. The telescope
+    /// wins for structure fields, but local grading is preserved: an existing
+    /// image keeps its grade unless it is still Pending, in which case it
+    /// adopts the telescope's grade. Push grades back with `sync grades`.
+    Pull {
+        /// Telescope database (source, read-only): a registry slug or a .sqlite path.
+        #[arg(long)]
+        from: String,
+
+        /// Local database (destination, written): a registry slug or a .sqlite path.
+        #[arg(long)]
+        to: String,
+
+        /// Print the plan without writing to the destination.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Also copy the (large) imagedata thumbnail BLOBs.
+        #[arg(long)]
+        with_image_data: bool,
+
+        /// Restrict the pull to projects whose name matches (substring);
+        /// cascades to their targets, plans, and images.
+        #[arg(short, long)]
+        project: Option<String>,
+
+        /// Path to the database registry JSON file (only consulted when
+        /// --from/--to is a slug; defaults to the platform config directory).
+        #[arg(long)]
+        registry: Option<String>,
+
+        /// Verbose: print a per-entity trace of inserts/updates.
+        #[arg(short, long)]
+        verbose: bool,
+    },
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -556,9 +556,9 @@ pub enum SyncKind {
         #[arg(long)]
         dry_run: bool,
 
-        /// Also copy the (large) imagedata thumbnail BLOBs.
+        /// Skip copying the (large) imagedata thumbnail BLOBs (copied by default).
         #[arg(long)]
-        with_image_data: bool,
+        no_image_data: bool,
 
         /// Restrict the pull to projects whose name matches (substring);
         /// cascades to their targets, plans, and images.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -416,13 +416,14 @@ pub enum Commands {
         verbose: bool,
     },
 
-    /// Sync state between two Target Scheduler databases.
-    ///
-    /// Currently supports pushing grading state (accept/reject/pending plus the
-    /// reject reason) one-way from a source DB into a destination DB, matched
-    /// by the stable `acquiredimage.guid` (TS plugin schema v22+). The two DBs
-    /// are assumed same-lineage (one a copy/export of the other). The source
-    /// always wins — run it both ways for a crude bidirectional reconcile.
+    /// Sync state between two Target Scheduler databases, matched by the stable
+    /// `acquiredimage.guid` (TS plugin schema v22+). Two complementary one-way
+    /// operations: `sync pull` mirrors structure + captured images from a
+    /// telescope DB into your local DB (preserving your local grading), and
+    /// `sync grades` pushes your grading decisions from the local DB back into
+    /// the telescope DB. Use them together — pull to refresh, grade locally,
+    /// push grades back — rather than reversing one direction, which would
+    /// overwrite work.
     Sync {
         #[command(subcommand)]
         kind: SyncKind,

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -570,6 +570,36 @@ pub fn main() -> Result<()> {
                 } else {
                     println!("  imagedata        skipped (--no-image-data)");
                 }
+
+                // Human-readable byte size.
+                let human = |n: u64| -> String {
+                    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+                    let mut f = n as f64;
+                    let mut i = 0;
+                    while f >= 1024.0 && i < UNITS.len() - 1 {
+                        f /= 1024.0;
+                        i += 1;
+                    }
+                    if i == 0 {
+                        format!("{} {}", n, UNITS[0])
+                    } else {
+                        format!("{:.1} {}", f, UNITS[i])
+                    }
+                };
+                let suffix = if dry_run { " (planned)" } else { "" };
+                println!(
+                    "  ── total: inserted={} updated={}{}",
+                    summary.total_inserted(),
+                    summary.total_updated(),
+                    suffix
+                );
+                if summary.imagedata_synced {
+                    println!(
+                        "     imagedata copied: {}{}",
+                        human(summary.imagedata_bytes),
+                        suffix
+                    );
+                }
             }
         },
         Commands::Server {

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -357,6 +357,114 @@ pub fn main() -> Result<()> {
         } => {
             benchmark_psf(&fits_path, runs, verbose)?;
         }
+        Commands::Sync { kind } => match kind {
+            crate::cli::SyncKind::Grades {
+                from,
+                to,
+                dry_run,
+                status,
+                project,
+                target,
+                registry,
+                verbose,
+            } => {
+                use crate::commands::sync::{
+                    parse_status, resolve_db_path, sync_grades, SyncGradesOptions,
+                };
+                use crate::db_registry::DbRegistry;
+                use rusqlite::OpenFlags;
+                use std::path::{Path, PathBuf};
+
+                // Load the registry only when a side might be a slug (i.e. isn't
+                // already an existing file), so syncing two plain paths doesn't
+                // create a registry file as a side effect.
+                let need_registry = !Path::new(&from).is_file() || !Path::new(&to).is_file();
+                let registry_obj = if need_registry {
+                    let registry_path = match &registry {
+                        Some(p) => PathBuf::from(p),
+                        None => {
+                            DbRegistry::default_path().context("resolving default registry path")?
+                        }
+                    };
+                    Some(DbRegistry::load_or_init(&registry_path).with_context(|| {
+                        format!("loading registry at {}", registry_path.display())
+                    })?)
+                } else {
+                    None
+                };
+
+                let from_path = resolve_db_path(registry_obj.as_ref(), &from)?;
+                let to_path = resolve_db_path(registry_obj.as_ref(), &to)?;
+
+                // Refuse to "sync" a database with itself.
+                let from_canon =
+                    std::fs::canonicalize(&from_path).unwrap_or_else(|_| from_path.clone());
+                let to_canon = std::fs::canonicalize(&to_path).unwrap_or_else(|_| to_path.clone());
+                if from_canon == to_canon {
+                    return Err(anyhow::anyhow!(
+                        "Source and destination resolve to the same database ({}); nothing to sync",
+                        from_canon.display()
+                    ));
+                }
+
+                let status_filter = match status.as_deref() {
+                    Some(s) => Some(parse_status(s)?),
+                    None => None,
+                };
+
+                let src = Connection::open_with_flags(&from_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+                    .with_context(|| format!("opening source database {}", from_path.display()))?;
+                let dest = Connection::open_with_flags(&to_path, OpenFlags::SQLITE_OPEN_READ_WRITE)
+                    .with_context(|| {
+                        format!("opening destination database {}", to_path.display())
+                    })?;
+
+                let options = SyncGradesOptions {
+                    status_filter,
+                    project_filter: project,
+                    target_filter: target,
+                    dry_run,
+                    verbose,
+                };
+
+                if verbose {
+                    println!("Grade transitions (dest → src):");
+                }
+                let summary = sync_grades(&src, &dest, &options)?;
+
+                println!(
+                    "\nGrade sync {} {} → {}:",
+                    if dry_run { "(dry-run)" } else { "(live)" },
+                    from_path.display(),
+                    to_path.display(),
+                );
+                println!(
+                    "  source rows considered: {} (skipped, no guid: {})",
+                    summary.source_considered, summary.source_no_guid
+                );
+                println!("  matched in destination: {}", summary.matched);
+                println!(
+                    "    changed:   {}{}",
+                    summary.changed,
+                    if dry_run { " (would change)" } else { "" }
+                );
+                println!("    unchanged: {}", summary.unchanged);
+                println!(
+                    "  source guid not in destination: {}",
+                    summary.unmatched_source
+                );
+                println!("  destination guid not in source: {}", summary.dest_only);
+                if summary.duplicate_guids > 0 {
+                    println!("  duplicate guids skipped: {}", summary.duplicate_guids);
+                }
+                if !summary.transitions.is_empty() {
+                    println!("  transitions:");
+                    for (label, count) in &summary.transitions {
+                        println!("    {}: {}", label, count);
+                    }
+                }
+            }
+        },
         Commands::Server {
             config,
             registry,

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -424,13 +424,26 @@ pub fn main() -> Result<()> {
                     project_filter: project,
                     target_filter: target,
                     dry_run,
-                    verbose,
                 };
 
-                if verbose {
-                    println!("Grade transitions (dest → src):");
-                }
                 let summary = sync_grades(&src, &dest, &options)?;
+
+                if verbose && !summary.changes.is_empty() {
+                    use crate::models::GradingStatus;
+                    println!("Grade transitions (dest → src):");
+                    for c in &summary.changes {
+                        println!(
+                            "  {}  {} → {}{}",
+                            c.guid,
+                            GradingStatus::from_i32(c.from),
+                            GradingStatus::from_i32(c.to),
+                            c.reason
+                                .as_deref()
+                                .map(|r| format!("  [{}]", r))
+                                .unwrap_or_default(),
+                        );
+                    }
+                }
 
                 println!(
                     "\nGrade sync {} {} → {}:",

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -482,7 +482,7 @@ pub fn main() -> Result<()> {
                 from,
                 to,
                 dry_run,
-                with_image_data,
+                no_image_data,
                 project,
                 registry,
                 verbose,
@@ -530,7 +530,7 @@ pub fn main() -> Result<()> {
 
                 let options = PullOptions {
                     dry_run,
-                    with_image_data,
+                    with_image_data: !no_image_data,
                     project_filter: project,
                 };
 
@@ -568,7 +568,7 @@ pub fn main() -> Result<()> {
                 if summary.imagedata_synced {
                     tc("imagedata", &summary.imagedata);
                 } else {
-                    println!("  imagedata        skipped (pass --with-image-data to copy blobs)");
+                    println!("  imagedata        skipped (--no-image-data)");
                 }
             }
         },

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -477,6 +477,100 @@ pub fn main() -> Result<()> {
                     }
                 }
             }
+
+            crate::cli::SyncKind::Pull {
+                from,
+                to,
+                dry_run,
+                with_image_data,
+                project,
+                registry,
+                verbose,
+            } => {
+                use crate::commands::sync::{resolve_db_path, sync_pull, PullOptions, TableCounts};
+                use crate::db_registry::DbRegistry;
+                use rusqlite::OpenFlags;
+                use std::path::{Path, PathBuf};
+
+                // Load the registry only when a side might be a slug.
+                let need_registry = !Path::new(&from).is_file() || !Path::new(&to).is_file();
+                let registry_obj = if need_registry {
+                    let registry_path = match &registry {
+                        Some(p) => PathBuf::from(p),
+                        None => {
+                            DbRegistry::default_path().context("resolving default registry path")?
+                        }
+                    };
+                    Some(DbRegistry::load_or_init(&registry_path).with_context(|| {
+                        format!("loading registry at {}", registry_path.display())
+                    })?)
+                } else {
+                    None
+                };
+
+                let from_path = resolve_db_path(registry_obj.as_ref(), &from)?;
+                let to_path = resolve_db_path(registry_obj.as_ref(), &to)?;
+
+                let from_canon =
+                    std::fs::canonicalize(&from_path).unwrap_or_else(|_| from_path.clone());
+                let to_canon = std::fs::canonicalize(&to_path).unwrap_or_else(|_| to_path.clone());
+                if from_canon == to_canon {
+                    return Err(anyhow::anyhow!(
+                        "Source and destination resolve to the same database ({}); nothing to pull",
+                        from_canon.display()
+                    ));
+                }
+
+                let src = Connection::open_with_flags(&from_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+                    .with_context(|| format!("opening source database {}", from_path.display()))?;
+                let dest = Connection::open_with_flags(&to_path, OpenFlags::SQLITE_OPEN_READ_WRITE)
+                    .with_context(|| {
+                        format!("opening destination database {}", to_path.display())
+                    })?;
+
+                let options = PullOptions {
+                    dry_run,
+                    with_image_data,
+                    project_filter: project,
+                };
+
+                let summary = sync_pull(&src, &dest, &options)?;
+
+                if verbose && !summary.changes.is_empty() {
+                    println!("Entity changes:");
+                    for c in &summary.changes {
+                        println!("  {}", c);
+                    }
+                }
+
+                let tc = |label: &str, c: &TableCounts| {
+                    println!(
+                        "  {:<16} inserted={} updated={} unchanged={}",
+                        label, c.inserted, c.updated, c.unchanged
+                    );
+                };
+                println!(
+                    "\nEntity pull {} {} → {}:",
+                    if dry_run { "(dry-run)" } else { "(live)" },
+                    from_path.display(),
+                    to_path.display(),
+                );
+                tc("exposuretemplate", &summary.exposuretemplate);
+                tc("project", &summary.project);
+                tc("ruleweight", &summary.ruleweight);
+                tc("target", &summary.target);
+                tc("exposureplan", &summary.exposureplan);
+                tc("acquiredimage", &summary.acquiredimage);
+                println!(
+                    "    grades: filled(pending→telescope)={} preserved(local)={}",
+                    summary.grade_filled, summary.grade_preserved
+                );
+                if summary.imagedata_synced {
+                    tc("imagedata", &summary.imagedata);
+                } else {
+                    println!("  imagedata        skipped (pass --with-image-data to copy blobs)");
+                }
+            }
         },
         Commands::Server {
             config,

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -544,9 +544,14 @@ pub fn main() -> Result<()> {
                 }
 
                 let tc = |label: &str, c: &TableCounts| {
+                    let skipped = if c.skipped > 0 {
+                        format!(" skipped={}", c.skipped)
+                    } else {
+                        String::new()
+                    };
                     println!(
-                        "  {:<16} inserted={} updated={} unchanged={}",
-                        label, c.inserted, c.updated, c.unchanged
+                        "  {:<16} inserted={} updated={} unchanged={}{}",
+                        label, c.inserted, c.updated, c.unchanged, skipped
                     );
                 };
                 println!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod regrade;
 pub mod reject_archive;
 pub mod show_images;
 pub mod stretch_to_png;
+pub mod sync;
 pub mod update_grade;
 pub mod visualize_psf;
 pub mod visualize_psf_multi_common;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,0 +1,435 @@
+//! Two-database grading-state sync.
+//!
+//! Pushes grading state (`gradingStatus` + `rejectreason`) one-way from a
+//! source Target Scheduler database into a destination database. Images are
+//! matched by the stable `acquiredimage.guid` (TS plugin schema v22+), so the
+//! two databases are assumed to be same-lineage (one a copy/export of the
+//! other). The source always wins; running the command in both directions
+//! gives a crude bidirectional reconcile.
+//!
+//! This module is intentionally pure DB logic so it can be unit-tested against
+//! a pair of in-memory SQLite databases. The CLI glue (argument resolution,
+//! connection opening, reporting) lives in `cli_main.rs`.
+
+use crate::commands::reject_archive::require_target_scheduler_guid;
+use crate::db::Database;
+use crate::db_registry::DbRegistry;
+use crate::models::GradingStatus;
+use anyhow::{anyhow, Context, Result};
+use rusqlite::Connection;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::PathBuf;
+
+/// Parse a grading-status filter string (`pending|accepted|rejected`).
+pub fn parse_status(s: &str) -> Result<GradingStatus> {
+    match s.to_lowercase().as_str() {
+        "pending" => Ok(GradingStatus::Pending),
+        "accepted" => Ok(GradingStatus::Accepted),
+        "rejected" => Ok(GradingStatus::Rejected),
+        other => Err(anyhow!(
+            "Invalid status '{}'. Use pending, accepted, or rejected",
+            other
+        )),
+    }
+}
+
+/// Resolve a `--from`/`--to` argument to a database file path. Prefers a
+/// registry slug match (when a registry is available); otherwise treats the
+/// argument as a path to an existing `.sqlite` file. Image directories are
+/// irrelevant for grade sync, so raw paths need no registry entry.
+pub fn resolve_db_path(registry: Option<&DbRegistry>, arg: &str) -> Result<PathBuf> {
+    if let Some(reg) = registry {
+        if let Some(entry) = reg.find(arg) {
+            return Ok(PathBuf::from(&entry.db_path));
+        }
+    }
+    let path = PathBuf::from(arg);
+    if path.is_file() {
+        return Ok(path);
+    }
+    Err(anyhow!(
+        "Could not resolve '{}': not a known registry slug and not an existing file path",
+        arg
+    ))
+}
+
+/// Knobs for a one-way grade push.
+pub struct SyncGradesOptions {
+    /// Only consider source rows with this grade (None = all).
+    pub status_filter: Option<GradingStatus>,
+    /// Restrict to source rows whose project name matches (substring).
+    pub project_filter: Option<String>,
+    /// Restrict to source rows whose target name matches (substring).
+    pub target_filter: Option<String>,
+    /// Compute the plan but make no writes to the destination.
+    pub dry_run: bool,
+    /// Print a per-image trace for each staged change.
+    pub verbose: bool,
+}
+
+/// Outcome counters for a grade push.
+#[derive(Debug, Default)]
+pub struct SyncSummary {
+    /// Source rows (after filters) that had a usable, non-duplicate guid.
+    pub source_considered: usize,
+    /// Source rows skipped because their guid was NULL/empty.
+    pub source_no_guid: usize,
+    /// Considered source rows whose guid matched a destination row.
+    pub matched: usize,
+    /// Matched rows where grade + reason already agreed.
+    pub unchanged: usize,
+    /// Matched rows updated in the destination.
+    pub changed: usize,
+    /// Considered source rows whose guid was absent from the destination.
+    pub unmatched_source: usize,
+    /// Destination guids never matched by a considered source row.
+    pub dest_only: usize,
+    /// Distinct guids skipped because they appeared more than once in either DB.
+    pub duplicate_guids: usize,
+    /// Per-transition counts, e.g. `"Pending→Rejected" => 12`.
+    pub transitions: BTreeMap<String, usize>,
+}
+
+fn grade_from_i32(v: i32) -> Result<GradingStatus> {
+    match v {
+        0 => Ok(GradingStatus::Pending),
+        1 => Ok(GradingStatus::Accepted),
+        2 => Ok(GradingStatus::Rejected),
+        other => Err(anyhow!(
+            "Unexpected gradingStatus value {} in source database",
+            other
+        )),
+    }
+}
+
+/// Push grading state from `src` into `dest`, matching by `acquiredimage.guid`.
+///
+/// Both databases must have the `guid` column (TS schema v22+); otherwise this
+/// returns an error naming the offending side. The destination is written in a
+/// single transaction (unless `dry_run`).
+pub fn sync_grades(
+    src: &Connection,
+    dest: &Connection,
+    opts: &SyncGradesOptions,
+) -> Result<SyncSummary> {
+    require_target_scheduler_guid(src).context("source database")?;
+    require_target_scheduler_guid(dest).context("destination database")?;
+
+    let src_db = Database::new(src);
+    let dest_db = Database::new(dest);
+
+    let src_rows = src_db.query_images(
+        opts.status_filter,
+        opts.project_filter.as_deref(),
+        opts.target_filter.as_deref(),
+        None,
+    )?;
+    let dest_rows = dest_db.query_images(None, None, None, None)?;
+
+    let mut summary = SyncSummary::default();
+
+    // Build destination guid -> (id, grade, reason); drop any guid that occurs
+    // more than once (ambiguous — guids are meant to be unique).
+    let mut dest_map: HashMap<String, (i32, i32, Option<String>)> = HashMap::new();
+    let mut dest_dups: HashSet<String> = HashSet::new();
+    for (img, _, _) in &dest_rows {
+        match img.guid.as_deref() {
+            Some(g) if !g.is_empty() => {
+                if dest_dups.contains(g) {
+                    continue;
+                }
+                if dest_map.remove(g).is_some() {
+                    dest_dups.insert(g.to_string());
+                } else {
+                    dest_map.insert(
+                        g.to_string(),
+                        (img.id, img.grading_status, img.reject_reason.clone()),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Count guid occurrences in the (filtered) source to spot duplicates.
+    let mut src_counts: HashMap<&str, usize> = HashMap::new();
+    for (img, _, _) in &src_rows {
+        if let Some(g) = img.guid.as_deref() {
+            if !g.is_empty() {
+                *src_counts.entry(g).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let mut matched_dest: HashSet<&str> = HashSet::new();
+    let mut src_dup_guids: HashSet<&str> = HashSet::new();
+    let mut updates: Vec<(i32, GradingStatus, Option<String>)> = Vec::new();
+
+    for (img, _, _) in &src_rows {
+        let guid = match img.guid.as_deref() {
+            Some(g) if !g.is_empty() => g,
+            _ => {
+                summary.source_no_guid += 1;
+                continue;
+            }
+        };
+        if src_counts.get(guid).copied().unwrap_or(0) > 1 {
+            src_dup_guids.insert(guid);
+            continue;
+        }
+        summary.source_considered += 1;
+
+        if dest_dups.contains(guid) {
+            // Ambiguous on the destination side; leave it alone.
+            continue;
+        }
+        let (dest_id, dest_grade, dest_reason) = match dest_map.get(guid) {
+            Some(entry) => entry,
+            None => {
+                summary.unmatched_source += 1;
+                continue;
+            }
+        };
+        matched_dest.insert(guid);
+        summary.matched += 1;
+
+        if img.grading_status == *dest_grade && img.reject_reason == *dest_reason {
+            summary.unchanged += 1;
+            continue;
+        }
+
+        let status = grade_from_i32(img.grading_status)?;
+        updates.push((*dest_id, status, img.reject_reason.clone()));
+        summary.changed += 1;
+        let label = format!(
+            "{}→{}",
+            GradingStatus::from_i32(*dest_grade),
+            GradingStatus::from_i32(img.grading_status),
+        );
+        *summary.transitions.entry(label).or_insert(0) += 1;
+
+        if opts.verbose {
+            println!(
+                "  {}  {} → {}{}",
+                guid,
+                GradingStatus::from_i32(*dest_grade),
+                GradingStatus::from_i32(img.grading_status),
+                img.reject_reason
+                    .as_deref()
+                    .map(|r| format!("  [{}]", r))
+                    .unwrap_or_default(),
+            );
+        }
+    }
+
+    summary.duplicate_guids = src_dup_guids.len() + dest_dups.len();
+    summary.dest_only = dest_map
+        .keys()
+        .filter(|g| !matched_dest.contains(g.as_str()))
+        .count();
+
+    if !opts.dry_run && !updates.is_empty() {
+        dest_db
+            .batch_update_grading_status(&updates)
+            .context("applying grade updates to destination")?;
+    }
+
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+
+    /// `images`: (Id, gradingStatus, guid, rejectreason).
+    fn setup_db(images: &[(i32, i32, Option<&str>, Option<&str>)], with_guid: bool) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE project (Id INTEGER PRIMARY KEY, profileId TEXT, name TEXT, description TEXT, guid TEXT);
+             CREATE TABLE target (Id INTEGER PRIMARY KEY, name TEXT, active INTEGER, ra REAL, dec REAL, projectId INTEGER, guid TEXT);
+             INSERT INTO project (Id, profileId, name, description, guid) VALUES (1, 'p', 'Proj', '', 'pg');
+             INSERT INTO target (Id, name, active, ra, dec, projectId, guid) VALUES (1, 'Tgt', 1, 0, 0, 1, 'tg');",
+        )
+        .unwrap();
+        if with_guid {
+            conn.execute_batch(
+                "CREATE TABLE acquiredimage (Id INTEGER PRIMARY KEY, projectId INTEGER, targetId INTEGER, acquireddate INTEGER, filtername TEXT, gradingStatus INTEGER, metadata TEXT, rejectreason TEXT, profileId TEXT, guid TEXT);",
+            )
+            .unwrap();
+        } else {
+            conn.execute_batch(
+                "CREATE TABLE acquiredimage (Id INTEGER PRIMARY KEY, projectId INTEGER, targetId INTEGER, acquireddate INTEGER, filtername TEXT, gradingStatus INTEGER, metadata TEXT, rejectreason TEXT, profileId TEXT);",
+            )
+            .unwrap();
+        }
+        for (id, grade, guid, reason) in images {
+            if with_guid {
+                conn.execute(
+                    "INSERT INTO acquiredimage (Id, projectId, targetId, acquireddate, filtername, gradingStatus, metadata, rejectreason, profileId, guid)
+                     VALUES (?, 1, 1, 0, 'L', ?, '{}', ?, 'p', ?)",
+                    params![id, grade, reason, guid],
+                )
+                .unwrap();
+            } else {
+                conn.execute(
+                    "INSERT INTO acquiredimage (Id, projectId, targetId, acquireddate, filtername, gradingStatus, metadata, rejectreason, profileId)
+                     VALUES (?, 1, 1, 0, 'L', ?, '{}', ?, 'p')",
+                    params![id, grade, reason],
+                )
+                .unwrap();
+            }
+        }
+        conn
+    }
+
+    fn opts() -> SyncGradesOptions {
+        SyncGradesOptions {
+            status_filter: None,
+            project_filter: None,
+            target_filter: None,
+            dry_run: false,
+            verbose: false,
+        }
+    }
+
+    fn grade_of(conn: &Connection, guid: &str) -> (i32, Option<String>) {
+        conn.query_row(
+            "SELECT gradingStatus, rejectreason FROM acquiredimage WHERE guid = ?",
+            params![guid],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn pushes_changes_leaves_agreements() {
+        // Destination uses different Ids on purpose: matching is by guid, not Id.
+        let src = setup_db(
+            &[
+                (1, 1, Some("g1"), None),           // Accepted
+                (2, 2, Some("g2"), Some("clouds")), // Rejected w/ reason
+                (3, 0, Some("g3"), None),           // Pending
+            ],
+            true,
+        );
+        let dest = setup_db(
+            &[
+                (100, 0, Some("g1"), None),
+                (200, 0, Some("g2"), None),
+                (300, 0, Some("g3"), None),
+            ],
+            true,
+        );
+
+        let summary = sync_grades(&src, &dest, &opts()).unwrap();
+        assert_eq!(summary.source_considered, 3);
+        assert_eq!(summary.matched, 3);
+        assert_eq!(summary.changed, 2); // g1, g2
+        assert_eq!(summary.unchanged, 1); // g3 already Pending
+        assert_eq!(summary.unmatched_source, 0);
+        assert_eq!(summary.dest_only, 0);
+
+        assert_eq!(grade_of(&dest, "g1"), (1, None));
+        assert_eq!(grade_of(&dest, "g2"), (2, Some("clouds".to_string())));
+        assert_eq!(grade_of(&dest, "g3"), (0, None));
+    }
+
+    #[test]
+    fn dry_run_makes_no_writes() {
+        let src = setup_db(&[(1, 2, Some("g1"), Some("bad"))], true);
+        let dest = setup_db(&[(100, 0, Some("g1"), None)], true);
+
+        let mut o = opts();
+        o.dry_run = true;
+        let summary = sync_grades(&src, &dest, &o).unwrap();
+        assert_eq!(summary.changed, 1);
+        // Destination untouched.
+        assert_eq!(grade_of(&dest, "g1"), (0, None));
+    }
+
+    #[test]
+    fn unmatched_and_dest_only_counted() {
+        let src = setup_db(&[(1, 1, Some("g1"), None), (2, 1, Some("g2"), None)], true);
+        let dest = setup_db(
+            &[(10, 0, Some("g1"), None), (20, 0, Some("g3"), None)],
+            true,
+        );
+
+        let summary = sync_grades(&src, &dest, &opts()).unwrap();
+        assert_eq!(summary.matched, 1); // g1
+        assert_eq!(summary.changed, 1); // g1 0->1
+        assert_eq!(summary.unmatched_source, 1); // g2 not in dest
+        assert_eq!(summary.dest_only, 1); // g3 not in source
+        assert_eq!(grade_of(&dest, "g1"), (1, None));
+        assert_eq!(grade_of(&dest, "g3"), (0, None)); // untouched
+    }
+
+    #[test]
+    fn status_filter_scopes_source() {
+        let src = setup_db(
+            &[(1, 2, Some("g1"), Some("x")), (2, 1, Some("g2"), None)],
+            true,
+        );
+        let dest = setup_db(
+            &[(10, 0, Some("g1"), None), (20, 0, Some("g2"), None)],
+            true,
+        );
+
+        let mut o = opts();
+        o.status_filter = Some(GradingStatus::Rejected);
+        let summary = sync_grades(&src, &dest, &o).unwrap();
+        assert_eq!(summary.source_considered, 1); // only g1 (Rejected)
+        assert_eq!(summary.changed, 1);
+        assert_eq!(grade_of(&dest, "g1"), (2, Some("x".to_string())));
+        assert_eq!(grade_of(&dest, "g2"), (0, None)); // not pushed (filtered out)
+    }
+
+    #[test]
+    fn rows_without_guid_are_skipped() {
+        let src = setup_db(&[(1, 1, Some("g1"), None), (2, 1, None, None)], true);
+        let dest = setup_db(&[(10, 0, Some("g1"), None)], true);
+
+        let summary = sync_grades(&src, &dest, &opts()).unwrap();
+        assert_eq!(summary.source_no_guid, 1);
+        assert_eq!(summary.source_considered, 1);
+        assert_eq!(summary.changed, 1);
+    }
+
+    #[test]
+    fn missing_guid_column_is_refused() {
+        let src = setup_db(&[(1, 1, Some("g1"), None)], true);
+        let dest = setup_db(&[(10, 0, None, None)], false); // no guid column
+        let err = sync_grades(&src, &dest, &opts()).unwrap_err();
+        assert!(format!("{:#}", err).contains("destination"));
+    }
+
+    #[test]
+    fn duplicate_dest_guid_is_skipped() {
+        let src = setup_db(&[(1, 2, Some("g1"), Some("x"))], true);
+        // g1 appears twice in destination -> ambiguous, must not be written.
+        let dest = setup_db(
+            &[(10, 0, Some("g1"), None), (11, 0, Some("g1"), None)],
+            true,
+        );
+
+        let summary = sync_grades(&src, &dest, &opts()).unwrap();
+        assert_eq!(summary.duplicate_guids, 1);
+        assert_eq!(summary.changed, 0);
+        // Both copies still Pending.
+        let count: i32 = dest
+            .query_row(
+                "SELECT COUNT(*) FROM acquiredimage WHERE guid='g1' AND gradingStatus=0",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn resolve_db_path_prefers_path_when_no_registry() {
+        // A non-existent arg with no registry errors out.
+        assert!(resolve_db_path(None, "definitely-not-a-real-file.sqlite").is_err());
+    }
+}

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -63,8 +63,17 @@ pub struct SyncGradesOptions {
     pub target_filter: Option<String>,
     /// Compute the plan but make no writes to the destination.
     pub dry_run: bool,
-    /// Print a per-image trace for each staged change.
-    pub verbose: bool,
+}
+
+/// A single staged grade change — a destination guid moving from one grade to
+/// another. Returned (rather than printed) so the CLI/UI layer can render a
+/// trace while the core sync stays side-effect free.
+#[derive(Debug, Clone)]
+pub struct GradeChange {
+    pub guid: String,
+    pub from: i32,
+    pub to: i32,
+    pub reason: Option<String>,
 }
 
 /// Outcome counters for a grade push.
@@ -88,6 +97,8 @@ pub struct SyncSummary {
     pub duplicate_guids: usize,
     /// Per-transition counts, e.g. `"Pending→Rejected" => 12`.
     pub transitions: BTreeMap<String, usize>,
+    /// Each staged change, in source iteration order (for verbose tracing).
+    pub changes: Vec<GradeChange>,
 }
 
 fn grade_from_i32(v: i32) -> Result<GradingStatus> {
@@ -207,22 +218,19 @@ pub fn sync_grades(
             GradingStatus::from_i32(img.grading_status),
         );
         *summary.transitions.entry(label).or_insert(0) += 1;
-
-        if opts.verbose {
-            println!(
-                "  {}  {} → {}{}",
-                guid,
-                GradingStatus::from_i32(*dest_grade),
-                GradingStatus::from_i32(img.grading_status),
-                img.reject_reason
-                    .as_deref()
-                    .map(|r| format!("  [{}]", r))
-                    .unwrap_or_default(),
-            );
-        }
+        summary.changes.push(GradeChange {
+            guid: guid.to_string(),
+            from: *dest_grade,
+            to: img.grading_status,
+            reason: img.reject_reason.clone(),
+        });
     }
 
-    summary.duplicate_guids = src_dup_guids.len() + dest_dups.len();
+    // Distinct guids that were ambiguous in either DB (a guid duplicated in
+    // *both* must only be counted once).
+    let mut dup_guids: HashSet<&str> = src_dup_guids.clone();
+    dup_guids.extend(dest_dups.iter().map(|g| g.as_str()));
+    summary.duplicate_guids = dup_guids.len();
     summary.dest_only = dest_map
         .keys()
         .filter(|g| !matched_dest.contains(g.as_str()))
@@ -289,7 +297,6 @@ mod tests {
             project_filter: None,
             target_filter: None,
             dry_run: false,
-            verbose: false,
         }
     }
 
@@ -425,6 +432,37 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn duplicate_guid_in_both_dbs_counts_once() {
+        // g1 is duplicated in BOTH source and destination. It must contribute
+        // a single distinct entry to duplicate_guids, not two.
+        let src = setup_db(
+            &[(1, 2, Some("g1"), Some("x")), (2, 2, Some("g1"), Some("y"))],
+            true,
+        );
+        let dest = setup_db(
+            &[(10, 0, Some("g1"), None), (11, 0, Some("g1"), None)],
+            true,
+        );
+
+        let summary = sync_grades(&src, &dest, &opts()).unwrap();
+        assert_eq!(summary.duplicate_guids, 1);
+        assert_eq!(summary.changed, 0);
+    }
+
+    #[test]
+    fn changes_trace_is_returned_not_printed() {
+        let src = setup_db(&[(1, 2, Some("g1"), Some("clouds"))], true);
+        let dest = setup_db(&[(10, 0, Some("g1"), None)], true);
+
+        let summary = sync_grades(&src, &dest, &opts()).unwrap();
+        assert_eq!(summary.changes.len(), 1);
+        let c = &summary.changes[0];
+        assert_eq!(c.guid, "g1");
+        assert_eq!((c.from, c.to), (0, 2));
+        assert_eq!(c.reason.as_deref(), Some("clouds"));
     }
 
     #[test]

--- a/src/commands/sync/grades.rs
+++ b/src/commands/sync/grades.rs
@@ -1,57 +1,20 @@
-//! Two-database grading-state sync.
+//! One-way grading-state push (our DB → telescope).
 //!
-//! Pushes grading state (`gradingStatus` + `rejectreason`) one-way from a
-//! source Target Scheduler database into a destination database. Images are
-//! matched by the stable `acquiredimage.guid` (TS plugin schema v22+), so the
-//! two databases are assumed to be same-lineage (one a copy/export of the
-//! other). The source always wins; running the command in both directions
-//! gives a crude bidirectional reconcile.
+//! Pushes grading state (`gradingStatus` + `rejectreason`) from a source Target
+//! Scheduler database into a destination database. Images are matched by the
+//! stable `acquiredimage.guid` (TS plugin schema v22+), so the two databases
+//! are assumed same-lineage (one a copy/export of the other). The source always
+//! wins; running it in both directions gives a crude bidirectional reconcile.
 //!
-//! This module is intentionally pure DB logic so it can be unit-tested against
-//! a pair of in-memory SQLite databases. The CLI glue (argument resolution,
-//! connection opening, reporting) lives in `cli_main.rs`.
+//! Pure DB logic: the CLI glue (argument resolution, connection opening,
+//! reporting) lives in `cli_main.rs`; shared helpers live in the module root.
 
 use crate::commands::reject_archive::require_target_scheduler_guid;
 use crate::db::Database;
-use crate::db_registry::DbRegistry;
 use crate::models::GradingStatus;
 use anyhow::{anyhow, Context, Result};
 use rusqlite::Connection;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::PathBuf;
-
-/// Parse a grading-status filter string (`pending|accepted|rejected`).
-pub fn parse_status(s: &str) -> Result<GradingStatus> {
-    match s.to_lowercase().as_str() {
-        "pending" => Ok(GradingStatus::Pending),
-        "accepted" => Ok(GradingStatus::Accepted),
-        "rejected" => Ok(GradingStatus::Rejected),
-        other => Err(anyhow!(
-            "Invalid status '{}'. Use pending, accepted, or rejected",
-            other
-        )),
-    }
-}
-
-/// Resolve a `--from`/`--to` argument to a database file path. Prefers a
-/// registry slug match (when a registry is available); otherwise treats the
-/// argument as a path to an existing `.sqlite` file. Image directories are
-/// irrelevant for grade sync, so raw paths need no registry entry.
-pub fn resolve_db_path(registry: Option<&DbRegistry>, arg: &str) -> Result<PathBuf> {
-    if let Some(reg) = registry {
-        if let Some(entry) = reg.find(arg) {
-            return Ok(PathBuf::from(&entry.db_path));
-        }
-    }
-    let path = PathBuf::from(arg);
-    if path.is_file() {
-        return Ok(path);
-    }
-    Err(anyhow!(
-        "Could not resolve '{}': not a known registry slug and not an existing file path",
-        arg
-    ))
-}
 
 /// Knobs for a one-way grade push.
 pub struct SyncGradesOptions {
@@ -463,11 +426,5 @@ mod tests {
         assert_eq!(c.guid, "g1");
         assert_eq!((c.from, c.to), (0, 2));
         assert_eq!(c.reason.as_deref(), Some("clouds"));
-    }
-
-    #[test]
-    fn resolve_db_path_prefers_path_when_no_registry() {
-        // A non-existent arg with no registry errors out.
-        assert!(resolve_db_path(None, "definitely-not-a-real-file.sqlite").is_err());
     }
 }

--- a/src/commands/sync/grades.rs
+++ b/src/commands/sync/grades.rs
@@ -125,18 +125,30 @@ pub fn sync_grades(
         }
     }
 
-    // Count guid occurrences in the (filtered) source to spot duplicates.
-    let mut src_counts: HashMap<&str, usize> = HashMap::new();
-    for (img, _, _) in &src_rows {
-        if let Some(g) = img.guid.as_deref() {
-            if !g.is_empty() {
-                *src_counts.entry(g).or_insert(0) += 1;
+    // Duplicate guids must be detected across ALL source images, not just the
+    // filtered subset: two ambiguous rows sharing a guid but with different
+    // grades could otherwise look unique under --status/--project/--target and
+    // push an arbitrary grade. (require_target_scheduler_guid guarantees guid.)
+    let src_dup_guids: HashSet<String> = {
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        let mut stmt = src.prepare("SELECT guid FROM acquiredimage")?;
+        let mut rows = stmt.query([])?;
+        while let Some(r) = rows.next()? {
+            if let Some(g) = r.get::<_, Option<String>>(0)? {
+                if !g.is_empty() {
+                    *counts.entry(g).or_insert(0) += 1;
+                }
             }
         }
-    }
+        counts
+            .into_iter()
+            .filter(|(_, c)| *c > 1)
+            .map(|(g, _)| g)
+            .collect()
+    };
 
     let mut matched_dest: HashSet<&str> = HashSet::new();
-    let mut src_dup_guids: HashSet<&str> = HashSet::new();
+    let mut skipped_dups: HashSet<&str> = HashSet::new();
     let mut updates: Vec<(i32, GradingStatus, Option<String>)> = Vec::new();
 
     for (img, _, _) in &src_rows {
@@ -147,16 +159,13 @@ pub fn sync_grades(
                 continue;
             }
         };
-        if src_counts.get(guid).copied().unwrap_or(0) > 1 {
-            src_dup_guids.insert(guid);
+        if src_dup_guids.contains(guid) || dest_dups.contains(guid) {
+            // Ambiguous in either DB — never push an arbitrary grade.
+            skipped_dups.insert(guid);
             continue;
         }
         summary.source_considered += 1;
 
-        if dest_dups.contains(guid) {
-            // Ambiguous on the destination side; leave it alone.
-            continue;
-        }
         let (dest_id, dest_grade, dest_reason) = match dest_map.get(guid) {
             Some(entry) => entry,
             None => {
@@ -189,11 +198,8 @@ pub fn sync_grades(
         });
     }
 
-    // Distinct guids that were ambiguous in either DB (a guid duplicated in
-    // *both* must only be counted once).
-    let mut dup_guids: HashSet<&str> = src_dup_guids.clone();
-    dup_guids.extend(dest_dups.iter().map(|g| g.as_str()));
-    summary.duplicate_guids = dup_guids.len();
+    // Distinct guids skipped because they were ambiguous in either DB.
+    summary.duplicate_guids = skipped_dups.len();
     summary.dest_only = dest_map
         .keys()
         .filter(|g| !matched_dest.contains(g.as_str()))
@@ -426,5 +432,24 @@ mod tests {
         assert_eq!(c.guid, "g1");
         assert_eq!((c.from, c.to), (0, 2));
         assert_eq!(c.reason.as_deref(), Some("clouds"));
+    }
+
+    #[test]
+    fn duplicate_source_guid_skipped_even_under_status_filter() {
+        // Two source rows share guid g1 with different grades. A --status filter
+        // selects only one, but duplicate detection is global, so g1 is still
+        // recognized as ambiguous and no arbitrary grade is pushed.
+        let src = setup_db(
+            &[(1, 1, Some("g1"), None), (2, 2, Some("g1"), Some("x"))],
+            true,
+        );
+        let dest = setup_db(&[(10, 0, Some("g1"), None)], true);
+
+        let mut o = opts();
+        o.status_filter = Some(GradingStatus::Accepted); // selects only the grade=1 row
+        let s = sync_grades(&src, &dest, &o).unwrap();
+        assert_eq!(s.changed, 0); // ambiguous -> nothing pushed
+        assert_eq!(s.duplicate_guids, 1);
+        assert_eq!(grade_of(&dest, "g1"), (0, None)); // destination untouched
     }
 }

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -1,0 +1,125 @@
+//! Two-database sync between N.I.N.A. Target Scheduler databases.
+//!
+//! - [`sync_grades`] pushes grading state (our DB → telescope), matched by
+//!   `acquiredimage.guid`.
+//! - [`sync_pull`] pulls structure + captured images (telescope → our DB),
+//!   matched by guid with FK remapping, preserving local grading work.
+//!
+//! Both cores are pure DB logic; CLI glue (argument resolution, connection
+//! opening, reporting) lives in `cli_main.rs`. Helpers shared by both kinds —
+//! `--from`/`--to` resolution, status parsing, the v22 capability guard — live
+//! here in the module root.
+
+mod grades;
+mod pull;
+
+pub use grades::{sync_grades, GradeChange, SyncGradesOptions, SyncSummary};
+pub use pull::{sync_pull, PullOptions, PullSummary, TableCounts};
+
+use crate::db_registry::DbRegistry;
+use crate::models::GradingStatus;
+use anyhow::{anyhow, Result};
+use rusqlite::{Connection, OptionalExtension};
+use std::path::PathBuf;
+
+/// Parse a grading-status filter string (`pending|accepted|rejected`).
+pub fn parse_status(s: &str) -> Result<GradingStatus> {
+    match s.to_lowercase().as_str() {
+        "pending" => Ok(GradingStatus::Pending),
+        "accepted" => Ok(GradingStatus::Accepted),
+        "rejected" => Ok(GradingStatus::Rejected),
+        other => Err(anyhow!(
+            "Invalid status '{}'. Use pending, accepted, or rejected",
+            other
+        )),
+    }
+}
+
+/// Resolve a `--from`/`--to` argument to a database file path. Prefers a
+/// registry slug match (when a registry is available); otherwise treats the
+/// argument as a path to an existing `.sqlite` file. Image directories are
+/// irrelevant for sync, so raw paths need no registry entry.
+pub fn resolve_db_path(registry: Option<&DbRegistry>, arg: &str) -> Result<PathBuf> {
+    if let Some(reg) = registry {
+        if let Some(entry) = reg.find(arg) {
+            return Ok(PathBuf::from(&entry.db_path));
+        }
+    }
+    let path = PathBuf::from(arg);
+    if path.is_file() {
+        return Ok(path);
+    }
+    Err(anyhow!(
+        "Could not resolve '{}': not a known registry slug and not an existing file path",
+        arg
+    ))
+}
+
+/// Core entity tables that must carry a `guid` column (TS plugin schema v22+)
+/// for `sync pull` to match rows across databases.
+pub const PULL_GUID_TABLES: &[&str] = &[
+    "project",
+    "target",
+    "exposuretemplate",
+    "exposureplan",
+    "acquiredimage",
+];
+
+/// Return true if `table` has a column named `column` (case-insensitive).
+pub fn table_has_column(conn: &Connection, table: &str, column: &str) -> bool {
+    // PRAGMA table_info can't be parameterized; table names here are constants.
+    conn.query_row(
+        &format!(
+            "SELECT 1 FROM pragma_table_info('{}') WHERE lower(name) = lower(?1)",
+            table
+        ),
+        [column],
+        |_| Ok(()),
+    )
+    .optional()
+    .ok()
+    .flatten()
+    .is_some()
+}
+
+/// Refuse to operate against a database that lacks `guid` columns on the core
+/// entity tables (added in TS plugin schema v22). `sync pull` matches rows by
+/// guid, so without it we cannot reliably remap entities across databases.
+pub fn require_pull_capable(conn: &Connection) -> Result<()> {
+    let missing: Vec<&str> = PULL_GUID_TABLES
+        .iter()
+        .copied()
+        .filter(|t| !table_has_column(conn, t, "guid"))
+        .collect();
+    if !missing.is_empty() {
+        return Err(anyhow!(
+            "This Target Scheduler database is missing the `guid` column on: {} \
+             (added in plugin schema v22). `sync pull` matches rows by guid to \
+             remap entities across databases.\n\nUpgrade by opening the database \
+             in a recent N.I.N.A. + Target Scheduler version.",
+            missing.join(", ")
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_db_path_prefers_path_when_no_registry() {
+        // A non-existent arg with no registry errors out.
+        assert!(resolve_db_path(None, "definitely-not-a-real-file.sqlite").is_err());
+    }
+
+    #[test]
+    fn table_has_column_detects_guid() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE project (Id INTEGER, name TEXT, guid TEXT);")
+            .unwrap();
+        assert!(table_has_column(&conn, "project", "guid"));
+        assert!(table_has_column(&conn, "project", "GUID")); // case-insensitive
+        assert!(!table_has_column(&conn, "project", "nope"));
+    }
+}

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -15,7 +15,7 @@
 use super::require_pull_capable;
 use anyhow::{anyhow, Context, Result};
 use rusqlite::types::Value;
-use rusqlite::{params, params_from_iter, Connection, OptionalExtension, ToSql, Transaction};
+use rusqlite::{params, params_from_iter, Connection, ToSql, Transaction};
 use std::collections::{HashMap, HashSet};
 
 /// Knobs for a pull.
@@ -35,6 +35,9 @@ pub struct TableCounts {
     pub inserted: usize,
     pub updated: usize,
     pub unchanged: usize,
+    /// Rows skipped as ambiguous: a duplicate guid in either DB, or a non-null
+    /// parent FK that didn't map to a destination row.
+    pub skipped: usize,
 }
 
 /// Outcome of a pull.
@@ -126,6 +129,111 @@ fn quoted(cols: &[&str]) -> String {
         .join(",")
 }
 
+/// Columns present in BOTH source and destination (intersection, in source
+/// order). Lets a source at a newer TS migration level than the destination
+/// (or vice-versa) sync the columns they share instead of failing the whole
+/// pull on an unknown column.
+fn shared_columns(src: &Connection, tx: &Transaction, table: &str) -> Result<Vec<String>> {
+    let src_cols = table_columns(src, table)?;
+    let dest_cols = table_columns(tx, table)?;
+    let dest_set: HashSet<String> = dest_cols.iter().map(|c| c.to_lowercase()).collect();
+    Ok(src_cols
+        .into_iter()
+        .filter(|c| dest_set.contains(&c.to_lowercase()))
+        .collect())
+}
+
+/// Distinct guids that appear more than once among the source rows of `table`
+/// selected by `filter_col ∈ allowed` (None = all rows). Such rows are skipped
+/// so two source entities can't silently merge onto one destination row.
+fn source_dup_guids(
+    src: &Connection,
+    table: &str,
+    filter_col: &str,
+    allowed: Option<&HashSet<i64>>,
+) -> Result<HashSet<String>> {
+    let mut counts: HashMap<String, u32> = HashMap::new();
+    let mut stmt = src.prepare(&format!("SELECT \"{}\", guid FROM {}", filter_col, table))?;
+    let mut rows = stmt.query([])?;
+    while let Some(r) = rows.next()? {
+        if let Some(a) = allowed {
+            match r.get::<_, Option<i64>>(0)? {
+                Some(k) if a.contains(&k) => {}
+                _ => continue,
+            }
+        }
+        if let Some(g) = r.get::<_, Option<String>>(1)? {
+            if !g.is_empty() {
+                *counts.entry(g).or_insert(0) += 1;
+            }
+        }
+    }
+    Ok(counts
+        .into_iter()
+        .filter(|(_, c)| *c > 1)
+        .map(|(g, _)| g)
+        .collect())
+}
+
+/// A destination `guid -> (dest Id, write-column values)` map paired with the
+/// set of guids that were ambiguous (appeared more than once) in the destination.
+type DestGuidMap = (HashMap<String, (i64, Vec<Value>)>, HashSet<String>);
+
+/// Build a destination `guid -> (Id, write-col values)` map. Guids that occur
+/// more than once in the destination are removed and returned in the dups set;
+/// matching against an ambiguous destination guid is unsafe, so callers skip it.
+fn dest_guid_map(
+    tx: &Transaction,
+    table: &str,
+    write_cols: &[&str],
+    guid_w: usize,
+) -> Result<DestGuidMap> {
+    let sql = format!("SELECT Id,{} FROM {}", quoted(write_cols), table);
+    let mut stmt = tx.prepare(&sql)?;
+    let n = write_cols.len();
+    let mut map: HashMap<String, (i64, Vec<Value>)> = HashMap::new();
+    let mut dups: HashSet<String> = HashSet::new();
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let dest_id: i64 = row.get(0)?;
+        let vals: Vec<Value> = (0..n)
+            .map(|i| row.get::<_, Value>(i + 1))
+            .collect::<rusqlite::Result<_>>()?;
+        if let Value::Text(g) = &vals[guid_w] {
+            if !g.is_empty() {
+                if dups.contains(g) {
+                    continue;
+                }
+                if map.remove(g).is_some() {
+                    dups.insert(g.clone());
+                } else {
+                    map.insert(g.clone(), (dest_id, vals));
+                }
+            }
+        }
+    }
+    Ok((map, dups))
+}
+
+/// Remap an FK column in place. Returns `false` if the column held a non-null id
+/// absent from `map` — the caller must skip the row rather than retain the
+/// source id (which could attach the child to an unrelated destination row).
+fn remap_fk_checked(values: &mut [Value], pos: Option<usize>, map: &HashMap<i64, i64>) -> bool {
+    match pos {
+        Some(p) => match values[p] {
+            Value::Integer(src_fk) => match map.get(&src_fk) {
+                Some(dest_fk) => {
+                    values[p] = Value::Integer(*dest_fk);
+                    true
+                }
+                None => false,
+            },
+            _ => true, // NULL (or non-integer) FK: nothing to remap
+        },
+        None => true, // column not in the shared set
+    }
+}
+
 struct GuidUpsert {
     /// Source local Id → destination local Id (for FK remapping of children).
     id_map: HashMap<i64, i64>,
@@ -143,7 +251,7 @@ fn upsert_guid_table(
     allowed_src_ids: Option<&HashSet<i64>>,
     changes: &mut Vec<String>,
 ) -> Result<GuidUpsert> {
-    let cols = table_columns(src, table)?;
+    let cols = shared_columns(src, tx, table)?;
     let id_pos = cols
         .iter()
         .position(|c| c.eq_ignore_ascii_case("Id"))
@@ -169,25 +277,10 @@ fn upsert_guid_table(
         })
         .collect();
 
-    // Destination guid -> (dest_id, write-col values), the pre-pull state.
-    let mut dest_map: HashMap<String, (i64, Vec<Value>)> = HashMap::new();
-    {
-        let sql = format!("SELECT Id,{} FROM {}", quoted(&write_cols), table);
-        let mut stmt = tx.prepare(&sql)?;
-        let n = write_cols.len();
-        let mut rows = stmt.query([])?;
-        while let Some(row) = rows.next()? {
-            let dest_id: i64 = row.get(0)?;
-            let vals: Vec<Value> = (0..n)
-                .map(|i| row.get::<_, Value>(i + 1))
-                .collect::<rusqlite::Result<_>>()?;
-            if let Value::Text(g) = &vals[guid_w] {
-                if !g.is_empty() {
-                    dest_map.insert(g.clone(), (dest_id, vals));
-                }
-            }
-        }
-    }
+    // Pre-pull destination state (guids ambiguous in dest are dropped), and the
+    // set of guids that are duplicated within the (filtered) source.
+    let (dest_map, dest_dups) = dest_guid_map(tx, table, &write_cols, guid_w)?;
+    let src_dups = source_dup_guids(src, table, "Id", allowed_src_ids)?;
 
     let insert_sql = format!(
         "INSERT INTO {} ({}) VALUES ({})",
@@ -231,14 +324,24 @@ fn upsert_guid_table(
             Value::Text(g) if !g.is_empty() => g.clone(),
             _ => continue,
         };
+        if src_dups.contains(&guid) || dest_dups.contains(&guid) {
+            counts.skipped += 1;
+            changes.push(format!("skip {} {} (ambiguous guid)", table, guid));
+            continue;
+        }
 
         let mut write_values: Vec<Value> = write_idx.iter().map(|&i| all_vals[i].clone()).collect();
+        let mut unmapped = false;
         for (pos, map) in &fk_positions {
-            if let Value::Integer(src_fk) = write_values[*pos] {
-                if let Some(dest_fk) = map.get(&src_fk) {
-                    write_values[*pos] = Value::Integer(*dest_fk);
-                }
+            if !remap_fk_checked(&mut write_values, Some(*pos), map) {
+                unmapped = true;
+                break;
             }
+        }
+        if unmapped {
+            counts.skipped += 1;
+            changes.push(format!("skip {} {} (unmapped parent)", table, guid));
+            continue;
         }
 
         match dest_map.get(&guid) {
@@ -287,7 +390,7 @@ fn upsert_acquired_images(
     summary: &mut PullSummary,
 ) -> Result<HashMap<i64, i64>> {
     let table = "acquiredimage";
-    let cols = table_columns(src, table)?;
+    let cols = shared_columns(src, tx, table)?;
     let ci = |n: &str| cols.iter().position(|c| c.eq_ignore_ascii_case(n));
     let id_pos = ci("Id").ok_or_else(|| anyhow!("acquiredimage.Id missing"))?;
     let guid_pos = ci("guid").ok_or_else(|| anyhow!("acquiredimage.guid missing"))?;
@@ -303,25 +406,9 @@ fn upsert_acquired_images(
     let tgt_w = wpos("targetId");
     let expo_w = wpos("exposureId");
 
-    // Destination guid -> (dest_id, write values).
-    let mut dest_map: HashMap<String, (i64, Vec<Value>)> = HashMap::new();
-    {
-        let sql = format!("SELECT Id,{} FROM {}", quoted(&write_cols), table);
-        let mut stmt = tx.prepare(&sql)?;
-        let n = write_cols.len();
-        let mut rows = stmt.query([])?;
-        while let Some(row) = rows.next()? {
-            let dest_id: i64 = row.get(0)?;
-            let vals: Vec<Value> = (0..n)
-                .map(|i| row.get::<_, Value>(i + 1))
-                .collect::<rusqlite::Result<_>>()?;
-            if let Value::Text(g) = &vals[guid_w] {
-                if !g.is_empty() {
-                    dest_map.insert(g.clone(), (dest_id, vals));
-                }
-            }
-        }
-    }
+    // Pre-pull destination state + duplicate-guid sets (ambiguous rows skipped).
+    let (dest_map, dest_dups) = dest_guid_map(tx, table, &write_cols, guid_w)?;
+    let src_dups = source_dup_guids(src, table, "projectId", allowed_project_ids)?;
 
     let insert_sql = format!(
         "INSERT INTO {} ({}) VALUES ({})",
@@ -365,11 +452,29 @@ fn upsert_acquired_images(
             Value::Text(g) if !g.is_empty() => g.clone(),
             _ => continue,
         };
+        if src_dups.contains(&guid) || dest_dups.contains(&guid) {
+            summary.acquiredimage.skipped += 1;
+            summary
+                .changes
+                .push(format!("skip acquiredimage {} (ambiguous guid)", guid));
+            continue;
+        }
 
         let mut write_values: Vec<Value> = write_idx.iter().map(|&i| all_vals[i].clone()).collect();
-        remap_fk(&mut write_values, proj_w, proj_map);
-        remap_fk(&mut write_values, tgt_w, tgt_map);
-        // exposureId references exposureplan.Id; if unmatched, write 0.
+        // projectId/targetId are required FKs: skip the row if either parent
+        // wasn't pulled, rather than retaining a source id that points at an
+        // unrelated destination row.
+        if !remap_fk_checked(&mut write_values, proj_w, proj_map)
+            || !remap_fk_checked(&mut write_values, tgt_w, tgt_map)
+        {
+            summary.acquiredimage.skipped += 1;
+            summary
+                .changes
+                .push(format!("skip acquiredimage {} (unmapped parent)", guid));
+            continue;
+        }
+        // exposureId is a soft reference to exposureplan.Id; if unmatched, write
+        // 0 (the "no plan" sentinel) — never retain the source id.
         if let Some(p) = expo_w {
             if let Value::Integer(src_plan) = write_values[p] {
                 write_values[p] = Value::Integer(plan_map.get(&src_plan).copied().unwrap_or(0));
@@ -419,16 +524,6 @@ fn upsert_acquired_images(
     }
 
     Ok(id_map)
-}
-
-fn remap_fk(values: &mut [Value], pos: Option<usize>, map: &HashMap<i64, i64>) {
-    if let Some(p) = pos {
-        if let Value::Integer(src_fk) = values[p] {
-            if let Some(dest_fk) = map.get(&src_fk) {
-                values[p] = Value::Integer(*dest_fk);
-            }
-        }
-    }
 }
 
 /// Upsert per-project rule weights (no guid; matched by `(projectId, name)`).
@@ -481,8 +576,12 @@ fn upsert_ruleweights(
     Ok(())
 }
 
-/// Copy imagedata BLOBs for pulled images (insert-only; blobs are immutable per
-/// image). In dry-run mode the rows are counted but not written.
+/// Copy imagedata BLOBs for pulled images (insert-only; blobs are immutable).
+///
+/// An acquired image can hold several ImageData records (one per `tag`), so the
+/// match is per `(acquiredimageid, tag)` — a destination already holding one tag
+/// still receives any other tags it's missing. In dry-run mode rows are counted
+/// (with sizes) but nothing is written.
 fn copy_imagedata(
     src: &Connection,
     tx: &Transaction,
@@ -491,35 +590,39 @@ fn copy_imagedata(
     bytes: &mut u64,
     dry_run: bool,
 ) -> Result<()> {
-    let mut exists_stmt =
-        tx.prepare("SELECT 1 FROM imagedata WHERE acquiredimageid = ?1 LIMIT 1")?;
-    let mut count_stmt = src.prepare(
-        "SELECT COUNT(*), COALESCE(SUM(LENGTH(imagedata)),0) FROM imagedata WHERE acquiredimageid = ?1",
-    )?;
-    let mut sel_stmt = src.prepare(
+    let mut existing_stmt = tx.prepare("SELECT tag FROM imagedata WHERE acquiredimageid = ?1")?;
+    let mut sel_len_stmt =
+        src.prepare("SELECT tag, LENGTH(imagedata) FROM imagedata WHERE acquiredimageid = ?1")?;
+    let mut sel_full_stmt = src.prepare(
         "SELECT tag, imagedata, width, height FROM imagedata WHERE acquiredimageid = ?1",
     )?;
     let mut ins_stmt = tx.prepare(
         "INSERT INTO imagedata (tag, imagedata, acquiredimageid, width, height) VALUES (?1,?2,?3,?4,?5)",
     )?;
     for (src_img, dest_img) in img_map {
-        let already = exists_stmt
-            .query_row(params![dest_img], |_| Ok(()))
-            .optional()?
-            .is_some();
-        if already {
-            counts.unchanged += 1;
-            continue;
+        // Tags already present at the destination for this image.
+        let mut existing: HashSet<Option<String>> = HashSet::new();
+        {
+            let mut rows = existing_stmt.query(params![dest_img])?;
+            while let Some(r) = rows.next()? {
+                existing.insert(r.get::<_, Option<String>>(0)?);
+            }
         }
         if dry_run {
-            let (n, sz): (i64, i64) =
-                count_stmt.query_row(params![src_img], |r| Ok((r.get(0)?, r.get(1)?)))?;
-            counts.inserted += n as usize;
-            *bytes += sz.max(0) as u64;
+            let mut rows = sel_len_stmt.query(params![src_img])?;
+            while let Some(r) = rows.next()? {
+                let tag: Option<String> = r.get(0)?;
+                if existing.contains(&tag) {
+                    counts.unchanged += 1;
+                } else {
+                    counts.inserted += 1;
+                    *bytes += r.get::<_, i64>(1).unwrap_or(0).max(0) as u64;
+                }
+            }
             continue;
         }
         #[allow(clippy::type_complexity)]
-        let blobs: Vec<(Option<String>, Option<Vec<u8>>, i64, i64)> = sel_stmt
+        let blobs: Vec<(Option<String>, Option<Vec<u8>>, i64, i64)> = sel_full_stmt
             .query_map(params![src_img], |r| {
                 Ok((
                     r.get(0)?,
@@ -530,6 +633,10 @@ fn copy_imagedata(
             })?
             .collect::<rusqlite::Result<_>>()?;
         for (tag, blob, w, h) in blobs {
+            if existing.contains(&tag) {
+                counts.unchanged += 1;
+                continue;
+            }
             *bytes += blob.as_ref().map(|b| b.len() as u64).unwrap_or(0);
             ins_stmt.execute(params![tag, blob, dest_img, w, h])?;
             counts.inserted += 1;
@@ -955,5 +1062,125 @@ mod tests {
         schema(&dest, false); // no guid columns
         let err = sync_pull(&src, &dest, &opts()).unwrap_err();
         assert!(format!("{:#}", err).contains("destination"));
+    }
+
+    #[test]
+    fn duplicate_source_guid_is_skipped() {
+        let src = Connection::open_in_memory().unwrap();
+        schema(&src, true);
+        // Two distinct projects sharing one guid — ambiguous, must not merge.
+        src.execute_batch(
+            "INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (1,'p','A','',1,1,'dup');
+             INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (2,'p','B','',1,1,'dup');",
+        ).unwrap();
+        let dest = empty_local();
+        let s = sync_pull(&src, &dest, &opts()).unwrap();
+        assert_eq!(s.project.inserted, 0);
+        assert_eq!(s.project.skipped, 2);
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM project"), 0);
+    }
+
+    #[test]
+    fn duplicate_dest_guid_skips_and_cascades() {
+        let src = telescope(); // project guid 'pg' with a target + images
+        let dest = empty_local();
+        // Destination already has the project guid twice -> ambiguous match.
+        dest.execute_batch(
+            "INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (1,'p','X','',1,1,'pg');
+             INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (2,'p','Y','',1,1,'pg');",
+        ).unwrap();
+        let s = sync_pull(&src, &dest, &opts()).unwrap();
+        // Source project can't be safely matched -> skipped, and its children
+        // can't remap their parent -> they skip too (no silent mis-attach).
+        assert_eq!(s.project.skipped, 1);
+        assert_eq!(s.target.skipped, 1);
+        assert_eq!(s.acquiredimage.skipped, 2);
+        assert_eq!(s.acquiredimage.inserted, 0);
+    }
+
+    #[test]
+    fn unmapped_parent_skips_child() {
+        // A target whose project is NOT in the source at all: its projectid
+        // can't remap, so the target must be skipped rather than attach to an
+        // unrelated destination project.
+        let src = Connection::open_in_memory().unwrap();
+        schema(&src, true);
+        src.execute_batch(
+            "INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid) VALUES (1,'Orphan',1,0,0,0,999,'tg-orphan');",
+        ).unwrap();
+        let dest = empty_local();
+        // Give dest a project at Id 999 to prove we do NOT attach to it.
+        dest.execute_batch(
+            "INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (999,'p','Unrelated','',1,1,'unrelated');",
+        ).unwrap();
+        let s = sync_pull(&src, &dest, &opts()).unwrap();
+        assert_eq!(s.target.inserted, 0);
+        assert_eq!(s.target.skipped, 1);
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM target"), 0);
+    }
+
+    #[test]
+    fn schema_drift_syncs_shared_columns() {
+        // Source carries a column the destination lacks (newer migration). The
+        // pull must succeed, syncing the shared columns.
+        let src = telescope();
+        src.execute("ALTER TABLE project ADD COLUMN futurecol TEXT", [])
+            .unwrap();
+        src.execute("UPDATE project SET futurecol='x' WHERE guid='pg'", [])
+            .unwrap();
+        let dest = empty_local(); // no futurecol
+        let s = sync_pull(&src, &dest, &opts()).unwrap();
+        assert_eq!(s.project.inserted, 1);
+        assert_eq!(
+            one::<String>(&dest, "SELECT name FROM project WHERE guid='pg'"),
+            "Caldwell"
+        );
+    }
+
+    #[test]
+    fn imagedata_copies_missing_tags() {
+        let src = telescope(); // img1 + img2 each have one imagedata row (tag '')
+                               // Give img1 a second tagged ImageData record.
+        src.execute(
+            "INSERT INTO imagedata (tag, imagedata, acquiredimageid, width, height) VALUES ('thumb', X'AABBCCDD', 1, 50, 50)",
+            [],
+        ).unwrap();
+        let dest = empty_local();
+        let mut o = opts();
+        o.with_image_data = true;
+        sync_pull(&src, &dest, &o).unwrap();
+        let img1: i64 = one(&dest, "SELECT Id FROM acquiredimage WHERE guid='img1'");
+        // Both tags copied.
+        assert_eq!(
+            one::<i64>(
+                &dest,
+                &format!(
+                    "SELECT COUNT(*) FROM imagedata WHERE acquiredimageid={}",
+                    img1
+                )
+            ),
+            2
+        );
+        // Drop one tag locally; a re-pull restores just the missing one.
+        dest.execute(
+            &format!(
+                "DELETE FROM imagedata WHERE acquiredimageid={} AND tag='thumb'",
+                img1
+            ),
+            [],
+        )
+        .unwrap();
+        let s = sync_pull(&src, &dest, &o).unwrap();
+        assert_eq!(s.imagedata.inserted, 1); // only the missing 'thumb'
+        assert_eq!(
+            one::<i64>(
+                &dest,
+                &format!(
+                    "SELECT COUNT(*) FROM imagedata WHERE acquiredimageid={}",
+                    img1
+                )
+            ),
+            2
+        );
     }
 }

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -51,10 +51,36 @@ pub struct PullSummary {
     /// Existing images whose local (non-Pending) grade was preserved.
     pub grade_preserved: usize,
     pub imagedata: TableCounts,
-    /// True when `--with-image-data` ran (else imagedata was left untouched).
+    /// Bytes of imagedata BLOBs copied (or, in dry-run, that would be copied).
+    pub imagedata_bytes: u64,
+    /// True when imagedata was synced (else it was left untouched).
     pub imagedata_synced: bool,
     /// Per-entity trace lines (for `--verbose`).
     pub changes: Vec<String>,
+}
+
+impl PullSummary {
+    /// Total rows inserted across every table.
+    pub fn total_inserted(&self) -> usize {
+        self.exposuretemplate.inserted
+            + self.project.inserted
+            + self.ruleweight.inserted
+            + self.target.inserted
+            + self.exposureplan.inserted
+            + self.acquiredimage.inserted
+            + self.imagedata.inserted
+    }
+
+    /// Total rows updated across every table.
+    pub fn total_updated(&self) -> usize {
+        self.exposuretemplate.updated
+            + self.project.updated
+            + self.ruleweight.updated
+            + self.target.updated
+            + self.exposureplan.updated
+            + self.acquiredimage.updated
+            + self.imagedata.updated
+    }
 }
 
 fn as_i64(v: &Value) -> Option<i64> {
@@ -462,12 +488,14 @@ fn copy_imagedata(
     tx: &Transaction,
     img_map: &HashMap<i64, i64>,
     counts: &mut TableCounts,
+    bytes: &mut u64,
     dry_run: bool,
 ) -> Result<()> {
     let mut exists_stmt =
         tx.prepare("SELECT 1 FROM imagedata WHERE acquiredimageid = ?1 LIMIT 1")?;
-    let mut count_stmt =
-        src.prepare("SELECT COUNT(*) FROM imagedata WHERE acquiredimageid = ?1")?;
+    let mut count_stmt = src.prepare(
+        "SELECT COUNT(*), COALESCE(SUM(LENGTH(imagedata)),0) FROM imagedata WHERE acquiredimageid = ?1",
+    )?;
     let mut sel_stmt = src.prepare(
         "SELECT tag, imagedata, width, height FROM imagedata WHERE acquiredimageid = ?1",
     )?;
@@ -484,8 +512,10 @@ fn copy_imagedata(
             continue;
         }
         if dry_run {
-            let n: i64 = count_stmt.query_row(params![src_img], |r| r.get(0))?;
+            let (n, sz): (i64, i64) =
+                count_stmt.query_row(params![src_img], |r| Ok((r.get(0)?, r.get(1)?)))?;
             counts.inserted += n as usize;
+            *bytes += sz.max(0) as u64;
             continue;
         }
         #[allow(clippy::type_complexity)]
@@ -500,6 +530,7 @@ fn copy_imagedata(
             })?
             .collect::<rusqlite::Result<_>>()?;
         for (tag, blob, w, h) in blobs {
+            *bytes += blob.as_ref().map(|b| b.len() as u64).unwrap_or(0);
             ins_stmt.execute(params![tag, blob, dest_img, w, h])?;
             counts.inserted += 1;
         }
@@ -627,7 +658,14 @@ pub fn sync_pull(src: &Connection, dest: &Connection, opts: &PullOptions) -> Res
 
     // 7. imagedata (optional, heavy)
     if opts.with_image_data {
-        copy_imagedata(src, &tx, &img_map, &mut summary.imagedata, opts.dry_run)?;
+        copy_imagedata(
+            src,
+            &tx,
+            &img_map,
+            &mut summary.imagedata,
+            &mut summary.imagedata_bytes,
+            opts.dry_run,
+        )?;
         summary.imagedata_synced = true;
     }
 
@@ -866,7 +904,9 @@ mod tests {
         let s = sync_pull(&src, &dest, &o).unwrap();
         assert!(s.imagedata_synced);
         assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM imagedata"), 2);
-        // Blob bound to the dest image Id.
+        assert_eq!(s.imagedata.inserted, 2);
+        assert_eq!(s.imagedata_bytes, 8); // two 4-byte blobs
+                                          // Blob bound to the dest image Id.
         let img1: i64 = one(&dest, "SELECT Id FROM acquiredimage WHERE guid='img1'");
         assert_eq!(
             one::<i64>(

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -143,26 +143,19 @@ fn shared_columns(src: &Connection, tx: &Transaction, table: &str) -> Result<Vec
         .collect())
 }
 
-/// Distinct guids that appear more than once among the source rows of `table`
-/// selected by `filter_col ∈ allowed` (None = all rows). Such rows are skipped
-/// so two source entities can't silently merge onto one destination row.
-fn source_dup_guids(
-    src: &Connection,
-    table: &str,
-    filter_col: &str,
-    allowed: Option<&HashSet<i64>>,
-) -> Result<HashSet<String>> {
+/// Distinct guids that appear more than once anywhere in the source `table`.
+///
+/// Counting is **global** (independent of any `--project` filter): a guid shared
+/// by two entities is ambiguous regardless of which one a given filtered pull
+/// selects, so it must be skipped consistently across runs — otherwise two
+/// filtered pulls selecting one each would each see a unique guid and merge both
+/// onto the same destination entity.
+fn source_dup_guids(src: &Connection, table: &str) -> Result<HashSet<String>> {
     let mut counts: HashMap<String, u32> = HashMap::new();
-    let mut stmt = src.prepare(&format!("SELECT \"{}\", guid FROM {}", filter_col, table))?;
+    let mut stmt = src.prepare(&format!("SELECT guid FROM {}", table))?;
     let mut rows = stmt.query([])?;
     while let Some(r) = rows.next()? {
-        if let Some(a) = allowed {
-            match r.get::<_, Option<i64>>(0)? {
-                Some(k) if a.contains(&k) => {}
-                _ => continue,
-            }
-        }
-        if let Some(g) = r.get::<_, Option<String>>(1)? {
+        if let Some(g) = r.get::<_, Option<String>>(0)? {
             if !g.is_empty() {
                 *counts.entry(g).or_insert(0) += 1;
             }
@@ -280,7 +273,7 @@ fn upsert_guid_table(
     // Pre-pull destination state (guids ambiguous in dest are dropped), and the
     // set of guids that are duplicated within the (filtered) source.
     let (dest_map, dest_dups) = dest_guid_map(tx, table, &write_cols, guid_w)?;
-    let src_dups = source_dup_guids(src, table, "Id", allowed_src_ids)?;
+    let src_dups = source_dup_guids(src, table)?;
 
     let insert_sql = format!(
         "INSERT INTO {} ({}) VALUES ({})",
@@ -408,7 +401,7 @@ fn upsert_acquired_images(
 
     // Pre-pull destination state + duplicate-guid sets (ambiguous rows skipped).
     let (dest_map, dest_dups) = dest_guid_map(tx, table, &write_cols, guid_w)?;
-    let src_dups = source_dup_guids(src, table, "projectId", allowed_project_ids)?;
+    let src_dups = source_dup_guids(src, table)?;
 
     let insert_sql = format!(
         "INSERT INTO {} ({}) VALUES ({})",
@@ -1077,6 +1070,26 @@ mod tests {
         let s = sync_pull(&src, &dest, &opts()).unwrap();
         assert_eq!(s.project.inserted, 0);
         assert_eq!(s.project.skipped, 2);
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM project"), 0);
+    }
+
+    #[test]
+    fn duplicate_source_guid_skipped_even_under_project_filter() {
+        // Two projects share a guid but have different names, so a --project
+        // filter can select just one. Detection is global, so it is still
+        // recognized as ambiguous and skipped — never merged across runs.
+        let src = Connection::open_in_memory().unwrap();
+        schema(&src, true);
+        src.execute_batch(
+            "INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (1,'p','Alpha','',1,1,'dup');
+             INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (2,'p','Beta','',1,1,'dup');",
+        ).unwrap();
+        let dest = empty_local();
+        let mut o = opts();
+        o.project_filter = Some("Alpha".to_string());
+        let s = sync_pull(&src, &dest, &o).unwrap();
+        assert_eq!(s.project.inserted, 0);
+        assert_eq!(s.project.skipped, 1); // Alpha was selected, but skipped as ambiguous
         assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM project"), 0);
     }
 

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -1,0 +1,919 @@
+//! Entity pull (telescope → our DB).
+//!
+//! Mirrors the telescope's scheduler structure and captured images into our
+//! local DB: projects, targets (coordinates), exposure templates/plans, rule
+//! weights, acquired images, and optionally the imagedata thumbnail BLOBs.
+//! Entities are matched by their stable `guid` (TS schema v22+); foreign keys
+//! are remapped onto the destination's local autoincrement Ids. The telescope
+//! wins for structure fields (upsert), but **local grading is preserved**: an
+//! existing image keeps its `gradingStatus`/`rejectreason` unless ours is still
+//! Pending, in which case it adopts the telescope's grade.
+//!
+//! Pure DB logic; the whole pull runs in one destination transaction (rolled
+//! back on `--dry-run`). CLI glue lives in `cli_main.rs`.
+
+use super::require_pull_capable;
+use anyhow::{anyhow, Context, Result};
+use rusqlite::types::Value;
+use rusqlite::{params, params_from_iter, Connection, OptionalExtension, ToSql, Transaction};
+use std::collections::{HashMap, HashSet};
+
+/// Knobs for a pull.
+pub struct PullOptions {
+    /// Compute & report the plan but roll back all writes.
+    pub dry_run: bool,
+    /// Also copy the (large) `imagedata` thumbnail BLOBs.
+    pub with_image_data: bool,
+    /// Restrict the pull to projects whose name matches (substring); cascades to
+    /// their targets, plans, and images.
+    pub project_filter: Option<String>,
+}
+
+/// Insert/update/unchanged counters for one table.
+#[derive(Debug, Default, Clone)]
+pub struct TableCounts {
+    pub inserted: usize,
+    pub updated: usize,
+    pub unchanged: usize,
+}
+
+/// Outcome of a pull.
+#[derive(Debug, Default)]
+pub struct PullSummary {
+    pub exposuretemplate: TableCounts,
+    pub project: TableCounts,
+    pub ruleweight: TableCounts,
+    pub target: TableCounts,
+    pub exposureplan: TableCounts,
+    pub acquiredimage: TableCounts,
+    /// Existing images whose Pending grade adopted the telescope's grade.
+    pub grade_filled: usize,
+    /// Existing images whose local (non-Pending) grade was preserved.
+    pub grade_preserved: usize,
+    pub imagedata: TableCounts,
+    /// True when `--with-image-data` ran (else imagedata was left untouched).
+    pub imagedata_synced: bool,
+    /// Per-entity trace lines (for `--verbose`).
+    pub changes: Vec<String>,
+}
+
+fn as_i64(v: &Value) -> Option<i64> {
+    match v {
+        Value::Integer(n) => Some(*n),
+        Value::Real(r) => Some(*r as i64),
+        _ => None,
+    }
+}
+
+/// SQLite-aware value equality (treats Integer/Real numerically) so idempotent
+/// re-pulls report `unchanged` rather than spurious updates.
+fn value_eq(a: &Value, b: &Value) -> bool {
+    use Value::*;
+    match (a, b) {
+        (Null, Null) => true,
+        (Integer(x), Integer(y)) => x == y,
+        (Real(x), Real(y)) => x == y,
+        (Integer(x), Real(y)) | (Real(y), Integer(x)) => (*x as f64) == *y,
+        (Text(x), Text(y)) => x == y,
+        (Blob(x), Blob(y)) => x == y,
+        _ => false,
+    }
+}
+
+fn values_equal(a: &[Value], b: &[Value]) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(x, y)| value_eq(x, y))
+}
+
+/// Column names of `table` in declared order.
+fn table_columns(conn: &Connection, table: &str) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info('{}')", table))?;
+    let cols = stmt
+        .query_map([], |r| r.get::<_, String>(1))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(cols)
+}
+
+fn quoted(cols: &[&str]) -> String {
+    cols.iter()
+        .map(|c| format!("\"{}\"", c))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+struct GuidUpsert {
+    /// Source local Id → destination local Id (for FK remapping of children).
+    id_map: HashMap<i64, i64>,
+    counts: TableCounts,
+}
+
+/// Upsert every (optionally filtered) source row of a guid-keyed `table` into
+/// the destination, matching by `guid` and remapping the named FK columns
+/// through the provided source-Id→dest-Id maps. Telescope wins on conflict.
+fn upsert_guid_table(
+    src: &Connection,
+    tx: &Transaction,
+    table: &str,
+    fk_remaps: &[(&str, &HashMap<i64, i64>)],
+    allowed_src_ids: Option<&HashSet<i64>>,
+    changes: &mut Vec<String>,
+) -> Result<GuidUpsert> {
+    let cols = table_columns(src, table)?;
+    let id_pos = cols
+        .iter()
+        .position(|c| c.eq_ignore_ascii_case("Id"))
+        .ok_or_else(|| anyhow!("table {} has no Id column", table))?;
+    let guid_pos = cols
+        .iter()
+        .position(|c| c.eq_ignore_ascii_case("guid"))
+        .ok_or_else(|| anyhow!("table {} has no guid column", table))?;
+
+    let write_idx: Vec<usize> = (0..cols.len()).filter(|&i| i != id_pos).collect();
+    let write_cols: Vec<&str> = write_idx.iter().map(|&i| cols[i].as_str()).collect();
+    let guid_w = write_cols
+        .iter()
+        .position(|c| c.eq_ignore_ascii_case("guid"))
+        .unwrap();
+    let fk_positions: Vec<(usize, &HashMap<i64, i64>)> = fk_remaps
+        .iter()
+        .filter_map(|(name, map)| {
+            write_cols
+                .iter()
+                .position(|c| c.eq_ignore_ascii_case(name))
+                .map(|p| (p, *map))
+        })
+        .collect();
+
+    // Destination guid -> (dest_id, write-col values), the pre-pull state.
+    let mut dest_map: HashMap<String, (i64, Vec<Value>)> = HashMap::new();
+    {
+        let sql = format!("SELECT Id,{} FROM {}", quoted(&write_cols), table);
+        let mut stmt = tx.prepare(&sql)?;
+        let n = write_cols.len();
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let dest_id: i64 = row.get(0)?;
+            let vals: Vec<Value> = (0..n)
+                .map(|i| row.get::<_, Value>(i + 1))
+                .collect::<rusqlite::Result<_>>()?;
+            if let Value::Text(g) = &vals[guid_w] {
+                if !g.is_empty() {
+                    dest_map.insert(g.clone(), (dest_id, vals));
+                }
+            }
+        }
+    }
+
+    let insert_sql = format!(
+        "INSERT INTO {} ({}) VALUES ({})",
+        table,
+        quoted(&write_cols),
+        write_cols.iter().map(|_| "?").collect::<Vec<_>>().join(",")
+    );
+    let update_sql = format!(
+        "UPDATE {} SET {} WHERE Id=?",
+        table,
+        write_cols
+            .iter()
+            .map(|c| format!("\"{}\"=?", c))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let mut ins_stmt = tx.prepare(&insert_sql)?;
+    let mut upd_stmt = tx.prepare(&update_sql)?;
+
+    let mut counts = TableCounts::default();
+    let mut id_map: HashMap<i64, i64> = HashMap::new();
+
+    let src_sql = format!("SELECT {} FROM {}", quoted(&cols_str(&cols)), table);
+    let mut src_stmt = src.prepare(&src_sql)?;
+    let ncols = cols.len();
+    let mut rows = src_stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let all_vals: Vec<Value> = (0..ncols)
+            .map(|i| row.get::<_, Value>(i))
+            .collect::<rusqlite::Result<_>>()?;
+        let src_id = match as_i64(&all_vals[id_pos]) {
+            Some(n) => n,
+            None => continue,
+        };
+        if let Some(allowed) = allowed_src_ids {
+            if !allowed.contains(&src_id) {
+                continue;
+            }
+        }
+        let guid = match &all_vals[guid_pos] {
+            Value::Text(g) if !g.is_empty() => g.clone(),
+            _ => continue,
+        };
+
+        let mut write_values: Vec<Value> = write_idx.iter().map(|&i| all_vals[i].clone()).collect();
+        for (pos, map) in &fk_positions {
+            if let Value::Integer(src_fk) = write_values[*pos] {
+                if let Some(dest_fk) = map.get(&src_fk) {
+                    write_values[*pos] = Value::Integer(*dest_fk);
+                }
+            }
+        }
+
+        match dest_map.get(&guid) {
+            Some((dest_id, cur_vals)) => {
+                id_map.insert(src_id, *dest_id);
+                if values_equal(&write_values, cur_vals) {
+                    counts.unchanged += 1;
+                } else {
+                    let mut p: Vec<&dyn ToSql> =
+                        write_values.iter().map(|v| v as &dyn ToSql).collect();
+                    let did = *dest_id;
+                    p.push(&did);
+                    upd_stmt.execute(p.as_slice())?;
+                    counts.updated += 1;
+                    changes.push(format!("update {} {}", table, guid));
+                }
+            }
+            None => {
+                ins_stmt.execute(params_from_iter(write_values.iter()))?;
+                let dest_id = tx.last_insert_rowid();
+                id_map.insert(src_id, dest_id);
+                counts.inserted += 1;
+                changes.push(format!("insert {} {}", table, guid));
+            }
+        }
+    }
+
+    Ok(GuidUpsert { id_map, counts })
+}
+
+fn cols_str(cols: &[String]) -> Vec<&str> {
+    cols.iter().map(|s| s.as_str()).collect()
+}
+
+/// Upsert acquired-image rows with the grade rule: new rows take the telescope
+/// grade; existing rows keep their local grade unless it's Pending (0), in
+/// which case they adopt the telescope's grade. FK columns
+/// (`projectId`/`targetId`/`exposureId`) are remapped.
+fn upsert_acquired_images(
+    src: &Connection,
+    tx: &Transaction,
+    proj_map: &HashMap<i64, i64>,
+    tgt_map: &HashMap<i64, i64>,
+    plan_map: &HashMap<i64, i64>,
+    allowed_project_ids: Option<&HashSet<i64>>,
+    summary: &mut PullSummary,
+) -> Result<HashMap<i64, i64>> {
+    let table = "acquiredimage";
+    let cols = table_columns(src, table)?;
+    let ci = |n: &str| cols.iter().position(|c| c.eq_ignore_ascii_case(n));
+    let id_pos = ci("Id").ok_or_else(|| anyhow!("acquiredimage.Id missing"))?;
+    let guid_pos = ci("guid").ok_or_else(|| anyhow!("acquiredimage.guid missing"))?;
+    let proj_pos = ci("projectId").ok_or_else(|| anyhow!("acquiredimage.projectId missing"))?;
+
+    let write_idx: Vec<usize> = (0..cols.len()).filter(|&i| i != id_pos).collect();
+    let write_cols: Vec<&str> = write_idx.iter().map(|&i| cols[i].as_str()).collect();
+    let wpos = |n: &str| write_cols.iter().position(|c| c.eq_ignore_ascii_case(n));
+    let guid_w = wpos("guid").unwrap();
+    let grade_w = wpos("gradingStatus").ok_or_else(|| anyhow!("gradingStatus missing"))?;
+    let reason_w = wpos("rejectreason");
+    let proj_w = wpos("projectId");
+    let tgt_w = wpos("targetId");
+    let expo_w = wpos("exposureId");
+
+    // Destination guid -> (dest_id, write values).
+    let mut dest_map: HashMap<String, (i64, Vec<Value>)> = HashMap::new();
+    {
+        let sql = format!("SELECT Id,{} FROM {}", quoted(&write_cols), table);
+        let mut stmt = tx.prepare(&sql)?;
+        let n = write_cols.len();
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let dest_id: i64 = row.get(0)?;
+            let vals: Vec<Value> = (0..n)
+                .map(|i| row.get::<_, Value>(i + 1))
+                .collect::<rusqlite::Result<_>>()?;
+            if let Value::Text(g) = &vals[guid_w] {
+                if !g.is_empty() {
+                    dest_map.insert(g.clone(), (dest_id, vals));
+                }
+            }
+        }
+    }
+
+    let insert_sql = format!(
+        "INSERT INTO {} ({}) VALUES ({})",
+        table,
+        quoted(&write_cols),
+        write_cols.iter().map(|_| "?").collect::<Vec<_>>().join(",")
+    );
+    let update_sql = format!(
+        "UPDATE {} SET {} WHERE Id=?",
+        table,
+        write_cols
+            .iter()
+            .map(|c| format!("\"{}\"=?", c))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let mut ins_stmt = tx.prepare(&insert_sql)?;
+    let mut upd_stmt = tx.prepare(&update_sql)?;
+
+    let mut id_map: HashMap<i64, i64> = HashMap::new();
+    let src_sql = format!("SELECT {} FROM {}", quoted(&cols_str(&cols)), table);
+    let mut src_stmt = src.prepare(&src_sql)?;
+    let ncols = cols.len();
+    let mut rows = src_stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let all_vals: Vec<Value> = (0..ncols)
+            .map(|i| row.get::<_, Value>(i))
+            .collect::<rusqlite::Result<_>>()?;
+        let src_id = match as_i64(&all_vals[id_pos]) {
+            Some(n) => n,
+            None => continue,
+        };
+        let src_proj = as_i64(&all_vals[proj_pos]);
+        if let Some(allowed) = allowed_project_ids {
+            match src_proj {
+                Some(p) if allowed.contains(&p) => {}
+                _ => continue,
+            }
+        }
+        let guid = match &all_vals[guid_pos] {
+            Value::Text(g) if !g.is_empty() => g.clone(),
+            _ => continue,
+        };
+
+        let mut write_values: Vec<Value> = write_idx.iter().map(|&i| all_vals[i].clone()).collect();
+        remap_fk(&mut write_values, proj_w, proj_map);
+        remap_fk(&mut write_values, tgt_w, tgt_map);
+        // exposureId references exposureplan.Id; if unmatched, write 0.
+        if let Some(p) = expo_w {
+            if let Value::Integer(src_plan) = write_values[p] {
+                write_values[p] = Value::Integer(plan_map.get(&src_plan).copied().unwrap_or(0));
+            }
+        }
+
+        match dest_map.get(&guid) {
+            Some((dest_id, cur_vals)) => {
+                id_map.insert(src_id, *dest_id);
+                let dest_grade = as_i64(&cur_vals[grade_w]).unwrap_or(0);
+                if dest_grade != 0 {
+                    // Preserve local decision.
+                    write_values[grade_w] = cur_vals[grade_w].clone();
+                    if let Some(rp) = reason_w {
+                        write_values[rp] = cur_vals[rp].clone();
+                    }
+                    summary.grade_preserved += 1;
+                } else if as_i64(&write_values[grade_w]).unwrap_or(0) != 0 {
+                    // Local Pending adopts the telescope's (non-Pending) grade.
+                    summary.grade_filled += 1;
+                }
+
+                if values_equal(&write_values, cur_vals) {
+                    summary.acquiredimage.unchanged += 1;
+                } else {
+                    let mut p: Vec<&dyn ToSql> =
+                        write_values.iter().map(|v| v as &dyn ToSql).collect();
+                    let did = *dest_id;
+                    p.push(&did);
+                    upd_stmt.execute(p.as_slice())?;
+                    summary.acquiredimage.updated += 1;
+                    summary
+                        .changes
+                        .push(format!("update acquiredimage {}", guid));
+                }
+            }
+            None => {
+                ins_stmt.execute(params_from_iter(write_values.iter()))?;
+                let dest_id = tx.last_insert_rowid();
+                id_map.insert(src_id, dest_id);
+                summary.acquiredimage.inserted += 1;
+                summary
+                    .changes
+                    .push(format!("insert acquiredimage {}", guid));
+            }
+        }
+    }
+
+    Ok(id_map)
+}
+
+fn remap_fk(values: &mut [Value], pos: Option<usize>, map: &HashMap<i64, i64>) {
+    if let Some(p) = pos {
+        if let Value::Integer(src_fk) = values[p] {
+            if let Some(dest_fk) = map.get(&src_fk) {
+                values[p] = Value::Integer(*dest_fk);
+            }
+        }
+    }
+}
+
+/// Upsert per-project rule weights (no guid; matched by `(projectId, name)`).
+fn upsert_ruleweights(
+    src: &Connection,
+    tx: &Transaction,
+    proj_map: &HashMap<i64, i64>,
+    counts: &mut TableCounts,
+    changes: &mut Vec<String>,
+) -> Result<()> {
+    let mut src_stmt = src.prepare("SELECT name, weight FROM ruleweight WHERE projectid = ?1")?;
+    for (src_proj, dest_proj) in proj_map {
+        let mut dest_existing: HashMap<String, (i64, f64)> = HashMap::new();
+        {
+            let mut ds =
+                tx.prepare("SELECT Id, name, weight FROM ruleweight WHERE projectid = ?1")?;
+            let mut rows = ds.query(params![dest_proj])?;
+            while let Some(r) = rows.next()? {
+                dest_existing.insert(r.get::<_, String>(1)?, (r.get(0)?, r.get(2)?));
+            }
+        }
+        let mut rows = src_stmt.query(params![src_proj])?;
+        while let Some(r) = rows.next()? {
+            let name: String = r.get(0)?;
+            let weight: f64 = r.get(1)?;
+            match dest_existing.get(&name) {
+                Some((id, w)) => {
+                    if (*w - weight).abs() < f64::EPSILON {
+                        counts.unchanged += 1;
+                    } else {
+                        tx.execute(
+                            "UPDATE ruleweight SET weight=?1 WHERE Id=?2",
+                            params![weight, id],
+                        )?;
+                        counts.updated += 1;
+                        changes.push(format!("update ruleweight {}", name));
+                    }
+                }
+                None => {
+                    tx.execute(
+                        "INSERT INTO ruleweight (name, weight, projectid) VALUES (?1,?2,?3)",
+                        params![name, weight, dest_proj],
+                    )?;
+                    counts.inserted += 1;
+                    changes.push(format!("insert ruleweight {}", name));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Copy imagedata BLOBs for pulled images (insert-only; blobs are immutable per
+/// image). In dry-run mode the rows are counted but not written.
+fn copy_imagedata(
+    src: &Connection,
+    tx: &Transaction,
+    img_map: &HashMap<i64, i64>,
+    counts: &mut TableCounts,
+    dry_run: bool,
+) -> Result<()> {
+    let mut exists_stmt =
+        tx.prepare("SELECT 1 FROM imagedata WHERE acquiredimageid = ?1 LIMIT 1")?;
+    let mut count_stmt =
+        src.prepare("SELECT COUNT(*) FROM imagedata WHERE acquiredimageid = ?1")?;
+    let mut sel_stmt = src.prepare(
+        "SELECT tag, imagedata, width, height FROM imagedata WHERE acquiredimageid = ?1",
+    )?;
+    let mut ins_stmt = tx.prepare(
+        "INSERT INTO imagedata (tag, imagedata, acquiredimageid, width, height) VALUES (?1,?2,?3,?4,?5)",
+    )?;
+    for (src_img, dest_img) in img_map {
+        let already = exists_stmt
+            .query_row(params![dest_img], |_| Ok(()))
+            .optional()?
+            .is_some();
+        if already {
+            counts.unchanged += 1;
+            continue;
+        }
+        if dry_run {
+            let n: i64 = count_stmt.query_row(params![src_img], |r| r.get(0))?;
+            counts.inserted += n as usize;
+            continue;
+        }
+        #[allow(clippy::type_complexity)]
+        let blobs: Vec<(Option<String>, Option<Vec<u8>>, i64, i64)> = sel_stmt
+            .query_map(params![src_img], |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get::<_, i64>(2).unwrap_or(0),
+                    r.get::<_, i64>(3).unwrap_or(0),
+                ))
+            })?
+            .collect::<rusqlite::Result<_>>()?;
+        for (tag, blob, w, h) in blobs {
+            ins_stmt.execute(params![tag, blob, dest_img, w, h])?;
+            counts.inserted += 1;
+        }
+    }
+    Ok(())
+}
+
+/// Compute the set of source row Ids in `table` whose `fk_col` is in `parents`.
+fn child_ids(
+    src: &Connection,
+    table: &str,
+    fk_col: &str,
+    parents: &HashSet<i64>,
+) -> Result<HashSet<i64>> {
+    let mut set = HashSet::new();
+    let mut stmt = src.prepare(&format!("SELECT Id, \"{}\" FROM {}", fk_col, table))?;
+    let mut rows = stmt.query([])?;
+    while let Some(r) = rows.next()? {
+        let id: i64 = r.get(0)?;
+        let fk: Option<i64> = r.get(1)?;
+        if let Some(fk) = fk {
+            if parents.contains(&fk) {
+                set.insert(id);
+            }
+        }
+    }
+    Ok(set)
+}
+
+/// Pull telescope structure + captures into the destination DB.
+pub fn sync_pull(src: &Connection, dest: &Connection, opts: &PullOptions) -> Result<PullSummary> {
+    require_pull_capable(src).context("source database")?;
+    require_pull_capable(dest).context("destination database")?;
+
+    let tx = dest.unchecked_transaction()?;
+    let mut summary = PullSummary::default();
+
+    // Resolve the project filter into cascading source-Id sets.
+    let included_projects: Option<HashSet<i64>> = match &opts.project_filter {
+        Some(sub) => {
+            let mut stmt = src.prepare("SELECT Id FROM project WHERE name LIKE ?1")?;
+            let ids: HashSet<i64> = stmt
+                .query_map(params![format!("%{}%", sub)], |r| r.get::<_, i64>(0))?
+                .collect::<rusqlite::Result<_>>()?;
+            Some(ids)
+        }
+        None => None,
+    };
+    let included_targets: Option<HashSet<i64>> = match &included_projects {
+        Some(projs) => Some(child_ids(src, "target", "projectid", projs)?),
+        None => None,
+    };
+    let included_plans: Option<HashSet<i64>> = match &included_targets {
+        Some(tgts) => Some(child_ids(src, "exposureplan", "targetid", tgts)?),
+        None => None,
+    };
+
+    // 1. exposuretemplate — profile-scoped, no FK; synced fully so plan FKs resolve.
+    let tmpl = upsert_guid_table(
+        src,
+        &tx,
+        "exposuretemplate",
+        &[],
+        None,
+        &mut summary.changes,
+    )?;
+    summary.exposuretemplate = tmpl.counts;
+    let tmpl_map = tmpl.id_map;
+
+    // 2. project
+    let proj = upsert_guid_table(
+        src,
+        &tx,
+        "project",
+        &[],
+        included_projects.as_ref(),
+        &mut summary.changes,
+    )?;
+    summary.project = proj.counts;
+    let proj_map = proj.id_map;
+
+    // 3. ruleweight (children of pulled projects)
+    upsert_ruleweights(
+        src,
+        &tx,
+        &proj_map,
+        &mut summary.ruleweight,
+        &mut summary.changes,
+    )?;
+
+    // 4. target (remap projectid)
+    let tgt = upsert_guid_table(
+        src,
+        &tx,
+        "target",
+        &[("projectid", &proj_map)],
+        included_targets.as_ref(),
+        &mut summary.changes,
+    )?;
+    summary.target = tgt.counts;
+    let tgt_map = tgt.id_map;
+
+    // 5. exposureplan (remap targetid + exposureTemplateId)
+    let plan = upsert_guid_table(
+        src,
+        &tx,
+        "exposureplan",
+        &[("targetid", &tgt_map), ("exposureTemplateId", &tmpl_map)],
+        included_plans.as_ref(),
+        &mut summary.changes,
+    )?;
+    summary.exposureplan = plan.counts;
+    let plan_map = plan.id_map;
+
+    // 6. acquiredimage (grade fill-if-pending; remap proj/tgt/exposureId)
+    let img_map = upsert_acquired_images(
+        src,
+        &tx,
+        &proj_map,
+        &tgt_map,
+        &plan_map,
+        included_projects.as_ref(),
+        &mut summary,
+    )?;
+
+    // 7. imagedata (optional, heavy)
+    if opts.with_image_data {
+        copy_imagedata(src, &tx, &img_map, &mut summary.imagedata, opts.dry_run)?;
+        summary.imagedata_synced = true;
+    }
+
+    if opts.dry_run {
+        tx.rollback()?;
+    } else {
+        tx.commit()?;
+    }
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a representative v22 scheduler schema (optionally without guids).
+    fn schema(conn: &Connection, with_guid: bool) {
+        let g = if with_guid { ", guid TEXT" } else { "" };
+        conn.execute_batch(&format!(
+            "CREATE TABLE project (Id INTEGER PRIMARY KEY, profileId TEXT, name TEXT, description TEXT, state INTEGER, priority INTEGER{g});
+             CREATE TABLE target (Id INTEGER PRIMARY KEY, name TEXT, active INTEGER, ra REAL, dec REAL, epochcode INTEGER, projectid INTEGER{g});
+             CREATE TABLE exposuretemplate (Id INTEGER PRIMARY KEY, profileId TEXT, name TEXT, filtername TEXT, gain INTEGER{g});
+             CREATE TABLE exposureplan (Id INTEGER PRIMARY KEY, profileId TEXT, exposure REAL, desired INTEGER, acquired INTEGER, accepted INTEGER, targetid INTEGER, exposureTemplateId INTEGER{g});
+             CREATE TABLE acquiredimage (Id INTEGER PRIMARY KEY, projectId INTEGER, targetId INTEGER, acquireddate INTEGER, filtername TEXT, gradingStatus INTEGER NOT NULL, metadata TEXT NOT NULL, rejectreason TEXT, profileId TEXT, exposureId INTEGER{g});
+             CREATE TABLE ruleweight (Id INTEGER PRIMARY KEY, name TEXT, weight REAL, projectid INTEGER);
+             CREATE TABLE imagedata (Id INTEGER PRIMARY KEY, tag TEXT, imagedata BLOB, acquiredimageid INTEGER, width INTEGER DEFAULT 0, height INTEGER DEFAULT 0);"
+        ))
+        .unwrap();
+    }
+
+    fn opts() -> PullOptions {
+        PullOptions {
+            dry_run: false,
+            with_image_data: false,
+            project_filter: None,
+        }
+    }
+
+    /// Seed one project (guid pg) with one target (tg), one template (eg), one
+    /// plan (lg, exposureplan.Id=1), and images. Returns the connection.
+    fn telescope() -> Connection {
+        let c = Connection::open_in_memory().unwrap();
+        schema(&c, true);
+        c.execute_batch(
+            "INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (1,'p','Caldwell','',1,5,'pg');
+             INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid) VALUES (1,'C33',1,10.6,41.2,0,1,'tg');
+             INSERT INTO exposuretemplate (Id,profileId,name,filtername,gain,guid) VALUES (1,'p','Ha','Ha',100,'eg');
+             INSERT INTO exposureplan (Id,profileId,exposure,desired,acquired,accepted,targetid,exposureTemplateId,guid) VALUES (1,'p',300,50,10,8,1,1,'lg');
+             INSERT INTO ruleweight (Id,name,weight,projectid) VALUES (1,'Priority',1.0,1);
+             INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,rejectreason,profileId,exposureId,guid)
+               VALUES (1,1,1,1000,'Ha',1,'{\"FileName\":\"a.fits\"}',NULL,'p',1,'img1');
+             INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,rejectreason,profileId,exposureId,guid)
+               VALUES (2,1,1,2000,'Ha',2,'{\"FileName\":\"b.fits\"}','clouds','p',1,'img2');
+             INSERT INTO imagedata (Id,tag,imagedata,acquiredimageid,width,height) VALUES (1,'',X'01020304',1,100,100);
+             INSERT INTO imagedata (Id,tag,imagedata,acquiredimageid,width,height) VALUES (2,'',X'05060708',2,100,100);",
+        )
+        .unwrap();
+        c
+    }
+
+    fn empty_local() -> Connection {
+        let c = Connection::open_in_memory().unwrap();
+        schema(&c, true);
+        c
+    }
+
+    fn one<T: rusqlite::types::FromSql>(c: &Connection, sql: &str) -> T {
+        c.query_row(sql, [], |r| r.get(0)).unwrap()
+    }
+
+    #[test]
+    fn inserts_full_tree_into_empty_local() {
+        let src = telescope();
+        let dest = empty_local();
+        let s = sync_pull(&src, &dest, &opts()).unwrap();
+
+        assert_eq!(s.project.inserted, 1);
+        assert_eq!(s.target.inserted, 1);
+        assert_eq!(s.exposuretemplate.inserted, 1);
+        assert_eq!(s.exposureplan.inserted, 1);
+        assert_eq!(s.acquiredimage.inserted, 2);
+        assert_eq!(s.ruleweight.inserted, 1);
+
+        // Referential integrity: target.projectid points at the new project Id,
+        // and acquiredimage FKs resolve.
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM acquiredimage ai JOIN project p ON ai.projectId=p.Id JOIN target t ON ai.targetId=t.Id"), 2);
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM exposureplan ep JOIN target t ON ep.targetid=t.Id JOIN exposuretemplate et ON ep.exposureTemplateId=et.Id"), 1);
+        // New image takes the telescope grade.
+        assert_eq!(
+            one::<i64>(
+                &dest,
+                "SELECT gradingStatus FROM acquiredimage WHERE guid='img1'"
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn remaps_fks_when_local_ids_differ() {
+        let src = telescope();
+        let dest = empty_local();
+        // Pre-seed dest with unrelated rows so autoincrement assigns DIFFERENT
+        // Ids to the pulled project/target than their source Ids.
+        dest.execute_batch(
+            "INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (50,'p','Other','',1,1,'other-pg');
+             INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid) VALUES (70,'OtherT',1,0,0,0,50,'other-tg');",
+        ).unwrap();
+
+        sync_pull(&src, &dest, &opts()).unwrap();
+        // Pulled project got a fresh Id (not 1); its target points at it.
+        let proj_id: i64 = one(&dest, "SELECT Id FROM project WHERE guid='pg'");
+        assert_ne!(proj_id, 1);
+        let tgt_proj: i64 = one(&dest, "SELECT projectid FROM target WHERE guid='tg'");
+        assert_eq!(tgt_proj, proj_id);
+        // acquiredimage.exposureId remapped to the dest plan Id.
+        let plan_id: i64 = one(&dest, "SELECT Id FROM exposureplan WHERE guid='lg'");
+        assert_eq!(
+            one::<i64>(
+                &dest,
+                "SELECT exposureId FROM acquiredimage WHERE guid='img1'"
+            ),
+            plan_id
+        );
+    }
+
+    #[test]
+    fn preserves_local_grade_but_fills_pending() {
+        let src = telescope();
+        let dest = empty_local();
+        // dest already has img1 (locally Accepted=1 -> but set to Rejected=2 to
+        // prove preservation) and img2 still Pending(0).
+        dest.execute_batch(
+            "INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (1,'p','Caldwell','',1,5,'pg');
+             INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid) VALUES (1,'C33',1,10.6,41.2,0,1,'tg');
+             INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,rejectreason,profileId,exposureId,guid)
+               VALUES (1,1,1,1000,'Ha',2,'{}','local-reject','p',0,'img1');
+             INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,rejectreason,profileId,exposureId,guid)
+               VALUES (2,1,1,2000,'Ha',0,'{}',NULL,'p',0,'img2');",
+        ).unwrap();
+
+        let s = sync_pull(&src, &dest, &opts()).unwrap();
+        // img1 local Rejected preserved despite telescope Accepted(1).
+        assert_eq!(
+            one::<i64>(
+                &dest,
+                "SELECT gradingStatus FROM acquiredimage WHERE guid='img1'"
+            ),
+            2
+        );
+        assert_eq!(
+            one::<String>(
+                &dest,
+                "SELECT rejectreason FROM acquiredimage WHERE guid='img1'"
+            ),
+            "local-reject"
+        );
+        // img2 was Pending -> adopts telescope Rejected(2) + reason.
+        assert_eq!(
+            one::<i64>(
+                &dest,
+                "SELECT gradingStatus FROM acquiredimage WHERE guid='img2'"
+            ),
+            2
+        );
+        assert_eq!(
+            one::<String>(
+                &dest,
+                "SELECT rejectreason FROM acquiredimage WHERE guid='img2'"
+            ),
+            "clouds"
+        );
+        assert_eq!(s.grade_preserved, 1);
+        assert_eq!(s.grade_filled, 1);
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let src = telescope();
+        let dest = empty_local();
+        sync_pull(&src, &dest, &opts()).unwrap();
+        let s = sync_pull(&src, &dest, &opts()).unwrap();
+        // Second run changes nothing.
+        assert_eq!(s.project.inserted + s.project.updated, 0);
+        assert_eq!(s.target.inserted + s.target.updated, 0);
+        assert_eq!(s.exposureplan.inserted + s.exposureplan.updated, 0);
+        assert_eq!(s.acquiredimage.inserted + s.acquiredimage.updated, 0);
+        assert_eq!(s.acquiredimage.unchanged, 2);
+    }
+
+    #[test]
+    fn updates_changed_structure_fields() {
+        let src = telescope();
+        let dest = empty_local();
+        sync_pull(&src, &dest, &opts()).unwrap();
+        // Telescope changes project state and plan acquired count.
+        src.execute("UPDATE project SET state=3, priority=9 WHERE guid='pg'", [])
+            .unwrap();
+        src.execute("UPDATE exposureplan SET acquired=42 WHERE guid='lg'", [])
+            .unwrap();
+        let s = sync_pull(&src, &dest, &opts()).unwrap();
+        assert_eq!(s.project.updated, 1);
+        assert_eq!(s.exposureplan.updated, 1);
+        assert_eq!(
+            one::<i64>(&dest, "SELECT state FROM project WHERE guid='pg'"),
+            3
+        );
+        assert_eq!(
+            one::<i64>(&dest, "SELECT acquired FROM exposureplan WHERE guid='lg'"),
+            42
+        );
+    }
+
+    #[test]
+    fn dry_run_writes_nothing() {
+        let src = telescope();
+        let dest = empty_local();
+        let mut o = opts();
+        o.dry_run = true;
+        let s = sync_pull(&src, &dest, &o).unwrap();
+        assert_eq!(s.acquiredimage.inserted, 2); // planned
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM acquiredimage"), 0); // but nothing written
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM project"), 0);
+    }
+
+    #[test]
+    fn imagedata_gated_on_flag() {
+        let src = telescope();
+        let dest = empty_local();
+        // Default: no blobs.
+        sync_pull(&src, &dest, &opts()).unwrap();
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM imagedata"), 0);
+
+        // With flag: blobs copied for the pulled images.
+        let mut o = opts();
+        o.with_image_data = true;
+        let s = sync_pull(&src, &dest, &o).unwrap();
+        assert!(s.imagedata_synced);
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM imagedata"), 2);
+        // Blob bound to the dest image Id.
+        let img1: i64 = one(&dest, "SELECT Id FROM acquiredimage WHERE guid='img1'");
+        assert_eq!(
+            one::<i64>(
+                &dest,
+                &format!(
+                    "SELECT COUNT(*) FROM imagedata WHERE acquiredimageid={}",
+                    img1
+                )
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn project_filter_scopes_pull() {
+        let src = telescope();
+        // Add a second project + target + image that must NOT be pulled.
+        src.execute_batch(
+            "INSERT INTO project (Id,profileId,name,description,state,priority,guid) VALUES (2,'p','Messier','',1,5,'pg2');
+             INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid) VALUES (2,'M31',1,0,0,0,2,'tg2');
+             INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,rejectreason,profileId,exposureId,guid)
+               VALUES (3,2,2,3000,'L',1,'{}',NULL,'p',0,'img3');",
+        ).unwrap();
+        let dest = empty_local();
+        let mut o = opts();
+        o.project_filter = Some("Caldwell".to_string());
+        sync_pull(&src, &dest, &o).unwrap();
+        assert_eq!(one::<i64>(&dest, "SELECT COUNT(*) FROM project"), 1);
+        assert_eq!(
+            one::<i64>(
+                &dest,
+                "SELECT COUNT(*) FROM acquiredimage WHERE guid='img3'"
+            ),
+            0
+        );
+        assert_eq!(
+            one::<i64>(&dest, "SELECT COUNT(*) FROM target WHERE guid='tg2'"),
+            0
+        );
+    }
+
+    #[test]
+    fn refuses_pre_v22_database() {
+        let src = telescope();
+        let dest = Connection::open_in_memory().unwrap();
+        schema(&dest, false); // no guid columns
+        let err = sync_pull(&src, &dest, &opts()).unwrap_err();
+        assert!(format!("{:#}", err).contains("destination"));
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -1007,32 +1007,6 @@ mod tests {
     }
 
     #[test]
-    fn test_schema_detection_old_schema() {
-        // Test with the old schema database (no guid columns)
-        let db_path = std::path::Path::new("schedulerdb.sqlite");
-        if !db_path.exists() {
-            eprintln!("Skipping test: schedulerdb.sqlite not found");
-            return;
-        }
-
-        let conn = Connection::open(db_path).expect("Failed to open old schema database");
-        let caps = SchemaCapabilities::detect(&conn);
-
-        assert!(
-            !caps.has_acquiredimage_guid,
-            "Old schema should not have acquiredimage.guid"
-        );
-        assert!(
-            !caps.has_project_guid,
-            "Old schema should not have project.guid"
-        );
-        assert!(
-            !caps.has_target_guid,
-            "Old schema should not have target.guid"
-        );
-    }
-
-    #[test]
     fn test_schema_detection_new_schema() {
         // Test with the new schema database (has guid columns)
         let db_path = std::path::Path::new("schedulerdb-2.sqlite");
@@ -1050,34 +1024,6 @@ mod tests {
         );
         assert!(caps.has_project_guid, "New schema should have project.guid");
         assert!(caps.has_target_guid, "New schema should have target.guid");
-    }
-
-    #[test]
-    fn test_database_queries_old_schema() {
-        let db_path = std::path::Path::new("schedulerdb.sqlite");
-        if !db_path.exists() {
-            eprintln!("Skipping test: schedulerdb.sqlite not found");
-            return;
-        }
-
-        let conn = Connection::open(db_path).expect("Failed to open old schema database");
-        let db = Database::new(&conn);
-
-        // Verify schema detection
-        assert!(!db.schema_capabilities().has_acquiredimage_guid);
-
-        // Test basic queries work
-        let projects = db.get_all_projects().expect("Failed to get projects");
-        assert!(!projects.is_empty(), "Should have projects");
-        for project in &projects {
-            assert!(
-                project.guid.is_none(),
-                "Old schema projects should have no guid"
-            );
-        }
-
-        let stats = db.get_overall_statistics().expect("Failed to get stats");
-        assert!(stats.total_images > 0, "Should have images");
     }
 
     #[test]


### PR DESCRIPTION
## What

Two complementary, single-direction `sync` subcommands for moving data between N.I.N.A. Target Scheduler databases, matched by the stable `guid` (TS schema v22+). Together they implement the telescope ⇄ local grading-mirror workflow. Use them together — pull to refresh, grade locally, push grades back — rather than reversing one direction (which would overwrite local grading).

### `sync grades --from <local> --to <telescope>` — push grades back
One-way push of grading state (`gradingStatus` + `rejectreason`); source wins. Match by `acquiredimage.guid`. Filters: `--status`, `--project`, `--target`. Single transaction. Reports considered / matched / changed / unchanged / unmatched-source / dest-only with a per-transition breakdown. Duplicate-guid detection is **global** over the whole source table, so a filter can't make an ambiguous guid look unique.

### `sync pull --from <telescope> --to <local>` — mirror structure + captures
Pulls `exposuretemplate`, `project`, `ruleweight`, `target`, `exposureplan`, `acquiredimage`, and `imagedata` thumbnail blobs into the local DB:
- **FK remapping:** tables are processed in dependency order, building `src_guid → dest_Id` maps so child FKs (target→project, plan→target+template, image→project+target+exposureId, ruleweight→project) are remapped onto the destination's local autoincrement Ids. A generic guid-keyed upsert reads the **intersection** of source/destination columns (`shared_columns`) so DBs at different migration levels still sync their shared columns. `ruleweight` (no guid) matches by `(projectId, name)`; `imagedata` matches per `(acquiredimageid, tag)` and is insert-only.
- **Safety:** required parent FKs that don't map cause the row to be **skipped** (never attached to an unrelated dest row); duplicate guids on **either** side (global detection) are skipped so children can't silently merge.
- **Telescope wins for structure** (upsert: insert new, update changed fields — project state, plan counts, coordinates). **Local grading is preserved:** a new image takes the telescope grade; an existing image keeps its grade unless still Pending, in which case it adopts the telescope's.
- **imagedata blobs are copied by default**; pass `--no-image-data` to skip them. The summary ends with an overall total and the **size copied** (e.g. `imagedata copied: 53.6 MiB`).
- Whole pull runs in **one transaction, rolled back on `--dry-run`**. `--project` scopes the pull and cascades to that project's targets/plans/images.

## Decisions baked in (from discussion)
- Match by guid (v22+ enforced on both sides via `require_target_scheduler_guid` / `require_pull_capable`).
- Grades on pull: fill-only-if-local-Pending. Image blobs: **on by default, `--no-image-data` to skip**. Commands: separate single-direction kinds. Structure: upsert, telescope wins.
- `--from`/`--to` accept a registry slug **or** a raw `.sqlite` path; source READ_ONLY, dest READ_WRITE; same-path refused.

## Structure
`src/commands/sync.rs` → `src/commands/sync/{mod,grades,pull}.rs` (shared helpers in `mod.rs`; the `crate::commands::sync::*` path is preserved via re-exports).

## Testing
- **27 sync unit tests** (grades + pull + module): insert tree, FK remap with mismatched local Ids, grade preserve vs fill-if-pending, idempotency, structure update, dry-run rollback, imagedata gating + multi-tag copy, project scoping, v22 guard, global duplicate-guid detection (source/dest, and under filters), unmapped-parent skip, and schema drift. `cargo fmt`/`clippy -D warnings` clean.
- End-to-end on a fork of a real v22 scheduler DB: deleted a project + cascade and locally re-graded images, then pulled — deleted project/targets/plans/images restored with a clean `PRAGMA foreign_key_check` (0 orphans), local Rejected grade preserved over telescope Accepted, Pending image filled from telescope, idempotent re-runs (all unchanged), `--no-image-data` vs default blob copy verified with byte totals. Round-trip `sync grades` back still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)