### PR TITLE
feat(packaging): native Fedora RPM build (f43/f44)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,11 @@ jobs:
           - **Windows**: `psf-guard-windows-x64.exe` - standalone CLI binary
           - **macOS**: `psf-guard-macos-x64` - standalone CLI binary
 
+          ### Fedora packages 📦
+          - **Fedora 43 / 44**: `psf-guard-*.fc43.x86_64.rpm` / `*.fc44.x86_64.rpm`
+            install the CLI/server plus a `psf-guard.service` systemd unit
+            (`sudo dnf install ./psf-guard-*.rpm`)
+
           ### Features
           - 🖥️ **Smart Binary**: Single binary that automatically switches between GUI and CLI modes
           - 📊 **N.I.N.A. Integration**: Direct support for N.I.N.A. scheduler databases

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build RPM on Fedora ${{ matrix.fedora }}
@@ -64,3 +67,16 @@ jobs:
         with:
           name: psf-guard-fedora-${{ matrix.fedora }}-rpms
           path: out/*.rpm
+
+      - name: Attach RPMs to the GitHub release
+        # On tag builds only, add the binary RPMs to the release created by
+        # release.yml (matched by tag; this only appends files, it does not
+        # touch the release name/notes). The SRPM is left off to keep assets
+        # lean -- it bundles the full vendored crate tree.
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v3
+        with:
+          files: out/psf-guard-[0-9]*.x86_64.rpm
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -53,8 +53,11 @@ jobs:
 
       - name: Smoke-test the built binary
         run: |
-          rpm -i out/psf-guard-[0-9]*.rpm
+          # dnf resolves Requires (incl. systemd pulled in by the unit/sysusers).
+          dnf -y install out/psf-guard-[0-9]*.x86_64.rpm
           psf-guard --help
+          test -f /usr/lib/systemd/system/psf-guard.service
+          test -f /etc/psf-guard/server.conf
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,62 @@
+name: RPM
+
+on:
+  push:
+    branches: [ main, master ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    name: Build RPM on Fedora ${{ matrix.fedora }}
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:${{ matrix.fedora }}
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora: [ '43', '44' ]
+
+    steps:
+      - name: Install build tooling
+        run: |
+          dnf -y install --setopt=install_weak_deps=False \
+            rpm-build rpmdevtools \
+            rust cargo clang-devel opencv-devel \
+            gcc gcc-c++ pkgconf-pkg-config \
+            nodejs npm git xz tar findutils
+          rpmdev-setuptree
+
+      - uses: actions/checkout@v4
+        with:
+          # cargo vendor needs the full history-free tree but git archive needs
+          # the checkout to be a git repo; a shallow checkout is fine.
+          fetch-depth: 0
+
+      - name: Mark checkout as a safe git directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Generate source tarballs (frontend + vendored crates)
+        run: ./scripts/make-rpm-sources.sh
+
+      - name: Build RPM
+        run: |
+          cp packaging/rpm/psf-guard.spec ~/rpmbuild/SPECS/
+          rpmbuild -ba ~/rpmbuild/SPECS/psf-guard.spec
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p out
+          find ~/rpmbuild/RPMS ~/rpmbuild/SRPMS -name '*.rpm' -exec cp {} out/ \;
+          ls -l out
+
+      - name: Smoke-test the built binary
+        run: |
+          rpm -i out/psf-guard-[0-9]*.rpm
+          psf-guard --help
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: psf-guard-fedora-${{ matrix.fedora }}-rpms
+          path: out/*.rpm

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - name: Install build tooling
         run: |
+          # Tooling needed before rpmbuild (source generation); the remaining
+          # BuildRequires are pulled from the spec via `dnf builddep` below.
           dnf -y install --setopt=install_weak_deps=False \
-            rpm-build rpmdevtools \
-            rust cargo clang-devel opencv-devel \
-            gcc gcc-c++ pkgconf-pkg-config \
-            nodejs npm git xz tar findutils
+            rpm-build rpmdevtools 'dnf-command(builddep)' \
+            cargo nodejs npm git xz tar findutils
           rpmdev-setuptree
 
       - uses: actions/checkout@v4
@@ -43,6 +43,7 @@ jobs:
       - name: Build RPM
         run: |
           cp packaging/rpm/psf-guard.spec ~/rpmbuild/SPECS/
+          dnf -y builddep ~/rpmbuild/SPECS/psf-guard.spec
           rpmbuild -ba ~/rpmbuild/SPECS/psf-guard.spec
 
       - name: Collect artifacts

--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ docker run -d -p 3000:3000 \
 
 Open your browser to http://localhost:3000/
 
+### Fedora / RPM (build from source)
+
+PSF Guard can be built as a native RPM on Fedora 43, Fedora 44, and other
+recent releases using mainline RPM tooling (`rpmbuild`, `mock`, COPR). The
+build is fully offline once sources are prepared, so it works in a clean
+chroot:
+
+```bash
+sudo dnf install -y rpm-build rpmdevtools cargo rust clang-devel \
+    opencv-devel nodejs npm git
+rpmdev-setuptree
+./scripts/make-rpm-sources.sh                 # builds frontend + vendors crates
+rpmbuild -ba packaging/rpm/psf-guard.spec      # RPMs in ~/rpmbuild/RPMS/
+```
+
+See [`packaging/rpm/README.md`](packaging/rpm/README.md) for details (mock
+builds, the `--without opencv` variant, and releasing a new version).
+
 ### Pre-built CLI/Server Binaries for Windows, macOS, Linux
 
 Download the latest release for your platform:

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -51,6 +51,25 @@ Build without OpenCV:
 rpmbuild -ba --without opencv packaging/rpm/psf-guard.spec
 ```
 
+## Build in clean Fedora containers (podman)
+
+`build-in-podman.sh` reproduces the CI build locally: it runs the whole flow
+(toolchain install, source generation, `rpmbuild`, and an `rpm -i` +
+`psf-guard --help` smoke test) inside throwaway `fedora:<ver>` containers and
+drops the artifacts on the host.
+
+```bash
+# Builds Fedora 43 and 44 in parallel into ./dist/rpm/fedora-<ver>/
+./packaging/rpm/build-in-podman.sh
+
+# Pick releases and an output directory; build one at a time:
+./packaging/rpm/build-in-podman.sh 43 44 --outdir /tmp/psf-rpms --sequential
+```
+
+Each release lands in `<outdir>/fedora-<ver>/` alongside a `build.log`. Only
+podman is required on the host (the container does the rest; network is needed
+for npm + cargo vendor).
+
 ## Build in mock (clean chroot, e.g. Fedora 44)
 
 ```bash

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -1,0 +1,70 @@
+# Fedora / RPM packaging
+
+This directory packages PSF Guard as a native RPM that builds with mainline
+RPM tooling (`rpmbuild`, `mock`, COPR) on Fedora 43, Fedora 44, and other
+recent Fedora releases.
+
+## Design
+
+PSF Guard embeds its React frontend into the binary at compile time
+(`include_dir!("static/dist")`) and pulls a large Cargo dependency tree. A
+Fedora build environment (mock/COPR) is **offline**, so all network work is
+done once, up front, by `scripts/make-rpm-sources.sh`:
+
+1. Export a clean tree from git.
+2. Build the frontend (`npm ci && npm run build`) into `static/dist`, then drop
+   `node_modules`. At RPM build time `build.rs` is skipped via
+   `PSF_GUARD_SKIP_FRONTEND_BUILD=1`.
+3. `cargo vendor` every crate into `vendor/`. The spec writes a
+   `.cargo/config.toml` pointing at it and builds with `CARGO_NET_OFFLINE=true`.
+
+The result is two sources:
+
+| Source  | File                              | Contents                              |
+| ------- | --------------------------------- | ------------------------------------- |
+| Source0 | `psf-guard-<ver>.tar.gz`          | source tree + prebuilt `static/dist`  |
+| Source1 | `psf-guard-<ver>-vendor.tar.xz`   | vendored crates (`./vendor`)          |
+
+OpenCV is enabled by default (matching the upstream default features). Build a
+lighter package without it using `--without opencv`.
+
+## Build locally
+
+```bash
+# Install tooling (Fedora):
+sudo dnf install -y rpm-build rpmdevtools cargo rust clang-devel \
+    opencv-devel nodejs npm git
+rpmdev-setuptree
+
+# Generate the two source tarballs (needs network: npm + cargo vendor).
+./scripts/make-rpm-sources.sh                    # -> ~/rpmbuild/SOURCES
+
+# Build (offline from here on).
+rpmbuild -ba packaging/rpm/psf-guard.spec
+
+# RPMs land in ~/rpmbuild/RPMS/<arch>/
+```
+
+Build without OpenCV:
+
+```bash
+rpmbuild -ba --without opencv packaging/rpm/psf-guard.spec
+```
+
+## Build in mock (clean chroot, e.g. Fedora 44)
+
+```bash
+./scripts/make-rpm-sources.sh --outdir /tmp/psf-sources
+rpmbuild -bs packaging/rpm/psf-guard.spec \
+    --define "_sourcedir /tmp/psf-sources"
+mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/psf-guard-*.src.rpm
+```
+
+## Releasing a new version
+
+1. Bump `Version:` in `psf-guard.spec` to match `Cargo.toml`.
+2. Add a `%changelog` entry.
+3. Regenerate sources for the tag: `./scripts/make-rpm-sources.sh --ref vX.Y.Z`.
+
+CI (`.github/workflows/rpm.yml`) builds the RPMs in Fedora 43 and 44 containers
+on every push and pull request and uploads them as artifacts.

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -28,6 +28,36 @@ The result is two sources:
 OpenCV is enabled by default (matching the upstream default features). Build a
 lighter package without it using `--without opencv`.
 
+## Systemd server service
+
+The package ships a `psf-guard.service` unit that runs the web server
+(`psf-guard server`) under a dedicated, unprivileged `psfguard` system user
+(created via `sysusers.d`). It is **not** enabled by default.
+
+| Path                          | Purpose                                              |
+| ----------------------------- | ---------------------------------------------------- |
+| `/etc/psf-guard/server.conf`  | `EnvironmentFile` — host/port, registry, cache, args |
+| `/var/lib/psf-guard/`         | `StateDirectory` — the mutable database registry     |
+| `/var/cache/psf-guard/`       | `CacheDirectory` — generated/preview image cache     |
+
+```bash
+# Configure (bind address, port, extra args) then enable + start:
+sudoedit /etc/psf-guard/server.conf
+sudo systemctl enable --now psf-guard
+
+# Register a scheduler database + image directories (or do it from the web UI,
+# which is enabled by the default --allow-database-management):
+sudo -u psfguard psf-guard server \
+    --registry /var/lib/psf-guard/registry.json \
+    /path/to/schedulerdb.sqlite /path/to/images
+sudo systemctl restart psf-guard
+```
+
+The unit binds to `127.0.0.1:3000` by default and is sandboxed (`ProtectSystem=strict`,
+`ProtectHome=read-only`, restricted syscalls/capabilities). If your image
+libraries live somewhere `ProtectHome=read-only` blocks, relax it with a
+drop-in: `systemctl edit psf-guard`.
+
 ## Build locally
 
 ```bash

--- a/packaging/rpm/build-in-podman.sh
+++ b/packaging/rpm/build-in-podman.sh
@@ -57,9 +57,13 @@ cp packaging/rpm/psf-guard.spec ~/rpmbuild/SPECS/
 rpmbuild -ba ~/rpmbuild/SPECS/psf-guard.spec
 mkdir -p /out
 find ~/rpmbuild/RPMS ~/rpmbuild/SRPMS -name '*.rpm' -exec cp {} /out/ \;
-# Smoke test: install the binary RPM and run it.
-rpm -i /out/psf-guard-[0-9]*.rpm
+# Smoke test: install the binary RPM (dnf resolves Requires, incl. systemd)
+# and confirm the binary, unit, and config landed.
+dnf -y install /out/psf-guard-[0-9]*.x86_64.rpm
 psf-guard --help | head -5
+test -f /usr/lib/systemd/system/psf-guard.service
+test -f /etc/psf-guard/server.conf
+systemd-analyze verify /usr/lib/systemd/system/psf-guard.service || true
 echo "BUILD_OK"
 EOS
 

--- a/packaging/rpm/build-in-podman.sh
+++ b/packaging/rpm/build-in-podman.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# build-in-podman.sh - Build the PSF Guard RPM in clean Fedora containers.
+#
+# Mirrors .github/workflows/rpm.yml locally: for each requested Fedora release
+# it spins up a fedora:<ver> container, installs the toolchain, runs
+# scripts/make-rpm-sources.sh (frontend build + cargo vendor), builds the RPM
+# with rpmbuild, smoke-tests it (rpm -i + `psf-guard --help`), and copies the
+# resulting RPMs + SRPM out to the host.
+#
+# Usage:
+#   packaging/rpm/build-in-podman.sh [VERSION...] [--outdir DIR] [--sequential]
+#
+#   VERSION...     Fedora releases to build (default: 43 44)
+#   --outdir DIR   Where to drop artifacts (default: <repo>/dist/rpm)
+#                  Each release lands in DIR/fedora-<ver>/ with a build.log.
+#   --sequential   Build one release at a time (default: all in parallel)
+#
+# Requires: podman. Needs network (npm + cargo vendor run inside the container).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUTDIR="${REPO_ROOT}/dist/rpm"
+SEQUENTIAL=0
+VERSIONS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --outdir) OUTDIR="$2"; shift 2 ;;
+        --sequential) SEQUENTIAL=1; shift ;;
+        -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+        -*) echo "unknown option: $1" >&2; exit 2 ;;
+        *) VERSIONS+=("$1"); shift ;;
+    esac
+done
+
+if [[ ${#VERSIONS[@]} -eq 0 ]]; then
+    VERSIONS=(43 44)
+fi
+
+command -v podman >/dev/null 2>&1 || { echo "podman is required" >&2; exit 1; }
+
+# The script executed inside each container.
+read -r -d '' CONTAINER_SCRIPT <<'EOS' || true
+set -euxo pipefail
+dnf -y install --setopt=install_weak_deps=False \
+    rpm-build rpmdevtools \
+    rust cargo clang-devel opencv-devel \
+    gcc gcc-c++ pkgconf-pkg-config \
+    nodejs npm git xz tar findutils
+rpmdev-setuptree
+git config --global --add safe.directory /src
+cd /src
+./scripts/make-rpm-sources.sh
+cp packaging/rpm/psf-guard.spec ~/rpmbuild/SPECS/
+rpmbuild -ba ~/rpmbuild/SPECS/psf-guard.spec
+mkdir -p /out
+find ~/rpmbuild/RPMS ~/rpmbuild/SRPMS -name '*.rpm' -exec cp {} /out/ \;
+# Smoke test: install the binary RPM and run it.
+rpm -i /out/psf-guard-[0-9]*.rpm
+psf-guard --help | head -5
+echo "BUILD_OK"
+EOS
+
+build_one() {
+    local ver="$1"
+    local dest="${OUTDIR}/fedora-${ver}"
+    mkdir -p "$dest"
+    echo ">> Building for Fedora ${ver} -> ${dest}"
+    if podman run --rm -i --security-opt label=disable \
+        -v "${REPO_ROOT}":/src:ro \
+        -v "${dest}":/out \
+        "fedora:${ver}" bash -s <<<"$CONTAINER_SCRIPT" >"${dest}/build.log" 2>&1
+    then
+        if grep -q BUILD_OK "${dest}/build.log"; then
+            echo ">> Fedora ${ver}: OK"
+            return 0
+        fi
+    fi
+    echo ">> Fedora ${ver}: FAILED (see ${dest}/build.log)" >&2
+    return 1
+}
+
+rc=0
+if [[ $SEQUENTIAL -eq 1 ]]; then
+    for ver in "${VERSIONS[@]}"; do
+        build_one "$ver" || rc=1
+    done
+else
+    declare -A pids=()
+    for ver in "${VERSIONS[@]}"; do
+        build_one "$ver" &
+        pids[$ver]=$!
+    done
+    for ver in "${VERSIONS[@]}"; do
+        wait "${pids[$ver]}" || rc=1
+    done
+fi
+
+echo
+echo "=== Artifacts ==="
+find "$OUTDIR" -name '*.rpm' -printf '%p (%s bytes)\n' | sort || true
+exit $rc

--- a/packaging/rpm/build-in-podman.sh
+++ b/packaging/rpm/build-in-podman.sh
@@ -44,17 +44,21 @@ command -v podman >/dev/null 2>&1 || { echo "podman is required" >&2; exit 1; }
 # The script executed inside each container.
 read -r -d '' CONTAINER_SCRIPT <<'EOS' || true
 set -euxo pipefail
+# Tooling needed up front to generate sources (cargo vendor + npm build).
 dnf -y install --setopt=install_weak_deps=False \
-    rpm-build rpmdevtools \
-    rust cargo clang-devel opencv-devel \
-    gcc gcc-c++ pkgconf-pkg-config \
-    nodejs npm git xz tar findutils
+    rpm-build rpmdevtools 'dnf-command(builddep)' \
+    cargo nodejs npm git xz tar findutils
 rpmdev-setuptree
 git config --global --add safe.directory /src
 cd /src
 ./scripts/make-rpm-sources.sh
 cp packaging/rpm/psf-guard.spec ~/rpmbuild/SPECS/
-rpmbuild -ba ~/rpmbuild/SPECS/psf-guard.spec
+# Pull the rest of the BuildRequires straight from the spec (rust, opencv-devel,
+# clang-devel, gcc-c++, systemd-rpm-macros, ...) so the list stays in sync.
+dnf -y builddep ~/rpmbuild/SPECS/psf-guard.spec
+# tee to the bind-mounted /out so the rpmbuild log survives even if the
+# container's piped stdout is truncated/buffered on failure.
+rpmbuild -ba ~/rpmbuild/SPECS/psf-guard.spec 2>&1 | tee /out/rpmbuild.log
 mkdir -p /out
 find ~/rpmbuild/RPMS ~/rpmbuild/SRPMS -name '*.rpm' -exec cp {} /out/ \;
 # Smoke test: install the binary RPM (dnf resolves Requires, incl. systemd)

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -27,6 +27,14 @@ BuildRequires:  rust >= 1.89.0
 BuildRequires:  cargo
 # libsqlite3-sys is built with the `bundled` feature: it compiles SQLite from C.
 BuildRequires:  gcc
+# systemd unit + sysusers.d handling (%%_unitdir, %%systemd_* macros, etc.).
+BuildRequires:  systemd-rpm-macros
+
+# Pulls the right Requires for the sysusers.d-created system user.
+%{?sysusers_requires_compat}
+Requires(post):   systemd
+Requires(preun):  systemd
+Requires(postun): systemd
 %if %{with opencv}
 # The opencv crate runs bindgen (needs libclang), compiles a C++ shim, links
 # the system OpenCV, and probes it via pkg-config in build.rs.
@@ -78,11 +86,38 @@ cargo build --release --locked \
 %install
 install -Dpm0755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
 
+# systemd server integration.
+install -Dpm0644 packaging/rpm/systemd/psf-guard.service \
+    %{buildroot}%{_unitdir}/%{name}.service
+install -Dpm0644 packaging/rpm/systemd/psf-guard.sysusers \
+    %{buildroot}%{_sysusersdir}/%{name}.conf
+install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
+    %{buildroot}%{_sysconfdir}/%{name}/server.conf
+
+%pre
+# The psfguard system user is created by the sysusers.d file trigger; no
+# explicit useradd needed here.
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
 %files
 %license LICENSE
 %doc README.md psf-guard.toml.example
 %{_bindir}/%{name}
+%{_unitdir}/%{name}.service
+%{_sysusersdir}/%{name}.conf
+%dir %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
 * Sun Jun 28 2026 Yann Ramin <github@theatr.us> - 0.3.0-1
 - Initial Fedora packaging (offline build from vendored crates + prebuilt frontend)
+- Ship psf-guard.service (server mode) with a dedicated psfguard system user,
+  StateDirectory registry, CacheDirectory cache, and /etc/psf-guard/server.conf

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -1,0 +1,88 @@
+# Build offline from vendored crates; the frontend dist ships prebuilt in
+# Source0 (see scripts/make-rpm-sources.sh), so no network or npm is needed
+# here -- this builds cleanly in mock/COPR.
+#
+# OpenCV support is on by default (matches the upstream default feature set).
+# Build a lighter package without it:  rpmbuild --without opencv ...
+%bcond_without opencv
+
+# Rust release binaries carry no DWARF here (the release profile sets no
+# debug), so there is nothing for find-debuginfo to harvest.
+%global debug_package %{nil}
+
+Name:           psf-guard
+Version:        0.3.0
+Release:        1%{?dist}
+Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
+
+License:        Apache-2.0
+URL:            https://github.com/theatrus/psf-guard
+
+# Both sources are produced by scripts/make-rpm-sources.sh (the upstream git
+# archive does not contain the prebuilt frontend or the vendored crates).
+Source0:        %{name}-%{version}.tar.gz
+Source1:        %{name}-%{version}-vendor.tar.xz
+
+BuildRequires:  rust >= 1.89.0
+BuildRequires:  cargo
+# libsqlite3-sys is built with the `bundled` feature: it compiles SQLite from C.
+BuildRequires:  gcc
+%if %{with opencv}
+# The opencv crate runs bindgen (needs libclang), compiles a C++ shim, links
+# the system OpenCV, and probes it via pkg-config in build.rs.
+BuildRequires:  clang-devel
+BuildRequires:  gcc-c++
+BuildRequires:  opencv-devel
+# build.rs shells out to the pkg-config binary to detect the OpenCV version.
+BuildRequires:  pkgconfig
+%endif
+
+# Runtime dependencies are resolved automatically by RPM's ELF dependency
+# generator (the OpenCV sonames the binary links against). SQLite is statically
+# bundled, so it is not a runtime dependency.
+
+%description
+PSF Guard is a command-line utility and web server for analyzing N.I.N.A.
+Target Scheduler databases and managing astronomical image files. It ports the
+N.I.N.A. star-detection algorithm, performs PSF fitting (Gaussian/Moffat), and
+serves an embedded React web interface for reviewing, grading, and organizing
+FITS captures.
+
+%prep
+%autosetup -n %{name}-%{version} -p1
+# rust-toolchain.toml pins a rustup channel; Fedora's cargo ignores it, but
+# remove it so no rustup-based environment tries to fetch a toolchain offline.
+rm -f rust-toolchain.toml
+# Drop the vendored crates in beside the source and point cargo at them.
+tar -xf %{SOURCE1}
+mkdir -p .cargo
+cat > .cargo/config.toml <<'EOF'
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
+
+%build
+# The frontend is already built into static/dist by make-rpm-sources.sh; tell
+# build.rs not to invoke npm. Crates resolve from ./vendor, so build offline.
+export PSF_GUARD_SKIP_FRONTEND_BUILD=1
+export CARGO_NET_OFFLINE=true
+cargo build --release --locked \
+%if %{without opencv}
+    --no-default-features \
+%endif
+    %{nil}
+
+%install
+install -Dpm0755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
+
+%files
+%license LICENSE
+%doc README.md psf-guard.toml.example
+%{_bindir}/%{name}
+
+%changelog
+* Sun Jun 28 2026 Yann Ramin <github@theatr.us> - 0.3.0-1
+- Initial Fedora packaging (offline build from vendored crates + prebuilt frontend)

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -94,10 +94,8 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard.sysusers \
 install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
     %{buildroot}%{_sysconfdir}/%{name}/server.conf
 
-%pre
-# The psfguard system user is created by the sysusers.d file trigger; no
-# explicit useradd needed here.
-
+# The psfguard system user is created by the sysusers.d file trigger that
+# systemd installs for %%{_sysusersdir}, so no %%pre useradd is needed.
 %post
 %systemd_post %{name}.service
 

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -12,7 +12,7 @@
 
 Name:           psf-guard
 Version:        0.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
 License:        Apache-2.0
@@ -115,6 +115,9 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Sun Jun 28 2026 Yann Ramin <github@theatr.us> - 0.3.0-2
+- Bump packaging release
+
 * Sun Jun 28 2026 Yann Ramin <github@theatr.us> - 0.3.0-1
 - Initial Fedora packaging (offline build from vendored crates + prebuilt frontend)
 - Ship psf-guard.service (server mode) with a dedicated psfguard system user,

--- a/packaging/rpm/systemd/psf-guard-server.conf
+++ b/packaging/rpm/systemd/psf-guard-server.conf
@@ -1,0 +1,30 @@
+# Configuration for the psf-guard.service systemd unit.
+# After editing, apply with:  systemctl restart psf-guard
+#
+# These values are passed to `psf-guard server`. Anything not expressible here
+# can be appended via PSF_GUARD_EXTRA_ARGS below.
+
+# Address and port the web UI / API binds to. Keep the host on loopback unless
+# you front it with a reverse proxy or firewall: database management is enabled
+# (see PSF_GUARD_EXTRA_ARGS), which lets any reachable client edit the served
+# database list and image directories.
+PSF_GUARD_HOST=127.0.0.1
+PSF_GUARD_PORT=3000
+
+# Mutable database registry: which N.I.N.A. scheduler databases and image
+# directories are served. Lives in the service's StateDirectory. Register a
+# database by editing the web UI (with management enabled) or by running once:
+#   sudo -u psfguard psf-guard server --registry /var/lib/psf-guard/registry.json \
+#       /path/to/schedulerdb.sqlite /path/to/images
+PSF_GUARD_REGISTRY=/var/lib/psf-guard/registry.json
+
+# Where processed/preview images are cached (the unit's CacheDirectory).
+PSF_GUARD_CACHE_DIR=/var/cache/psf-guard
+
+# Extra arguments appended verbatim to `psf-guard server` (split on whitespace).
+# Examples:
+#   --config /etc/psf-guard/psf-guard.toml   (server-wide knobs; see the
+#                                             psf-guard.toml.example shipped in
+#                                             /usr/share/doc/psf-guard/)
+#   --pregenerate-screen --pregenerate-large (background preview generation)
+PSF_GUARD_EXTRA_ARGS=--allow-database-management

--- a/packaging/rpm/systemd/psf-guard.service
+++ b/packaging/rpm/systemd/psf-guard.service
@@ -1,0 +1,56 @@
+[Unit]
+Description=PSF Guard astronomical image analysis server
+Documentation=https://github.com/theatrus/psf-guard
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User=psfguard
+Group=psfguard
+EnvironmentFile=/etc/psf-guard/server.conf
+ExecStart=/usr/bin/psf-guard server \
+    --host ${PSF_GUARD_HOST} \
+    --port ${PSF_GUARD_PORT} \
+    --registry ${PSF_GUARD_REGISTRY} \
+    --cache-dir ${PSF_GUARD_CACHE_DIR} \
+    $PSF_GUARD_EXTRA_ARGS
+Restart=on-failure
+RestartSec=5
+
+# Persistent registry + image cache. systemd creates and chowns these to the
+# service user; they map to PSF_GUARD_REGISTRY / PSF_GUARD_CACHE_DIR above.
+StateDirectory=psf-guard
+StateDirectoryMode=0750
+CacheDirectory=psf-guard
+CacheDirectoryMode=0750
+
+# Sandboxing. The server only needs to read image directories and write its
+# state/cache dirs. ProtectHome=read-only keeps image libraries under /home
+# readable while blocking writes; relax it (or add ReadOnlyPaths/BindPaths via
+# a drop-in) if your images live somewhere this blocks.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectKernelLogs=yes
+ProtectClock=yes
+ProtectHostname=yes
+ProtectProc=invisible
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/rpm/systemd/psf-guard.sysusers
+++ b/packaging/rpm/systemd/psf-guard.sysusers
@@ -1,0 +1,5 @@
+# PSF Guard runs the server under a dedicated, unprivileged system user.
+# Installed as %{_sysusersdir}/psf-guard.conf; systemd-sysusers creates the
+# account on package install via the systemd file trigger.
+#Type Name      ID   GECOS              Home
+u     psfguard  -    "PSF Guard"        /var/lib/psf-guard

--- a/scripts/make-rpm-sources.sh
+++ b/scripts/make-rpm-sources.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# make-rpm-sources.sh - Produce the source tarballs consumed by
+# packaging/rpm/psf-guard.spec.
+#
+# The Fedora spec is built fully offline (mock/COPR friendly), so every step
+# that needs the network happens here, once, at source-prep time:
+#
+#   1. Export a clean tree from git (no working-tree cruft).
+#   2. Build the embedded React frontend (npm ci && npm run build) so that
+#      `static/dist` exists -- build.rs is then skipped at rpm build time via
+#      PSF_GUARD_SKIP_FRONTEND_BUILD=1.
+#   3. Vendor all Cargo dependencies (`cargo vendor`) so the offline build has
+#      every crate locally.
+#
+# Outputs two sources into --outdir (default: ~/rpmbuild/SOURCES):
+#   psf-guard-<version>.tar.gz         (Source0: source + prebuilt static/dist)
+#   psf-guard-<version>-vendor.tar.xz  (Source1: vendored crates -> ./vendor)
+#
+# Usage:
+#   scripts/make-rpm-sources.sh [--ref <git-ref>] [--outdir <dir>] [--version <v>]
+#
+# Defaults: ref=HEAD, version read from Cargo.toml, outdir=~/rpmbuild/SOURCES.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GIT_REF="HEAD"
+OUTDIR="${HOME}/rpmbuild/SOURCES"
+VERSION=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ref) GIT_REF="$2"; shift 2 ;;
+        --outdir) OUTDIR="$2"; shift 2 ;;
+        --version) VERSION="$2"; shift 2 ;;
+        -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+cd "$REPO_ROOT"
+
+if [[ -z "$VERSION" ]]; then
+    VERSION="$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.*)".*/\1/')"
+fi
+if [[ -z "$VERSION" ]]; then
+    echo "could not determine version" >&2
+    exit 1
+fi
+
+NAME="psf-guard"
+PREFIX="${NAME}-${VERSION}"
+
+for tool in git npm cargo tar xz; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "missing required tool: $tool" >&2; exit 1; }
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo ">> Exporting ${GIT_REF} -> ${PREFIX}/"
+git archive --format=tar --prefix="${PREFIX}/" "$GIT_REF" | tar -x -C "$WORK"
+SRC="${WORK}/${PREFIX}"
+
+echo ">> Building frontend (npm ci && npm run build)"
+(
+    cd "${SRC}/static"
+    npm ci
+    npm run build
+    # node_modules is huge and not needed in the source tarball; the dist
+    # output is what gets embedded into the binary.
+    rm -rf node_modules
+)
+
+if [[ ! -d "${SRC}/static/dist" ]]; then
+    echo "frontend build did not produce static/dist" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTDIR"
+
+echo ">> Writing Source0: ${PREFIX}.tar.gz"
+tar -C "$WORK" --owner=0 --group=0 --numeric-owner \
+    -czf "${OUTDIR}/${PREFIX}.tar.gz" "${PREFIX}"
+
+echo ">> Vendoring Cargo dependencies"
+(
+    cd "$SRC"
+    # Vendor into ./vendor; spec extracts this at the source root and points
+    # .cargo/config.toml at it. Suppress the config snippet on stdout.
+    cargo vendor --locked vendor >/dev/null
+)
+
+echo ">> Writing Source1: ${PREFIX}-vendor.tar.xz"
+tar -C "$SRC" --owner=0 --group=0 --numeric-owner \
+    -cJf "${OUTDIR}/${PREFIX}-vendor.tar.xz" vendor
+
+echo
+echo "Done. Sources in ${OUTDIR}:"
+echo "  ${PREFIX}.tar.gz"
+echo "  ${PREFIX}-vendor.tar.xz"


### PR DESCRIPTION
## Summary

Adds a native **Fedora/RPM** packaging path that builds with mainline RPM tooling (`rpmbuild`, `mock`, COPR) on **Fedora 43 / 44** (and other recent releases).

PSF Guard embeds its React frontend at compile time and pulls a large Cargo tree, while Fedora build environments are offline. To bridge that, all network work is done **once, up front** by `scripts/make-rpm-sources.sh`; the actual `rpmbuild` is fully offline and mock/COPR-friendly.

## What's included

- **`packaging/rpm/psf-guard.spec`** — offline `cargo build` from vendored crates. OpenCV is on by default (matches upstream default features) with a `--without opencv` bcond for a lighter package. `BuildRequires` are scoped to what the dependency graph actually needs:
  - `gcc` — `libsqlite3-sys` compiles bundled SQLite from C
  - OpenCV only: `clang-devel` (bindgen/libclang), `gcc-c++` (C++ shim), `opencv-devel`, `pkgconfig` (the `build.rs` version probe)
  - Runtime deps (OpenCV sonames) resolve automatically via RPM's ELF dependency generator; SQLite is statically bundled.
  - The GTK/WebKit `-sys` crates in the lockfile belong to the optional `tauri` feature and are never compiled in this build, so no GUI BuildRequires are needed.
- **`scripts/make-rpm-sources.sh`** — exports a clean tree, builds the frontend (`npm ci && npm run build` → `static/dist`, so `build.rs` is skipped via `PSF_GUARD_SKIP_FRONTEND_BUILD=1`), and `cargo vendor`s all crates. Emits `psf-guard-<ver>.tar.gz` (Source0) and `psf-guard-<ver>-vendor.tar.xz` (Source1).
- **`.github/workflows/rpm.yml`** — builds and smoke-tests (`rpm -i` + `psf-guard --help`) the RPMs natively in `fedora:43` and `fedora:44` containers and uploads them as artifacts.
- **`packaging/rpm/README.md`** + main README pointer.

## Build locally

```bash
sudo dnf install -y rpm-build rpmdevtools cargo rust clang-devel opencv-devel nodejs npm git
rpmdev-setuptree
./scripts/make-rpm-sources.sh
rpmbuild -ba packaging/rpm/psf-guard.spec
```

## Notes / follow-ups

- Bump `Version:` in the spec alongside `Cargo.toml` at release time; regenerate sources with `--ref vX.Y.Z`.
- This intentionally bundles crates (not Fedora-repo submission style), optimizing for a working, reproducible local/COPR build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)