### PR TITLE
test: robust test timeouts on slow CI (playwright annotated + vitest SequenceView)

### DIFF
--- a/static/e2e/preview-generation.spec.ts
+++ b/static/e2e/preview-generation.spec.ts
@@ -90,6 +90,15 @@ test('cache miss returns 202, and the batch status endpoint drives generation to
 test('annotated images generate on-demand through the same queue', async ({
   request,
 }) => {
+  // Annotated generation is genuinely heavy: it runs full-frame star
+  // detection (thousands of stars on a ~60 MP fixture, ~20 s single-threaded
+  // on a fast dev box, more on a shared CI runner) before drawing overlays —
+  // unlike the cheap preview stretch. `max_stars` does NOT bound that cost
+  // (detection finds every star and only the *drawn* set is capped), so the
+  // path is inherently slow. Give this one test a generous budget instead of
+  // the 30 s default so a slow-but-correct runner doesn't flake.
+  test.setTimeout(180_000);
+
   const base = `/api/db/${encodeURIComponent(dbId)}`;
 
   // Annotated cache miss also 202s (same async path as previews).
@@ -97,20 +106,29 @@ test('annotated images generate on-demand through the same queue', async ({
   expect(miss.status()).toBe(202);
   expect(miss.headers()['content-type']).toMatch(/application\/json/);
 
-  // Poll the batch endpoint with kind:'annotated' until ready.
-  await expect
-    .poll(
-      async () => {
-        const r = await request.post(`${base}/images/generation-status`, {
-          data: {
-            requests: [{ image_id: 1, kind: 'annotated', size: 'large' }],
-          },
-        });
-        return (await r.json()).data.statuses[0].state;
-      },
-      { timeout: 30_000, intervals: [500] }
-    )
-    .toBe('ready');
+  // Poll the batch endpoint with kind:'annotated' until it's ready. Fail fast
+  // (with the server's message) if generation actually errors, rather than
+  // silently burning the whole timeout on a job that will never be ready.
+  const statusReq = {
+    data: { requests: [{ image_id: 1, kind: 'annotated', size: 'large' }] },
+  };
+  const deadline = Date.now() + 150_000;
+  let state = 'generating';
+  while (Date.now() < deadline) {
+    const r = await request.post(`${base}/images/generation-status`, statusReq);
+    const status = (await r.json()).data.statuses[0];
+    state = status.state;
+    if (state === 'ready') break;
+    if (state === 'error') {
+      throw new Error(
+        `annotated generation reported error: ${status.error ?? '<no detail>'}`
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  expect(state, 'annotated generation should reach ready before the deadline').toBe(
+    'ready'
+  );
 
   // The annotated endpoint now serves a PNG.
   const hit = await request.get(`${base}/images/1/annotated?size=large`);

--- a/static/vite.config.ts
+++ b/static/vite.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
+    // The jsdom + MSW + userEvent component tests (e.g. SequenceView) can take
+    // several seconds on a loaded/slow CI runner — the whole suite ran ~15 s for
+    // 19 tests on Windows CI. Vitest's 5 s default flakes there, so raise the
+    // ceiling. This still fails a genuinely hung test, just not a slow-but-fine one.
+    testTimeout: 20_000,
     // Don't let vitest scan the Playwright suite — those specs use
     // `@playwright/test` and can't run under vitest.
     exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**'],


### PR DESCRIPTION
Two test-timeout flakes that surface only on the slow Windows CI runner. Both block a green `main`.

## 1. Playwright: annotated generation (`preview-generation.spec.ts`)

The `annotated images generate on-demand` e2e test timed out at 30 s. It was added in #150 but e2e was **skipped** on every run since (blocked by the Windows failure from #148, fixed in #152), so it never ran green in CI until now.

Root cause is genuine cost: annotated generation runs **full-frame star detection** (2007 stars on the ~60 MP fixture, ~21 s single-threaded locally, more on a shared runner) before drawing overlays. `max_stars` doesn't bound it (detection finds every star; only the *drawn* set is capped). Both the Playwright per-test timeout (global 30 s) and the `.poll()` (30 s) were too tight.

Fix: `test.setTimeout(180_000)` for that one heavy test + an explicit 150 s deadline loop that **fails fast** with the server's message if generation reports `error`.

## 2. Vitest: `SequenceView.test.tsx`

While validating #1, the Windows `test` job failed on a *different* flake: `SequenceView.test.tsx > clicking a target card keeps the db/project context` timed out at vitest's **5 s** default — the jsdom + MSW + userEvent suite ran ~15 s for 19 tests on the Windows runner. It passes ~1 s locally; the failure is runner slowness, not a hang. That flake fails the `test` job, which then **skips** the `needs: test` e2e job (which is why #1 couldn't even be observed).

Fix: raise the global vitest `testTimeout` to 20 s. A genuinely hung test still fails; a slow-but-correct one no longer flakes.

## Verification

- **Local:** the annotated e2e test passes (~13 s) against a release server + the real 117 MB fixtures; all 3 preview-generation specs green. All 19 `SequenceView` vitest tests pass. `tsc`/`eslint` clean.
- **CI (this PR):** the `test` matrix must now pass on Windows (vitest fix), unblocking the `Playwright end-to-end (Linux)` job (timeout fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)