### PR TITLE
fix(ui): analysis view drops db context when picking a target

### DIFF
--- a/static/src/App.tsx
+++ b/static/src/App.tsx
@@ -16,6 +16,12 @@ function App() {
   const navigate = useNavigate();
   const location = useLocation();
   const { showStats, setShowStats } = useGridState();
+
+  // Carry the active (db, project, target, filter…) query context when switching
+  // between scoped views, so navigation never drops the ?db= slug and strands
+  // the user on an empty view.
+  const toScoped = (path: string) =>
+    location.search ? `${path}${location.search}` : path;
   const [showHelp, setShowHelp] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   // We track this only to short-circuit checks against Tauri-only commands;
@@ -114,12 +120,12 @@ function App() {
             </button>
           )}
           {!isOnGrid && (
-            <button onClick={() => navigate('/grid')} className="header-button">
+            <button onClick={() => navigate(toScoped('/grid'))} className="header-button">
               Images
             </button>
           )}
           {!isOnSequence && (
-            <button onClick={() => navigate('/sequence')} className="header-button">
+            <button onClick={() => navigate(toScoped('/sequence'))} className="header-button">
               Sequence
             </button>
           )}

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -170,7 +170,15 @@ export default function SequenceView() {
                 <button
                   key={t.id}
                   className="target-card-btn"
-                  onClick={() => navigate(`/sequence?project=${projectId}&target=${t.id}`)}
+                  onClick={() => {
+                    // Preserve the existing query context (notably ?db=) and
+                    // just set the chosen target, instead of rebuilding the URL
+                    // from scratch and dropping the db slug.
+                    const params = new URLSearchParams(searchParams);
+                    params.set('project', String(projectId));
+                    params.set('target', String(t.id));
+                    navigate(`/sequence?${params.toString()}`);
+                  }}
                 >
                   <span className="target-card-name">{t.name}</span>
                   <span className="target-card-count">{t.image_count} images</span>

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../test/msw-server';
@@ -150,6 +150,38 @@ describe('SequenceView: rendering states', () => {
       expect(screen.getByText('M42')).toBeInTheDocument();
     });
     expect(screen.getByText('NGC7000')).toBeInTheDocument();
+  });
+
+  it('clicking a target card keeps the db/project context (no blank analysis)', async () => {
+    setupDefaultHandlers();
+
+    // Probe the live router location so we can assert the URL after navigation.
+    let search = '';
+    function LocationProbe() {
+      search = useLocation().search;
+      return null;
+    }
+
+    const Wrapper = createWrapper('/sequence?db=test&project=1');
+    render(
+      <Wrapper>
+        <SequenceView />
+        <LocationProbe />
+      </Wrapper>
+    );
+
+    // From the target-selection screen, click into a target's analysis.
+    const card = await screen.findByText('M42');
+    await userEvent.click(card);
+
+    // The db slug (and project/target) must survive the navigation — dropping
+    // ?db= is what stranded the user on a blank analysis view.
+    await waitFor(() => {
+      const params = new URLSearchParams(search);
+      expect(params.get('db')).toBe('test');
+      expect(params.get('project')).toBe('1');
+      expect(params.get('target')).toBe('1'); // M42 = id 1
+    });
   });
 
   it('shows loading state while analyzing', async () => {


### PR DESCRIPTION
## Problem

Picking a target in the analysis (Sequence) view dropped you into a blank analysis with no project/db set.

The view (`/sequence`, `SequenceView`) reads its context — `dbId`, `projectId`, `targetId` — from the URL via `useDbProjectTarget()` (`?db=<slug>&project=<n>&target=<n>`), and gates every data query on `enabled: !!dbId && ...`. So the instant `?db=` is lost, all queries disable and the view renders empty.

## Root cause

Two navigations rebuilt the URL by hand and dropped the `db` context:

1. **`SequenceView.tsx`** — the empty-state target cards navigated to `` `/sequence?project=${projectId}&target=${t.id}` `` with **no `db`**. This is the exact "pick a target → blank" path.
2. **`App.tsx`** — the header `Sequence`/`Images` buttons did `navigate('/sequence')` / `navigate('/grid')` with **no params at all**, dropping db/project/target entirely.

(The header `ProjectTargetSelector` was already correct — it uses `updateParams`, which preserves `db`.)

## Fix
- **App.tsx**: `toScoped(path)` appends the current `location.search`; the `Images`/`Sequence` buttons now carry the active context between scoped views.
- **SequenceView.tsx**: the target card clones the existing `searchParams` (keeping `db`, filters, …) and just sets `project`/`target` — mirroring the filter dropdown beside it.

## Test
New regression test *"clicking a target card keeps the db/project context"*: renders the target-selection screen at `/sequence?db=test&project=1`, clicks the M42 card, and asserts the resulting URL still carries `db=test` (+ `project=1`, `target=1`). Fails against the old code.

## Validation
`tsc` clean; **58 frontend tests pass** (incl. the new one); no new lint errors (pre-existing `tauri.ts` `@ts-ignore` lints untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)