### PR TITLE
Async on-demand preview generation via the interactive queue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,35 @@ the lever is how many frames run at once.
   interactive, `background_worker_ratio` → background. Both optional, clamped
   to `[0.05, 1.0]`, absent → compiled-in defaults.
 
+### Async on-demand preview generation (2026-07)
+Preview/annotated PNGs are no longer generated inside the request. `src/server/preview_queue.rs`
+holds a process-global `PreviewQueue` on `AppState`: on a cache miss the
+preview/annotated handlers `enqueue_preview(GenJob)` and return **HTTP 202**
+`{state:"generating"}` immediately (never blocking the `<img>` GET). The queue
+is a bounded, `Priority::Interactive` pool (semaphore sized lazily via
+`plan_workers` + a frame probe) where each job holds a
+`begin_interactive_job()` guard, so background pre-generation yields to
+user-driven preview work. Dedup is by full `cache_path`; generation writes to
+a temp file then atomically renames, so a readiness poll never sees a partial
+PNG (the pregen paths in `mod.rs` do the same now).
+- **Batch status**: `POST /api/db/{id}/images/generation-status` takes
+  `{requests:[{image_id,kind,size,stretch?,midtone?,shadow?,max_stars?}]}` and
+  returns parallel `{state: ready|generating|error}` — coalesces a whole grid's
+  polling into one request; enqueues unknown items idempotently.
+- **Cache keys**: `preview_cache_key` / `annotated_cache_key` in `handlers.rs`
+  are shared by the artifact handler, the status endpoint, and pregen so all
+  address the same file.
+- **Frontend** (`static/src`): optimistic `<img>` + poll-on-error. `hooks/previewPoll.ts`
+  is a singleton coordinator that batches pending descriptors (per DB) into one
+  `getGenerationStatus` POST every ~800ms; `hooks/useAsyncImage.ts` drives an
+  `<img>` (renders directly on a cache hit — zero extra requests; on the 202
+  error joins the poller, shows "Generating…", reloads with a cache-buster when
+  ready). `components/PreviewImage.tsx` wraps grid/sequence images;
+  `ImageDetailView`/`ImageComparisonView` use the hook directly (preserving the
+  zoom transforms), and `ensurePreviewReady` replaces the `new Image()` zoom-
+  switch preloads + `useImagePreloader` warming so an uncached 'original'
+  actually generates before the zoom swaps to it.
+
 ### Two-DB sync (2026-06)
 Lives in `src/commands/sync/` (`mod.rs` shared helpers + `grades.rs` + `pull.rs`).
 Two complementary single-direction kinds, structured as `sync <kind>` so more

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -7,7 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -877,293 +877,170 @@ pub async fn update_image_grade(
     Ok(Json(ApiResponse::success(())))
 }
 
-// Image preview endpoint
-#[axum::debug_handler(state = Arc<AppState>)]
-pub async fn get_image_preview(
-    ctx: DbContext,
-    Path((_db_id, image_id)): Path<(String, i32)>,
-    Query(options): Query<PreviewOptions>,
-) -> Result<impl IntoResponse, AppError> {
-    let start_time = std::time::Instant::now();
-    let size = options.size.as_deref().unwrap_or("screen");
-    tracing::debug!(
-        "🖼️  Generating preview for image {} (size: {})",
-        image_id,
-        size
-    );
+/// Shared DB lookup for the image handlers: the acquired-image row, the FITS
+/// basename (from `metadata.FileName`), and the target name.
+fn resolve_image_meta(
+    ctx: &DatabaseContext,
+    image_id: i32,
+) -> Result<(crate::models::AcquiredImage, String, String), AppError> {
+    let conn = ctx.db();
+    let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+    let db = Database::new(&conn);
 
-    use crate::image_analysis::FitsImage;
-    use crate::server::cache::CacheManager;
+    let image = db
+        .get_images_by_ids(&[image_id])
+        .map_err(|_| AppError::DatabaseError)?
+        .into_iter()
+        .next()
+        .ok_or(AppError::NotFound)?;
 
-    // Get image metadata from database
-    let (image, file_only, target_name) = {
-        let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
-        let db = Database::new(&conn);
+    let target = db
+        .get_targets_by_ids(&[image.target_id])
+        .map_err(|_| AppError::DatabaseError)?
+        .into_iter()
+        .next()
+        .ok_or(AppError::NotFound)?;
+    let target_name = target.name.clone();
 
-        // Get image metadata
-        let images = db
-            .get_images_by_ids(&[image_id])
-            .map_err(|_| AppError::DatabaseError)?;
+    let metadata: serde_json::Value = serde_json::from_str(&image.metadata)
+        .map_err(|_| AppError::BadRequest("Invalid metadata".to_string()))?;
+    let filename = metadata["FileName"]
+        .as_str()
+        .ok_or_else(|| AppError::BadRequest("No filename in metadata".to_string()))?;
+    let file_only = filename
+        .split(&['\\', '/'][..])
+        .next_back()
+        .ok_or_else(|| AppError::BadRequest("Invalid filename format".to_string()))?
+        .to_string();
 
-        let image = images.into_iter().next().ok_or(AppError::NotFound)?;
+    Ok((image, file_only, target_name))
+}
 
-        // Get target name
-        let targets = db
-            .get_targets_by_ids(&[image.target_id])
-            .map_err(|_| AppError::DatabaseError)?;
-
-        let target = targets.into_iter().next().ok_or(AppError::NotFound)?;
-        let target_name = target.name.clone();
-
-        // Extract filename from metadata
-        let metadata: serde_json::Value = serde_json::from_str(&image.metadata)
-            .map_err(|_| AppError::BadRequest("Invalid metadata".to_string()))?;
-
-        let filename = metadata["FileName"]
-            .as_str()
-            .ok_or_else(|| AppError::BadRequest("No filename in metadata".to_string()))?;
-
-        // Extract just the filename from the full path
-        let file_only = filename
-            .split(&['\\', '/'][..])
-            .next_back()
-            .ok_or_else(|| AppError::BadRequest("Invalid filename format".to_string()))?
-            .to_string();
-
-        (image, file_only, target_name)
-    }; // Connection is dropped here
-
-    // Determine cache parameters
-    let stretch = options.stretch.unwrap_or(true);
-    let midtone = options.midtone.unwrap_or(0.2);
-    let shadow = options.shadow.unwrap_or(-2.8);
-
-    // Create comprehensive cache key including file identity and acquisition details
-    let cache_key = format!(
+/// Cache key for a stretched preview PNG. Must stay identical between the
+/// preview handler, the status endpoint, and the pre-generation path so all
+/// three address the same file.
+fn preview_cache_key(
+    image: &crate::models::AcquiredImage,
+    file_only: &str,
+    size: &str,
+    stretch: bool,
+    midtone: f64,
+    shadow: f64,
+) -> String {
+    format!(
         "{}_{}_{}_{}_{}_{}_{}_{}_{}",
-        image_id,
+        image.id,
         image.project_id,
         image.target_id,
-        image.acquired_date.unwrap_or(0), // Include acquisition timestamp
-        file_only.replace(&['.', ' ', '-'][..], "_"), // Include filename
+        image.acquired_date.unwrap_or(0),
+        file_only.replace(&['.', ' ', '-'][..], "_"),
         size,
         if stretch { "stretch" } else { "linear" },
-        (midtone * 10000.0) as i32, // Higher precision
-        (shadow * 10000.0) as i32   // Higher precision
-    );
+        (midtone * 10000.0) as i32,
+        (shadow * 10000.0) as i32,
+    )
+}
 
-    tracing::trace!("🔑 Cache key for image {}: {}", image_id, cache_key);
+/// Cache key for an annotated (star-marked) PNG. Same stability requirement.
+fn annotated_cache_key(
+    image: &crate::models::AcquiredImage,
+    file_only: &str,
+    size: &str,
+    max_stars: usize,
+) -> String {
+    format!(
+        "annotated_{}_{}_{}_{}_{}_{}_{}",
+        image.id,
+        image.project_id,
+        image.target_id,
+        image.acquired_date.unwrap_or(0),
+        file_only.replace(&['.', ' ', '-'][..], "_"),
+        size,
+        max_stars,
+    )
+}
 
-    let cache_manager = CacheManager::new(PathBuf::from(&ctx.cache_dir));
-    if let Err(e) = cache_manager.ensure_category_dir("previews") {
-        tracing::error!(
-            "❌ Failed to create cache directory for image {}: {}",
-            image_id,
-            e
-        );
-        return Err(AppError::InternalError(format!(
-            "Failed to create cache directory: {}",
-            e
-        )));
-    }
-    let cache_path = cache_manager.get_cached_path("previews", &cache_key, "png");
+/// Resolve the on-disk cache path for a preview/annotated artifact, creating
+/// the category dir. `category` is `"previews"` or `"annotated"`.
+fn artifact_cache_path(
+    ctx: &DatabaseContext,
+    category: &str,
+    key: &str,
+) -> Result<PathBuf, AppError> {
+    let cm = crate::server::cache::CacheManager::new(PathBuf::from(&ctx.cache_dir));
+    cm.ensure_category_dir(category)
+        .map_err(|e| AppError::InternalError(format!("Failed to create cache directory: {}", e)))?;
+    Ok(cm.get_cached_path(category, key, "png"))
+}
 
-    tracing::trace!("📂 Cache path for image {}: {:?}", image_id, cache_path);
-
-    // Check if cached version exists
-    if cache_manager.is_cached(&cache_path) {
-        tracing::debug!("💾 Cache HIT for image {} - serving from cache", image_id);
-
-        // Serve from cache
-        let mut file = File::open(&cache_path)
-            .await
-            .map_err(|_| AppError::InternalError("Failed to read cache".to_string()))?;
-
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer)
-            .await
-            .map_err(|_| AppError::InternalError("Failed to read file".to_string()))?;
-
-        tracing::debug!(
-            "⚡ Preview served from cache for image {} in {:?}",
-            image_id,
-            start_time.elapsed()
-        );
-
-        return Ok((
-            StatusCode::OK,
-            [
-                (CONTENT_TYPE, "image/png"),
-                (CACHE_CONTROL, "max-age=86400"), // TODO: Use configurable cache expiry
-            ],
-            buffer,
-        ));
-    }
-
-    tracing::debug!("💫 Cache MISS for image {} - generating preview", image_id);
-
-    // Add timeout for file finding to prevent hanging
-    let find_start = std::time::Instant::now();
-
-    // Find the FITS file
-    let fits_path = match find_fits_file(&ctx, &image, &target_name, &file_only) {
-        Ok(path) => {
-            tracing::info!(
-                "✅ Found FITS file for image {} in {:?}: {:?}",
-                image_id,
-                find_start.elapsed(),
-                path
-            );
-            path
-        }
-        Err(AppError::NotFound) => {
-            tracing::warn!(
-                "⚠️ FITS file not found for image {} (filename: {}) after {:?}",
-                image_id,
-                file_only,
-                find_start.elapsed()
-            );
-            return Err(AppError::NotFound);
-        }
-        Err(e) => {
-            tracing::error!(
-                "❌ Error finding FITS file for image {} (filename: {}) after {:?}: {:?}",
-                image_id,
-                file_only,
-                find_start.elapsed(),
-                e
-            );
-            return Err(e);
-        }
-    };
-
-    // Load FITS file (just to verify it exists and is valid)
-    let _fits = match FitsImage::from_file(&fits_path) {
-        Ok(fits) => fits,
-        Err(e) => {
-            tracing::error!(
-                "❌ Failed to load FITS file for image {} at path {:?}: {}",
-                image_id,
-                fits_path,
-                e
-            );
-            return Err(AppError::InternalError(format!(
-                "Failed to load FITS: {}",
-                e
-            )));
-        }
-    };
-
-    // Determine target size
-    let max_dimensions = match size {
-        "large" => Some((2000, 2000)),
-        "screen" => Some((1200, 1200)),
-        "original" => None,      // No resize for original
-        _ => Some((1200, 1200)), // Default to screen size for unknown values
-    };
-
-    // Use the existing stretch_to_png function to write directly to cache
-    use crate::commands::stretch_to_png::stretch_to_png_with_resize;
-
-    // Create a temporary path for the cache file
-    let cache_path_str = cache_path.to_string_lossy().to_string();
-
-    // Generate the stretched PNG with optional resizing
-    tracing::trace!(
-        "🎨 Generating PNG for image {} with size {:?}",
-        image_id,
-        max_dimensions
-    );
-
-    // Generate the PNG - wrap in spawn_blocking to prevent blocking the async runtime
-    tracing::trace!(
-        "🎨 Starting PNG generation for image {} to cache path: {}",
-        image_id,
-        cache_path_str
-    );
-
-    let fits_path_str = fits_path.to_string_lossy().to_string();
-    let cache_path_str_clone = cache_path_str.clone();
-    let generation_result = tokio::task::spawn_blocking(move || {
-        stretch_to_png_with_resize(
-            &fits_path_str,
-            Some(cache_path_str_clone),
-            midtone,
-            shadow,
-            false, // logarithmic
-            false, // invert
-            max_dimensions,
-        )
-    })
-    .await
-    .map_err(|e| {
-        tracing::error!(
-            "❌ PNG generation task panicked for image {}: {}",
-            image_id,
-            e
-        );
-        AppError::InternalError("PNG generation task failed".to_string())
-    })?;
-
-    match generation_result {
-        Ok(_) => {
-            tracing::trace!("✅ PNG generation completed for image {}", image_id);
-        }
-        Err(e) => {
-            tracing::error!(
-                "❌ Failed to generate PNG preview for image {} from {:?}: {}",
-                image_id,
-                fits_path,
-                e
-            );
-            return Err(AppError::InternalError(format!(
-                "Failed to generate preview: {}",
-                e
-            )));
-        }
-    }
-
-    // Read the file back into memory
-    let png_buffer = match tokio::fs::read(&cache_path).await {
-        Ok(buffer) => {
-            tracing::trace!(
-                "📖 Read generated PNG for image {} ({} bytes)",
-                image_id,
-                buffer.len()
-            );
-            buffer
-        }
-        Err(e) => {
-            tracing::error!(
-                "❌ Failed to read generated PNG for image {} from cache path {}: {}",
-                image_id,
-                cache_path_str,
-                e
-            );
-            // Try to clean up the potentially corrupted cache file
-            let _ = tokio::fs::remove_file(&cache_path).await;
-            return Err(AppError::InternalError(
-                "Failed to read generated PNG".to_string(),
-            ));
-        }
-    };
-
-    tracing::debug!(
-        "✅ Generated and cached preview for image {} in {:?} ({} bytes)",
-        image_id,
-        start_time.elapsed(),
-        png_buffer.len()
-    );
-
+/// Serve a cached PNG from disk.
+async fn serve_cached_png(cache_path: &std::path::Path) -> Result<Response, AppError> {
+    let buffer = tokio::fs::read(cache_path)
+        .await
+        .map_err(|_| AppError::InternalError("Failed to read cache".to_string()))?;
     Ok((
         StatusCode::OK,
         [
             (CONTENT_TYPE, "image/png"),
-            (CACHE_CONTROL, "max-age=86400"), // Cache for 1 day
+            (CACHE_CONTROL, "max-age=86400"),
         ],
-        png_buffer,
-    ))
+        buffer,
+    )
+        .into_response())
+}
+
+/// The immediate "not ready — poll for it" response on a cache miss. `<img>`
+/// treats the non-image body as an error and the frontend then batch-polls the
+/// generation-status endpoint.
+fn generating_response() -> Response {
+    (
+        StatusCode::ACCEPTED,
+        [(CACHE_CONTROL, "no-store")],
+        Json(ApiResponse::success(
+            crate::server::preview_queue::GenerationStatus {
+                state: crate::server::preview_queue::GenerationState::Generating,
+                error: None,
+            },
+        )),
+    )
+        .into_response()
+}
+
+// Image preview endpoint. Cache hit → 200 PNG; miss → enqueue on the bounded
+// interactive queue and return 202 (never generates inside the request).
+#[axum::debug_handler(state = Arc<AppState>)]
+pub async fn get_image_preview(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path((_db_id, image_id)): Path<(String, i32)>,
+    Query(options): Query<PreviewOptions>,
+) -> Result<Response, AppError> {
+    let size = options.size.as_deref().unwrap_or("screen");
+    let stretch = options.stretch.unwrap_or(true);
+    let midtone = options.midtone.unwrap_or(0.2);
+    let shadow = options.shadow.unwrap_or(-2.8);
+
+    let (image, file_only, target_name) = resolve_image_meta(&ctx, image_id)?;
+    let cache_key = preview_cache_key(&image, &file_only, size, stretch, midtone, shadow);
+    let cache_path = artifact_cache_path(&ctx, "previews", &cache_key)?;
+
+    if cache_path.exists() {
+        return serve_cached_png(&cache_path).await;
+    }
+
+    // Miss: resolve the source (404 if truly missing), hand generation to the
+    // bounded interactive queue, and tell the client to poll.
+    let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
+    state.enqueue_preview(crate::server::preview_queue::GenJob {
+        fits_path,
+        cache_path,
+        kind: crate::server::preview_queue::GenKind::Preview {
+            midtone,
+            shadow,
+            max_dimensions: crate::server::preview_queue::max_dimensions_for_size(size),
+        },
+    });
+    Ok(generating_response())
 }
 
 // Helper function to find FITS file
@@ -1429,217 +1306,165 @@ pub async fn get_image_stars(
     Ok(Json(ApiResponse::success(response)))
 }
 
+// Annotated (star-marked) image endpoint. Same async model as the preview:
+// cache hit → 200 PNG; miss → enqueue on the interactive queue and 202.
 #[axum::debug_handler(state = Arc<AppState>)]
 pub async fn get_annotated_image(
+    State(state): State<Arc<AppState>>,
     ctx: DbContext,
     Path((_db_id, image_id)): Path<(String, i32)>,
     Query(options): Query<PreviewOptions>,
-) -> Result<impl IntoResponse, AppError> {
-    use crate::commands::annotate_stars_common::create_annotated_image;
-    use crate::image_analysis::FitsImage;
-    use crate::server::cache::CacheManager;
-    use image::codecs::png::{CompressionType, FilterType, PngEncoder};
-    use image::{ColorType, ImageEncoder, Rgb};
-
-    // Get image metadata from database
-    let (image, file_only, target_name) = {
-        let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
-        let db = Database::new(&conn);
-
-        let images = db
-            .get_images_by_ids(&[image_id])
-            .map_err(|_| AppError::DatabaseError)?;
-
-        let image = images.into_iter().next().ok_or(AppError::NotFound)?;
-
-        // Get target name
-        let targets = db
-            .get_targets_by_ids(&[image.target_id])
-            .map_err(|_| AppError::DatabaseError)?;
-
-        let target = targets.into_iter().next().ok_or(AppError::NotFound)?;
-        let target_name = target.name.clone();
-
-        let metadata: serde_json::Value = serde_json::from_str(&image.metadata)
-            .map_err(|_| AppError::BadRequest("Invalid metadata".to_string()))?;
-
-        let filename = metadata["FileName"]
-            .as_str()
-            .ok_or_else(|| AppError::BadRequest("No filename in metadata".to_string()))?;
-
-        let file_only = filename
-            .split(&['\\', '/'][..])
-            .next_back()
-            .ok_or_else(|| AppError::BadRequest("Invalid filename format".to_string()))?
-            .to_string();
-
-        (image, file_only, target_name)
-    };
-
-    // Determine size parameter
+) -> Result<Response, AppError> {
     let size = options.size.as_deref().unwrap_or("screen");
+    let max_stars = options.max_stars.unwrap_or(1000) as usize;
 
-    // Create comprehensive cache key for annotated image
-    let max_stars = options.max_stars.unwrap_or(1000);
-    let cache_key = format!(
-        "annotated_{}_{}_{}_{}_{}_{}_{}",
-        image_id,
-        image.project_id,
-        image.target_id,
-        image.acquired_date.unwrap_or(0),
-        file_only.replace(&['.', ' ', '-'][..], "_"),
-        size,
-        max_stars
-    );
-    let cache_manager = CacheManager::new(PathBuf::from(&ctx.cache_dir));
-    cache_manager
-        .ensure_category_dir("annotated")
-        .map_err(|e| AppError::InternalError(format!("Failed to create cache directory: {}", e)))?;
-    let cache_path = cache_manager.get_cached_path("annotated", &cache_key, "png");
+    let (image, file_only, target_name) = resolve_image_meta(&ctx, image_id)?;
+    let cache_key = annotated_cache_key(&image, &file_only, size, max_stars);
+    let cache_path = artifact_cache_path(&ctx, "annotated", &cache_key)?;
 
-    // Check if cached version exists
-    if cache_manager.is_cached(&cache_path) {
-        // Serve from cache
-        let mut file = File::open(&cache_path)
-            .await
-            .map_err(|_| AppError::InternalError("Failed to read cache".to_string()))?;
-
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer)
-            .await
-            .map_err(|_| AppError::InternalError("Failed to read file".to_string()))?;
-
-        return Ok((
-            StatusCode::OK,
-            [
-                (CONTENT_TYPE, "image/png"),
-                (CACHE_CONTROL, "max-age=86400"), // TODO: Use configurable cache expiry
-            ],
-            buffer,
-        ));
+    if cache_path.exists() {
+        return serve_cached_png(&cache_path).await;
     }
 
-    // Find FITS file path first (this is fast)
     let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
+    state.enqueue_preview(crate::server::preview_queue::GenJob {
+        fits_path,
+        cache_path,
+        kind: crate::server::preview_queue::GenKind::Annotated {
+            max_stars,
+            size: size.to_string(),
+        },
+    });
+    Ok(generating_response())
+}
 
-    // Move expensive operations to spawn_blocking
-    let fits_path_str = fits_path.to_string_lossy().to_string();
-    let size_str = size.to_string();
-    let final_image = tokio::task::spawn_blocking(move || {
-        // Load FITS file
-        let fits = FitsImage::from_file(std::path::Path::new(&fits_path_str))
-            .map_err(|e| anyhow::anyhow!("Failed to load FITS: {}", e))?;
+/// One artifact whose readiness the frontend wants to know, sent in a batch so
+/// a grid of generating images produces a single poll instead of one per image.
+#[derive(Debug, Deserialize)]
+pub struct GenStatusItem {
+    pub image_id: i32,
+    /// "preview" (default) or "annotated".
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub size: Option<String>,
+    #[serde(default)]
+    pub stretch: Option<bool>,
+    #[serde(default)]
+    pub midtone: Option<f64>,
+    #[serde(default)]
+    pub shadow: Option<f64>,
+    #[serde(default)]
+    pub max_stars: Option<u32>,
+}
 
-        // Create annotated image using the common function
-        let max_stars = options.max_stars.unwrap_or(1000) as usize;
-        let rgb_image = create_annotated_image(
-            &fits,
-            max_stars,          // max_stars from parameter
-            0.2,                // midtone_factor
-            -2.8,               // shadow_clipping
-            Rgb([255, 255, 0]), // yellow color
-        )
-        .map_err(|e| anyhow::anyhow!("Failed to create annotated image: {}", e))?;
+#[derive(Debug, Deserialize)]
+pub struct GenerationStatusRequest {
+    pub requests: Vec<GenStatusItem>,
+}
 
-        // Resize if needed based on size parameter
-        let final_image = match size_str.as_str() {
-            "large" => {
-                // Check if we need to resize for "large"
-                if fits.width > 2000 || fits.height > 2000 {
-                    let aspect_ratio = fits.width as f32 / fits.height as f32;
-                    let (new_width, new_height) = if fits.width > fits.height {
-                        (2000, (2000.0 / aspect_ratio) as u32)
-                    } else {
-                        ((2000.0 * aspect_ratio) as u32, 2000)
-                    };
-                    image::imageops::resize(
-                        &rgb_image,
-                        new_width,
-                        new_height,
-                        image::imageops::FilterType::Lanczos3,
-                    )
-                } else {
-                    rgb_image
-                }
+#[derive(Debug, Serialize)]
+pub struct GenerationStatusBatch {
+    /// Parallel to the request's `requests`.
+    pub statuses: Vec<crate::server::preview_queue::GenerationStatus>,
+}
+
+/// POST /api/db/{db_id}/images/generation-status
+///
+/// Batch readiness poll for on-demand previews / annotated images. For each
+/// item: cached → `ready`; generating → `generating`; failed → `error`;
+/// unknown → enqueue (idempotent) and report `generating`. Coalesces a whole
+/// grid's polling into one request instead of one-per-image.
+pub async fn post_generation_status(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Json(req): Json<GenerationStatusRequest>,
+) -> Result<Json<ApiResponse<GenerationStatusBatch>>, AppError> {
+    let statuses = req
+        .requests
+        .iter()
+        .map(|item| resolve_and_status(&state, &ctx, item))
+        .collect();
+    Ok(Json(ApiResponse::success(GenerationStatusBatch {
+        statuses,
+    })))
+}
+
+/// Resolve one status item to a `GenerationStatus`, enqueuing generation when
+/// the artifact is neither cached nor already known to the queue.
+fn resolve_and_status(
+    state: &Arc<AppState>,
+    ctx: &DatabaseContext,
+    item: &GenStatusItem,
+) -> crate::server::preview_queue::GenerationStatus {
+    use crate::server::preview_queue::{GenJob, GenKind, GenerationState, GenerationStatus};
+
+    let err = |msg: &str| GenerationStatus {
+        state: GenerationState::Error,
+        error: Some(msg.to_string()),
+    };
+
+    let size = item.size.clone().unwrap_or_else(|| "screen".to_string());
+    let (image, file_only, target_name) = match resolve_image_meta(ctx, item.image_id) {
+        Ok(m) => m,
+        Err(_) => return err("image not found"),
+    };
+
+    let (cache_path, kind) = match item.kind.as_deref() {
+        Some("annotated") => {
+            let max_stars = item.max_stars.unwrap_or(1000) as usize;
+            let key = annotated_cache_key(&image, &file_only, &size, max_stars);
+            match artifact_cache_path(ctx, "annotated", &key) {
+                Ok(p) => (
+                    p,
+                    GenKind::Annotated {
+                        max_stars,
+                        size: size.clone(),
+                    },
+                ),
+                Err(_) => return err("cache error"),
             }
-            "screen" => {
-                // Resize for screen viewing
-                if fits.width > 1200 || fits.height > 1200 {
-                    let aspect_ratio = fits.width as f32 / fits.height as f32;
-                    let (new_width, new_height) = if fits.width > fits.height {
-                        (1200, (1200.0 / aspect_ratio) as u32)
-                    } else {
-                        ((1200.0 * aspect_ratio) as u32, 1200)
-                    };
-                    image::imageops::resize(
-                        &rgb_image,
-                        new_width,
-                        new_height,
-                        image::imageops::FilterType::Lanczos3,
-                    )
-                } else {
-                    rgb_image
-                }
+        }
+        _ => {
+            let stretch = item.stretch.unwrap_or(true);
+            let midtone = item.midtone.unwrap_or(0.2);
+            let shadow = item.shadow.unwrap_or(-2.8);
+            let key = preview_cache_key(&image, &file_only, &size, stretch, midtone, shadow);
+            match artifact_cache_path(ctx, "previews", &key) {
+                Ok(p) => (
+                    p,
+                    GenKind::Preview {
+                        midtone,
+                        shadow,
+                        max_dimensions: crate::server::preview_queue::max_dimensions_for_size(
+                            &size,
+                        ),
+                    },
+                ),
+                Err(_) => return err("cache error"),
             }
-            "original" => rgb_image, // No resize for original
-            _ => {
-                // Default to screen size for unknown values
-                if fits.width > 1200 || fits.height > 1200 {
-                    let aspect_ratio = fits.width as f32 / fits.height as f32;
-                    let (new_width, new_height) = if fits.width > fits.height {
-                        (1200, (1200.0 / aspect_ratio) as u32)
-                    } else {
-                        ((1200.0 * aspect_ratio) as u32, 1200)
-                    };
-                    image::imageops::resize(
-                        &rgb_image,
-                        new_width,
-                        new_height,
-                        image::imageops::FilterType::Lanczos3,
-                    )
-                } else {
-                    rgb_image
-                }
+        }
+    };
+
+    if let Some(status) = state.preview_queue.status(&cache_path) {
+        return status;
+    }
+
+    // Neither cached, in-flight, nor errored: ensure it's enqueued to generate.
+    match find_fits_file(ctx, &image, &target_name, &file_only) {
+        Ok(fits_path) => {
+            state.enqueue_preview(GenJob {
+                fits_path,
+                cache_path,
+                kind,
+            });
+            GenerationStatus {
+                state: GenerationState::Generating,
+                error: None,
             }
-        };
-
-        Ok::<image::RgbImage, anyhow::Error>(final_image)
-    })
-    .await
-    .map_err(|e| {
-        AppError::InternalError(format!("Annotated image generation task panicked: {}", e))
-    })?
-    .map_err(|e| AppError::InternalError(format!("Failed to generate annotated image: {}", e)))?;
-
-    // Save to cache
-    let cache_file = std::fs::File::create(&cache_path)
-        .map_err(|_| AppError::InternalError("Failed to create cache file".to_string()))?;
-    let writer = std::io::BufWriter::new(cache_file);
-
-    // Create PNG encoder with best compression
-    let encoder = PngEncoder::new_with_quality(writer, CompressionType::Best, FilterType::Adaptive);
-
-    let (img_width, img_height) = final_image.dimensions();
-
-    // Write the image data
-    encoder
-        .write_image(&final_image, img_width, img_height, ColorType::Rgb8.into())
-        .map_err(|_| AppError::InternalError("Failed to write PNG".to_string()))?;
-
-    // Read the file back into memory
-    let png_buffer = tokio::fs::read(&cache_path)
-        .await
-        .map_err(|_| AppError::InternalError("Failed to read generated PNG".to_string()))?;
-
-    Ok((
-        StatusCode::OK,
-        [
-            (CONTENT_TYPE, "image/png"),
-            (CACHE_CONTROL, "max-age=86400"), // Cache for 1 day
-        ],
-        png_buffer,
-    ))
+        }
+        Err(_) => err("source file not found"),
+    }
 }
 
 // PSF multi image parameters

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1380,22 +1380,54 @@ pub async fn post_generation_status(
     ctx: DbContext,
     Json(req): Json<GenerationStatusRequest>,
 ) -> Result<Json<ApiResponse<GenerationStatusBatch>>, AppError> {
+    // Batch the DB work: one images lookup + one targets lookup for the whole
+    // request, instead of two locked point queries per item. A DB error fails
+    // the whole batch with a 5xx — which the frontend simply retries on the
+    // next poll tick — so a transient lock never collapses into a permanent
+    // per-tile "error"; only an id genuinely absent from the results is
+    // terminal.
+    let ids: Vec<i32> = req.requests.iter().map(|r| r.image_id).collect();
+    let (images_by_id, target_names): (
+        HashMap<i32, crate::models::AcquiredImage>,
+        HashMap<i32, String>,
+    ) = {
+        let conn = ctx.db();
+        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let db = Database::new(&conn);
+        let images = db
+            .get_images_by_ids(&ids)
+            .map_err(|_| AppError::DatabaseError)?;
+        let target_ids: Vec<i32> = images.iter().map(|i| i.target_id).collect();
+        let targets = db
+            .get_targets_by_ids(&target_ids)
+            .map_err(|_| AppError::DatabaseError)?;
+        (
+            images.into_iter().map(|i| (i.id, i)).collect(),
+            targets.into_iter().map(|t| (t.id, t.name)).collect(),
+        )
+    };
+
     let statuses = req
         .requests
         .iter()
-        .map(|item| resolve_and_status(&state, &ctx, item))
+        .map(|item| status_for_item(&state, &ctx, item, &images_by_id, &target_names))
         .collect();
     Ok(Json(ApiResponse::success(GenerationStatusBatch {
         statuses,
     })))
 }
 
-/// Resolve one status item to a `GenerationStatus`, enqueuing generation when
-/// the artifact is neither cached nor already known to the queue.
-fn resolve_and_status(
+/// Resolve one status item to a `GenerationStatus` from pre-fetched image /
+/// target maps, enqueuing generation when the artifact is neither cached nor
+/// already known to the queue. An id absent from `images_by_id` is a genuinely
+/// unknown image (permanent `error`); transient DB failures are handled one
+/// level up (the batch 5xx → frontend retry).
+fn status_for_item(
     state: &Arc<AppState>,
     ctx: &DatabaseContext,
     item: &GenStatusItem,
+    images_by_id: &HashMap<i32, crate::models::AcquiredImage>,
+    target_names: &HashMap<i32, String>,
 ) -> crate::server::preview_queue::GenerationStatus {
     use crate::server::preview_queue::{GenJob, GenKind, GenerationState, GenerationStatus};
 
@@ -1404,16 +1436,21 @@ fn resolve_and_status(
         error: Some(msg.to_string()),
     };
 
-    let size = item.size.clone().unwrap_or_else(|| "screen".to_string());
-    let (image, file_only, target_name) = match resolve_image_meta(ctx, item.image_id) {
-        Ok(m) => m,
-        Err(_) => return err("image not found"),
+    let Some(image) = images_by_id.get(&item.image_id) else {
+        return err("image not found");
+    };
+    let Some(target_name) = target_names.get(&image.target_id) else {
+        return err("target not found");
+    };
+    let Some(file_only) = filename_from_metadata(&image.metadata) else {
+        return err("no filename in metadata");
     };
 
+    let size = item.size.clone().unwrap_or_else(|| "screen".to_string());
     let (cache_path, kind) = match item.kind.as_deref() {
         Some("annotated") => {
             let max_stars = item.max_stars.unwrap_or(1000) as usize;
-            let key = annotated_cache_key(&image, &file_only, &size, max_stars);
+            let key = annotated_cache_key(image, &file_only, &size, max_stars);
             match artifact_cache_path(ctx, "annotated", &key) {
                 Ok(p) => (
                     p,
@@ -1429,7 +1466,7 @@ fn resolve_and_status(
             let stretch = item.stretch.unwrap_or(true);
             let midtone = item.midtone.unwrap_or(0.2);
             let shadow = item.shadow.unwrap_or(-2.8);
-            let key = preview_cache_key(&image, &file_only, &size, stretch, midtone, shadow);
+            let key = preview_cache_key(image, &file_only, &size, stretch, midtone, shadow);
             match artifact_cache_path(ctx, "previews", &key) {
                 Ok(p) => (
                     p,
@@ -1451,7 +1488,7 @@ fn resolve_and_status(
     }
 
     // Neither cached, in-flight, nor errored: ensure it's enqueued to generate.
-    match find_fits_file(ctx, &image, &target_name, &file_only) {
+    match find_fits_file(ctx, image, target_name, &file_only) {
         Ok(fits_path) => {
             state.enqueue_preview(GenJob {
                 fits_path,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -640,33 +640,18 @@ async fn pregenerate_preview(
         _ => Some((1200, 1200)),
     };
 
-    // Generate preview atomically (temp file then rename) so a concurrent
-    // viewer's readiness poll never observes a half-written PNG.
-    let fits_path_str = fits_path.to_string_lossy().to_string();
-    let cache_path_final = cache_path;
-    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-        use crate::commands::stretch_to_png::stretch_to_png_with_resize;
-        let tmp = crate::server::preview_queue::temp_path(&cache_path_final);
-        match stretch_to_png_with_resize(
-            &fits_path_str,
-            Some(tmp.to_string_lossy().into_owned()),
-            0.2,   // midtone
-            -2.8,  // shadow
-            false, // logarithmic
-            false, // invert
+    // Generate atomically via the shared queue helper (temp file then rename),
+    // so a concurrent viewer's readiness poll never observes a half-written PNG.
+    let job = crate::server::preview_queue::GenJob {
+        fits_path,
+        cache_path,
+        kind: crate::server::preview_queue::GenKind::Preview {
+            midtone: 0.2,
+            shadow: -2.8,
             max_dimensions,
-        ) {
-            Ok(()) => {
-                std::fs::rename(&tmp, &cache_path_final)?;
-                Ok(())
-            }
-            Err(e) => {
-                let _ = std::fs::remove_file(&tmp);
-                Err(e)
-            }
-        }
-    })
-    .await??;
+        },
+    };
+    tokio::task::spawn_blocking(move || crate::server::preview_queue::generate(&job)).await??;
 
     tracing::trace!("✅ Generated {} preview for image {}", size, image_id);
     Ok(true) // Successfully generated
@@ -739,18 +724,18 @@ async fn pregenerate_annotated(
     let fits_path = handlers::find_fits_file(ctx, &image_data, target_name, file_only)
         .map_err(|_| anyhow::anyhow!("FITS file not found for image {}", image_id))?;
 
-    // Generate atomically via the shared helper — consistent sizing with the
-    // on-demand path, and temp-then-rename so a viewer never sees a partial file.
-    let cache_path_final = cache_path;
-    tokio::task::spawn_blocking(move || {
-        crate::server::preview_queue::generate_annotated(
-            &fits_path,
-            &cache_path_final,
-            size,
-            max_stars as usize,
-        )
-    })
-    .await??;
+    // Generate atomically via the shared queue helper — consistent sizing with
+    // the on-demand path, and temp-then-rename so a viewer never sees a partial
+    // file (the old direct File::create write was NOT atomic).
+    let job = crate::server::preview_queue::GenJob {
+        fits_path,
+        cache_path,
+        kind: crate::server::preview_queue::GenKind::Annotated {
+            max_stars: max_stars as usize,
+            size: size.to_string(),
+        },
+    };
+    tokio::task::spawn_blocking(move || crate::server::preview_queue::generate(&job)).await??;
 
     tracing::trace!("✅ Generated annotated image for image {}", image_id);
     Ok(true) // Successfully generated

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,6 +4,7 @@ pub mod database_context;
 pub mod embedded_static;
 pub mod extract;
 pub mod handlers;
+pub mod preview_queue;
 pub mod slug;
 pub mod spatial_scan;
 pub mod state;
@@ -218,6 +219,10 @@ async fn run_server_internal(
         )
         .route("/images", get(handlers::get_images))
         .route("/images/{image_id}", get(handlers::get_image))
+        .route(
+            "/images/generation-status",
+            post(handlers::post_generation_status),
+        )
         .route(
             "/images/{image_id}/preview",
             get(handlers::get_image_preview),
@@ -635,22 +640,31 @@ async fn pregenerate_preview(
         _ => Some((1200, 1200)),
     };
 
-    // Generate preview using existing stretch function
+    // Generate preview atomically (temp file then rename) so a concurrent
+    // viewer's readiness poll never observes a half-written PNG.
     let fits_path_str = fits_path.to_string_lossy().to_string();
-    let cache_path_str = cache_path.to_string_lossy().to_string();
-
-    tokio::task::spawn_blocking(move || {
+    let cache_path_final = cache_path;
+    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
         use crate::commands::stretch_to_png::stretch_to_png_with_resize;
-
-        stretch_to_png_with_resize(
+        let tmp = crate::server::preview_queue::temp_path(&cache_path_final);
+        match stretch_to_png_with_resize(
             &fits_path_str,
-            Some(cache_path_str),
+            Some(tmp.to_string_lossy().into_owned()),
             0.2,   // midtone
             -2.8,  // shadow
             false, // logarithmic
             false, // invert
             max_dimensions,
-        )
+        ) {
+            Ok(()) => {
+                std::fs::rename(&tmp, &cache_path_final)?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = std::fs::remove_file(&tmp);
+                Err(e)
+            }
+        }
     })
     .await??;
 
@@ -665,11 +679,7 @@ async fn pregenerate_annotated(
     file_only: &str,
     target_name: &str,
 ) -> Result<bool> {
-    use crate::commands::annotate_stars_common::create_annotated_image;
-    use crate::image_analysis::FitsImage;
     use crate::server::cache::CacheManager;
-    use image::codecs::png::{CompressionType, FilterType, PngEncoder};
-    use image::{ColorType, ImageEncoder, Rgb};
 
     // Get image data from database first (needed for cache key)
     let image_data = {
@@ -729,37 +739,16 @@ async fn pregenerate_annotated(
     let fits_path = handlers::find_fits_file(ctx, &image_data, target_name, file_only)
         .map_err(|_| anyhow::anyhow!("FITS file not found for image {}", image_id))?;
 
-    // Generate annotated image
-    let fits_path_str = fits_path.to_string_lossy().to_string();
-    let cache_path_clone = cache_path.clone();
-
-    tokio::task::spawn_blocking(move || -> Result<()> {
-        // Load FITS file
-        let fits = FitsImage::from_file(std::path::Path::new(&fits_path_str))?;
-
-        // Create annotated image
-        let rgb_image = create_annotated_image(
-            &fits,
-            max_stars,          // Use the same max_stars as cache key
-            0.2,                // midtone_factor
-            -2.8,               // shadow_clipping
-            Rgb([255, 255, 0]), // yellow color
-        )?;
-
-        // Save to cache
-        let cache_file = std::fs::File::create(&cache_path_clone)?;
-        let writer = std::io::BufWriter::new(cache_file);
-        let encoder =
-            PngEncoder::new_with_quality(writer, CompressionType::Best, FilterType::Adaptive);
-
-        encoder.write_image(
-            &rgb_image,
-            rgb_image.width(),
-            rgb_image.height(),
-            ColorType::Rgb8.into(),
-        )?;
-
-        Ok::<(), anyhow::Error>(())
+    // Generate atomically via the shared helper — consistent sizing with the
+    // on-demand path, and temp-then-rename so a viewer never sees a partial file.
+    let cache_path_final = cache_path;
+    tokio::task::spawn_blocking(move || {
+        crate::server::preview_queue::generate_annotated(
+            &fits_path,
+            &cache_path_final,
+            size,
+            max_stars as usize,
+        )
     })
     .await??;
 

--- a/src/server/preview_queue.rs
+++ b/src/server/preview_queue.rs
@@ -1,0 +1,362 @@
+//! Bounded interactive queue for on-demand preview / annotated PNG generation.
+//!
+//! Previously the preview and annotated handlers generated a missing PNG
+//! *inside the request* (a multi-second `spawn_blocking`), so the browser's
+//! `<img>` GET stayed pending the whole time and nothing bounded how many ran
+//! at once. This queue moves that work off the request: on a cache miss the
+//! handler enqueues a job and returns immediately (HTTP 202), and this pool
+//! generates the PNG with bounded, interactive-priority concurrency.
+//!
+//! It reuses PR #149's machinery: the pool is sized by
+//! [`crate::concurrency::plan_workers`] at [`Priority::Interactive`] (memory-
+//! bounded via a frame probe), and every job holds an
+//! [`AppState::begin_interactive_job`] guard for its lifetime, so background
+//! pre-generation yields cores + memory to user-driven preview work.
+//!
+//! Because readiness is now observed by a *different* request (via
+//! `Path::exists`), generation writes to a temp file and atomically renames,
+//! so a poll never sees a half-written PNG.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use tokio::sync::Semaphore;
+
+use crate::concurrency::{self, Priority, WorkerPolicy};
+use crate::server::state::AppState;
+
+/// What to generate for a job. Mirrors the two artifact handlers.
+#[derive(Debug, Clone)]
+pub enum GenKind {
+    Preview {
+        midtone: f64,
+        shadow: f64,
+        max_dimensions: Option<(u32, u32)>,
+    },
+    Annotated {
+        max_stars: usize,
+        size: String,
+    },
+}
+
+/// A resolved generation request: where the source is, where the artifact goes.
+#[derive(Debug, Clone)]
+pub struct GenJob {
+    pub fits_path: PathBuf,
+    pub cache_path: PathBuf,
+    pub kind: GenKind,
+}
+
+/// Readiness of a cache artifact, as reported to the polling frontend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GenerationState {
+    Ready,
+    Generating,
+    Error,
+}
+
+/// Status payload for one artifact (batch-status response element).
+#[derive(Debug, Clone, Serialize)]
+pub struct GenerationStatus {
+    pub state: GenerationState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl GenerationStatus {
+    fn ready() -> Self {
+        Self {
+            state: GenerationState::Ready,
+            error: None,
+        }
+    }
+    fn generating() -> Self {
+        Self {
+            state: GenerationState::Generating,
+            error: None,
+        }
+    }
+    fn error(msg: String) -> Self {
+        Self {
+            state: GenerationState::Error,
+            error: Some(msg),
+        }
+    }
+}
+
+/// Recent-error map cap, so a run of unresolvable frames can't grow it forever.
+const MAX_RECENT_ERRORS: usize = 512;
+
+#[derive(Default)]
+struct QueueInner {
+    /// `cache_path`s currently being generated (dedup).
+    in_flight: HashSet<PathBuf>,
+    /// `cache_path` -> last generation error message.
+    recent_errors: HashMap<PathBuf, String>,
+}
+
+/// Process-global interactive preview/annotated generation queue. Held on
+/// [`AppState`]; the actual dispatch lives in [`AppState::enqueue_preview`] so
+/// it can take an interactive-job guard from the same `AppState`.
+#[derive(Default)]
+pub struct PreviewQueue {
+    inner: Mutex<QueueInner>,
+    /// Sized lazily on first job (needs a real frame to probe for the memory
+    /// ceiling); reused thereafter.
+    semaphore: Mutex<Option<Arc<Semaphore>>>,
+}
+
+impl PreviewQueue {
+    /// Report the state of one artifact by its `cache_path`. Pure read — does
+    /// not enqueue (the caller enqueues when appropriate).
+    pub fn status(&self, cache_path: &Path) -> Option<GenerationStatus> {
+        // A completed artifact is always the truth, even if a stale error entry
+        // lingers.
+        if cache_path.exists() {
+            return Some(GenerationStatus::ready());
+        }
+        let inner = self.inner.lock().unwrap();
+        if inner.in_flight.contains(cache_path) {
+            return Some(GenerationStatus::generating());
+        }
+        inner
+            .recent_errors
+            .get(cache_path)
+            .map(|e| GenerationStatus::error(e.clone()))
+    }
+
+    /// Lazily create (and reuse) the concurrency-bounding semaphore, sized from
+    /// a representative frame so a big sensor on a high-core box can't OOM.
+    fn semaphore(&self, policy: &WorkerPolicy, sample_fits: &Path) -> Arc<Semaphore> {
+        let mut slot = self.semaphore.lock().unwrap();
+        if let Some(s) = &*slot {
+            return Arc::clone(s);
+        }
+        let frame_pixels = concurrency::probe_frame_pixels(sample_fits);
+        let budget = concurrency::plan_workers(None, policy, Priority::Interactive, frame_pixels);
+        tracing::info!(
+            "🖼️ Preview generation pool: {} worker(s) — {}",
+            budget.workers,
+            budget.rationale
+        );
+        let s = Arc::new(Semaphore::new(budget.workers.max(1)));
+        *slot = Some(Arc::clone(&s));
+        s
+    }
+}
+
+impl AppState {
+    /// Enqueue a preview/annotated generation job on the bounded interactive
+    /// pool. Idempotent: a `cache_path` already present or already in-flight is
+    /// a no-op, so the same artifact is never generated twice concurrently and
+    /// re-requests are cheap.
+    pub fn enqueue_preview(self: &Arc<Self>, job: GenJob) {
+        // Dedup + claim the slot under the lock. `insert` returns false when
+        // the path was already in-flight.
+        {
+            let mut inner = self.preview_queue.inner.lock().unwrap();
+            if job.cache_path.exists() || !inner.in_flight.insert(job.cache_path.clone()) {
+                return;
+            }
+        }
+
+        let sem = self
+            .preview_queue
+            .semaphore(&self.worker_policy(), &job.fits_path);
+        let state = Arc::clone(self);
+        tokio::spawn(async move {
+            // Mark interactive-active for the whole job so background pregen
+            // yields; drops even if the task is cancelled/panics.
+            let _guard = state.begin_interactive_job();
+            // Bound concurrency to the interactive budget. A closed semaphore
+            // (never happens — we never close it) would just skip the permit.
+            let _permit = sem.acquire_owned().await;
+
+            let cache_path = job.cache_path.clone();
+            let outcome = tokio::task::spawn_blocking(move || generate(&job)).await;
+
+            let mut inner = state.preview_queue.inner.lock().unwrap();
+            inner.in_flight.remove(&cache_path);
+            match outcome {
+                Ok(Ok(())) => {
+                    inner.recent_errors.remove(&cache_path);
+                }
+                Ok(Err(e)) => record_error(&mut inner, cache_path, e.to_string()),
+                Err(join) => record_error(&mut inner, cache_path, format!("panicked: {join}")),
+            }
+        });
+    }
+}
+
+fn record_error(inner: &mut QueueInner, cache_path: PathBuf, msg: String) {
+    tracing::warn!(
+        "🖼️ Preview generation failed for {}: {}",
+        cache_path.display(),
+        msg
+    );
+    if inner.recent_errors.len() >= MAX_RECENT_ERRORS {
+        inner.recent_errors.clear();
+    }
+    inner.recent_errors.insert(cache_path, msg);
+}
+
+/// Generate one artifact to a unique temp path, then atomically rename into
+/// place, so a concurrent `Path::exists` poll never observes a partial file.
+fn generate(job: &GenJob) -> anyhow::Result<()> {
+    let tmp = temp_path(&job.cache_path);
+    let result = match &job.kind {
+        GenKind::Preview {
+            midtone,
+            shadow,
+            max_dimensions,
+        } => crate::commands::stretch_to_png::stretch_to_png_with_resize(
+            &job.fits_path.to_string_lossy(),
+            Some(tmp.to_string_lossy().into_owned()),
+            *midtone,
+            *shadow,
+            false, // logarithmic
+            false, // invert
+            *max_dimensions,
+        ),
+        GenKind::Annotated { max_stars, size } => {
+            generate_annotated(&job.fits_path, &tmp, size, *max_stars)
+        }
+    };
+
+    match result {
+        Ok(()) => {
+            std::fs::rename(&tmp, &job.cache_path)?;
+            Ok(())
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(e)
+        }
+    }
+}
+
+/// Unique sibling temp path for atomic-rename generation.
+pub fn temp_path(cache_path: &Path) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let mut s = cache_path.as_os_str().to_os_string();
+    s.push(format!(
+        ".tmp.{}.{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    PathBuf::from(s)
+}
+
+/// Build the annotated (star-marked) PNG for a frame and write it to `out_path`.
+/// Extracted from the former inline handler body so the queue worker and the
+/// pre-generation task share one implementation.
+pub fn generate_annotated(
+    fits_path: &Path,
+    out_path: &Path,
+    size: &str,
+    max_stars: usize,
+) -> anyhow::Result<()> {
+    use crate::commands::annotate_stars_common::create_annotated_image;
+    use crate::image_analysis::FitsImage;
+    use image::codecs::png::{CompressionType, FilterType, PngEncoder};
+    use image::{ColorType, ImageEncoder, Rgb};
+
+    let fits = FitsImage::from_file(fits_path)?;
+    let rgb = create_annotated_image(&fits, max_stars, 0.2, -2.8, Rgb([255, 255, 0]))?;
+    let final_image = resize_rgb_for_size(rgb, fits.width, fits.height, size);
+
+    let file = std::fs::File::create(out_path)?;
+    let writer = std::io::BufWriter::new(file);
+    let encoder = PngEncoder::new_with_quality(writer, CompressionType::Best, FilterType::Adaptive);
+    let (w, h) = final_image.dimensions();
+    encoder.write_image(&final_image, w, h, ColorType::Rgb8.into())?;
+    Ok(())
+}
+
+/// Resize an RGB image to the requested size bucket (matches the preview
+/// dimension buckets): `large` → 2000px, `original` → none, else → 1200px.
+fn resize_rgb_for_size(
+    img: image::RgbImage,
+    width: usize,
+    height: usize,
+    size: &str,
+) -> image::RgbImage {
+    let cap: Option<u32> = match size {
+        "original" => None,
+        "large" => Some(2000),
+        _ => Some(1200),
+    };
+    let Some(cap) = cap else { return img };
+    if width as u32 <= cap && height as u32 <= cap {
+        return img;
+    }
+    let aspect = width as f32 / height as f32;
+    let (nw, nh) = if width > height {
+        (cap, (cap as f32 / aspect) as u32)
+    } else {
+        ((cap as f32 * aspect) as u32, cap)
+    };
+    image::imageops::resize(&img, nw, nh, image::imageops::FilterType::Lanczos3)
+}
+
+/// Pixel dimension bucket for a preview `size` (shared by the preview handler
+/// and the queue): `large` → 2000², `original` → none, else → 1200².
+pub fn max_dimensions_for_size(size: &str) -> Option<(u32, u32)> {
+    match size {
+        "large" => Some((2000, 2000)),
+        "original" => None,
+        _ => Some((1200, 1200)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn temp_path_is_unique_sibling() {
+        let cache = PathBuf::from("/cache/previews/abc.png");
+        let a = temp_path(&cache);
+        let b = temp_path(&cache);
+        assert_ne!(a, b, "temp paths must be unique per call");
+        assert_eq!(a.parent(), cache.parent(), "temp file stays in cache dir");
+        assert!(a.to_string_lossy().contains("abc.png.tmp."));
+    }
+
+    #[test]
+    fn status_none_when_unknown() {
+        let q = PreviewQueue::default();
+        // Not cached, not in-flight, no error -> None (caller decides to enqueue).
+        assert!(q.status(Path::new("/nonexistent/x.png")).is_none());
+    }
+
+    #[test]
+    fn status_reports_in_flight_and_error() {
+        let q = PreviewQueue::default();
+        let p = PathBuf::from("/nonexistent/y.png");
+        q.inner.lock().unwrap().in_flight.insert(p.clone());
+        assert_eq!(q.status(&p).unwrap().state, GenerationState::Generating);
+
+        q.inner.lock().unwrap().in_flight.remove(&p);
+        q.inner
+            .lock()
+            .unwrap()
+            .recent_errors
+            .insert(p.clone(), "boom".into());
+        let s = q.status(&p).unwrap();
+        assert_eq!(s.state, GenerationState::Error);
+        assert_eq!(s.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn max_dimensions_buckets() {
+        assert_eq!(max_dimensions_for_size("large"), Some((2000, 2000)));
+        assert_eq!(max_dimensions_for_size("screen"), Some((1200, 1200)));
+        assert_eq!(max_dimensions_for_size("original"), None);
+        assert_eq!(max_dimensions_for_size("weird"), Some((1200, 1200)));
+    }
+}

--- a/src/server/preview_queue.rs
+++ b/src/server/preview_queue.rs
@@ -206,7 +206,10 @@ fn record_error(inner: &mut QueueInner, cache_path: PathBuf, msg: String) {
 
 /// Generate one artifact to a unique temp path, then atomically rename into
 /// place, so a concurrent `Path::exists` poll never observes a partial file.
-fn generate(job: &GenJob) -> anyhow::Result<()> {
+/// Shared by the on-demand queue and the background pre-generation task, so
+/// both are atomic and a pregen/queue double-generate can't clobber a reader.
+/// Blocking; call from `spawn_blocking`.
+pub fn generate(job: &GenJob) -> anyhow::Result<()> {
     let tmp = temp_path(&job.cache_path);
     let result = match &job.kind {
         GenKind::Preview {
@@ -227,11 +230,10 @@ fn generate(job: &GenJob) -> anyhow::Result<()> {
         }
     };
 
-    match result {
-        Ok(()) => {
-            std::fs::rename(&tmp, &job.cache_path)?;
-            Ok(())
-        }
+    // Clean up the temp file on both a generation failure and a rename
+    // failure, so a failed run never orphans a `.tmp.*` file.
+    match result.and_then(|()| std::fs::rename(&tmp, &job.cache_path).map_err(Into::into)) {
+        Ok(()) => Ok(()),
         Err(e) => {
             let _ = std::fs::remove_file(&tmp);
             Err(e)

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -54,6 +54,10 @@ pub struct AppState {
     /// scan the user is waiting on. An `Arc` so a [`InteractiveJobGuard`] can
     /// decrement it on drop from a `spawn_blocking` task.
     active_interactive_jobs: Arc<AtomicUsize>,
+    /// Bounded, interactive-priority queue for on-demand preview / annotated
+    /// PNG generation (see `preview_queue`). Process-global so total concurrent
+    /// generation is bounded regardless of how many databases are loaded.
+    pub preview_queue: crate::server::preview_queue::PreviewQueue,
 }
 
 /// RAII marker that an interactive CPU-heavy job is running. Increments the
@@ -326,6 +330,7 @@ impl AppState {
             allow_database_management: RwLock::new(false),
             worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
             active_interactive_jobs: Arc::new(AtomicUsize::new(0)),
+            preview_queue: crate::server::preview_queue::PreviewQueue::default(),
         })
     }
 
@@ -427,6 +432,7 @@ impl AppState {
             allow_database_management: RwLock::new(false),
             worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
             active_interactive_jobs: Arc::new(AtomicUsize::new(0)),
+            preview_queue: crate::server::preview_queue::PreviewQueue::default(),
         }
     }
 }

--- a/static/e2e/preview-generation.spec.ts
+++ b/static/e2e/preview-generation.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from '@playwright/test';
+import {
+  registerFixtureDb,
+  resetDatabases,
+  waitForCacheReady,
+} from './helpers';
+
+/**
+ * Regression coverage for async on-demand preview generation.
+ *
+ * On a cache miss the server no longer blocks the request generating the PNG;
+ * it enqueues on a bounded interactive queue and returns HTTP 202. The
+ * frontend loads optimistically, shows a "Generating…" indicator, and
+ * *batch*-polls a single `generation-status` endpoint (one request for a whole
+ * grid, not one poll per image) until the image is ready, then swaps it in.
+ *
+ * Each test registers the fixture DB under a UNIQUE slug, which gives it a
+ * fresh per-DB cache directory — so the preview PNGs are guaranteed uncached
+ * and actually exercise the generate → ready path (rather than a cache hit
+ * left behind by an earlier spec).
+ */
+
+let dbId: string;
+let slugCounter = 0;
+
+test.beforeEach(async ({ request }) => {
+  await resetDatabases(request);
+  slugCounter += 1;
+  const entry = await registerFixtureDb(request, {
+    name: `Preview Gen e2e ${slugCounter}`,
+    slug: `preview-gen-e2e-${slugCounter}`,
+  });
+  dbId = entry.id;
+  await waitForCacheReady(request, dbId);
+});
+
+test('cache miss returns 202, and the batch status endpoint drives generation to ready', async ({
+  request,
+}) => {
+  const base = `/api/db/${encodeURIComponent(dbId)}`;
+
+  // Uncached (fresh slug): the preview GET must NOT block-and-200. It returns
+  // 202 with a JSON "generating" body after enqueuing.
+  const miss = await request.get(`${base}/images/1/preview?size=screen`);
+  expect(
+    miss.status(),
+    `expected 202 on cache miss, body: ${await miss.text().catch(() => '<unread>')}`
+  ).toBe(202);
+  expect(miss.headers()['content-type']).toMatch(/application\/json/);
+  expect((await miss.json()).data.state).toBe('generating');
+
+  // Batch status for two images in ONE request → statuses parallel to input.
+  const statusRes = await request.post(`${base}/images/generation-status`, {
+    data: {
+      requests: [
+        { image_id: 1, kind: 'preview', size: 'screen' },
+        { image_id: 3, kind: 'preview', size: 'screen' },
+      ],
+    },
+  });
+  expect(statusRes.ok()).toBeTruthy();
+  const statuses = (await statusRes.json()).data.statuses as Array<{
+    state: string;
+  }>;
+  expect(statuses).toHaveLength(2);
+  for (const s of statuses) {
+    expect(['generating', 'ready']).toContain(s.state);
+  }
+
+  // Poll the batch endpoint until image 1 finishes generating.
+  await expect
+    .poll(
+      async () => {
+        const r = await request.post(`${base}/images/generation-status`, {
+          data: { requests: [{ image_id: 1, kind: 'preview', size: 'screen' }] },
+        });
+        return (await r.json()).data.statuses[0].state;
+      },
+      { timeout: 30_000, intervals: [500] }
+    )
+    .toBe('ready');
+
+  // Now the same preview URL serves a real PNG (cache hit → 200).
+  const hit = await request.get(`${base}/images/1/preview?size=screen`);
+  expect(hit.status()).toBe(200);
+  expect(hit.headers()['content-type']).toMatch(/^image\//);
+  expect((await hit.body()).byteLength).toBeGreaterThan(0);
+});
+
+test('grid shows a generating indicator, batch-polls status, and resolves to real pixels', async ({
+  page,
+}) => {
+  // Observe the async-generation network behavior.
+  const preview202: string[] = [];
+  const batchPollSizes: number[] = [];
+
+  page.on('response', (res) => {
+    if (res.url().includes('/preview?') && res.status() === 202) {
+      preview202.push(res.url());
+    }
+  });
+  page.on('request', (req) => {
+    if (
+      req.method() === 'POST' &&
+      req.url().includes('/images/generation-status')
+    ) {
+      let size = 0;
+      try {
+        size = (req.postDataJSON()?.requests ?? []).length;
+      } catch {
+        /* ignore non-JSON */
+      }
+      batchPollSizes.push(size);
+    }
+  });
+
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+
+  // While the queue works, the "Generating…" placeholder is shown.
+  await expect(page.locator('.preview-status-box').first()).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Every card's preview eventually decodes to real pixels (would be
+  // naturalWidth 0 if the poll → reload path were broken).
+  const cards = page.locator('.image-card');
+  await expect(cards.first()).toBeVisible();
+  const count = await cards.count();
+  expect(count).toBeGreaterThan(1);
+  for (let i = 0; i < count; i++) {
+    const img = cards.nth(i).locator('img').first();
+    await page.waitForFunction(
+      (el) =>
+        el instanceof HTMLImageElement && el.complete && el.naturalWidth > 0,
+      await img.elementHandle(),
+      { timeout: 40_000 }
+    );
+  }
+
+  // Once every image is ready the indicator is gone.
+  await expect(page.locator('.preview-status-box')).toHaveCount(0, {
+    timeout: 10_000,
+  });
+
+  // Behavior: previews 202'd on miss (non-blocking) and the frontend polled
+  // the single batch endpoint, coalescing multiple images into one request
+  // rather than one status poll per image.
+  expect(preview202.length, 'previews should 202 on a cache miss').toBeGreaterThan(
+    0
+  );
+  expect(
+    batchPollSizes.length,
+    'frontend should poll the batch generation-status endpoint'
+  ).toBeGreaterThan(0);
+  expect(
+    Math.max(0, ...batchPollSizes),
+    'at least one status poll should coalesce multiple images'
+  ).toBeGreaterThan(1);
+});

--- a/static/e2e/preview-generation.spec.ts
+++ b/static/e2e/preview-generation.spec.ts
@@ -87,6 +87,38 @@ test('cache miss returns 202, and the batch status endpoint drives generation to
   expect((await hit.body()).byteLength).toBeGreaterThan(0);
 });
 
+test('annotated images generate on-demand through the same queue', async ({
+  request,
+}) => {
+  const base = `/api/db/${encodeURIComponent(dbId)}`;
+
+  // Annotated cache miss also 202s (same async path as previews).
+  const miss = await request.get(`${base}/images/1/annotated?size=large`);
+  expect(miss.status()).toBe(202);
+  expect(miss.headers()['content-type']).toMatch(/application\/json/);
+
+  // Poll the batch endpoint with kind:'annotated' until ready.
+  await expect
+    .poll(
+      async () => {
+        const r = await request.post(`${base}/images/generation-status`, {
+          data: {
+            requests: [{ image_id: 1, kind: 'annotated', size: 'large' }],
+          },
+        });
+        return (await r.json()).data.statuses[0].state;
+      },
+      { timeout: 30_000, intervals: [500] }
+    )
+    .toBe('ready');
+
+  // The annotated endpoint now serves a PNG.
+  const hit = await request.get(`${base}/images/1/annotated?size=large`);
+  expect(hit.status()).toBe(200);
+  expect(hit.headers()['content-type']).toMatch(/^image\//);
+  expect((await hit.body()).byteLength).toBeGreaterThan(0);
+});
+
 test('grid shows a generating indicator, batch-polls status, and resolves to real pixels', async ({
   page,
 }) => {

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3181,3 +3181,29 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* Async preview-generation placeholder (PreviewImage / poll-on-error). Fills a
+   position:relative container (e.g. .image-preview, .detail-image) while the
+   server generates the PNG on the interactive queue. */
+.preview-status-box {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px;
+  text-align: center;
+  color: var(--color-text-secondary, #888);
+  background: var(--color-bg-primary, #1a1a1a);
+  z-index: 1;
+}
+
+.preview-status-label {
+  font-size: 0.8rem;
+}
+
+.preview-status-error {
+  color: #666;
+}

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -22,6 +22,8 @@ import type {
   ImageQualityResponse,
   SpatialScanRequest,
   SpatialScanStatus,
+  PreviewDescriptor,
+  GenerationStatus,
 } from './types';
 
 // Default API instance (used as fallback)
@@ -205,6 +207,31 @@ export const apiClient = {
     );
     if (!data.data) throw new Error('Star detection failed');
     return data.data;
+  },
+
+  // Batch readiness poll for on-demand previews/annotated images. One request
+  // for a whole grid of pending images instead of one poll per image. Returns
+  // statuses parallel to `requests`.
+  getGenerationStatus: async (
+    dbId: string,
+    requests: PreviewDescriptor[]
+  ): Promise<GenerationStatus[]> => {
+    const apiInstance = await getApi();
+    const body = {
+      requests: requests.map((d) => ({
+        image_id: d.imageId,
+        kind: d.kind,
+        size: d.size,
+        stretch: d.stretch,
+        midtone: d.midtone,
+        shadow: d.shadow,
+        max_stars: d.maxStars,
+      })),
+    };
+    const { data } = await apiInstance.post<
+      ApiResponse<{ statuses: GenerationStatus[] }>
+    >(dbPath(dbId, '/images/generation-status'), body);
+    return data.data?.statuses ?? [];
   },
 
   getPreviewUrl: (dbId: string, imageId: number, options?: PreviewOptions): string => {

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -79,6 +79,27 @@ export interface PreviewOptions {
   max_stars?: number;
 }
 
+// Readiness of an on-demand preview/annotated artifact (the server generates
+// it asynchronously on a bounded interactive queue; the frontend batch-polls).
+export type GenerationState = 'ready' | 'generating' | 'error';
+
+export interface GenerationStatus {
+  state: GenerationState;
+  error?: string;
+}
+
+// Identifies one artifact for the batch generation-status poll. Mirrors the
+// query params of getPreviewUrl / getAnnotatedUrl.
+export interface PreviewDescriptor {
+  imageId: number;
+  kind: 'preview' | 'annotated';
+  size: 'screen' | 'large' | 'original';
+  stretch?: boolean;
+  midtone?: number;
+  shadow?: number;
+  maxStars?: number;
+}
+
 export interface ServerInfo {
   version: string;
   cache_directory: string;

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import type { Image } from '../api/types';
 import { GradingStatus } from '../api/types';
 import { apiClient } from '../api/client';
+import PreviewImage from './PreviewImage';
+import { ensurePreviewReady } from '../hooks/previewPoll';
 
 interface ImageCardProps {
   dbId: string;
@@ -14,8 +16,6 @@ interface ImageCardProps {
 
 export default function ImageCard({ dbId, image, isSelected, onClick, onDoubleClick, qualityScore }: ImageCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
-  const imgRef = useRef<HTMLImageElement>(null);
-  const [imageError, setImageError] = useState(false);
 
   // Scroll into view when selected
   useEffect(() => {
@@ -24,11 +24,15 @@ export default function ImageCard({ dbId, image, isSelected, onClick, onDoubleCl
     }
   }, [isSelected]);
 
-  // Preload full size image when selected (for quick detail view opening)
+  // Preload full size image when selected (for quick detail view opening).
+  // Warms the interactive queue so the 'large' preview is generated if needed.
   useEffect(() => {
     if (isSelected && image.id) {
-      const preloadImg = new Image();
-      preloadImg.src = apiClient.getPreviewUrl(dbId, image.id, { size: 'large' });
+      void ensurePreviewReady(
+        dbId,
+        apiClient.getPreviewUrl(dbId, image.id, { size: 'large' }),
+        { imageId: image.id, kind: 'preview', size: 'large' }
+      );
     }
   }, [isSelected, image.id, dbId]);
 
@@ -79,41 +83,13 @@ export default function ImageCard({ dbId, image, isSelected, onClick, onDoubleCl
       onDoubleClick={onDoubleClick}
     >
       <div className="image-preview">
-        {imageError ? (
-          <div className="image-error-placeholder" style={{ 
-            width: '100%', 
-            paddingBottom: '100%', // Maintain aspect ratio
-            background: '#1a1a1a',
-            position: 'relative',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}>
-            <div style={{
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              textAlign: 'center',
-              color: '#666'
-            }}>
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ marginBottom: '8px' }}>
-                <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-                <line x1="9" y1="9" x2="15" y2="15" />
-                <line x1="15" y1="9" x2="9" y2="15" />
-              </svg>
-              <div style={{ fontSize: '0.8rem' }}>Image not found</div>
-            </div>
-          </div>
-        ) : (
-          <img
-            ref={imgRef}
-            src={apiClient.getPreviewUrl(dbId, image.id, { size: 'screen' })}
-            alt={`${image.target_name} - ${image.filter_name || 'No filter'}`}
-            loading="lazy"
-            onError={() => setImageError(true)}
-          />
-        )}
+        <PreviewImage
+          dbId={dbId}
+          src={apiClient.getPreviewUrl(dbId, image.id, { size: 'screen' })}
+          descriptor={{ imageId: image.id, kind: 'preview', size: 'screen' }}
+          alt={`${image.target_name} - ${image.filter_name || 'No filter'}`}
+          loading="lazy"
+        />
         {qualityScore !== undefined && (
           <div
             className="quality-dot"

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -2,8 +2,10 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { apiClient } from '../api/client';
-import { GradingStatus, type Image } from '../api/types';
+import { GradingStatus, type Image, type PreviewDescriptor } from '../api/types';
 import { useImageZoom } from '../hooks/useImageZoom';
+import { useAsyncImage } from '../hooks/useAsyncImage';
+import { ensurePreviewReady } from '../hooks/previewPoll';
 
 interface ImageComparisonViewProps {
   dbId: string;
@@ -114,7 +116,34 @@ export default function ImageComparisonView({
   // Store the target zoom level when user zooms
   const targetRightZoomRef = useRef<number | null>(null);
   const targetLeftZoomRef = useRef<number | null>(null);
-  
+
+  // Async loading for both comparison images (poll-on-error + "Generating…").
+  // The size each pane requests must match its <img> below so the readiness
+  // poll addresses the same cache file.
+  const leftSize: 'large' | 'original' =
+    useLeftOriginal ||
+    (leftOriginalLoaded && targetLeftZoomRef.current !== null && targetLeftZoomRef.current > 1.0)
+      ? 'original'
+      : 'large';
+  const leftSrc = showStars
+    ? apiClient.getAnnotatedUrl(dbId, leftImageId, leftSize, maxStars)
+    : apiClient.getPreviewUrl(dbId, leftImageId, { size: leftSize });
+  const leftDescriptor: PreviewDescriptor = showStars
+    ? { imageId: leftImageId, kind: 'annotated', size: leftSize, maxStars }
+    : { imageId: leftImageId, kind: 'preview', size: leftSize };
+  const asyncLeft = useAsyncImage(dbId, leftSrc, leftDescriptor);
+
+  const rightSize: 'large' | 'original' =
+    useRightOriginal || useLeftOriginal ? 'original' : 'large';
+  const rightIdForUrl = rightImageId ?? 0;
+  const rightSrc = showStars
+    ? apiClient.getAnnotatedUrl(dbId, rightIdForUrl, rightSize, maxStars)
+    : apiClient.getPreviewUrl(dbId, rightIdForUrl, { size: rightSize });
+  const rightDescriptor: PreviewDescriptor = showStars
+    ? { imageId: rightIdForUrl, kind: 'annotated', size: rightSize, maxStars }
+    : { imageId: rightIdForUrl, kind: 'preview', size: rightSize };
+  const asyncRight = useAsyncImage(dbId, rightSrc, rightDescriptor);
+
   // Capture zoom intent before image change
   useEffect(() => {
     const visualScale = rightZoom.getVisualScale();
@@ -201,31 +230,33 @@ export default function ImageComparisonView({
                          (targetLeftZoomRef.current && targetLeftZoomRef.current > 0.8 && state === 'large');
     
     if (shouldPreload && !leftOriginalLoaded && !leftOriginalRef.current) {
+      leftOriginalRef.current = new Image(); // guard: preload only once
       const originalUrl = showStars
         ? apiClient.getAnnotatedUrl(dbId, leftImageId, 'original', maxStars)
         : apiClient.getPreviewUrl(dbId, leftImageId, { size: 'original' });
+      const descriptor: PreviewDescriptor = showStars
+        ? { imageId: leftImageId, kind: 'annotated', size: 'original', maxStars }
+        : { imageId: leftImageId, kind: 'preview', size: 'original' };
 
-      const img = new Image();
-      img.src = originalUrl;
-      leftOriginalRef.current = img;
-      
-      img.onload = () => {
+      // Route through the interactive queue so an uncached 'original' is
+      // generated (its 202 is not a failure); only flip once it's ready.
+      void ensurePreviewReady(dbId, originalUrl, descriptor).then((ok) => {
+        if (!ok) return;
         setLeftOriginalLoaded(true);
-        
+
         // If we were waiting for original due to high zoom, switch immediately
         const currentVisualScale = leftZoom.getVisualScale();
         const currentState = leftImageStateRef.current;
         if (currentState === 'large' && currentVisualScale > 1.0) {
           leftImageStateRef.current = 'switching-to-original';
           setUseLeftOriginal(true);
-          // Delay state update to allow render
           setTimeout(() => {
             if (leftImageStateRef.current === 'switching-to-original') {
               leftImageStateRef.current = 'original';
             }
           }, 300);
         }
-      };
+      });
     }
     
     // State machine transitions based on visual scale - only switch to original, never back
@@ -273,32 +304,32 @@ export default function ImageComparisonView({
                          (targetRightZoomRef.current && targetRightZoomRef.current > 0.8 && state === 'large') ||
                          (useLeftOriginal && state === 'large');
     
-    if (shouldPreload && !rightOriginalLoaded && !rightOriginalRef.current) {
+    if (shouldPreload && !rightOriginalLoaded && !rightOriginalRef.current && rightImageId) {
+      rightOriginalRef.current = new Image(); // guard: preload only once
       const originalUrl = showStars
         ? apiClient.getAnnotatedUrl(dbId, rightImageId, 'original', maxStars)
         : apiClient.getPreviewUrl(dbId, rightImageId, { size: 'original' });
+      const descriptor: PreviewDescriptor = showStars
+        ? { imageId: rightImageId, kind: 'annotated', size: 'original', maxStars }
+        : { imageId: rightImageId, kind: 'preview', size: 'original' };
 
-      const img = new Image();
-      img.src = originalUrl;
-      rightOriginalRef.current = img;
-      
-      img.onload = () => {
+      void ensurePreviewReady(dbId, originalUrl, descriptor).then((ok) => {
+        if (!ok) return;
         setRightOriginalLoaded(true);
-        
+
         // If we were waiting for original due to high zoom OR left is using original, switch immediately
         const currentVisualScale = rightZoom.getVisualScale();
         const currentState = rightImageStateRef.current;
         if (currentState === 'large' && (currentVisualScale > 1.0 || useLeftOriginal)) {
           rightImageStateRef.current = 'switching-to-original';
           setUseRightOriginal(true);
-          // Delay state update to allow render
           setTimeout(() => {
             if (rightImageStateRef.current === 'switching-to-original') {
               rightImageStateRef.current = 'original';
             }
           }, 300);
         }
-      };
+      });
     }
     
     // State machine transitions based on visual scale OR left image state
@@ -491,7 +522,7 @@ export default function ImageComparisonView({
                 onMouseUp={leftZoom.handleMouseUp}
                 onMouseLeave={leftZoom.handleMouseUp}
               >
-                {leftImageError ? (
+                {leftImageError || asyncLeft.state === 'error' ? (
                   <div className="comparison-image-error" style={{
                     width: '100%',
                     height: '100%',
@@ -517,15 +548,13 @@ export default function ImageComparisonView({
                 ) : (
                   <img
                     ref={leftZoom.imageRef}
-                    src={showStars
-                      ? apiClient.getAnnotatedUrl(dbId, leftImageId, (useLeftOriginal || (leftOriginalLoaded && targetLeftZoomRef.current && targetLeftZoomRef.current > 1.0)) ? 'original' : 'large', maxStars)
-                      : apiClient.getPreviewUrl(dbId, leftImageId, { size: (useLeftOriginal || (leftOriginalLoaded && targetLeftZoomRef.current && targetLeftZoomRef.current > 1.0)) ? 'original' : 'large' })
-                    }
+                    src={asyncLeft.src}
                     alt={`${leftImage.target_name} - ${leftImage.filter_name || 'No filter'}`}
-                    onError={() => setLeftImageError(true)}
+                    onError={asyncLeft.onError}
                     onLoad={(e) => {
+                    asyncLeft.onLoad();
                     setLeftImageLoaded(true);
-                    
+
                     const img = e.currentTarget;
                     const newWidth = img.naturalWidth;
                     const newHeight = img.naturalHeight;
@@ -561,6 +590,12 @@ export default function ImageComparisonView({
                   }}
                   draggable={false}
                   />
+                )}
+                {asyncLeft.state === 'generating' && (
+                  <div className="preview-status-box">
+                    <div className="loading-spinner" />
+                    <span className="preview-status-label">Generating…</span>
+                  </div>
                 )}
               </div>
             </div>
@@ -644,7 +679,7 @@ export default function ImageComparisonView({
                     onMouseUp={syncZoom ? leftZoom.handleMouseUp : rightZoom.handleMouseUp}
                     onMouseLeave={syncZoom ? leftZoom.handleMouseUp : rightZoom.handleMouseUp}
                   >
-                    {rightImageError ? (
+                    {rightImageError || asyncRight.state === 'error' ? (
                       <div className="comparison-image-error" style={{
                         width: '100%',
                         height: '100%',
@@ -668,22 +703,18 @@ export default function ImageComparisonView({
                         </div>
                       </div>
                     ) : (() => {
-                      // Match the left image's size for consistency
-                      const shouldUseOriginal = useRightOriginal || useLeftOriginal;
-                      const imageSize = shouldUseOriginal ? 'original' : 'large';
-                      
+                      // Size is chosen at the top (rightSize) so the readiness
+                      // poll addresses the same cache file as this <img>.
                       return (
                         <img
                           ref={rightZoom.imageRef}
-                          src={showStars
-                            ? apiClient.getAnnotatedUrl(dbId, rightImageId!, imageSize, maxStars)
-                            : apiClient.getPreviewUrl(dbId, rightImageId!, { size: imageSize })
-                          }
+                          src={asyncRight.src}
                         alt={`${rightImage.target_name} - ${rightImage.filter_name || 'No filter'}`}
-                        onError={() => setRightImageError(true)}
+                        onError={asyncRight.onError}
                         onLoad={(e) => {
+                        asyncRight.onLoad();
                         setRightImageLoaded(true);
-                        
+
                         const img = e.currentTarget;
                         const newWidth = img.naturalWidth;
                         const newHeight = img.naturalHeight;
@@ -721,6 +752,12 @@ export default function ImageComparisonView({
                         />
                       );
                     })()}
+                    {asyncRight.state === 'generating' && (
+                      <div className="preview-status-box">
+                        <div className="loading-spinner" />
+                        <span className="preview-status-label">Generating…</span>
+                      </div>
+                    )}
                   </div>
                 </div>
 

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -591,10 +591,12 @@ export default function ImageComparisonView({
                   draggable={false}
                   />
                 )}
-                {asyncLeft.state === 'generating' && (
+                {(asyncLeft.state === 'generating' || asyncLeft.state === 'loading') && (
                   <div className="preview-status-box">
                     <div className="loading-spinner" />
-                    <span className="preview-status-label">Generating…</span>
+                    <span className="preview-status-label">
+                      {asyncLeft.state === 'generating' ? 'Generating…' : 'Loading…'}
+                    </span>
                   </div>
                 )}
               </div>
@@ -752,10 +754,12 @@ export default function ImageComparisonView({
                         />
                       );
                     })()}
-                    {asyncRight.state === 'generating' && (
+                    {(asyncRight.state === 'generating' || asyncRight.state === 'loading') && (
                       <div className="preview-status-box">
                         <div className="loading-spinner" />
-                        <span className="preview-status-label">Generating…</span>
+                        <span className="preview-status-label">
+                          {asyncRight.state === 'generating' ? 'Generating…' : 'Loading…'}
+                        </span>
                       </div>
                     )}
                   </div>

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -43,8 +43,6 @@ export default function ImageComparisonView({
   // Track image loading
   const [leftImageLoaded, setLeftImageLoaded] = useState(false);
   const [rightImageLoaded, setRightImageLoaded] = useState(false);
-  const [leftImageError, setLeftImageError] = useState(false);
-  const [rightImageError, setRightImageError] = useState(false);
   
   // Track original image preloading
   const [leftOriginalLoaded, setLeftOriginalLoaded] = useState(false);
@@ -102,13 +100,11 @@ export default function ImageComparisonView({
   // Reset loaded state when images change
   useEffect(() => {
     setLeftImageLoaded(false);
-    setLeftImageError(false);
     leftZoom.resetInitialization();
   }, [leftImageId, showStars, leftZoom]);
-  
+
   useEffect(() => {
     setRightImageLoaded(false);
-    setRightImageError(false);
     rightZoom.resetInitialization();
   }, [rightImageId, showStars, rightZoom]);
 
@@ -522,7 +518,7 @@ export default function ImageComparisonView({
                 onMouseUp={leftZoom.handleMouseUp}
                 onMouseLeave={leftZoom.handleMouseUp}
               >
-                {leftImageError || asyncLeft.state === 'error' ? (
+                {asyncLeft.state === 'error' ? (
                   <div className="comparison-image-error" style={{
                     width: '100%',
                     height: '100%',
@@ -681,7 +677,7 @@ export default function ImageComparisonView({
                     onMouseUp={syncZoom ? leftZoom.handleMouseUp : rightZoom.handleMouseUp}
                     onMouseLeave={syncZoom ? leftZoom.handleMouseUp : rightZoom.handleMouseUp}
                   >
-                    {rightImageError || asyncRight.state === 'error' ? (
+                    {asyncRight.state === 'error' ? (
                       <div className="comparison-image-error" style={{
                         width: '100%',
                         height: '100%',

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -396,14 +396,19 @@ export default function ImageDetailView({
                   draggable={false}
                 />
               )}
-              {!showPsf && asyncImg.state === 'generating' && (
-                <div className="image-loading-overlay">
-                  <div className="loading-content">
-                    <div className="loading-spinner"></div>
-                    <span className="loading-text">Generating preview…</span>
+              {!showPsf &&
+                (asyncImg.state === 'generating' || asyncImg.state === 'loading') && (
+                  <div className="image-loading-overlay">
+                    <div className="loading-content">
+                      <div className="loading-spinner"></div>
+                      <span className="loading-text">
+                        {asyncImg.state === 'generating'
+                          ? 'Generating preview…'
+                          : 'Loading…'}
+                      </span>
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
             </div>
           </div>
 

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -3,8 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { apiClient } from '../api/client';
 import { GradingStatus } from '../api/types';
+import type { PreviewDescriptor } from '../api/types';
 import { useImagePreloader } from '../hooks/useImagePreloader';
 import { useImageZoom } from '../hooks/useImageZoom';
+import { useAsyncImage } from '../hooks/useAsyncImage';
+import { ensurePreviewReady } from '../hooks/previewPoll';
 import UndoRedoToolbar from './UndoRedoToolbar';
 
 interface ImageDetailViewProps {
@@ -45,7 +48,6 @@ export default function ImageDetailView({
   const [maxStars] = useState(1000);
   const [imageSize, setImageSize] = useState<'screen' | 'large' | 'original'>('large');
   const [isOriginalLoaded, setIsOriginalLoaded] = useState(false);
-  const preloadedOriginalRef = useRef<HTMLImageElement | null>(null);
   const [useOriginalImage, setUseOriginalImage] = useState(false);
   const imageDimensionsRef = useRef<{ width: number; height: number }>({ width: 0, height: 0 });
   const [imageError, setImageError] = useState(false);
@@ -76,6 +78,18 @@ export default function ImageDetailView({
     includeStarData: showStars,
     imageSize: imageSize,
   });
+
+  // Async loading for the main preview/annotated image (PSF has its own
+  // endpoint and is not queued here). On a cache miss the server returns 202
+  // and this drives a "Generating…" indicator, then reloads when ready.
+  const mainSize: 'large' | 'original' = useOriginalImage ? 'original' : 'large';
+  const nonPsfSrc = showStars
+    ? apiClient.getAnnotatedUrl(dbId, imageId, mainSize, maxStars)
+    : apiClient.getPreviewUrl(dbId, imageId, { size: mainSize });
+  const nonPsfDescriptor: PreviewDescriptor = showStars
+    ? { imageId, kind: 'annotated', size: mainSize, maxStars }
+    : { imageId, kind: 'preview', size: mainSize };
+  const asyncImg = useAsyncImage(dbId, nonPsfSrc, nonPsfDescriptor);
 
   // Fetch image details
   const { data: image, isLoading, isFetching } = useQuery({
@@ -185,19 +199,20 @@ export default function ImageDetailView({
     const visualScale = zoom.getVisualScale();
     const state = imageStateRef.current;
     
-    // Preload when visual zoom > 80%
+    // Preload when visual zoom > 80%. Route through the interactive queue so an
+    // uncached 'original' is actually generated (its 202 is not a failure);
+    // only flip to it once generation completes.
     if (visualScale > 0.8 && !isOriginalLoaded && state === 'large') {
       const originalUrl = showStars
         ? apiClient.getAnnotatedUrl(dbId, imageId, 'original', maxStars)
         : apiClient.getPreviewUrl(dbId, imageId, { size: 'original' });
-      
-      const img = new Image();
-      img.src = originalUrl;
-      preloadedOriginalRef.current = img;
-      
-      img.onload = () => {
-        setIsOriginalLoaded(true);
-      };
+      const originalDescriptor: PreviewDescriptor = showStars
+        ? { imageId, kind: 'annotated', size: 'original', maxStars }
+        : { imageId, kind: 'preview', size: 'original' };
+
+      void ensurePreviewReady(dbId, originalUrl, originalDescriptor).then((ok) => {
+        if (ok) setIsOriginalLoaded(true);
+      });
     }
     
     // State machine transitions based on visual scale - only switch to original, never back
@@ -218,7 +233,6 @@ export default function ImageDetailView({
   // Reset preload state when image changes
   useEffect(() => {
     setIsOriginalLoaded(false);
-    preloadedOriginalRef.current = null;
     setUseOriginalImage(false);
     imageDimensionsRef.current = { width: 0, height: 0 };
     imageStateRef.current = 'large';
@@ -297,7 +311,7 @@ export default function ImageDetailView({
                   </div>
                 </div>
               ) : null}
-              {imageError ? (
+              {imageError || (!showPsf && asyncImg.state === 'error') ? (
                 <div className="detail-image-error" style={{
                   width: '100%',
                   height: '100%',
@@ -334,9 +348,7 @@ export default function ImageDetailView({
                           sort_by: 'r2',
                           selection: 'top-n',
                         })
-                      : showStars
-                        ? apiClient.getAnnotatedUrl(dbId, imageId, useOriginalImage ? 'original' : 'large', maxStars)
-                        : apiClient.getPreviewUrl(dbId, imageId, { size: useOriginalImage ? 'original' : 'large' })
+                      : asyncImg.src
                   }
                   alt={`${image.target_name} - ${image.filter_name || 'No filter'}`}
                   style={{
@@ -344,16 +356,18 @@ export default function ImageDetailView({
                     cursor: zoom.zoomState.scale > 1 ? 'grab' : 'default',
                     transformOrigin: '0 0',
                   }}
-                  onError={() => setImageError(true)}
+                  onError={showPsf ? () => setImageError(true) : asyncImg.onError}
                   onLoad={(e) => {
                   // Remove loading class when image loads
                   e.currentTarget.classList.remove('loading');
-                  
-                  // Clear PSF loading state when PSF image loads
+
+                  // Clear PSF loading state / mark the async image ready.
                   if (showPsf) {
                     setPsfImageLoading(false);
+                  } else {
+                    asyncImg.onLoad();
                   }
-                  
+
                   const img = e.currentTarget;
                   const newWidth = img.naturalWidth;
                   const newHeight = img.naturalHeight;
@@ -381,6 +395,14 @@ export default function ImageDetailView({
                   }}
                   draggable={false}
                 />
+              )}
+              {!showPsf && asyncImg.state === 'generating' && (
+                <div className="image-loading-overlay">
+                  <div className="loading-content">
+                    <div className="loading-spinner"></div>
+                    <span className="loading-text">Generating preview…</span>
+                  </div>
+                </div>
               )}
             </div>
           </div>

--- a/static/src/components/LazyImageCard.tsx
+++ b/static/src/components/LazyImageCard.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useInView } from 'react-intersection-observer';
 import type { Image } from '../api/types';
 import { GradingStatus } from '../api/types';
 import { apiClient } from '../api/client';
+import PreviewImage from './PreviewImage';
+import { ensurePreviewReady } from '../hooks/previewPoll';
 
 interface LazyImageCardProps {
   dbId: string;
@@ -14,8 +16,6 @@ interface LazyImageCardProps {
 
 export default function LazyImageCard({ dbId, image, isSelected, onClick, onDoubleClick }: LazyImageCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
-  const [imageLoaded, setImageLoaded] = useState(false);
-  const [imageError, setImageError] = useState(false);
   const { ref: inViewRef, inView } = useInView({
     threshold: 0,
     rootMargin: '200px',
@@ -35,11 +35,15 @@ export default function LazyImageCard({ dbId, image, isSelected, onClick, onDoub
     }
   }, [isSelected]);
 
-  // Preload full size image when selected (for quick detail view opening)
+  // Preload full size image when selected (for quick detail view opening).
+  // Warms the interactive queue so the 'large' preview is generated if needed.
   useEffect(() => {
     if (isSelected && image.id) {
-      const preloadImg = new Image();
-      preloadImg.src = apiClient.getPreviewUrl(dbId, image.id, { size: 'large' });
+      void ensurePreviewReady(
+        dbId,
+        apiClient.getPreviewUrl(dbId, image.id, { size: 'large' }),
+        { imageId: image.id, kind: 'preview', size: 'large' }
+      );
     }
   }, [isSelected, image.id, dbId]);
 
@@ -91,42 +95,13 @@ export default function LazyImageCard({ dbId, image, isSelected, onClick, onDoub
     >
       <div className="image-preview">
         {inView ? (
-          imageError ? (
-            <div className="image-error-placeholder" style={{ 
-              width: '100%', 
-              paddingBottom: '100%', // Maintain aspect ratio
-              background: '#1a1a1a',
-              position: 'relative',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center'
-            }}>
-              <div style={{
-                position: 'absolute',
-                top: '50%',
-                left: '50%',
-                transform: 'translate(-50%, -50%)',
-                textAlign: 'center',
-                color: '#666'
-              }}>
-                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" style={{ marginBottom: '8px' }}>
-                  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-                  <line x1="9" y1="9" x2="15" y2="15" />
-                  <line x1="15" y1="9" x2="9" y2="15" />
-                </svg>
-                <div style={{ fontSize: '0.8rem' }}>Image not found</div>
-              </div>
-            </div>
-          ) : (
-            <img
-              src={apiClient.getPreviewUrl(dbId, image.id, { size: 'screen' })}
-              alt={`${image.target_name} - ${image.filter_name || 'No filter'}`}
-              loading="lazy"
-              onLoad={() => setImageLoaded(true)}
-              onError={() => setImageError(true)}
-              style={{ opacity: imageLoaded ? 1 : 0, transition: 'opacity 0.3s' }}
-            />
-          )
+          <PreviewImage
+            dbId={dbId}
+            src={apiClient.getPreviewUrl(dbId, image.id, { size: 'screen' })}
+            descriptor={{ imageId: image.id, kind: 'preview', size: 'screen' }}
+            alt={`${image.target_name} - ${image.filter_name || 'No filter'}`}
+            loading="lazy"
+          />
         ) : (
           <div className="image-placeholder" style={{ 
             width: '100%', 

--- a/static/src/components/PreviewImage.tsx
+++ b/static/src/components/PreviewImage.tsx
@@ -55,6 +55,10 @@ export default function PreviewImage({
         </div>
       )}
       {img.state === 'error' && (fallback ?? <PreviewError />)}
+      {/* The img stays in layout (never display:none) so it actually loads —
+          a lazy + display:none image has no box and the browser never fetches
+          it, so onError/onLoad would never fire. While pending/error the
+          opaque .preview-status-box above covers it; when ready it shows. */}
       <img
         src={img.src}
         alt={alt}
@@ -62,7 +66,7 @@ export default function PreviewImage({
         onLoad={img.onLoad}
         onError={img.onError}
         className={className}
-        style={{ ...imgStyle, display: img.state === 'ready' ? undefined : 'none' }}
+        style={imgStyle}
       />
     </>
   );

--- a/static/src/components/PreviewImage.tsx
+++ b/static/src/components/PreviewImage.tsx
@@ -1,0 +1,89 @@
+import { useEffect } from 'react';
+import { useAsyncImage } from '../hooks/useAsyncImage';
+import type { PreviewDescriptor } from '../api/types';
+
+interface PreviewImageProps {
+  dbId: string;
+  /** Preview/annotated URL from apiClient.getPreviewUrl / getAnnotatedUrl. */
+  src: string;
+  /** Identifies the artifact for the batch generation-status poll. */
+  descriptor: PreviewDescriptor;
+  alt: string;
+  loading?: 'lazy' | 'eager';
+  /** Applied to the rendered <img>. */
+  className?: string;
+  imgStyle?: React.CSSProperties;
+  /** Shown when generation ultimately fails. */
+  fallback?: React.ReactNode;
+  onReady?: () => void;
+}
+
+/**
+ * Preview `<img>` that loads optimistically and, on a cache miss (the server's
+ * 202), shows a "Generating…" indicator while the shared batch poller waits for
+ * the async queue to produce it — then swaps in the image. A cache hit renders
+ * immediately with no extra request.
+ */
+export default function PreviewImage({
+  dbId,
+  src,
+  descriptor,
+  alt,
+  loading = 'lazy',
+  className,
+  imgStyle,
+  fallback,
+  onReady,
+}: PreviewImageProps) {
+  const img = useAsyncImage(dbId, src, descriptor);
+
+  useEffect(() => {
+    if (img.state === 'ready') onReady?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [img.state]);
+
+  const pending = img.state === 'loading' || img.state === 'generating';
+
+  return (
+    <>
+      {pending && (
+        <div className="preview-status-box">
+          <div className="loading-spinner" />
+          {img.state === 'generating' && (
+            <span className="preview-status-label">Generating…</span>
+          )}
+        </div>
+      )}
+      {img.state === 'error' && (fallback ?? <PreviewError />)}
+      <img
+        src={img.src}
+        alt={alt}
+        loading={loading}
+        onLoad={img.onLoad}
+        onError={img.onError}
+        className={className}
+        style={{ ...imgStyle, display: img.state === 'ready' ? undefined : 'none' }}
+      />
+    </>
+  );
+}
+
+function PreviewError() {
+  return (
+    <div className="preview-status-box preview-status-error">
+      <svg
+        width="32"
+        height="32"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+        <line x1="9" y1="9" x2="15" y2="15" />
+        <line x1="15" y1="9" x2="9" y2="15" />
+      </svg>
+      <span className="preview-status-label">Image not found</span>
+    </div>
+  );
+}

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -7,6 +7,7 @@ import { useSpatialScan } from '../hooks/useSpatialScan';
 import { useGrading } from '../hooks/useGrading';
 import { useDbProjectTarget } from '../hooks/useUrlState';
 import UndoRedoToolbar from './UndoRedoToolbar';
+import PreviewImage from './PreviewImage';
 import type { ScoredSequence, ImageQualityResult } from '../api/types';
 
 function formatCategory(category: string): string {
@@ -524,8 +525,10 @@ function SequenceImageCard({
       onDoubleClick={onDoubleClick}
     >
       <div className="sequence-image-preview">
-        <img
+        <PreviewImage
+          dbId={dbId}
           src={apiClient.getPreviewUrl(dbId, quality.image_id, { size: 'screen' })}
+          descriptor={{ imageId: quality.image_id, kind: 'preview', size: 'screen' }}
           alt={`Image ${quality.image_id}`}
           loading="lazy"
         />

--- a/static/src/hooks/__tests__/previewPoll.test.ts
+++ b/static/src/hooks/__tests__/previewPoll.test.ts
@@ -1,0 +1,127 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
+import {
+  registerPending,
+  descriptorKey,
+  __resetForTest,
+} from '../previewPoll';
+import { apiClient } from '../../api/client';
+import type { PreviewDescriptor, GenerationStatus } from '../../api/types';
+
+const preview = (imageId: number): PreviewDescriptor => ({
+  imageId,
+  kind: 'preview',
+  size: 'screen',
+});
+
+let statusSpy: MockInstance<typeof apiClient.getGenerationStatus>;
+
+/** Make getGenerationStatus reply with `map(descriptor)` for each request. */
+function respondWith(map: (d: PreviewDescriptor) => GenerationStatus) {
+  statusSpy.mockImplementation(async (_dbId, requests) => requests.map(map));
+}
+
+describe('previewPoll coordinator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    statusSpy = vi.spyOn(apiClient, 'getGenerationStatus');
+  });
+
+  afterEach(() => {
+    __resetForTest();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('resolves onReady, then stops polling once idle', async () => {
+    respondWith(() => ({ state: 'ready' }));
+    const onReady = vi.fn();
+    registerPending('db1', preview(1), { onReady, onError: vi.fn() });
+
+    await vi.advanceTimersByTimeAsync(50); // fire the immediate poll
+    expect(onReady).toHaveBeenCalledTimes(1);
+
+    // Entry removed → timer stops → no further polls.
+    const callsAfterReady = statusSpy.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(statusSpy.mock.calls.length).toBe(callsAfterReady);
+  });
+
+  it('coalesces multiple pending images into a single batched request', async () => {
+    respondWith(() => ({ state: 'generating' })); // keep them pending
+    registerPending('db1', preview(1), { onReady: vi.fn(), onError: vi.fn() });
+    registerPending('db1', preview(2), { onReady: vi.fn(), onError: vi.fn() });
+    registerPending('db1', preview(3), { onReady: vi.fn(), onError: vi.fn() });
+
+    // Immediate poll + one interval tick: a tick sees all three pending.
+    await vi.advanceTimersByTimeAsync(900);
+
+    const maxBatch = Math.max(
+      0,
+      ...statusSpy.mock.calls.map(([, requests]) => requests.length)
+    );
+    expect(maxBatch).toBeGreaterThan(1);
+    // Every batched request is scoped to the one database.
+    for (const [dbId] of statusSpy.mock.calls) expect(dbId).toBe('db1');
+  });
+
+  it('dedups identical descriptors but notifies every subscriber', async () => {
+    respondWith(() => ({ state: 'ready' }));
+    const a = vi.fn();
+    const b = vi.fn();
+    registerPending('db1', preview(7), { onReady: a, onError: vi.fn() });
+    registerPending('db1', preview(7), { onReady: b, onError: vi.fn() });
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    // One descriptor in the request (deduped by key) …
+    expect(statusSpy.mock.calls[0][1]).toHaveLength(1);
+    // … but both subscribers fired.
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports terminal errors via onError', async () => {
+    respondWith(() => ({ state: 'error', error: 'source file not found' }));
+    const onReady = vi.fn();
+    const onError = vi.fn();
+    registerPending('db1', preview(9), { onReady, onError });
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(onError).toHaveBeenCalledWith('source file not found');
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  it('unregister before resolution prevents the callback and stops the timer', async () => {
+    respondWith(() => ({ state: 'generating' }));
+    const onReady = vi.fn();
+    const unregister = registerPending('db1', preview(5), {
+      onReady,
+      onError: vi.fn(),
+    });
+    unregister();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(onReady).not.toHaveBeenCalled();
+    // Nothing pending → after the in-flight immediate poll the timer is idle.
+    const calls = statusSpy.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(statusSpy.mock.calls.length).toBe(calls);
+  });
+
+  it('descriptorKey distinguishes size and kind', () => {
+    expect(descriptorKey(preview(1))).not.toBe(
+      descriptorKey({ imageId: 1, kind: 'annotated', size: 'screen' })
+    );
+    expect(descriptorKey(preview(1))).not.toBe(
+      descriptorKey({ imageId: 1, kind: 'preview', size: 'large' })
+    );
+  });
+});

--- a/static/src/hooks/previewPoll.ts
+++ b/static/src/hooks/previewPoll.ts
@@ -33,6 +33,17 @@ const pendingByDb = new Map<string, Map<string, Pending>>();
 let timer: ReturnType<typeof setInterval> | null = null;
 let polling = false;
 
+/** Test-only: clear all pending state and stop the timer, so the module
+ *  singleton doesn't leak between unit tests. */
+export function __resetForTest(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  pendingByDb.clear();
+  polling = false;
+}
+
 export function descriptorKey(d: PreviewDescriptor): string {
   return [
     d.kind,

--- a/static/src/hooks/previewPoll.ts
+++ b/static/src/hooks/previewPoll.ts
@@ -1,0 +1,180 @@
+import { apiClient } from '../api/client';
+import type { PreviewDescriptor } from '../api/types';
+
+/**
+ * Process-wide coordinator that batches "is this preview generated yet?" polls.
+ *
+ * The server generates missing preview/annotated PNGs asynchronously on a
+ * bounded interactive queue and answers the image request with HTTP 202. Each
+ * waiting `<img>` registers its descriptor here; a single timer coalesces all
+ * pending descriptors (per database) into one POST to the batch
+ * `generation-status` endpoint, so a grid of N generating images produces one
+ * poll per tick, not N. When a descriptor becomes `ready` its subscribers are
+ * told to reload; on `error` they fall back.
+ */
+
+export interface PollSubscriber {
+  onReady: () => void;
+  onError: (message?: string) => void;
+}
+
+interface Pending {
+  descriptor: PreviewDescriptor;
+  subscribers: Set<PollSubscriber>;
+}
+
+const POLL_INTERVAL_MS = 800;
+// Cap per request so one huge grid doesn't send a giant body; extra descriptors
+// simply poll on the next tick.
+const MAX_BATCH = 100;
+
+// dbId -> (descriptor key -> Pending)
+const pendingByDb = new Map<string, Map<string, Pending>>();
+let timer: ReturnType<typeof setInterval> | null = null;
+let polling = false;
+
+export function descriptorKey(d: PreviewDescriptor): string {
+  return [
+    d.kind,
+    d.imageId,
+    d.size,
+    d.stretch ?? '',
+    d.midtone ?? '',
+    d.shadow ?? '',
+    d.maxStars ?? '',
+  ].join('|');
+}
+
+/**
+ * Register interest in a descriptor's readiness. Returns an unregister fn;
+ * call it when the image loads, errors terminally, or the component unmounts.
+ */
+export function registerPending(
+  dbId: string,
+  descriptor: PreviewDescriptor,
+  subscriber: PollSubscriber
+): () => void {
+  let byKey = pendingByDb.get(dbId);
+  if (!byKey) {
+    byKey = new Map();
+    pendingByDb.set(dbId, byKey);
+  }
+  const key = descriptorKey(descriptor);
+  let entry = byKey.get(key);
+  if (!entry) {
+    entry = { descriptor, subscribers: new Set() };
+    byKey.set(key, entry);
+  }
+  entry.subscribers.add(subscriber);
+  ensureTimer();
+
+  return () => {
+    const map = pendingByDb.get(dbId);
+    const e = map?.get(key);
+    if (!e) return;
+    e.subscribers.delete(subscriber);
+    if (e.subscribers.size === 0) map!.delete(key);
+    if (map && map.size === 0) pendingByDb.delete(dbId);
+  };
+}
+
+function ensureTimer() {
+  if (timer) return;
+  timer = setInterval(poll, POLL_INTERVAL_MS);
+  // Kick one immediately so the first pending image doesn't wait a full tick.
+  void poll();
+}
+
+function stopTimerIfIdle() {
+  if (pendingByDb.size === 0 && timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+function resolveEntry(
+  dbId: string,
+  key: string,
+  notify: (subs: Set<PollSubscriber>) => void
+) {
+  const map = pendingByDb.get(dbId);
+  const entry = map?.get(key);
+  if (!entry) return;
+  // Drop first so a subscriber's synchronous re-register (e.g. reload → new
+  // pending on a fresh error) starts a clean entry.
+  map!.delete(key);
+  if (map!.size === 0) pendingByDb.delete(dbId);
+  notify(entry.subscribers);
+}
+
+async function poll() {
+  if (polling) return; // don't overlap slow ticks
+  polling = true;
+  try {
+    for (const [dbId, byKey] of Array.from(pendingByDb.entries())) {
+      const entries = Array.from(byKey.entries()); // [key, Pending][]
+      for (let i = 0; i < entries.length; i += MAX_BATCH) {
+        const chunk = entries.slice(i, i + MAX_BATCH);
+        let statuses;
+        try {
+          statuses = await apiClient.getGenerationStatus(
+            dbId,
+            chunk.map(([, e]) => e.descriptor)
+          );
+        } catch {
+          continue; // transient network error: retry next tick
+        }
+        chunk.forEach(([key], idx) => {
+          const st = statuses[idx];
+          if (!st) return;
+          if (st.state === 'ready') {
+            resolveEntry(dbId, key, (subs) => subs.forEach((s) => s.onReady()));
+          } else if (st.state === 'error') {
+            resolveEntry(dbId, key, (subs) =>
+              subs.forEach((s) => s.onError(st.error))
+            );
+          }
+          // 'generating' → keep polling
+        });
+      }
+    }
+  } finally {
+    polling = false;
+    stopTimerIfIdle();
+  }
+}
+
+/**
+ * Kick generation of an artifact and resolve when it's ready (or failed).
+ * For the `new Image()` preload / zoom-switch paths that aren't rendered
+ * `<img>` elements. Fetching the image URL returns 202 and enqueues; then we
+ * ride the same batch poller. Resolves `true` when ready, `false` on error.
+ */
+export function ensurePreviewReady(
+  dbId: string,
+  imageUrl: string,
+  descriptor: PreviewDescriptor
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let unregister: (() => void) | null = null;
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      unregister?.();
+      resolve(ok);
+    };
+    // Warm the cache: the 202 enqueues generation server-side. A 200 means it
+    // was already cached — resolve immediately.
+    const probe = new Image();
+    probe.onload = () => finish(true);
+    probe.onerror = () => {
+      if (settled) return;
+      unregister = registerPending(dbId, descriptor, {
+        onReady: () => finish(true),
+        onError: () => finish(false),
+      });
+    };
+    probe.src = imageUrl;
+  });
+}

--- a/static/src/hooks/useAsyncImage.ts
+++ b/static/src/hooks/useAsyncImage.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { registerPending } from './previewPoll';
+import type { PreviewDescriptor } from '../api/types';
+
+export type AsyncImageState = 'loading' | 'ready' | 'generating' | 'error';
+
+export interface AsyncImageResult {
+  /** Feed this to `<img src>` (carries a cache-buster after a reload). */
+  src: string;
+  state: AsyncImageState;
+  onLoad: () => void;
+  onError: () => void;
+}
+
+/**
+ * Optimistic image loading with batched poll-on-error.
+ *
+ * - Renders `src` directly, so a cache hit loads instantly with zero extra
+ *   requests (the common case once pre-generation has run).
+ * - On error — a 202 "generating" from the server, or a transient failure —
+ *   it joins the shared batch poller (`previewPoll`) and reports
+ *   `state: 'generating'`. When the artifact becomes ready it bumps a
+ *   cache-buster and reloads (now a fast 200); a terminal failure reports
+ *   `state: 'error'`.
+ */
+export function useAsyncImage(
+  dbId: string | null | undefined,
+  src: string,
+  descriptor: PreviewDescriptor
+): AsyncImageResult {
+  const [state, setState] = useState<AsyncImageState>('loading');
+  const [reloadTick, setReloadTick] = useState(0);
+  const unregisterRef = useRef<null | (() => void)>(null);
+  // Latest descriptor without making `onError` depend on its object identity.
+  const descRef = useRef(descriptor);
+  descRef.current = descriptor;
+
+  // Reset when the underlying src changes (new image / size / stars toggle).
+  useEffect(() => {
+    setState('loading');
+    setReloadTick(0);
+    return () => {
+      unregisterRef.current?.();
+      unregisterRef.current = null;
+    };
+  }, [src]);
+
+  const onLoad = useCallback(() => {
+    unregisterRef.current?.();
+    unregisterRef.current = null;
+    setState('ready');
+  }, []);
+
+  const onError = useCallback(() => {
+    unregisterRef.current?.();
+    if (!dbId) {
+      unregisterRef.current = null;
+      setState('error');
+      return;
+    }
+    setState('generating');
+    unregisterRef.current = registerPending(dbId, descRef.current, {
+      onReady: () => {
+        unregisterRef.current = null;
+        setState('loading');
+        setReloadTick((t) => t + 1); // force <img> to re-fetch (now cached)
+      },
+      onError: () => {
+        unregisterRef.current = null;
+        setState('error');
+      },
+    });
+  }, [dbId]);
+
+  const displaySrc =
+    reloadTick > 0 ? withParam(src, 'v', String(reloadTick)) : src;
+  return { src: displaySrc, state, onLoad, onError };
+}
+
+function withParam(url: string, key: string, value: string): string {
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}${key}=${encodeURIComponent(value)}`;
+}

--- a/static/src/hooks/useImagePreloader.ts
+++ b/static/src/hooks/useImagePreloader.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { apiClient } from '../api/client';
+import { ensurePreviewReady } from './previewPoll';
 
 /**
  * Hook to preload images for smooth navigation
@@ -28,32 +29,26 @@ export function useImagePreloader(
   useEffect(() => {
     if (!currentImageId || !dbId) return;
 
-    // Preload the next N images
+    // Preload the next N images. Warming goes through the interactive queue
+    // (ensurePreviewReady), so an uncached preview is actually generated —
+    // and its 202 no longer counts as a preload failure — by the time the
+    // user navigates to it.
     const imagesToPreload = nextImageIds.slice(0, preloadCount);
-    const preloadPromises: Promise<void>[] = [];
 
     imagesToPreload.forEach((imageId) => {
-      // Preload the regular preview
-      const previewUrl = apiClient.getPreviewUrl(dbId, imageId, { size: imageSize });
-      const previewImg = new Image();
-      previewImg.src = previewUrl;
-      preloadPromises.push(
-        new Promise((resolve) => {
-          previewImg.onload = () => resolve();
-          previewImg.onerror = () => resolve(); // Resolve even on error to not block
-        })
+      void ensurePreviewReady(
+        dbId,
+        apiClient.getPreviewUrl(dbId, imageId, { size: imageSize }),
+        { imageId, kind: 'preview', size: imageSize }
       );
 
-      // Optionally preload annotated version
+      // Optionally warm the annotated version (getAnnotatedUrl defaults to
+      // 'large' with 1000 stars).
       if (includeAnnotated) {
-        const annotatedUrl = apiClient.getAnnotatedUrl(dbId, imageId);
-        const annotatedImg = new Image();
-        annotatedImg.src = annotatedUrl;
-        preloadPromises.push(
-          new Promise((resolve) => {
-            annotatedImg.onload = () => resolve();
-            annotatedImg.onerror = () => resolve();
-          })
+        void ensurePreviewReady(
+          dbId,
+          apiClient.getAnnotatedUrl(dbId, imageId),
+          { imageId, kind: 'annotated', size: 'large' }
         );
       }
     });


### PR DESCRIPTION
## Problem

`get_image_preview` / `get_annotated_image` generated a missing PNG **synchronously inside the request** (a multi-second `spawn_blocking`), so the browser's `<img>` GET stayed pending the whole time. A grid or the zoom-switch loading many previews could exhaust the browser's ~6 connections-per-host and stall the UI, and nothing bounded how many generations ran at once.

## What changed

Moves on-demand generation onto a **bounded interactive queue** and returns immediately; the frontend keeps its fast path for cached images and, only on a miss, shows a "Generating…" indicator and **batch-polls** until ready.

### Backend — `src/server/preview_queue.rs`
- Process-global `PreviewQueue` on `AppState`. On a cache miss the handlers `enqueue_preview(GenJob)` and return **HTTP 202** `{state:"generating"}` — no in-request generation.
- Bounded `Priority::Interactive` pool (semaphore sized lazily via `plan_workers` + a frame probe, reusing #149). Each job holds a `begin_interactive_job()` guard, so **background pre-generation yields** to user-driven preview work.
- Dedup by `cache_path`; generation writes to a **temp file then atomically renames**, so a readiness poll never sees a partial PNG. The pregen paths now do the same.
- New `POST /api/db/{id}/images/generation-status` — **batch** readiness for many artifacts in one request (enqueues unknowns idempotently). Shared `preview_cache_key`/`annotated_cache_key` keep the artifact handler, status endpoint, and pregen addressing the same file.

### Frontend — `static/src`
Optimistic `<img>` + **batched poll-on-error** (chosen approach: zero overhead when cached):
- `hooks/previewPoll.ts` — singleton coordinator that coalesces all pending images (per DB) into **one** `generation-status` POST every ~800ms, instead of one poll per image.
- `hooks/useAsyncImage.ts` — renders `src` directly (cache hit = instant); on the 202 error joins the poller, reports `generating`, and reloads with a cache-buster when ready.
- `components/PreviewImage.tsx` wraps grid/sequence images; `ImageDetailView` / `ImageComparisonView` use the hook directly (preserving zoom transforms). `ensurePreviewReady` replaces the `new Image()` **zoom-switch preloads** (both panes) and `useImagePreloader` warming, so an uncached `original` actually generates before the zoom swaps to it.

## Verification
- `cargo fmt`/`clippy`/`test` green (queue unit tests: dedup, status transitions, atomic-temp-path, buckets). Frontend `tsc -b` + `vite build` + `eslint` clean (no new issues).
- **Live** against a copy of the real scheduler DB (opencv binary, fresh cache): cache miss → 202; batch status `generating`→`ready`; then 200 PNG. Interactive pool sized to **9 workers (memory allows 35)**. One batch request for 5 images → 5 parallel statuses. **0 leftover temp files** (atomic writes). No generation errors.
- Not driven in a real browser (extension not connected here); the backend contract the frontend depends on is fully verified and the frontend compiles/lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)