### PR TITLE
Priority-aware worker pool: parallelize occlusion scan + background pregen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,8 +191,10 @@ Design, phases, tracker: [REJECT_ARCHIVE_PLAN.md](./REJECT_ARCHIVE_PLAN.md).
   (reference presence filter) — that remains the dead-cell metric's job.
 - **Server/UI trigger**: `src/server/spatial_scan.rs` + `POST
   /api/db/{id}/analysis/spatial-scan` runs the same computation as a
-  singleton per-DB background task (2 worker threads, ~8s/frame full-frame)
-  over a target's FITS files (paths via `find_fits_file`). Results live in
+  singleton per-DB background task (~8s/frame full-frame) over a target's
+  FITS files (paths via `find_fits_file`). Worker count is sized by
+  `concurrency::plan_workers` (see the parallelism note below), not a fixed
+  2. Results live in
   `DatabaseContext.spatial_metrics` and persist to
   `<cache_dir>/spatial_metrics.json` (survives restarts; entries invalidated
   by filename change; re-scan skips cached, `force` recomputes).
@@ -201,6 +203,36 @@ Design, phases, tracker: [REJECT_ARCHIVE_PLAN.md](./REJECT_ARCHIVE_PLAN.md).
   scan has run. Frontend: "Scan Occlusion" button in SequenceView
   (`useSpatialScan` hook, 1s progress poll, auto-invalidates
   sequence-analysis queries when the scan finishes).
+
+### Worker-pool parallelism policy (2026-07)
+All CPU-bound parallel work is sized through `src/concurrency.rs` instead of
+hardcoded caps. The per-frame work (FITS load → star detection →
+`compute_spatial_metrics` / stretch-to-PNG) is single-threaded internally, so
+the lever is how many frames run at once.
+- **`WorkerPolicy`** groups the tunables: `interactive_ratio` (default 0.5),
+  `background_ratio` (default 0.25), `memory_budget_fraction` (0.5),
+  `hard_max_workers` (64), `peak_bytes_per_pixel` (32). Threads through
+  `ServerConfig` → `AppState` → the scan handler as one value.
+- **`plan_workers(requested, &policy, priority, frame_pixels)`** →
+  `WorkerBudget { workers, rationale }`. An explicit `--threads` override wins
+  (clamped to `[1, hard_max]`); otherwise `round(cores * ratio_for(priority))`,
+  then capped by `memory_budget_fraction * available_RAM / (frame_pixels *
+  peak_bytes_per_pixel)` when the frame size + RAM are known. `frame_pixels`
+  comes from `probe_frame_pixels` (reads NAXIS1×NAXIS2 without loading data).
+- **Memory probe** `available_memory_bytes()`: Linux `/proc/meminfo`
+  MemAvailable, macOS `sysctl hw.memsize` (libc), Windows `GlobalMemoryStatusEx`
+  (windows-sys). `None` → skip the memory cap.
+- **`parallel_index(len, workers, f)`** is the shared atomic work-stealing pool
+  both the CLI `screen-fits` and server scan use.
+- **Priority + yielding**: interactive work (server "Scan Occlusion", CLI
+  `screen-fits`) uses `Priority::Interactive`; the server scan holds an
+  `AppState::begin_interactive_job()` guard for its lifetime. Background image
+  pre-generation uses `Priority::Background` (fewer cores) AND pauses whenever
+  `AppState::interactive_job_active()` — so a user-triggered scan gets the
+  cores and memory, and background pre-warming resumes when it's idle.
+- **Config** (`[server]` in the TOML `--config`): `scan_worker_ratio` →
+  interactive, `background_worker_ratio` → background. Both optional, clamped
+  to `[0.05, 1.0]`, absent → compiled-in defaults.
 
 ### Two-DB sync (2026-06)
 Lives in `src/commands/sync/` (`mod.rs` shared helpers + `grades.rs` + `pull.rs`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,6 +3659,7 @@ dependencies = [
  "image",
  "imageproc",
  "include_dir",
+ "libc",
  "mime_guess",
  "nalgebra",
  "opencv",
@@ -3677,6 +3678,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,13 @@ humantime = "2.3"
 tauri = { version = "2.11.1", features = ["custom-protocol"], optional = true }
 tauri-plugin-dialog = { version = "2.7.1", optional = true }
 dirs = "6.0"
+# Platform memory probes for the occlusion-scan worker budget in
+# `concurrency` (both already in the tree transitively). Linux uses
+# /proc/meminfo and needs no crate.
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -288,7 +288,8 @@ pub enum Commands {
         #[arg(long, default_value = "0.08")]
         dead_cell_rise: f64,
 
-        /// Worker threads for frame analysis (default: min(cores, 4))
+        /// Worker threads for frame analysis (default: all cores, bounded by
+        /// available memory)
         #[arg(long)]
         threads: Option<usize>,
 

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -722,6 +722,7 @@ pub fn main() -> Result<()> {
             let cache_directory = app_config.get_cache_directory();
             let server_host = app_config.get_host();
             let server_port = app_config.get_port();
+            let worker_policy = app_config.get_worker_policy();
             let databases = db_registry.databases.clone();
 
             let runtime = tokio::runtime::Runtime::new()?;
@@ -735,6 +736,7 @@ pub fn main() -> Result<()> {
                     pregeneration_config,
                     Some(registry_path),
                     allow_database_management,
+                    worker_policy,
                 )
                 .await
             })?;

--- a/src/commands/screen_fits.rs
+++ b/src/commands/screen_fits.rs
@@ -455,53 +455,51 @@ fn collect_fits_files(dir: &Path) -> Result<Vec<PathBuf>> {
 
 /// Analyze all frames, in parallel worker threads.
 fn analyze_frames(files: &[PathBuf], options: &ScreenOptions) -> Result<Vec<FrameRecord>> {
-    let threads = options
-        .threads
-        .unwrap_or_else(|| {
-            std::thread::available_parallelism()
-                .map(|n| n.get())
-                .unwrap_or(4)
-                .min(4)
-        })
-        .max(1);
+    // Default to all cores (bounded by available memory); `--threads`
+    // overrides. The old min(4) cap left most of a modern machine idle.
+    // Foreground CLI work, so the interactive tier applies.
+    let frame_pixels = files
+        .first()
+        .and_then(|p| crate::concurrency::probe_frame_pixels(p));
+    let budget = crate::concurrency::plan_workers(
+        options.threads,
+        &crate::concurrency::WorkerPolicy::all_cores(),
+        crate::concurrency::Priority::Interactive,
+        frame_pixels,
+    );
+    eprintln!(
+        "Analyzing with {} worker thread(s) — {}",
+        budget.workers, budget.rationale
+    );
 
-    let next = AtomicUsize::new(0);
     let done = AtomicUsize::new(0);
     let records: Mutex<Vec<FrameRecord>> = Mutex::new(Vec::with_capacity(files.len()));
     let total = files.len();
 
-    std::thread::scope(|scope| {
-        for _ in 0..threads {
-            scope.spawn(|| loop {
-                let i = next.fetch_add(1, Ordering::Relaxed);
-                if i >= total {
-                    break;
-                }
-                let path = &files[i];
-                match analyze_one_frame(path, options) {
-                    Ok(record) => {
-                        let n = done.fetch_add(1, Ordering::Relaxed) + 1;
-                        eprintln!(
-                            "[{}/{}] {}: {} stars, hfr {:.2}, dead {}, bg spread {:.3}",
-                            n,
-                            total,
-                            path.file_name().and_then(|s| s.to_str()).unwrap_or("?"),
-                            record.star_count,
-                            record.avg_hfr,
-                            record
-                                .dead_cell_fraction
-                                .map(|d| format!("{:.0}%", d * 100.0))
-                                .unwrap_or_else(|| "n/a".to_string()),
-                            record.bg_cell_spread,
-                        );
-                        records.lock().unwrap().push(record);
-                    }
-                    Err(e) => {
-                        done.fetch_add(1, Ordering::Relaxed);
-                        eprintln!("Error analyzing {}: {}", path.display(), e);
-                    }
-                }
-            });
+    crate::concurrency::parallel_index(total, budget.workers, |i| {
+        let path = &files[i];
+        match analyze_one_frame(path, options) {
+            Ok(record) => {
+                let n = done.fetch_add(1, Ordering::Relaxed) + 1;
+                eprintln!(
+                    "[{}/{}] {}: {} stars, hfr {:.2}, dead {}, bg spread {:.3}",
+                    n,
+                    total,
+                    path.file_name().and_then(|s| s.to_str()).unwrap_or("?"),
+                    record.star_count,
+                    record.avg_hfr,
+                    record
+                        .dead_cell_fraction
+                        .map(|d| format!("{:.0}%", d * 100.0))
+                        .unwrap_or_else(|| "n/a".to_string()),
+                    record.bg_cell_spread,
+                );
+                records.lock().unwrap().push(record);
+            }
+            Err(e) => {
+                done.fetch_add(1, Ordering::Relaxed);
+                eprintln!("Error analyzing {}: {}", path.display(), e);
+            }
         }
     });
 

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1,0 +1,514 @@
+//! Shared worker-count policy and pool helper for the CPU-bound parallel
+//! operations in psf-guard: the CLI `screen-fits` command, the server "Scan
+//! Occlusion" task, and background image pre-generation.
+//!
+//! Each of these processes one FITS frame per worker; the heavy per-frame work
+//! (`FitsImage::from_file` → star detection → `compute_spatial_metrics`, or a
+//! stretch-to-PNG) is single-threaded internally, so the only lever is *how
+//! many frames run at once*. Historically these paths hardcoded low caps (2
+//! for the server scan, 4 for the CLI) or ran fully sequentially, leaving most
+//! cores idle. This module scales the worker count to the machine while
+//! staying inside three guardrails:
+//!
+//! 1. **Priority** — [`Priority::Interactive`] work (a user asked for it) gets
+//!    the interactive core budget; [`Priority::Background`] work (pre-warming
+//!    caches) gets a smaller budget and is expected to *yield* to interactive
+//!    work entirely while it runs (the caller gates on that — see
+//!    `AppState::interactive_job_active`).
+//! 2. **Core budget** — a fraction of the logical cores per priority. The CLI
+//!    uses all cores for its foreground scan; the server leaves headroom to
+//!    keep serving the UI (`interactive_ratio`, default 0.5) and throttles
+//!    background work harder (`background_ratio`, default 0.25).
+//! 3. **Memory ceiling** — full-frame work holds several f64 buffers, so N
+//!    in-flight frames on a big sensor can consume many GB. We cap workers at
+//!    `budget_fraction * available_RAM / per_frame_peak` so a high-core box
+//!    with a large sensor can't OOM.
+//!
+//! An explicit operator override (`--threads`) bypasses the ratio and is
+//! trusted, clamped only to `[1, hard_max_workers]`.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Default fraction of cores interactive (user-triggered) work uses. Balanced:
+/// fast scans while leaving half the machine to serve the UI.
+pub const DEFAULT_INTERACTIVE_RATIO: f64 = 0.5;
+
+/// Default fraction of cores background (cache pre-warming) work uses. Lower
+/// than interactive so it stays out of the way; it is additionally expected to
+/// pause entirely while an interactive job runs.
+pub const DEFAULT_BACKGROUND_RATIO: f64 = 0.25;
+
+/// Absolute backstop on workers regardless of cores / memory / override.
+/// Guards against a pathological core count or a fat-fingered override; the
+/// core ratio and memory ceiling normally bind well below this.
+pub const DEFAULT_HARD_MAX_WORKERS: usize = 64;
+
+/// Estimated peak resident bytes per image pixel while one frame is being
+/// processed. The raw frame is `u16` (2 bytes/px), but HocusFocus detection
+/// converts to `f64` and holds several full-frame working buffers at once
+/// (`float_data`, its `structure_map` clone, wavelet/gaussian scratch). 32 is
+/// a deliberately conservative envelope of that transient peak with margin;
+/// the memory ceiling is a safety backstop, not a precise allocator.
+pub const DEFAULT_PEAK_BYTES_PER_PIXEL: usize = 32;
+
+/// Fraction of the probed system memory a pool may budget for in-flight
+/// frames. Leaves the rest for the OS page cache, the server's other work,
+/// and other processes. Applied to *available* RAM on Linux/Windows and
+/// *total* RAM on macOS (see [`available_memory_bytes`]), so 0.5 is a safe
+/// universal choice.
+pub const DEFAULT_MEMORY_BUDGET_FRACTION: f64 = 0.5;
+
+/// Fallback core count when the platform can't report parallelism.
+const FALLBACK_CORES: usize = 4;
+
+/// How much of the machine a piece of work is entitled to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Priority {
+    /// User asked for it and is waiting — use the interactive core budget.
+    Interactive,
+    /// Opportunistic cache pre-warming — use the smaller background budget and
+    /// stay out of interactive work's way.
+    Background,
+}
+
+/// Tunables for the CPU-bound parallel operations, grouped so the whole policy
+/// threads through the server (`ServerConfig` → `AppState`) and CLI as one
+/// value instead of a fan-out of loose parameters. Only the two ratios are
+/// surfaced in the on-disk TOML; the rest carry their compiled-in defaults but
+/// live here so a future knob is a one-line addition rather than another
+/// signature change.
+#[derive(Debug, Clone, Copy)]
+pub struct WorkerPolicy {
+    /// Fraction of logical cores for interactive work (`0.0..=1.0`). The CLI
+    /// uses `1.0` (all cores); the server default is
+    /// [`DEFAULT_INTERACTIVE_RATIO`].
+    pub interactive_ratio: f64,
+    /// Fraction of logical cores for background work (`0.0..=1.0`), default
+    /// [`DEFAULT_BACKGROUND_RATIO`].
+    pub background_ratio: f64,
+    /// Fraction of probed RAM to budget for in-flight frames.
+    pub memory_budget_fraction: f64,
+    /// Absolute cap on workers.
+    pub hard_max_workers: usize,
+    /// Estimated peak resident bytes per image pixel during processing.
+    pub peak_bytes_per_pixel: usize,
+}
+
+impl Default for WorkerPolicy {
+    fn default() -> Self {
+        Self {
+            interactive_ratio: DEFAULT_INTERACTIVE_RATIO,
+            background_ratio: DEFAULT_BACKGROUND_RATIO,
+            memory_budget_fraction: DEFAULT_MEMORY_BUDGET_FRACTION,
+            hard_max_workers: DEFAULT_HARD_MAX_WORKERS,
+            peak_bytes_per_pixel: DEFAULT_PEAK_BYTES_PER_PIXEL,
+        }
+    }
+}
+
+impl WorkerPolicy {
+    /// A policy whose interactive tier uses all cores (the CLI default),
+    /// memory-bounded as usual.
+    pub fn all_cores() -> Self {
+        Self {
+            interactive_ratio: 1.0,
+            ..Self::default()
+        }
+    }
+
+    /// This policy with `interactive_ratio` replaced (clamped to `[0, 1]`).
+    pub fn with_interactive_ratio(mut self, ratio: f64) -> Self {
+        self.interactive_ratio = ratio.clamp(0.0, 1.0);
+        self
+    }
+
+    /// This policy with `background_ratio` replaced (clamped to `[0, 1]`).
+    pub fn with_background_ratio(mut self, ratio: f64) -> Self {
+        self.background_ratio = ratio.clamp(0.0, 1.0);
+        self
+    }
+
+    /// The core ratio for the given priority.
+    pub fn ratio_for(&self, priority: Priority) -> f64 {
+        match priority {
+            Priority::Interactive => self.interactive_ratio,
+            Priority::Background => self.background_ratio,
+        }
+    }
+}
+
+/// The resolved worker count plus a human-readable explanation for logs.
+#[derive(Debug, Clone)]
+pub struct WorkerBudget {
+    pub workers: usize,
+    pub rationale: String,
+}
+
+/// Logical core count, or [`FALLBACK_CORES`] if the platform won't say.
+pub fn logical_cores() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(FALLBACK_CORES)
+}
+
+/// Plan how many workers to run for a piece of work.
+///
+/// - `requested`: explicit override (CLI `--threads`). `Some(n)` wins outright
+///   (clamped to `[1, hard_max_workers]`); the operator takes responsibility.
+/// - `policy`: the tuning policy (per-priority core ratios, memory budget, caps).
+/// - `priority`: which core budget applies.
+/// - `frame_pixels`: pixel count of a representative frame, if known, used for
+///   the memory ceiling. `None` skips the memory cap.
+pub fn plan_workers(
+    requested: Option<usize>,
+    policy: &WorkerPolicy,
+    priority: Priority,
+    frame_pixels: Option<usize>,
+) -> WorkerBudget {
+    let cores = logical_cores();
+    let available_bytes = available_memory_bytes();
+    let (workers, rationale) = compute_worker_count(
+        requested,
+        cores,
+        frame_pixels,
+        available_bytes,
+        policy,
+        policy.ratio_for(priority),
+    );
+    WorkerBudget { workers, rationale }
+}
+
+/// Pure core of [`plan_workers`] — takes every input explicitly (including the
+/// already-resolved `ratio`) so it is fully unit-testable without probing the
+/// host.
+fn compute_worker_count(
+    requested: Option<usize>,
+    cores: usize,
+    frame_pixels: Option<usize>,
+    available_bytes: Option<u64>,
+    policy: &WorkerPolicy,
+    ratio: f64,
+) -> (usize, String) {
+    let hard_max = policy.hard_max_workers.max(1);
+
+    if let Some(n) = requested {
+        let workers = n.clamp(1, hard_max);
+        return (workers, format!("explicit override: {} worker(s)", workers));
+    }
+
+    let cores = cores.max(1);
+    let ratio = ratio.clamp(0.0, 1.0);
+    // Round to nearest, but never below 1 — a tiny ratio still makes progress.
+    let scaled = (((cores as f64 * ratio).round() as usize).max(1)).min(hard_max);
+
+    // Memory ceiling, when we can estimate both the frame size and the RAM.
+    let per_pixel = policy.peak_bytes_per_pixel.max(1) as u64;
+    let mem_cap = match (frame_pixels, available_bytes) {
+        (Some(px), Some(avail)) if px > 0 => {
+            let per_frame = (px as u64).saturating_mul(per_pixel).max(1);
+            let budget = (avail as f64 * policy.memory_budget_fraction) as u64;
+            Some((budget / per_frame).max(1) as usize)
+        }
+        _ => None,
+    };
+
+    let mut workers = scaled;
+    let mut rationale = format!("{} of {} core(s) at ratio {:.2}", scaled, cores, ratio);
+    if let Some(cap) = mem_cap {
+        if cap < workers {
+            rationale = format!(
+                "{}, capped to {} by memory (~{} MB/frame)",
+                rationale,
+                cap,
+                frame_pixels
+                    .map(|px| (px as u64 * per_pixel) / (1024 * 1024))
+                    .unwrap_or(0),
+            );
+            workers = cap;
+        } else {
+            rationale = format!("{} (memory allows {})", rationale, cap);
+        }
+    }
+
+    (workers.max(1), rationale)
+}
+
+/// Run `f(i)` for every `i` in `0..len` across `workers` scoped threads using
+/// atomic work-stealing, blocking until all items are processed. This is the
+/// shared pool the CLI and server scans use; `f` is `Sync` (shared by all
+/// workers) and must do its own synchronization for any shared output.
+///
+/// A panic in `f` propagates out of the scope (aborting under the release
+/// profile's `panic = "abort"`); callers that must survive a bad frame should
+/// catch inside `f`.
+pub fn parallel_index<F>(len: usize, workers: usize, f: F)
+where
+    F: Fn(usize) + Sync,
+{
+    if len == 0 {
+        return;
+    }
+    let workers = workers.clamp(1, len);
+    let next = AtomicUsize::new(0);
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| loop {
+                let i = next.fetch_add(1, Ordering::Relaxed);
+                if i >= len {
+                    break;
+                }
+                f(i);
+            });
+        }
+    });
+}
+
+/// Best-effort system memory in bytes, or `None` when the platform can't be
+/// probed (then the caller skips the memory ceiling).
+///
+/// - Linux: `MemAvailable` from `/proc/meminfo` (the kernel's estimate of
+///   allocatable memory without swapping), falling back to `MemTotal`.
+/// - macOS: `hw.memsize` (total physical RAM) via `sysctl`.
+/// - Windows: `ullAvailPhys` (available physical RAM) via
+///   `GlobalMemoryStatusEx`.
+/// - Other: `None`.
+pub fn available_memory_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+        let mut mem_total = None;
+        for line in text.lines() {
+            if let Some(rest) = line.strip_prefix("MemAvailable:") {
+                if let Some(kb) = parse_meminfo_kb(rest) {
+                    return Some(kb);
+                }
+            } else if let Some(rest) = line.strip_prefix("MemTotal:") {
+                mem_total = parse_meminfo_kb(rest);
+            }
+        }
+        return mem_total;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // hw.memsize: total physical memory in bytes.
+        let mut size: u64 = 0;
+        let mut len = std::mem::size_of::<u64>();
+        let name = c"hw.memsize";
+        // SAFETY: `name` is a valid NUL-terminated C string; `size`/`len`
+        // point to properly sized, initialized storage that outlives the call.
+        let rc = unsafe {
+            libc::sysctlbyname(
+                name.as_ptr(),
+                &mut size as *mut u64 as *mut libc::c_void,
+                &mut len,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        return if rc == 0 && size > 0 {
+            Some(size)
+        } else {
+            None
+        };
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+        // SAFETY: MEMORYSTATUSEX is a plain-old-data struct; zeroing it and
+        // setting dwLength to its size is exactly what the API requires. The
+        // call writes only within `status`, which outlives it.
+        let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+        status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+        let ok = unsafe { GlobalMemoryStatusEx(&mut status) };
+        return if ok != 0 && status.ullAvailPhys > 0 {
+            Some(status.ullAvailPhys)
+        } else {
+            None
+        };
+    }
+
+    #[allow(unreachable_code)]
+    None
+}
+
+/// Parse a `/proc/meminfo` value line tail like ` 16384000 kB` into bytes.
+#[cfg(any(target_os = "linux", test))]
+fn parse_meminfo_kb(rest: &str) -> Option<u64> {
+    let kb: u64 = rest.split_whitespace().next()?.parse().ok()?;
+    Some(kb.saturating_mul(1024))
+}
+
+/// Peak-memory estimate (bytes) for analyzing one frame of `pixels` pixels,
+/// using the default per-pixel envelope. Exposed so callers can size a shared
+/// budget if they ever pipeline frames.
+pub fn estimated_frame_peak_bytes(pixels: usize) -> usize {
+    pixels.saturating_mul(DEFAULT_PEAK_BYTES_PER_PIXEL)
+}
+
+/// Read `NAXIS1 * NAXIS2` from a FITS primary header without loading the pixel
+/// data, so a scan can size its worker pool to the sensor. `None` if the file
+/// or the axes can't be read.
+pub fn probe_frame_pixels(path: &Path) -> Option<usize> {
+    use fitrs::Fits;
+
+    let fits = Fits::open(path).ok()?;
+    let hdu = fits.get(0)?;
+    // fitrs Debug-renders header values as `IntegerNumber(9576)` etc. Same
+    // pattern the rest of the codebase uses to pull numbers from headers.
+    let re =
+        regex::Regex::new(r"(?:FloatingPoint|Integer|RealFloatingNumber|IntegerNumber)\(([^)]+)\)")
+            .ok()?;
+    let axis = |key: &str| -> Option<usize> {
+        let v = hdu.value(key)?;
+        let s = format!("{:?}", v);
+        let caps = re.captures(&s)?;
+        caps[1].trim().parse::<f64>().ok().map(|n| n as usize)
+    };
+    let w = axis("NAXIS1")?;
+    let h = axis("NAXIS2")?;
+    (w > 0 && h > 0).then_some(w * h)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pol() -> WorkerPolicy {
+        WorkerPolicy::default()
+    }
+
+    #[test]
+    fn explicit_override_wins_and_is_clamped() {
+        // Override ignores ratio, cores and memory entirely.
+        let (w, _) = compute_worker_count(
+            Some(6),
+            4,
+            Some(50_000_000),
+            Some(1_000_000_000),
+            &pol(),
+            0.5,
+        );
+        assert_eq!(w, 6);
+        // Clamped to >= 1.
+        let (w, _) = compute_worker_count(Some(0), 8, None, None, &pol(), 1.0);
+        assert_eq!(w, 1);
+        // Clamped to hard_max_workers.
+        let (w, _) = compute_worker_count(Some(9999), 8, None, None, &pol(), 1.0);
+        assert_eq!(w, DEFAULT_HARD_MAX_WORKERS);
+    }
+
+    #[test]
+    fn scales_by_core_ratio_when_no_override() {
+        // Half of 16 cores.
+        let (w, _) = compute_worker_count(None, 16, None, None, &pol(), 0.5);
+        assert_eq!(w, 8);
+        // All cores.
+        let (w, _) = compute_worker_count(None, 18, None, None, &pol(), 1.0);
+        assert_eq!(w, 18);
+        // Rounds to nearest: 0.5 * 4 = 2.
+        let (w, _) = compute_worker_count(None, 4, None, None, &pol(), 0.5);
+        assert_eq!(w, 2);
+        // Never below 1 even with a tiny ratio.
+        let (w, _) = compute_worker_count(None, 4, None, None, &pol(), 0.01);
+        assert_eq!(w, 1);
+    }
+
+    #[test]
+    fn priority_selects_ratio() {
+        let policy = WorkerPolicy::default();
+        assert_eq!(
+            policy.ratio_for(Priority::Interactive),
+            DEFAULT_INTERACTIVE_RATIO
+        );
+        assert_eq!(
+            policy.ratio_for(Priority::Background),
+            DEFAULT_BACKGROUND_RATIO
+        );
+        // Background gets fewer cores than interactive at the same core count.
+        let interactive = plan_from(&policy, Priority::Interactive, 16);
+        let background = plan_from(&policy, Priority::Background, 16);
+        assert_eq!(interactive, 8);
+        assert_eq!(background, 4);
+        assert!(background < interactive);
+    }
+
+    // Helper: resolve worker count for a policy/priority at a fixed core count,
+    // no override, no memory cap.
+    fn plan_from(policy: &WorkerPolicy, priority: Priority, cores: usize) -> usize {
+        compute_worker_count(None, cores, None, None, policy, policy.ratio_for(priority)).0
+    }
+
+    #[test]
+    fn memory_ceiling_caps_workers() {
+        // 50 MP frame -> 50e6 * 32 = 1.6 GB peak/frame.
+        let frame_px = 50_000_000usize;
+        // 8 GB available, budget fraction 0.5 -> 4 GB / 1.6 GB = 2 workers,
+        // even though the ratio would allow 16.
+        let (w, reason) = compute_worker_count(
+            None,
+            32,
+            Some(frame_px),
+            Some(8 * 1024 * 1024 * 1024),
+            &pol(),
+            1.0,
+        );
+        assert_eq!(w, 2, "reason: {reason}");
+        assert!(reason.contains("memory"));
+    }
+
+    #[test]
+    fn memory_ceiling_does_not_raise_below_core_budget() {
+        // Plenty of RAM: the core budget (4) binds, not memory.
+        let (w, reason) = compute_worker_count(
+            None,
+            8,
+            Some(20_000_000),
+            Some(256 * 1024 * 1024 * 1024),
+            &pol(),
+            0.5,
+        );
+        assert_eq!(w, 4);
+        assert!(reason.contains("memory allows"));
+    }
+
+    #[test]
+    fn no_memory_probe_falls_back_to_core_budget() {
+        let (w, _) = compute_worker_count(None, 12, Some(50_000_000), None, &pol(), 0.5);
+        assert_eq!(w, 6);
+        let (w, _) =
+            compute_worker_count(None, 12, None, Some(64 * 1024 * 1024 * 1024), &pol(), 0.5);
+        assert_eq!(w, 6);
+    }
+
+    #[test]
+    fn parallel_index_covers_every_item_once() {
+        use std::sync::atomic::AtomicU64;
+        let len = 1000;
+        let counters: Vec<AtomicU64> = (0..len).map(|_| AtomicU64::new(0)).collect();
+        parallel_index(len, 8, |i| {
+            counters[i].fetch_add(1, Ordering::Relaxed);
+        });
+        assert!(counters.iter().all(|c| c.load(Ordering::Relaxed) == 1));
+        // Empty input is a no-op.
+        parallel_index(0, 4, |_| panic!("must not be called"));
+    }
+
+    #[test]
+    fn parse_meminfo_line() {
+        assert_eq!(parse_meminfo_kb(" 16384000 kB").unwrap(), 16384000 * 1024);
+        assert_eq!(parse_meminfo_kb("       512 kB").unwrap(), 512 * 1024);
+        assert!(parse_meminfo_kb("  not-a-number kB").is_none());
+    }
+
+    #[test]
+    fn memory_probe_is_plausible_on_this_platform() {
+        // On Linux/macOS the probe should return a sane, nonzero value; other
+        // platforms legitimately return None.
+        if let Some(bytes) = available_memory_bytes() {
+            assert!(bytes >= 128 * 1024 * 1024, "implausibly small: {bytes}");
+        }
+    }
+}

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -12,8 +12,9 @@
 //!
 //! 1. **Priority** — [`Priority::Interactive`] work (a user asked for it) gets
 //!    the interactive core budget; [`Priority::Background`] work (pre-warming
-//!    caches) gets a smaller budget and is expected to *yield* to interactive
-//!    work entirely while it runs (the caller gates on that — see
+//!    caches) gets a smaller budget and *yields* to interactive work: the
+//!    caller stops dispatching new background items the moment an interactive
+//!    job appears and lets in-flight ones drain (see
 //!    `AppState::interactive_job_active`).
 //! 2. **Core budget** — a fraction of the logical cores per priority. The CLI
 //!    uses all cores for its foreground scan; the server leaves headroom to
@@ -339,13 +340,6 @@ pub fn available_memory_bytes() -> Option<u64> {
 fn parse_meminfo_kb(rest: &str) -> Option<u64> {
     let kb: u64 = rest.split_whitespace().next()?.parse().ok()?;
     Some(kb.saturating_mul(1024))
-}
-
-/// Peak-memory estimate (bytes) for analyzing one frame of `pixels` pixels,
-/// using the default per-pixel envelope. Exposed so callers can size a shared
-/// budget if they ever pipeline frames.
-pub fn estimated_frame_peak_bytes(pixels: usize) -> usize {
-    pixels.saturating_mul(DEFAULT_PEAK_BYTES_PER_PIXEL)
 }
 
 /// Read `NAXIS1 * NAXIS2` from a FITS primary header without loading the pixel

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,19 @@ pub struct ServerConfig {
     pub host: Option<String>,
     /// Enable CORS (default: true)
     pub cors: Option<bool>,
+    /// Fraction of logical CPU cores interactive, user-triggered work (the
+    /// occlusion / spatial scan) may use (0.0–1.0, default 0.5). It runs on
+    /// the blocking pool while the server keeps serving the UI, so this leaves
+    /// headroom; it is further bounded by available memory and a hard maximum.
+    /// `1.0` uses all cores. See `concurrency::WorkerPolicy`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan_worker_ratio: Option<f64>,
+    /// Fraction of logical CPU cores background work (image-preview
+    /// pre-generation) may use (0.0–1.0, default 0.25). Kept below
+    /// `scan_worker_ratio`; background work additionally pauses entirely while
+    /// an interactive scan is running. See `concurrency::WorkerPolicy`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub background_worker_ratio: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,6 +86,8 @@ impl Default for ServerConfig {
             port: Some(3000),
             host: Some("0.0.0.0".to_string()),
             cors: Some(true),
+            scan_worker_ratio: None,
+            background_worker_ratio: None,
         }
     }
 }
@@ -155,6 +170,26 @@ impl Config {
 
     pub fn get_cors_enabled(&self) -> bool {
         self.server.cors.unwrap_or(true)
+    }
+
+    /// Effective worker tuning policy for the parallel scans and background
+    /// pre-generation. The on-disk TOML surfaces the two core ratios; the other
+    /// knobs keep their compiled-in defaults. Ratios are clamped to
+    /// `[0.05, 1.0]` so a typo can't disable the work or over-subscribe.
+    pub fn get_worker_policy(&self) -> crate::concurrency::WorkerPolicy {
+        let interactive = self
+            .server
+            .scan_worker_ratio
+            .unwrap_or(crate::concurrency::DEFAULT_INTERACTIVE_RATIO)
+            .clamp(0.05, 1.0);
+        let background = self
+            .server
+            .background_worker_ratio
+            .unwrap_or(crate::concurrency::DEFAULT_BACKGROUND_RATIO)
+            .clamp(0.05, 1.0);
+        crate::concurrency::WorkerPolicy::default()
+            .with_interactive_ratio(interactive)
+            .with_background_ratio(background)
     }
 
     pub fn get_cache_directory(&self) -> String {
@@ -369,6 +404,82 @@ directory = "./cache"
         assert_eq!(pregen_config.screen, Some(false));
         assert_eq!(pregen_config.large, Some(true));
         assert_eq!(pregen_config.workers, Some(4));
+    }
+
+    #[test]
+    fn test_worker_ratios_default_and_clamp() {
+        // Absent -> compiled-in defaults.
+        let config = Config::default();
+        let policy = config.get_worker_policy();
+        assert_eq!(
+            policy.interactive_ratio,
+            crate::concurrency::DEFAULT_INTERACTIVE_RATIO
+        );
+        assert_eq!(
+            policy.background_ratio,
+            crate::concurrency::DEFAULT_BACKGROUND_RATIO
+        );
+
+        // Configured values are honored.
+        let mut config = Config::default();
+        config.server.scan_worker_ratio = Some(0.75);
+        config.server.background_worker_ratio = Some(0.1);
+        let policy = config.get_worker_policy();
+        assert_eq!(policy.interactive_ratio, 0.75);
+        assert_eq!(policy.background_ratio, 0.1);
+
+        // Out-of-range values are clamped so a typo can't disable the work or
+        // over-subscribe.
+        config.server.scan_worker_ratio = Some(0.0);
+        config.server.background_worker_ratio = Some(5.0);
+        let policy = config.get_worker_policy();
+        assert_eq!(policy.interactive_ratio, 0.05);
+        assert_eq!(policy.background_ratio, 1.0);
+    }
+
+    #[test]
+    fn test_worker_ratios_toml_roundtrip() {
+        // The knobs live in [server] alongside port/host and round-trip.
+        let toml = r#"
+[server]
+port = 3000
+scan_worker_ratio = 0.25
+background_worker_ratio = 0.1
+
+[cache]
+directory = "./cache"
+"#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        let policy = config.get_worker_policy();
+        assert_eq!(policy.interactive_ratio, 0.25);
+        assert_eq!(policy.background_ratio, 0.1);
+
+        // Absent keys must keep parsing (backward compatibility) and default.
+        let toml_no_key = r#"
+[server]
+port = 3000
+
+[cache]
+directory = "./cache"
+"#;
+        let config: Config = toml_edit::de::from_str(toml_no_key).unwrap();
+        let policy = config.get_worker_policy();
+        assert_eq!(
+            policy.interactive_ratio,
+            crate::concurrency::DEFAULT_INTERACTIVE_RATIO
+        );
+        assert_eq!(
+            policy.background_ratio,
+            crate::concurrency::DEFAULT_BACKGROUND_RATIO
+        );
+
+        // Default serialization omits the keys (kept clean like the other
+        // optional knobs) so older binaries ignore them cleanly.
+        let json = toml_edit::ser::to_string_pretty(&Config::default()).unwrap();
+        assert!(
+            !json.contains("scan_worker_ratio") && !json.contains("background_worker_ratio"),
+            "default config should not write the keys: {json}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod accord_imaging;
 pub mod cli;
 pub mod commands;
+pub mod concurrency;
 pub mod config;
 pub mod db;
 pub mod db_registry;

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -2480,6 +2480,7 @@ fn merge_spatial_metrics(
 /// running (or nothing needs computing) this returns `started: false` with
 /// the current progress. Poll GET on the same path for progress.
 pub async fn start_spatial_scan(
+    State(state): State<Arc<AppState>>,
     ctx: DbContext,
     Json(req): Json<SpatialScanRequest>,
 ) -> Result<Json<ApiResponse<SpatialScanStatusResponse>>, AppError> {
@@ -2567,7 +2568,13 @@ pub async fn start_spatial_scan(
 
     let ctx_arc = ctx.0.clone();
     let target_id = req.target_id;
+    let worker_policy = state.worker_policy();
+    // Mark this as an interactive job for its whole lifetime so background
+    // pre-generation yields cores + memory to it. Moved into the blocking task
+    // and dropped when the scan returns (or panics).
+    let interactive_guard = state.begin_interactive_job();
     tokio::task::spawn_blocking(move || {
+        let _interactive_guard = interactive_guard;
         // Any panic below would be silently swallowed by tokio (the join
         // handle is dropped) and leave the singleton wedged at running=true;
         // catch it and always finalize.
@@ -2589,10 +2596,28 @@ pub async fn start_spatial_scan(
                     }
                 }
             }
+            // Size the worker pool to the machine (configured core ratio) and
+            // the sensor (peak memory of one in-flight frame, probed from the
+            // first resolvable file). Leaves headroom for request serving.
+            let frame_pixels = items
+                .first()
+                .and_then(|it| crate::concurrency::probe_frame_pixels(&it.fits_path));
+            let budget = crate::concurrency::plan_workers(
+                None,
+                &worker_policy,
+                crate::concurrency::Priority::Interactive,
+                frame_pixels,
+            );
+            tracing::info!(
+                "📐 Spatial scan concurrency: {} worker(s) — {}",
+                budget.workers,
+                budget.rationale
+            );
             crate::server::spatial_scan::run_scan(
                 &ctx_arc.spatial_metrics,
                 &ctx_arc.cache_dir_path,
                 &items,
+                budget.workers,
             );
         }));
         if scan_body.is_err() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -43,6 +43,9 @@ pub struct ServerConfig {
     /// Allow HTTP clients to mutate the configured database list. Off by
     /// default for CLI servers; Tauri always enables it.
     pub allow_database_management: bool,
+    /// Tuning policy for the parallel scans and background pre-generation.
+    /// See `concurrency::WorkerPolicy`.
+    pub worker_policy: crate::concurrency::WorkerPolicy,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -55,6 +58,7 @@ pub async fn run_server(
     pregeneration_config: PregenerationConfig,
     registry_path: Option<PathBuf>,
     allow_database_management: bool,
+    worker_policy: crate::concurrency::WorkerPolicy,
 ) -> anyhow::Result<()> {
     // Initialize tracing with environment-based filtering (for CLI mode)
     // Set RUST_LOG=debug for debug logs, RUST_LOG=info for info logs, etc.
@@ -78,6 +82,7 @@ pub async fn run_server(
         pregeneration_config,
         registry_path,
         allow_database_management,
+        worker_policy,
     };
 
     run_server_internal(config, None).await
@@ -141,6 +146,13 @@ async fn run_server_internal(
             tracing::info!("✅ Application state initialized successfully");
             state.set_registry_path(config.registry_path.clone());
             state.set_allow_database_management(config.allow_database_management);
+            state.set_worker_policy(config.worker_policy);
+            tracing::info!(
+                "📐 Worker ratios — interactive {:.2}, background {:.2} (of {} logical cores)",
+                config.worker_policy.interactive_ratio,
+                config.worker_policy.background_ratio,
+                crate::concurrency::logical_cores()
+            );
             if config.allow_database_management {
                 tracing::warn!(
                     "⚠️ Database management via HTTP is ENABLED. Anyone who can reach \
@@ -321,24 +333,33 @@ pub async fn run_server_with_shutdown(
 }
 
 async fn background_pregeneration_task(state: Arc<AppState>) {
+    use std::sync::Arc;
     use std::time::Duration;
-    use tokio::time::{interval, sleep};
+    use tokio::task::JoinSet;
+    use tokio::time::interval;
 
     tracing::info!("🎨 Starting background image pre-generation task");
 
-    // Rate limiting configuration
-    let rate_limit_delay = Duration::from_millis(500); // 2 images per second max
-    let batch_size = 10; // Process 10 images at a time
     let scan_interval = Duration::from_secs(300); // Re-scan every 5 minutes
-
     let mut interval_timer = interval(scan_interval);
 
     loop {
-        // Wait for next scan interval
         interval_timer.tick().await;
 
         // Iterate every configured database; pre-generation is per-DB work.
         for ctx in state.all_databases() {
+            // Yield to interactive work: while a user-triggered scan is
+            // running anywhere in the process, skip this cycle entirely so we
+            // don't take cores or memory from a job the user is waiting on. We
+            // re-check on the next tick.
+            if state.interactive_job_active() {
+                tracing::debug!(
+                    "⏸️ Pre-generation paused (db={}): interactive job running",
+                    ctx.id
+                );
+                continue;
+            }
+
             tracing::debug!(
                 "🔍 Scanning db={} for images needing pre-generation",
                 ctx.id
@@ -361,150 +382,124 @@ async fn background_pregeneration_task(state: Arc<AppState>) {
                 continue;
             }
 
+            // Background worker budget: fewer cores than interactive work, and
+            // it will pause the moment an interactive job starts (below).
+            let budget = crate::concurrency::plan_workers(
+                None,
+                &state.worker_policy(),
+                crate::concurrency::Priority::Background,
+                None,
+            );
+            let concurrency = budget.workers.max(1);
+
             tracing::info!(
-                "🎯 Found {} images for pre-generation in db={}",
+                "🎯 Pre-generating up to {} images (db={}) with {} background worker(s) — {}",
                 images.len(),
-                ctx.id
+                ctx.id,
+                concurrency,
+                budget.rationale
             );
 
-            let mut processed_count = 0;
-            let mut generated_count = 0;
-            let mut skipped_count = 0;
-            let mut error_count = 0;
+            // Bound in-flight work to the background budget with a semaphore;
+            // each permit is held for one image's whole (multi-format) job.
+            let sem = Arc::new(tokio::sync::Semaphore::new(concurrency));
+            let mut join_set: JoinSet<(u64, u64, u64)> = JoinSet::new();
+            let mut dispatched = 0usize;
+            let mut yielded_early = false;
 
-            for batch in images.chunks(batch_size) {
-                for (image_id, file_only, target_name) in batch {
-                    let mut _formats_processed = 0;
-
-                    if state.pregeneration_config.screen_enabled {
-                        match pregenerate_preview(
-                            &state,
-                            &ctx,
-                            *image_id,
-                            file_only,
-                            target_name,
-                            "screen",
-                        )
-                        .await
-                        {
-                            Ok(generated) => {
-                                _formats_processed += 1;
-                                if generated {
-                                    generated_count += 1;
-                                } else {
-                                    skipped_count += 1;
-                                }
-                            }
-                            Err(e) => {
-                                error_count += 1;
-                                tracing::warn!(
-                                    "⚠️ Failed to pre-generate screen preview for image {} (db={}): {}",
-                                    image_id, ctx.id, e
-                                );
-                            }
-                        }
-                    }
-
-                    if state.pregeneration_config.large_enabled {
-                        match pregenerate_preview(
-                            &state,
-                            &ctx,
-                            *image_id,
-                            file_only,
-                            target_name,
-                            "large",
-                        )
-                        .await
-                        {
-                            Ok(generated) => {
-                                _formats_processed += 1;
-                                if generated {
-                                    generated_count += 1;
-                                } else {
-                                    skipped_count += 1;
-                                }
-                            }
-                            Err(e) => {
-                                error_count += 1;
-                                tracing::warn!(
-                                    "⚠️ Failed to pre-generate large preview for image {} (db={}): {}",
-                                    image_id, ctx.id, e
-                                );
-                            }
-                        }
-                    }
-
-                    if state.pregeneration_config.original_enabled {
-                        match pregenerate_preview(
-                            &state,
-                            &ctx,
-                            *image_id,
-                            file_only,
-                            target_name,
-                            "original",
-                        )
-                        .await
-                        {
-                            Ok(generated) => {
-                                _formats_processed += 1;
-                                if generated {
-                                    generated_count += 1;
-                                } else {
-                                    skipped_count += 1;
-                                }
-                            }
-                            Err(e) => {
-                                error_count += 1;
-                                tracing::warn!(
-                                    "⚠️ Failed to pre-generate original preview for image {} (db={}): {}",
-                                    image_id, ctx.id, e
-                                );
-                            }
-                        }
-                    }
-
-                    if state.pregeneration_config.annotated_enabled {
-                        match pregenerate_annotated(&state, &ctx, *image_id, file_only, target_name)
-                            .await
-                        {
-                            Ok(generated) => {
-                                _formats_processed += 1;
-                                if generated {
-                                    generated_count += 1;
-                                } else {
-                                    skipped_count += 1;
-                                }
-                            }
-                            Err(e) => {
-                                error_count += 1;
-                                tracing::warn!(
-                                    "⚠️ Failed to pre-generate annotated image for image {} (db={}): {}",
-                                    image_id, ctx.id, e
-                                );
-                            }
-                        }
-                    }
-
-                    processed_count += 1;
-                    sleep(rate_limit_delay).await;
+            for (image_id, file_only, target_name) in images {
+                // Yield mid-cycle: stop dispatching new work as soon as an
+                // interactive job appears; already-running tasks drain.
+                if state.interactive_job_active() {
+                    yielded_early = true;
+                    break;
                 }
 
-                tracing::debug!(
-                    "📈 Pre-generation progress for db={}: {}/{} images processed",
-                    ctx.id,
-                    processed_count,
-                    images.len()
-                );
+                let permit = match Arc::clone(&sem).acquire_owned().await {
+                    Ok(p) => p,
+                    Err(_) => break, // semaphore closed (shouldn't happen)
+                };
+                let state = Arc::clone(&state);
+                let ctx = Arc::clone(&ctx);
+                join_set.spawn(async move {
+                    let _permit = permit;
+                    pregenerate_one_image(&state, &ctx, image_id, &file_only, &target_name).await
+                });
+                dispatched += 1;
             }
 
-            if processed_count > 0 {
+            let (mut generated, mut skipped, mut errors) = (0u64, 0u64, 0u64);
+            while let Some(res) = join_set.join_next().await {
+                if let Ok((g, s, e)) = res {
+                    generated += g;
+                    skipped += s;
+                    errors += e;
+                }
+            }
+
+            if dispatched > 0 {
                 tracing::info!(
-                    "✅ Pre-generation cycle complete for db={}: {} generated, {} skipped, {} errors ({} images processed)",
-                    ctx.id, generated_count, skipped_count, error_count, processed_count
+                    "✅ Pre-generation cycle for db={}: {} generated, {} skipped, {} errors ({} images{})",
+                    ctx.id,
+                    generated,
+                    skipped,
+                    errors,
+                    dispatched,
+                    if yielded_early {
+                        ", paused early to yield to interactive work"
+                    } else {
+                        ""
+                    }
                 );
             }
         }
     }
+}
+
+/// Pre-generate every enabled preview format for one image. Returns
+/// `(generated, skipped, errors)` counts across the formats.
+async fn pregenerate_one_image(
+    state: &Arc<AppState>,
+    ctx: &Arc<crate::server::database_context::DatabaseContext>,
+    image_id: i32,
+    file_only: &str,
+    target_name: &str,
+) -> (u64, u64, u64) {
+    let (mut generated, mut skipped, mut errors) = (0u64, 0u64, 0u64);
+
+    let mut tally = |result: Result<bool>, what: &str| match result {
+        Ok(true) => generated += 1,
+        Ok(false) => skipped += 1,
+        Err(e) => {
+            errors += 1;
+            tracing::warn!(
+                "⚠️ Failed to pre-generate {} for image {} (db={}): {}",
+                what,
+                image_id,
+                ctx.id,
+                e
+            );
+        }
+    };
+
+    if state.pregeneration_config.screen_enabled {
+        let r = pregenerate_preview(state, ctx, image_id, file_only, target_name, "screen").await;
+        tally(r, "screen preview");
+    }
+    if state.pregeneration_config.large_enabled {
+        let r = pregenerate_preview(state, ctx, image_id, file_only, target_name, "large").await;
+        tally(r, "large preview");
+    }
+    if state.pregeneration_config.original_enabled {
+        let r = pregenerate_preview(state, ctx, image_id, file_only, target_name, "original").await;
+        tally(r, "original preview");
+    }
+    if state.pregeneration_config.annotated_enabled {
+        let r = pregenerate_annotated(state, ctx, image_id, file_only, target_name).await;
+        tally(r, "annotated image");
+    }
+
+    (generated, skipped, errors)
 }
 
 async fn get_all_images_for_pregeneration(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -383,12 +383,15 @@ async fn background_pregeneration_task(state: Arc<AppState>) {
             }
 
             // Background worker budget: fewer cores than interactive work, and
-            // it will pause the moment an interactive job starts (below).
+            // it will pause the moment an interactive job starts (below). Probe
+            // a representative frame so the same memory ceiling as the scan
+            // applies — pre-generation loads full-frame buffers too.
+            let frame_pixels = probe_pregen_frame_pixels(&ctx, &images).await;
             let budget = crate::concurrency::plan_workers(
                 None,
                 &state.worker_policy(),
                 crate::concurrency::Priority::Background,
-                None,
+                frame_pixels,
             );
             let concurrency = budget.workers.max(1);
 
@@ -454,6 +457,40 @@ async fn background_pregeneration_task(state: Arc<AppState>) {
             }
         }
     }
+}
+
+/// Best-effort pixel count of a representative frame from `images`, used to
+/// size the background pool's memory ceiling. Resolves each image's FITS via
+/// the same lookup pre-generation uses and probes its `NAXIS` without loading
+/// pixels; returns the first hit. Tries a handful so one missing file doesn't
+/// defeat the probe. `None` (e.g. all files missing) falls back to a
+/// core-only budget.
+async fn probe_pregen_frame_pixels(
+    ctx: &Arc<crate::server::database_context::DatabaseContext>,
+    images: &[(i32, String, String)],
+) -> Option<usize> {
+    use crate::db::Database;
+
+    for (image_id, file_only, target_name) in images.iter().take(8) {
+        let image_data = {
+            let conn = ctx.db();
+            let Ok(conn) = conn.lock() else { continue };
+            let db = Database::new(&conn);
+            match db.get_images_by_ids(&[*image_id]) {
+                Ok(v) => v.into_iter().next(),
+                Err(_) => None,
+            }
+        };
+        let Some(image_data) = image_data else {
+            continue;
+        };
+        if let Ok(path) = handlers::find_fits_file(ctx, &image_data, target_name, file_only) {
+            if let Some(px) = crate::concurrency::probe_frame_pixels(&path) {
+                return Some(px);
+            }
+        }
+    }
+    None
 }
 
 /// Pre-generate every enabled preview format for one image. Returns

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -386,7 +386,7 @@ async fn background_pregeneration_task(state: Arc<AppState>) {
             // it will pause the moment an interactive job starts (below). Probe
             // a representative frame so the same memory ceiling as the scan
             // applies — pre-generation loads full-frame buffers too.
-            let frame_pixels = probe_pregen_frame_pixels(&ctx, &images).await;
+            let frame_pixels = probe_pregen_frame_pixels(&ctx, &images);
             let budget = crate::concurrency::plan_workers(
                 None,
                 &state.worker_policy(),
@@ -460,32 +460,19 @@ async fn background_pregeneration_task(state: Arc<AppState>) {
 }
 
 /// Best-effort pixel count of a representative frame from `images`, used to
-/// size the background pool's memory ceiling. Resolves each image's FITS via
-/// the same lookup pre-generation uses and probes its `NAXIS` without loading
-/// pixels; returns the first hit. Tries a handful so one missing file doesn't
-/// defeat the probe. `None` (e.g. all files missing) falls back to a
-/// core-only budget.
-async fn probe_pregen_frame_pixels(
+/// size the background pool's memory ceiling. Resolves basenames through the
+/// directory-tree cache (O(1) each, no DB) and probes the first on-disk FITS's
+/// `NAXIS` without loading pixels. Scans the whole list until a file resolves,
+/// so a leading run of not-on-disk rows (e.g. images for other targets) can't
+/// defeat it. `None` (nothing resolvable) falls back to a core-only budget.
+fn probe_pregen_frame_pixels(
     ctx: &Arc<crate::server::database_context::DatabaseContext>,
     images: &[(i32, String, String)],
 ) -> Option<usize> {
-    use crate::db::Database;
-
-    for (image_id, file_only, target_name) in images.iter().take(8) {
-        let image_data = {
-            let conn = ctx.db();
-            let Ok(conn) = conn.lock() else { continue };
-            let db = Database::new(&conn);
-            match db.get_images_by_ids(&[*image_id]) {
-                Ok(v) => v.into_iter().next(),
-                Err(_) => None,
-            }
-        };
-        let Some(image_data) = image_data else {
-            continue;
-        };
-        if let Ok(path) = handlers::find_fits_file(ctx, &image_data, target_name, file_only) {
-            if let Some(px) = crate::concurrency::probe_frame_pixels(&path) {
+    let tree = ctx.get_directory_tree().ok()?;
+    for (_image_id, file_only, _target_name) in images {
+        if let Some(path) = tree.find_file_first(file_only) {
+            if let Some(px) = crate::concurrency::probe_frame_pixels(path) {
                 return Some(px);
             }
         }

--- a/src/server/spatial_scan.rs
+++ b/src/server/spatial_scan.rs
@@ -209,7 +209,7 @@ pub fn try_begin_scan(
 
 /// Run the scan synchronously (call from `spawn_blocking`). `work` must only
 /// contain images that actually need computing. `workers` is the desired
-/// concurrency (see `concurrency::plan_scan_workers`), clamped here to the
+/// concurrency (see `concurrency::plan_workers`), clamped here to the
 /// amount of work. Detection is CPU-bound at several seconds per full-frame
 /// image, so each worker roughly adds one frame's worth of throughput.
 pub fn run_scan(

--- a/src/server/spatial_scan.rs
+++ b/src/server/spatial_scan.rs
@@ -207,76 +207,70 @@ pub fn try_begin_scan(
     true
 }
 
-/// Worker threads for the scan. Detection is CPU-bound at several seconds
-/// per full-frame image; two workers roughly halve the wall clock while
-/// leaving cores free to keep serving requests.
-const SCAN_WORKERS: usize = 2;
-
 /// Run the scan synchronously (call from `spawn_blocking`). `work` must only
-/// contain images that actually need computing.
-pub fn run_scan(store: &RwLock<SpatialMetricsStore>, cache_dir: &Path, work: &[ScanWorkItem]) {
+/// contain images that actually need computing. `workers` is the desired
+/// concurrency (see `concurrency::plan_scan_workers`), clamped here to the
+/// amount of work. Detection is CPU-bound at several seconds per full-frame
+/// image, so each worker roughly adds one frame's worth of throughput.
+pub fn run_scan(
+    store: &RwLock<SpatialMetricsStore>,
+    cache_dir: &Path,
+    work: &[ScanWorkItem],
+    workers: usize,
+) {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     let spatial_config = SpatialAnalysisConfig::default();
-    let next = AtomicUsize::new(0);
     let since_persist = AtomicUsize::new(0);
-    let workers = SCAN_WORKERS.min(work.len()).max(1);
 
-    std::thread::scope(|scope| {
-        for _ in 0..workers {
-            scope.spawn(|| loop {
-                let i = next.fetch_add(1, Ordering::Relaxed);
-                if i >= work.len() {
-                    break;
-                }
-                let item = &work[i];
-                {
-                    let mut s = store.write().unwrap();
-                    s.progress.current_file = Some(item.filename.clone());
-                }
+    // Shared work-stealing pool sized by the caller's worker budget.
+    crate::concurrency::parallel_index(work.len(), workers, |i| {
+        let item = &work[i];
+        {
+            let mut s = store.write().unwrap();
+            s.progress.current_file = Some(item.filename.clone());
+        }
 
-                // A panic here (malformed FITS tripping an assert deep in
-                // detection) must not escape: it would propagate through
-                // thread::scope, skip the finalization below, and leave the
-                // per-DB scan singleton wedged at running=true until restart.
-                // compute_one holds no store lock, so catching cannot poison.
-                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    compute_one(item, &spatial_config)
-                }))
-                .unwrap_or_else(|panic| {
-                    let msg = panic
-                        .downcast_ref::<&str>()
-                        .map(|s| s.to_string())
-                        .or_else(|| panic.downcast_ref::<String>().cloned())
-                        .unwrap_or_else(|| "panic during analysis".to_string());
-                    Err(anyhow::anyhow!("panicked: {}", msg))
-                });
+        // A panic here (malformed FITS tripping an assert deep in detection)
+        // must not escape: it would propagate through the pool's thread::scope,
+        // skip the finalization below, and leave the per-DB scan singleton
+        // wedged at running=true until restart. compute_one holds no store
+        // lock, so catching cannot poison.
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            compute_one(item, &spatial_config)
+        }))
+        .unwrap_or_else(|panic| {
+            let msg = panic
+                .downcast_ref::<&str>()
+                .map(|s| s.to_string())
+                .or_else(|| panic.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "panic during analysis".to_string());
+            Err(anyhow::anyhow!("panicked: {}", msg))
+        });
 
-                match outcome {
-                    Ok(entry) => {
-                        let mut s = store.write().unwrap();
-                        s.metrics.insert(item.image_id, entry);
-                        s.progress.processed += 1;
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "📐 Spatial scan failed for image {} ({}): {}",
-                            item.image_id,
-                            item.filename,
-                            e
-                        );
-                        let mut s = store.write().unwrap();
-                        s.progress.errors += 1;
-                        s.progress.processed += 1;
-                        s.progress.last_error = Some(format!("{}: {}", item.filename, e));
-                    }
-                }
+        match outcome {
+            Ok(entry) => {
+                let mut s = store.write().unwrap();
+                s.metrics.insert(item.image_id, entry);
+                s.progress.processed += 1;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "📐 Spatial scan failed for image {} ({}): {}",
+                    item.image_id,
+                    item.filename,
+                    e
+                );
+                let mut s = store.write().unwrap();
+                s.progress.errors += 1;
+                s.progress.processed += 1;
+                s.progress.last_error = Some(format!("{}: {}", item.filename, e));
+            }
+        }
 
-                if since_persist.fetch_add(1, Ordering::Relaxed) + 1 >= PERSIST_EVERY {
-                    since_persist.store(0, Ordering::Relaxed);
-                    persist(store, cache_dir);
-                }
-            });
+        if since_persist.fetch_add(1, Ordering::Relaxed) + 1 >= PERSIST_EVERY {
+            since_persist.store(0, Ordering::Relaxed);
+            persist(store, cache_dir);
         }
     });
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -430,3 +430,62 @@ impl AppState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_state() -> AppState {
+        AppState::new_for_test(Connection::open_in_memory().unwrap())
+    }
+
+    #[test]
+    fn interactive_job_gauge_tracks_guard_lifetime() {
+        let state = test_state();
+        // No interactive work initially — background may run.
+        assert!(!state.interactive_job_active());
+
+        {
+            let _guard = state.begin_interactive_job();
+            // A live guard means background work should yield.
+            assert!(state.interactive_job_active());
+        }
+        // Guard dropped -> gauge clears -> background may resume.
+        assert!(!state.interactive_job_active());
+    }
+
+    #[test]
+    fn interactive_job_gauge_nests() {
+        // Concurrent scans (e.g. across databases) must both have to finish
+        // before background work resumes; the gauge is a count, not a flag.
+        let state = test_state();
+        let g1 = state.begin_interactive_job();
+        let g2 = state.begin_interactive_job();
+        assert!(state.interactive_job_active());
+        drop(g1);
+        assert!(
+            state.interactive_job_active(),
+            "still active while one job remains"
+        );
+        drop(g2);
+        assert!(!state.interactive_job_active());
+    }
+
+    #[test]
+    fn interactive_guard_decrements_even_on_panic() {
+        // The whole point of the RAII guard: a panicking scan must not leave
+        // the gauge stuck > 0 and permanently starve background pre-generation.
+        let state = std::sync::Arc::new(test_state());
+        let state2 = std::sync::Arc::clone(&state);
+        let handle = std::thread::spawn(move || {
+            let _guard = state2.begin_interactive_job();
+            assert!(state2.interactive_job_active());
+            panic!("scan blew up");
+        });
+        assert!(handle.join().is_err(), "thread should have panicked");
+        assert!(
+            !state.interactive_job_active(),
+            "guard must decrement while unwinding"
+        );
+    }
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
@@ -43,6 +44,27 @@ pub struct AppState {
     /// untrustworthy client cannot mutate the user's configuration even if
     /// the server has a registry to persist to.
     pub allow_database_management: RwLock<bool>,
+    /// Tuning policy for the parallel scans and background pre-generation (see
+    /// `concurrency::WorkerPolicy`). Process-global; sourced from the TOML
+    /// `[server]` ratios, otherwise the compiled-in defaults.
+    pub worker_policy: RwLock<crate::concurrency::WorkerPolicy>,
+    /// Count of interactive (user-triggered) CPU-heavy jobs currently running,
+    /// process-wide. Background work reads this to yield: while it is nonzero,
+    /// pre-generation pauses so it doesn't compete for cores or memory with a
+    /// scan the user is waiting on. An `Arc` so a [`InteractiveJobGuard`] can
+    /// decrement it on drop from a `spawn_blocking` task.
+    active_interactive_jobs: Arc<AtomicUsize>,
+}
+
+/// RAII marker that an interactive CPU-heavy job is running. Increments the
+/// process-wide gauge on creation and decrements on drop, so background work
+/// yields for exactly the job's lifetime even if it panics.
+pub struct InteractiveJobGuard(Arc<AtomicUsize>);
+
+impl Drop for InteractiveJobGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 #[derive(Clone)]
@@ -302,6 +324,8 @@ impl AppState {
             cache_dir_root: cache_dir,
             registry_path: RwLock::new(None),
             allow_database_management: RwLock::new(false),
+            worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
+            active_interactive_jobs: Arc::new(AtomicUsize::new(0)),
         })
     }
 
@@ -320,6 +344,30 @@ impl AppState {
 
     pub fn database_management_allowed(&self) -> bool {
         *self.allow_database_management.read().unwrap()
+    }
+
+    /// Set the worker tuning policy (from the TOML `[server]` config).
+    pub fn set_worker_policy(&self, policy: crate::concurrency::WorkerPolicy) {
+        *self.worker_policy.write().unwrap() = policy;
+    }
+
+    /// The worker tuning policy in effect.
+    pub fn worker_policy(&self) -> crate::concurrency::WorkerPolicy {
+        *self.worker_policy.read().unwrap()
+    }
+
+    /// Mark the start of an interactive CPU-heavy job (e.g. an occlusion
+    /// scan). Hold the returned guard for the job's lifetime; background work
+    /// yields while any guard is alive.
+    pub fn begin_interactive_job(&self) -> InteractiveJobGuard {
+        self.active_interactive_jobs.fetch_add(1, Ordering::SeqCst);
+        InteractiveJobGuard(Arc::clone(&self.active_interactive_jobs))
+    }
+
+    /// Whether any interactive CPU-heavy job is currently running. Background
+    /// work checks this and pauses so it doesn't compete for cores or memory.
+    pub fn interactive_job_active(&self) -> bool {
+        self.active_interactive_jobs.load(Ordering::SeqCst) > 0
     }
 
     /// Convenience constructor for a single database. Computes a default slug
@@ -377,6 +425,8 @@ impl AppState {
             cache_dir_root: "/tmp/psf-guard-test".to_string(),
             registry_path: RwLock::new(None),
             allow_database_management: RwLock::new(false),
+            worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
+            active_interactive_jobs: Arc::new(AtomicUsize::new(0)),
         }
     }
 }

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -264,6 +264,7 @@ async fn start_server_for_tauri(
         // The Tauri app is local-only and trusted; always enable CRUD so the
         // settings panel can add/remove databases without an extra flag.
         allow_database_management: true,
+        worker_policy: config.get_worker_policy(),
     };
 
     crate::server::run_server_with_shutdown(server_config, shutdown_rx).await


### PR DESCRIPTION
## Problem

The occlusion / spatial-metrics scan under-used the machine. Star detection is single-threaded per frame, and the frame-level pools were capped far below core count:

- **Server "Scan Occlusion"** (`spatial_scan.rs`): hardcoded `SCAN_WORKERS = 2` regardless of the box.
- **CLI `screen-fits`** (`analyze_frames`): `available_parallelism().min(4)`.

Neither was memory-aware, and background pre-generation competed with foreground scans.

## What changed

New `src/concurrency.rs` — a shared worker-sizing policy every CPU-bound parallel path uses.

- **`WorkerPolicy`** groups the tunables (interactive/background core ratios, memory-budget fraction, hard max, per-pixel peak) so the policy threads through `ServerConfig` → `AppState` → the scan as one value (no loose-parameter fan-out).
- **`plan_workers(requested, &policy, priority, frame_pixels)`** → `round(cores * ratio)`, then capped by `budget_fraction * available_RAM / (pixels * peak_bytes_per_pixel)` so a big sensor on a high-core box can't OOM. An explicit `--threads` wins outright.
- **`available_memory_bytes()`** probes **Linux** (`/proc/meminfo`), **macOS** (`sysctl hw.memsize`) and **Windows** (`GlobalMemoryStatusEx`); `probe_frame_pixels` reads `NAXIS1×NAXIS2` without loading pixels.
- **`parallel_index`** is the shared atomic work-stealing pool; both `screen-fits` and server `run_scan` use it (deduplicated).

### Priorities + yielding
- **Interactive** work (server scan, CLI `screen-fits`) uses the interactive ratio (default **0.5** server / **1.0** CLI). The server scan holds an `AppState::begin_interactive_job()` guard for its lifetime.
- **Background** image pre-generation runs a bounded pool at the background ratio (default **0.25**) **and pauses whenever an interactive job is active** — so a user-triggered scan gets the cores + memory, and pre-warming resumes when idle. Replaces the old fixed 500ms-per-image trickle.

### Config
`[server]` in the TOML `--config`: `scan_worker_ratio` (interactive) and `background_worker_ratio`. Both optional, clamped to `[0.05, 1.0]`, default to compiled-in values. Backward-compatible (absent keys → defaults; default serialization omits them).

## Verification
- `cargo fmt` / `cargo clippy --all-targets` clean; **full test suite green** (11 new unit tests for the policy/memory/pool + config round-trips; existing `integration_spatial_scan` suite passes with the new `run_scan` signature).
- End-to-end `screen-fits` on repo FITS fixtures: default now uses all 18 cores (`memory allows 82`), `--threads 3` honored, verdicts unchanged.
- Tauri feature type-checks (the earlier local failure is the pre-existing opencv/libclang env issue, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)