### PR TITLE
fix(server): gate reopen-by-rename test to unix (fixes Windows CI)

### DIFF
--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -915,6 +915,9 @@ mod tests {
         .unwrap();
     }
 
+    // Only used by the unix-only replace-by-rename test below; gated to match so
+    // Windows (`-D warnings`) doesn't see it as dead code.
+    #[cfg(unix)]
     fn read_project(ctx: &DatabaseContext) -> String {
         let conn = ctx.db();
         let guard = lock_recover(&conn);
@@ -961,6 +964,14 @@ mod tests {
         .unwrap()
     }
 
+    // Unix-only: the proactive reopen this exercises is itself `#[cfg(unix)]`
+    // (identity fingerprint needs a stable dev/ino; `fingerprint_path` returns
+    // `None` elsewhere), and the setup — renaming a fresh file over one an open
+    // SQLite connection still holds — is a POSIX behavior. On Windows that
+    // rename fails with ERROR_ACCESS_DENIED (the default SQLite VFS opens
+    // without FILE_SHARE_DELETE), so there is nothing to test there; Windows
+    // relies on the reactive reopen-on-corruption path instead.
+    #[cfg(unix)]
     #[test]
     fn reopens_when_db_file_is_replaced_by_rename() {
         // Simulates an external process atomically replacing the scheduler DB


### PR DESCRIPTION
## Problem

The **`Test on windows-latest`** CI job has been red on `main` since #148. It fails the `reopens_when_db_file_is_replaced_by_rename` unit test:

```
thread 'server::database_context::tests::reopens_when_db_file_is_replaced_by_rename' panicked at src\server\database_context.rs:979:49:
called `Result::unwrap()` on an `Err` value: Os { code: 5, kind: PermissionDenied, message: "Access is denied." }
...
test result: FAILED. 257 passed; 1 failed; 5 ignored
```

The panic is in the test's **setup**, not the assertion: `std::fs::rename(&replacement, &db_path).unwrap()`.

## Why it can't pass on Windows

The test replaces the DB file by renaming a fresh file over one that an open SQLite connection still holds. That is a POSIX inode-swap. On Windows the default SQLite VFS opens the database **without `FILE_SHARE_DELETE`**, so a replace-over-open rename returns `ERROR_ACCESS_DENIED` — the scenario cannot even be constructed.

And the production behavior the test exercises — proactive, fingerprint-based reopen when the file identity changes — is **already `#[cfg(unix)]`-only** by design. `DbFingerprint` carries `dev`/`ino` only on unix; `fingerprint_path` returns `None` elsewhere and proactive detection is disabled, with Windows falling back to the reactive reopen-on-corruption path. So there is genuinely nothing for this test to assert on Windows.

## Fix

Gate the test — and `read_project`, the one helper only it uses — to `#[cfg(unix)]`, so Windows neither runs the impossible scenario nor trips `clippy --all-targets -- -D warnings` on the now-unused helper. The other helpers stay shared with `our_own_writes_do_not_trigger_a_reopen`, which continues to run everywhere.

**No production code changes.** Unix behavior and coverage are identical.

## Verification

- macOS: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and the `server::database_context` tests all pass (all 3 tests still run on unix).
- Windows path reasoned through: both gated items vanish under `#[cfg(not(unix))]`, leaving no dangling references or dead code. The CI Windows job on this PR is the live confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)