### PR TITLE
ci: quiet build-only quick-xml DoS advisories in cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,22 @@
+# cargo-audit configuration (read by `cargo audit`, incl. the CI
+# "Security audit" workflow).
+
+[advisories]
+# quick-xml 0.38.x has two high-severity DoS advisories (unbounded namespace
+# allocation / quadratic duplicate-attribute scan), both fixed in >= 0.41.0.
+#
+# In this project quick-xml is a BUILD-ONLY transitive dependency:
+#   psf-guard (build-dependency tauri-build)
+#     -> tauri-utils -> plist -> quick-xml
+# plist uses it to parse the app's own Info.plist at build time. It is NOT
+# linked into the shipped psf-guard binary and never parses untrusted /
+# network-supplied XML, so the DoS conditions don't apply to the deployed
+# server.
+#
+# There is no upstream fix path yet: plist pins `quick-xml ^0.38`, and even the
+# latest plist (1.9.0) only reaches quick-xml 0.39.x. Remove these ignores once
+# plist / tauri release a version depending on quick-xml >= 0.41.
+ignore = [
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]


### PR DESCRIPTION
## Problem

The **Security audit** workflow (`cargo audit`) fails on two high-severity (7.5) advisories, both in **`quick-xml 0.38.3`**:
- **RUSTSEC-2026-0194** — quadratic runtime on duplicate-attribute check (DoS)
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation (memory-exhaustion DoS)

Both were published April 2026 (after the last green run), so they surfaced against the refreshed advisory DB, not from a code change.

## Why an ignore (and not an upgrade)

`quick-xml` is a **build-only transitive dependency**:

```
psf-guard (build-dependency: tauri-build)
  └─ tauri-utils ─ plist 1.7.4 ─ quick-xml 0.38.3
```

`plist` uses it to parse the app's own `Info.plist` at build time. It is **not linked into the shipped `psf-guard` binary** and never parses untrusted/network XML, so the DoS conditions don't apply to the deployed server.

There's **no upstream fix path**: the fix needs `quick-xml >= 0.41.0`, but `plist` pins `^0.38`, and even the latest `plist 1.9.0` only reaches `quick-xml 0.39.4` (still flagged, plus a third advisory).

## Change

Add a documented `.cargo/audit.toml` ignoring RUSTSEC-2026-0194/0195, with the rationale and a note to remove it once `plist`/`tauri` ship a `quick-xml >= 0.41` update. `cargo audit` then exits 0 (the 24 unmaintained/yanked *warnings* were already non-failing).

Leaving this as a PR for review rather than self-merging, since it accepts two advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)