### PR TITLE
docs: rewrite README (flow, broken links, stale facts) + fix dead --host flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ points at your Target Scheduler database and image folders and gives you:
   database, so the scheduler knows to re-capture what you rejected.
 - **Safe reject archival** — move rejected frames (and their sidecars) out of
   the directory tree your stacking software scans, reversibly.
+- **Two-machine workflows** — sync projects, captured images, and grades
+  between the telescope's database and your grading machine.
 - **Star detection and PSF analysis** — a port of N.I.N.A.'s detector plus the
   HocusFocus detector, with Gaussian/Moffat PSF fitting and annotated output.
 
@@ -27,7 +29,9 @@ It runs as a desktop app (Windows/macOS/Linux), a self-hosted web server
 (Docker, NAS), or a standalone CLI.
 
 > **Back up your Target Scheduler database before first use.** PSF Guard
-> writes grades into it, and while it's careful, it's also young software.
+> writes grades into it, and its `sync` commands can merge entire databases —
+> projects, captured images, and grades — between machines. It's careful
+> (dry-run flags everywhere), but it's also young software.
 
 ## Screenshots
 
@@ -101,8 +105,18 @@ Then open http://localhost:3000/.
 
 ### Fedora RPM
 
-Native RPMs build on Fedora 43/44 with standard tooling (`rpmbuild`, `mock`,
-COPR), fully offline once sources are prepared:
+Releases after v0.3.0 attach prebuilt RPMs for Fedora 43 and 44 to the
+[releases page](https://github.com/theatrus/psf-guard/releases/latest):
+
+```bash
+sudo dnf install ./psf-guard-*.fc44.x86_64.rpm
+```
+
+The package installs the CLI/server plus a `psf-guard.service` systemd unit
+for running the web grader as a daemon.
+
+Prefer to build your own? Native RPMs build with standard tooling
+(`rpmbuild`, `mock`, COPR), fully offline once sources are prepared:
 
 ```bash
 sudo dnf install -y rpm-build rpmdevtools cargo rust clang-devel \
@@ -206,6 +220,26 @@ psf-guard restore-rejects --db my-db --all    # restores everything
 visible in the web UI. The legacy `filter-rejected` command still exists for
 its statistical-regrading flags but is deprecated in favor of `move-rejects`.
 
+## Syncing between machines
+
+Grade on one machine while the telescope keeps capturing on another. `sync`
+moves state between two scheduler databases — registry slugs or `.sqlite`
+paths — matching images by their stable GUID (Target Scheduler schema v22+):
+
+```bash
+# Mirror projects, targets and captured images FROM the telescope INTO your DB.
+# Your local grading is preserved; new images arrive with the telescope's grade.
+psf-guard sync pull --from telescope.sqlite --to my-db --dry-run
+
+# Push your grading decisions back TO the telescope (one-way, source wins).
+psf-guard sync grades --from my-db --to telescope.sqlite --dry-run
+```
+
+Use them as a loop — pull to refresh, grade locally, push grades back. Both
+directions support `--project` filters and `--dry-run` (`grades` also
+`--target` and `--status`), open the source read-only, and run in a single
+transaction.
+
 ## CLI reference
 
 One binary, many tools. `psf-guard --help` lists everything; the highlights:
@@ -219,24 +253,34 @@ psf-guard server --registry /tmp/scratch.json <db> <dirs...>  # throwaway sessio
 # Quality screening (see docs/SCREENING.md)
 psf-guard screen-fits ./lights --annotate ./diagnostics
 psf-guard screen-fits ./lights --regrade-db my-db --dry-run
+psf-guard screen-fits ./lights --format json         # or table, csv
 
 # Reject archival
 psf-guard move-rejects --db <slug> [--dry-run] [--project NAME] [--target NAME]
 psf-guard restore-rejects --db <slug> [--all] [--image-id N] [--dry-run]
 
+# Two-database sync (see "Syncing between machines" above)
+psf-guard sync pull --from telescope.sqlite --to my-db
+psf-guard sync grades --from my-db --to telescope.sqlite
+
 # Star detection & PSF analysis
 psf-guard analyze-fits image.fits [--detector nina|hocusfocus] [--compare-all]
 psf-guard annotate-stars image.fits [--max-stars 50]
+psf-guard visualize-psf image.fits [--star-index N]  # single-star fit residuals
 psf-guard visualize-psf-multi image.fits [--num-stars 25]
+psf-guard benchmark-psf image.fits                   # PSF fitting performance
 
 # FITS utilities
 psf-guard stretch-to-png image.fits -o output.png   # MTF auto-stretch
 psf-guard read-fits image.fits                      # header/metadata dump
 
-# Database queries
+# Database queries & manual grading
 psf-guard list-projects -d database.sqlite
 psf-guard list-targets "Project Name" -d database.sqlite
 psf-guard dump-grading -d database.sqlite [--project NAME]
+psf-guard show-images <IDS> -d database.sqlite
+psf-guard update-grade <ID> rejected -d database.sqlite
+psf-guard regrade database.sqlite [--dry-run]        # statistical re-grading
 ```
 
 Batch commands also support statistical outlier detection
@@ -276,6 +320,12 @@ psf-guard server --config psf-guard.toml
 [server]
 port = 3000
 host = "0.0.0.0"
+# Optional: fraction of CPU cores for parallel work (both default sensibly).
+# Interactive jobs (occlusion scans, on-demand previews) get scan_worker_ratio;
+# background pre-generation gets background_worker_ratio and pauses entirely
+# while an interactive job runs.
+#scan_worker_ratio = 0.5
+#background_worker_ratio = 0.25
 
 [cache]
 directory = "./cache"

--- a/README.md
+++ b/README.md
@@ -3,53 +3,168 @@
 [![CI](https://github.com/theatrus/psf-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/theatrus/psf-guard/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-A Rust utility for astronomical image analysis and grading, with N.I.N.A. Target Scheduler integration.
+**Image grading and quality screening for [N.I.N.A.](https://nighttime-imaging.eu/)
+astrophotography with the Target Scheduler plugin.**
+
+After an imaging session you're left with hundreds of subs — and some of them
+are ruined by clouds, a tree creeping into the frame, dome occlusion, or stray
+light that conventional star-count/HFR grading happily accepts. PSF Guard
+points at your Target Scheduler database and image folders and gives you:
+
+- **A fast visual grader** — web UI or desktop app with auto-stretched
+  previews, zoom/pan, side-by-side comparison, batch operations, and undo.
+- **Automatic quality screening** — grid-based spatial metrics and cross-frame
+  differential photometry that catch occlusion, small clouds, thin veils, and
+  errant light, with annotated diagnostic images explaining every verdict.
+- **Scheduler write-back** — every grade lands in the Target Scheduler
+  database, so the scheduler knows to re-capture what you rejected.
+- **Safe reject archival** — move rejected frames (and their sidecars) out of
+  the directory tree your stacking software scans, reversibly.
+- **Star detection and PSF analysis** — a port of N.I.N.A.'s detector plus the
+  HocusFocus detector, with Gaussian/Moffat PSF fitting and annotated output.
+
+It runs as a desktop app (Windows/macOS/Linux), a self-hosted web server
+(Docker, NAS), or a standalone CLI.
+
+> **Back up your Target Scheduler database before first use.** PSF Guard
+> writes grades into it, and while it's careful, it's also young software.
 
 ## Screenshots
 
 | Overview Dashboard | Image Grid | Side-by-Side Comparison |
 |:--:|:--:|:--:|
 | ![Overview](docs/overview.png) | ![Grid](docs/image_grid.png) | ![Compare](docs/compare.png) |
-| Complete project statistics and progress tracking | Grid view with filtering and batch operations | Synchronized zoom and detailed image comparison |
+| Project statistics and progress tracking | Grid view with filtering and batch operations | Synchronized zoom and detailed comparison |
 
 | Sequence Analysis & Quality Screening | Star Detection | PSF Fitting |
 |:--:|:--:|:--:|
 | ![Sequence Analysis](docs/sequence-analysis.png) | ![Annotated Stars](docs/annotated-stars.jpg) | ![PSF Visualization](docs/psf-visualization.jpg) |
-| Per-frame quality scores, cloud/occlusion classification, and one-click occlusion scanning | HocusFocus detector with annotated output (`annotate-stars`) | Observed / fitted / residual grids with Moffat & Gaussian models (`visualize-psf-multi`) |
+| Per-frame quality scores, cloud/occlusion classification, one-click occlusion scanning | HocusFocus detector with annotated output (`annotate-stars`) | Observed / fitted / residual grids with Moffat & Gaussian models (`visualize-psf-multi`) |
 
-## Features
+## Installation
 
-- **N.I.N.A. Integration**: Query and analyze Target Scheduler SQLite databases.
-  Note that Target Scheduler is required, using standard NINA file paths doesn't
-  work (yet), as we find images based on the database, and not based on the file
-  structure.
-- **Star Detection**: N.I.N.A. algorithm port + HocusFocus detector with PSF
-  fitting for analysis.
-- **Desktop App and Web Interface**: React-based UI for visual image grading
-  with zoom/pan, and comparisons, with auto-stretched images. Updates to grading
-  are written to the target scheduler DB to allow Target Scheduler to capture
-  more images if required. Ships as both a server for NAS hosting, and a
-  stand-alone desktop app.
-- **CLI tools**: Regrading, batch operations, fits processing, batch image moving.
-- **Quality Screening**: Automatic detection of occlusion (trees, dome),
-  small clouds, thin veils, errant light and static glow — grid-based
-  spatial metrics plus cross-frame differential photometry, with annotated
-  diagnostic images explaining every verdict. See
-  [docs/SCREENING.md](docs/SCREENING.md).
-- **Statistical Analysis**: Advanced outlier detection using HFR, star count,
-  and cloud detection in the batch modes.
-- **FITS Processing**: Convert to PNG, annotate stars, visualize PSF residuals
-- **Multi-Directory Support**: Scan multiple image directories with priority ordering
+### Desktop app (Windows / macOS / Linux)
 
-## Quality Screening
+Grab the installer for your platform from the
+**[latest release](https://github.com/theatrus/psf-guard/releases/latest)**:
 
-Screen light frames for occlusion, clouds, veils and stray light — problems
-that ruin integrations but pass conventional star-count/HFR grading. No
-database required for screening; optional write-back into the Target
-Scheduler DB closes the loop with `move-rejects`.
+| Platform | Asset |
+|----------|-------|
+| Windows x64 | `PSF.Guard_<version>_x64_en-US.msi` |
+| macOS (Apple Silicon) | `PSF.Guard_<version>_aarch64.dmg` |
+| Linux x64 | `PSF.Guard_<version>_amd64.deb` or `.AppImage` |
+
+Install, launch, and point the settings panel at your scheduler database and
+image directories. Releases after v0.3.0 also include a Windows NSIS
+installer (`-setup.exe`) that additionally installs a console
+`psf-guard-cli.exe` and adds it to your user `PATH`, so the full CLI works
+from any terminal.
+
+### Docker (Linux servers / NAS)
 
 ```bash
-# Screen a night and see per-frame verdicts (OK / WARN / REJECT)
+docker run -d -p 3000:3000 \
+  -v /path/to/schedulerdb.sqlite:/data/database.sqlite \
+  -v /path/to/images:/images:ro \
+  ghcr.io/theatrus/psf-guard:latest
+```
+
+Then open http://localhost:3000/. The database mount must be **writable** —
+grading writes back to it (that's the point!). Mount a TOML config at
+`/data/config.toml` and append `server --config /data/config.toml
+/data/database.sqlite /images` if you want to tune port, cache, or preview
+pre-generation (see [Configuration](#configuration)).
+
+### Standalone CLI binaries
+
+Version-independent download links, always pointing at the latest release:
+
+| Platform | Download | Notes |
+|----------|----------|-------|
+| Linux x64 | [`psf-guard-linux-x64`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-linux-x64) | Needs system OpenCV — Docker is easier |
+| macOS | [`psf-guard-macos-x64`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-macos-x64) | Needs Homebrew OpenCV |
+| Windows x64 | [`psf-guard-windows-x64.exe`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-windows-x64.exe) | Static binary, no dependencies |
+
+```bash
+# Linux / macOS
+chmod +x psf-guard-*
+./psf-guard-linux-x64 server schedulerdb.sqlite /path/to/images/
+```
+
+```bat
+:: Windows — back up the DB first, then serve it
+copy "%LOCALAPPDATA%\NINA\SchedulerPlugin\schedulerdb.sqlite" schedulerdb-backup.sqlite
+psf-guard-windows-x64.exe server "%LOCALAPPDATA%\NINA\SchedulerPlugin\schedulerdb.sqlite" C:\path\to\images
+```
+
+Then open http://localhost:3000/.
+
+### Fedora RPM
+
+Native RPMs build on Fedora 43/44 with standard tooling (`rpmbuild`, `mock`,
+COPR), fully offline once sources are prepared:
+
+```bash
+sudo dnf install -y rpm-build rpmdevtools cargo rust clang-devel \
+    opencv-devel nodejs npm git
+rpmdev-setuptree
+./scripts/make-rpm-sources.sh                  # builds frontend + vendors crates
+rpmbuild -ba packaging/rpm/psf-guard.spec      # RPMs land in ~/rpmbuild/RPMS/
+```
+
+See [`packaging/rpm/README.md`](packaging/rpm/README.md) for mock builds, the
+`--without opencv` variant, and release steps.
+
+### Build from source
+
+```bash
+git clone https://github.com/theatrus/psf-guard.git
+cd psf-guard
+cargo build --release
+./target/release/psf-guard server schedulerdb.sqlite /path/to/images/
+```
+
+You'll need Rust, Node.js/npm (the React frontend is embedded at build time),
+and OpenCV with clang. OpenCV is the painful one — the CI workflows under
+[`.github/workflows/`](.github/workflows/) are the authoritative package lists
+per platform (vcpkg on Windows, Homebrew on macOS, `libopencv-dev` on
+Debian/Ubuntu).
+
+## The web grader
+
+Open the UI and you get an overview dashboard (projects, targets, completion,
+grading progress), an image grid, and a comparison mode:
+
+- **Grid**: filter by project/target/status/date, multi-select with
+  Shift/Ctrl+Click, accept/reject/unmark with instant feedback, HFR and
+  star-count metadata on every card.
+- **Comparison**: side-by-side with synchronized (or independent) zoom and
+  pan — grade both frames at once.
+- **Smart loading**: fast previews first, full resolution on zoom; previews
+  generate on demand in the background, so a fresh install is browsable
+  immediately.
+- **Undo/redo** for every grading action.
+
+| Key | Action | Key | Action |
+|-----|--------|-----|--------|
+| K / → | Next image | A | Accept |
+| J / ← | Previous | X | Reject |
+| C | Compare | U | Unmark |
+| S | Stars overlay | + / − | Zoom |
+| Ctrl+Z | Undo | Ctrl+Y | Redo |
+
+Grades are written straight to the Target Scheduler database, so the
+scheduler's acquired-image counts stay accurate and rejected frames get
+re-shot.
+
+## Quality screening
+
+Screen light frames for occlusion, clouds, veils, and stray light — the
+failure modes that ruin integrations but pass star-count/HFR grading. No
+database needed; write-back into the scheduler DB is optional.
+
+```bash
+# Screen a night, get per-frame verdicts (OK / WARN / REJECT)
 psf-guard screen-fits "/path/to/2026-06-30/LIGHT"
 
 # Render annotated diagnostics showing WHY each frame was flagged
@@ -65,196 +180,97 @@ psf-guard move-rejects --db my-db
 |:--:|:--:|
 | ![Occlusion onset](docs/screening-onset.jpg) | ![Veiled field](docs/screening-veil.jpg) |
 
-The web UI's Sequence view (pictured under Screenshots above) has a **Scan
-Occlusion** button that runs the same analysis server-side in the background
-and surfaces classifications and coverage badges on affected frames.
+The web UI's Sequence view has a **Scan Occlusion** button that runs the same
+analysis server-side in the background and badges affected frames with their
+classification.
 
-Full documentation — detection stack, annotated diagnostic examples,
+Full documentation — the detection stack, annotated diagnostic examples,
 tuning, and safety properties: **[docs/SCREENING.md](docs/SCREENING.md)**.
 
-## Known Limits
+## Managing rejected files
 
-- Current, we only support **monochrome** images. Debayering a color image is
-  not implemented and weird things may happen if you use color camera FITS
-  files. Please reach out to psf-guard@theatr.us if you want to contribute some
-  color FITS files for testing :)
-- Some directory paths are presuming this N.I.N.A pattern:
-  `%DATEMINUS12%/%TARGETNAME%/%DATEMINUS12%/LIGHT/standardfilename.fits`, with
-  or without the leading date. Other paths may not be reliably detected, but I'm
-  happy to support more paths and patterns in the future.
-- `psf-guard` may eat your NINA Target Scheduler DB. Make a backup.
-- The `filter-rejected` workflow may eat your FITS files. I use it, but there
-  are lots of subtleties which may lead to bad results. Make a backup. Other
-  commands do not touch FITS files, but still, make a backup.
-
-## Quick Start with Web Grader
-
-### Desktop App (Recommended for Windows/macOS)
-
-**Download PSF Guard Desktop** - Get the native desktop application:
-
-| Platform | Download | Notes |
-|----------|----------|-------|
-| **Windows x64** | [`.msi installer`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard_0.3.0_x64_en-US.msi) | Native Windows installer |
-| **Windows x64** | [`.exe installer`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard_0.3.0_x64-setup.exe) | NSIS installer |
-| **macOS x64** | [`.dmg`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard_0.3.0_x64.dmg) | Drag-and-drop installer |
-| **Linux x64** | [`.deb package`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard_0.3.0_amd64.deb) | Ubuntu/Debian package |
-| **Linux x64** | [`.AppImage`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard_0.3.0_amd64.AppImage) | Portable application |
-
-**Installation:**
-1. Download the appropriate installer for your platform
-2. Install following standard platform conventions
-3. Launch PSF Guard from your applications menu
-4. Configure your database and image directories in the settings panel
-5. Start analyzing your images!
-
-### Docker (Recommended for Linux Servers)
+Once frames are rejected (by hand or by screening), archive them out of the
+directory tree your stacking software scans — reversibly:
 
 ```bash
-# Pull and run
-docker pull ghcr.io/theatrus/psf-guard:latest
+# Move rejects to <image_dir>/<Project>/REJECT/... with their sidecars.
+# Idempotent; every move is recorded for restore.
+psf-guard move-rejects --db my-db [--dry-run]
 
-docker run -d -p 3000:3000 \
-  -v /path/to/database.sqlite:/data/database.sqlite:ro \
-  -v /path/to/images:/images:ro \
-  -v /path/to/psf-guard.toml:/data/config.toml:ro \
-  ghcr.io/theatrus/psf-guard:latest \
-  server --config /data/config.toml
+# Changed your mind? Un-reject frames in the UI, then:
+psf-guard restore-rejects --db my-db          # restores only un-rejected files
+psf-guard restore-rejects --db my-db --all    # restores everything
 ```
 
-Open your browser to http://localhost:3000/
+`restore-rejects` never overwrites an existing file, and archived frames stay
+visible in the web UI. The legacy `filter-rejected` command still exists for
+its statistical-regrading flags but is deprecated in favor of `move-rejects`.
 
-### Fedora / RPM (build from source)
+## CLI reference
 
-PSF Guard can be built as a native RPM on Fedora 43, Fedora 44, and other
-recent releases using mainline RPM tooling (`rpmbuild`, `mock`, COPR). The
-build is fully offline once sources are prepared, so it works in a clean
-chroot:
+One binary, many tools. `psf-guard --help` lists everything; the highlights:
 
 ```bash
-sudo dnf install -y rpm-build rpmdevtools cargo rust clang-devel \
-    opencv-devel nodejs npm git
-rpmdev-setuptree
-./scripts/make-rpm-sources.sh                 # builds frontend + vendors crates
-rpmbuild -ba packaging/rpm/psf-guard.spec      # RPMs in ~/rpmbuild/RPMS/
+# Serve the web grader (registers the DB in the shared registry on first run)
+psf-guard server <database> <image-dirs...> [--port 3000]
+psf-guard server --config psf-guard.toml            # TOML for server knobs
+psf-guard server --registry /tmp/scratch.json <db> <dirs...>  # throwaway session
+
+# Quality screening (see docs/SCREENING.md)
+psf-guard screen-fits ./lights --annotate ./diagnostics
+psf-guard screen-fits ./lights --regrade-db my-db --dry-run
+
+# Reject archival
+psf-guard move-rejects --db <slug> [--dry-run] [--project NAME] [--target NAME]
+psf-guard restore-rejects --db <slug> [--all] [--image-id N] [--dry-run]
+
+# Star detection & PSF analysis
+psf-guard analyze-fits image.fits [--detector nina|hocusfocus] [--compare-all]
+psf-guard annotate-stars image.fits [--max-stars 50]
+psf-guard visualize-psf-multi image.fits [--num-stars 25]
+
+# FITS utilities
+psf-guard stretch-to-png image.fits -o output.png   # MTF auto-stretch
+psf-guard read-fits image.fits                      # header/metadata dump
+
+# Database queries
+psf-guard list-projects -d database.sqlite
+psf-guard list-targets "Project Name" -d database.sqlite
+psf-guard dump-grading -d database.sqlite [--project NAME]
 ```
 
-See [`packaging/rpm/README.md`](packaging/rpm/README.md) for details (mock
-builds, the `--without opencv` variant, and releasing a new version).
+Batch commands also support statistical outlier detection
+(`--enable-statistical`): per-target/filter HFR and star-count distribution
+analysis plus sequence-based cloud detection. Details in
+[docs/STATISTICAL_GRADING.md](docs/STATISTICAL_GRADING.md).
 
-### Pre-built CLI/Server Binaries for Windows, macOS, Linux
+## Configuration
 
-Download the latest release for your platform:
+### Databases: the registry
 
-| Platform | Download | Notes |
-|----------|----------|-------|
-| **Linux x64** | [`psf-guard-linux-x64`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-linux-x64) | Requires system libraries - use Docker instead |
-| **macOS x64** | [`psf-guard-macos-x64`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-macos-x64) | May require system libraries |
-| **Windows x64** | [`psf-guard-windows-x64.exe`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-windows-x64.exe) | Static binary |
+The server manages any number of scheduler databases. The list lives in a
+JSON registry at the platform config location — not in the TOML:
 
-**Note**: Native binaries for macOS and Linux require system libraries (SQLite,
-image processing libraries) that are not included. Docker is recommended for
-Linux deployments to ease the install pain. For macOS, you'll need Homebrew to
-install OpenCV.
+| Platform | Registry path |
+|----------|---------------|
+| Windows | `%APPDATA%\psf-guard\config.json` |
+| macOS | `~/Library/Application Support/psf-guard/config.json` |
+| Linux | `~/.config/psf-guard/config.json` |
 
+`psf-guard server <db> <dirs...>` **registers** that database on first run and
+reuses it afterwards; you can also manage the list from the desktop app's
+Settings panel or the `/api/databases` HTTP endpoints. For a one-off session
+that shouldn't touch your real config, pass `--registry /tmp/scratch.json`.
 
-```bash
-# Linux/macOS - make executable and run
-chmod +x psf-guard-*
-./psf-guard-linux-x64 server --config psf-guard.toml
+The default N.I.N.A. scheduler database on Windows lives at
+`%LOCALAPPDATA%\NINA\SchedulerPlugin\schedulerdb.sqlite`.
 
-# Windows
-copy "%LOCALAPPDATA%\NINA\SchedulerPlugin\schedulerdb.sqlite" schedulerdb-backup.sqlite
-psf-guard-linux-x64 server "%LOCALAPPDATA%\NINA\SchedulerPlugin\schedulerdb.sqlite"
- C:\where_images_are
-```
-
-Open your browser to http://localhost:3000/
-
-Note for Windows: This makes a local copy of the schedulerdb as an insurance
-policy when running psf-guard. You should always make a backup of the database
-in case something eats it.
-
-### Build from Source
-
-You'll need to make sure to include several build tools depending on platform.
-The best luck is probably from reading the .github/ CI files for package install
-instructions. The OpenCV dependency is large and annoying. Its even more large
-and annoying on Windows.
+### Server knobs: the TOML
 
 ```bash
-git clone https://github.com/theatrus/psf-guard.git
-cd psf-guard
-cargo build --release
-
-# Run server (traditional CLI args)
-./target/release/psf-guard server schedulerdb.sqlite /path/to/images/
-
-# Or using config file
-./target/release/psf-guard server --config psf-guard.toml
-
-# Open http://localhost:3000
-```
-
-### Multi-Directory Usage
-
-```bash
-# Scan multiple directories in priority order (first-hit wins)
-psf-guard server db.sqlite /primary/images/ /backup/images/ /archive/images/
-```
-
-### Multi-Database Support
-
-The server can manage many N.I.N.A. scheduler databases at once. The
-configured database list lives in a shared JSON registry at the platform
-config location (`~/Library/Application Support/psf-guard/config.json` on
-macOS, `~/.config/psf-guard/config.json` on Linux,
-`%APPDATA%\psf-guard\config.json` on Windows).
-
-```bash
-# Register a database (idempotent — registers it once, then reuses on later
-# runs). The server loads every configured database, not just this one.
-psf-guard server schedulerdb.sqlite /images/
-
-# Manage the list at runtime via the desktop app's Settings panel, or via
-# HTTP: POST/PUT/DELETE on /api/databases (see CLAUDE.md for the schema).
-```
-
-**Important — CLI behavior change:** `psf-guard server <db> <dirs>` now
-**persists** `<db>` into the shared registry on first run. Subsequent
-invocations pick it up automatically, even without args. If you previously
-relied on the "one-shot, untouched config" behavior, use a scratch
-registry file:
-
-```bash
-# Ad-hoc session that doesn't touch the user's real config.
-psf-guard server --registry /tmp/scratch.json schedulerdb.sqlite /images/
-```
-
-The registry is automatically migrated from the v1 single-DB format on
-first load (the old file is preserved as `config.json.bak`).
-
-## Configuration File
-
-PSF Guard supports TOML configuration files for easier management:
-
-```bash
-# Create from example
 cp psf-guard.toml.example psf-guard.toml
-# Edit with your settings
-nano psf-guard.toml
-
-# Use config file
 psf-guard server --config psf-guard.toml
 ```
-
-### Configuration Options
-
-The TOML config holds only server-wide knobs. **Databases and their image
-directories are not configured here** — they live in the database registry
-(JSON), by default at `<config>/psf-guard/config.json`. Register a database
-with `psf-guard server <db.sqlite> <image-dir>...`, or manage databases from
-the web UI / Tauri app.
 
 ```toml
 [server]
@@ -262,189 +278,65 @@ port = 3000
 host = "0.0.0.0"
 
 [cache]
-directory = "./cache"  
-file_ttl = "5m"        # Human readable: 30s, 5m, 1h, 2h30m, 1d
+directory = "./cache"
+file_ttl = "5m"        # 30s, 5m, 1h, 2h30m, 1d ...
 directory_ttl = "5m"
 
-[pregeneration]  # Optional
+[pregeneration]        # optional background preview warming
 enabled = true
-screen = true   # Generate 1200px previews
-large = false   # Generate 2000px previews
+screen = true          # 1200px previews
+large = false          # 2000px previews
 ```
 
-> A legacy `[database]` / `[images]` section is still parsed for backward
-> compatibility but is **ignored in server mode**; databases come from the
-> registry. Don't add it to new config files.
-
-Command line arguments override config file settings.
-
-## Database Location
-
-**Windows N.I.N.A.:**
-```
-%LOCALAPPDATA%\NINA\SchedulerPlugin\schedulerdb.sqlite
-```
-
-## Web Interface
-
-### Dashboard Overview
-The main dashboard provides a comprehensive view of your imaging projects:
-- **Statistics Cards**: Projects, targets, images, and completion percentage
-- **Progress Visualization**: Color-coded grading progress bars
-- **File Status**: Real-time file discovery and cache status
-- **Filter Summary**: Date ranges and filter usage statistics
-
-### Image Grid View
-- **Smart Filtering**: Filter by project, target, status, and date range
-- **Batch Operations**: Multi-select with Shift+Click, Ctrl+Click
-- **Real-time Status**: Accept/reject/unmark with immediate visual feedback
-- **Quick Navigation**: Keyboard shortcuts for efficient workflow
-- **Metadata Display**: HFR, star counts, and acquisition details
-
-### Comparison Mode
-- **Side-by-Side**: Compare images with synchronized zoom and pan
-- **Independent Controls**: Each image can be manipulated separately
-- **Quick Actions**: Accept, reject, or unmark both images simultaneously
-- **Navigation**: Easy switching between image pairs
-
-### Key Features
-- **Smart Loading**: Fast preview → full resolution on zoom
-- **Cache Progress**: Real-time directory scanning with progress indicators
-- **Undo/Redo**: Full history with Ctrl+Z/Ctrl+Y
-
-### Keyboard Shortcuts
-
-| Key | Action | Key | Action |
-|-----|--------|-----|--------|
-| K/→ | Next image | A | Accept |
-| J/← | Previous | X | Reject |  
-| C | Compare | U | Unmark |
-| S | Stars overlay | +/- | Zoom |
-| Ctrl+Z | Undo | Ctrl+Y | Redo |
-
-## CLI Commands
-
-### Core Commands
-
-```bash
-# Web server (CLI args; registers the DB into the shared config on first run)
-psf-guard server <database> <image-dirs...> [--port 3000]
-
-# Web server with isolated scratch registry (does NOT touch the user's real config)
-psf-guard server --registry /tmp/scratch.json <database> <image-dirs...>
-
-# Web server (TOML knobs file — port/cache/pregen; database list still comes
-# from the registry)
-psf-guard server --config psf-guard.toml [--port 8080]  # CLI overrides config
-
-# Archive rejected images out of the directory tree PixInsight scans
-# (default: <image_dir>/<Project>/REJECT/<rest> with same-stem sidecars).
-# Idempotent and reversible — see REJECT_ARCHIVE_PLAN.md for the design.
-psf-guard move-rejects --db <slug> [--dry-run]
-                       [--reject-segment NAME] [--reject-depth N]
-                       [--sidecar-exts ".xisf,.json,.txt"]
-                       [--project NAME] [--target NAME]
-
-# Move archived rejects back into the tree. By default restores only files
-# you've un-rejected in the UI (grade no longer Rejected); --all restores
-# everything. Never overwrites — restores beside an occupant with a
-# `.restored` suffix. Removes the archive row and prunes emptied dirs.
-psf-guard restore-rejects --db <slug> [--all]
-                          [--image-id N] [--guid X] [--dry-run]
-
-# Legacy: in-place rename `LIGHT/` → `LIGHT_REJECT/` as a sibling folder
-# under the same project root. Deprecated — files stay in the same tree
-# PixInsight loads. Still works for the statistical-regrading flags
-# (`--stat-*`) that `move-rejects` doesn't duplicate.
-psf-guard filter-rejected <database> <image-dir> [--dry-run] [--project NAME]
-
-# Screen lights for occlusion/clouds/stray light (see docs/SCREENING.md)
-psf-guard screen-fits ./lights --annotate ./diagnostics
-psf-guard screen-fits ./lights --regrade-db my-db --dry-run
-
-# Star detection analysis
-psf-guard analyze-fits image.fits [--compare-all] [--detector nina|hocusfocus]
-
-# Create annotated images
-psf-guard annotate-stars image.fits [--max-stars 50] [--color red|yellow]
-```
-
-### Database Queries
-
-```bash
-# List projects and targets
-psf-guard list-projects -d database.sqlite
-psf-guard list-targets "Project Name" -d database.sqlite
-
-# Export grading data
-psf-guard dump-grading -d database.sqlite [--project NAME]
-```
-
-### FITS Processing
-
-```bash
-# Convert with MTF stretch
-psf-guard stretch-to-png image.fits output.png
-
-# PSF analysis grid
-psf-guard visualize-psf-multi image.fits [--num-stars 25]
-
-# Metadata display
-psf-guard read-fits image.fits
-```
-
-## Statistical Grading
-
-Advanced outlier detection beyond database status:
-
-- **HFR Analysis**: Focus quality per target/filter
-- **Star Count**: Abnormal detection counts  
-- **Cloud Detection**: Sequence analysis for weather (bounded-baseline: multi-frame events are fully rejected, permanent condition changes re-baseline)
-- **Distribution Analysis**: MAD for skewed data
-
-Enable with `--enable-statistical` flag.
+Command-line arguments override the config file. (A legacy
+`[database]`/`[images]` section is still parsed but ignored in server mode —
+databases come from the registry.)
 
 ## REST API
 
+Per-database endpoints are nested under `/api/db/{db_id}/`; `GET
+/api/databases` lists the configured databases and their ids.
+
 ```bash
 # List images with filters
-curl "localhost:3000/api/images?project_id=2&status=pending"
+curl "localhost:3000/api/db/my-db/images?project_id=2&status=pending"
 
-# Update grading
-curl -X PUT localhost:3000/api/images/123/grade \
+# Update a grade
+curl -X PUT localhost:3000/api/db/my-db/images/123/grade \
   -H "Content-Type: application/json" \
   -d '{"status": "accepted"}'
 
-# Get processed images
-curl "localhost:3000/api/images/123/preview?size=large" -o preview.png
-curl "localhost:3000/api/images/123/annotated" -o stars.png
+# Fetch processed images
+curl "localhost:3000/api/db/my-db/images/123/preview?size=large" -o preview.png
+curl "localhost:3000/api/db/my-db/images/123/annotated" -o stars.png
 ```
 
-## Cache System
+## Known limitations
 
-- **Auto-refresh**: Both file and directory caches refresh every 5 minutes
-- **Manual refresh**: UI button for file cache, Shift+click for both
-- **Real-time progress**: Live updates during directory scanning
-- **Multi-directory**: Scans all directories with first-hit preference
+- **Monochrome only.** Color/OSC FITS files are not debayered and will do
+  weird things. Want color support? Sample FITS files are welcome at
+  psf-guard@theatr.us.
+- **Target Scheduler required.** Images are located via the scheduler
+  database, not by walking N.I.N.A.'s standard file layout (yet).
+- **Path assumptions.** Directory layouts matching
+  `%DATEMINUS12%/%TARGETNAME%/%DATEMINUS12%/LIGHT/...` (with or without the
+  leading date) are detected reliably; other patterns may not be. Happy to
+  support more — open an issue.
+- **Make backups.** Of the scheduler database always, and of your FITS files
+  before using file-moving commands. `move-rejects` is designed to be
+  reversible and non-destructive, but it's your data.
 
 ## Development
 
 ```bash
-# Setup
-cargo fmt && cargo clippy && cargo test
-
-# Run with logging
+cargo fmt && cargo clippy && cargo test    # the basics
 RUST_LOG=debug cargo run -- server db.sqlite images/
-
-# Frontend development
-cd static && npm run dev
-
-# OpenCV (optional, enhanced star detection)
-brew install opencv  # macOS
+cd static && npm run dev                   # frontend dev server
+cd static && npm run test:e2e              # Playwright end-to-end suite
 ```
 
-See [CLAUDE.md](CLAUDE.md) for architecture details.
+Architecture notes live in [CLAUDE.md](CLAUDE.md).
 
 ## License
 
-Apache License 2.0 - See [LICENSE](LICENSE)
+Apache License 2.0 — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ One binary, many tools. `psf-guard --help` lists everything; the highlights:
 psf-guard server <database> <image-dirs...> [--port 3000]
 psf-guard server --config psf-guard.toml            # TOML for server knobs
 psf-guard server --registry /tmp/scratch.json <db> <dirs...>  # throwaway session
+psf-guard server --host 127.0.0.1 <db> <dirs...>    # localhost only (default binds 0.0.0.0)
 
 # Quality screening (see docs/SCREENING.md)
 psf-guard screen-fits ./lights --annotate ./diagnostics

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -516,9 +516,9 @@ pub enum Commands {
         #[arg(short, long)]
         port: Option<u16>,
 
-        /// Host to bind to
-        #[arg(long, default_value = "127.0.0.1")]
-        host: String,
+        /// Host to bind to (overrides config file; defaults to 0.0.0.0)
+        #[arg(long)]
+        host: Option<String>,
 
         /// Enable background pre-generation of screen-sized preview images
         #[arg(long)]

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -644,7 +644,7 @@ pub fn main() -> Result<()> {
             static_dir,
             cache_dir,
             port,
-            host: _host,
+            host,
             pregenerate_screen,
             pregenerate_large,
             pregenerate_original,
@@ -695,7 +695,7 @@ pub fn main() -> Result<()> {
             } else {
                 Config::default()
             };
-            app_config.merge_with_cli(None, None, port, cache_dir);
+            app_config.merge_with_cli(None, None, port, host, cache_dir);
 
             // We deliberately do NOT call app_config.validate() — the DB path
             // requirement no longer applies (DBs come from the registry).

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,6 +131,7 @@ impl Config {
         database_path: Option<String>,
         image_dirs: Option<Vec<String>>,
         port: Option<u16>,
+        host: Option<String>,
         cache_dir: Option<String>,
     ) {
         // CLI database path overrides config (legacy; server mode ignores this)
@@ -148,6 +149,11 @@ impl Config {
         // CLI port overrides config
         if let Some(cli_port) = port {
             self.server.port = Some(cli_port);
+        }
+
+        // CLI host overrides config
+        if let Some(cli_host) = host {
+            self.server.host = Some(cli_host);
         }
 
         // CLI cache directory overrides config
@@ -360,16 +366,28 @@ directory = "./cache"
             Some("/new/database.sqlite".to_string()),
             Some(vec!["/new/images1".to_string(), "/new/images2".to_string()]),
             Some(8080),
+            Some("127.0.0.1".to_string()),
             Some("/new/cache".to_string()),
         );
 
         assert_eq!(config.get_port(), 8080);
+        assert_eq!(config.get_host(), "127.0.0.1");
         assert_eq!(config.get_cache_directory(), "/new/cache");
         assert_eq!(config.database.unwrap().path, "/new/database.sqlite");
         assert_eq!(
             config.images.unwrap().directories,
             vec!["/new/images1", "/new/images2"]
         );
+    }
+
+    #[test]
+    fn merge_with_cli_without_host_keeps_config_default() {
+        // Regression: --host used to carry a clap default of 127.0.0.1 that was
+        // then silently ignored — the server always bound the config default.
+        // Now the flag is optional: absent → config default (0.0.0.0) stands.
+        let mut config = Config::default();
+        config.merge_with_cli(None, None, None, None, None);
+        assert_eq!(config.get_host(), "0.0.0.0");
     }
 
     #[test]

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -250,7 +250,8 @@ async fn start_server_for_tauri(
 
     // Tauri server has no TOML config; pull port/host from defaults overridden
     // by what we computed above.
-    config.merge_with_cli(None, None, Some(port), Some(cache_dir.clone()));
+    // (host: the desktop app deliberately binds localhost below, not the config.)
+    config.merge_with_cli(None, None, Some(port), None, Some(cache_dir.clone()));
     let host = "127.0.0.1".to_string();
 
     let server_config = crate::server::ServerConfig {


### PR DESCRIPTION
## Why

The README had accreted into notes — screenshots → features → screening → scary warnings → install — with duplicated content and no narrative. And, as it turned out, **all eight release-download links were broken**.

## What changed

**Structure.** Now flows: pitch → highlights → screenshots → install (desktop / Docker / binaries / RPM / source) → the web grader → quality screening → managing rejects → CLI reference → configuration → REST API → known limitations → development. Duplicated feature descriptions merged; the honest backup warnings kept (one up-front callout + a Known Limitations section).

**Broken links, two root causes (both fixed):**
1. The `e2e-fixtures-v1` release had claimed GitHub's **"Latest"** slot, so *every* `releases/latest/download/...` URL resolved against the FITS-fixture release and 404'd. Fixed in release metadata (outside this PR's diff): **v0.3.0 re-marked Latest, fixtures release marked prerelease** — its direct-tag URLs, which the e2e manifest uses, still return 200 (verified).
2. The five desktop links used filenames that don't exist even on v0.3.0: lowercase `psf-guard_0.3.0_*` vs the real `PSF.Guard_0.3.0_*`, an x64 `.dmg` that's actually **aarch64**, and an NSIS `-setup.exe` that was never uploaded. Desktop installs now point at the **releases page** with asset-name patterns, so they can't rot on version bumps; the version-less CLI binaries keep direct `latest/download` links (now working).

**Stale facts corrected (each verified against the binary/routes/Dockerfile):**
- Docker example mounted the DB **read-only** (grading writes would fail) and overrode CMD with `--config` alone — which defines no databases since multi-DB moved them to the registry. Now mounts the DB writable at the default CMD's path, no command override needed.
- REST examples used pre-multi-DB paths → now `/api/db/{db_id}/...`.
- `stretch-to-png image.fits output.png` → output is actually `-o output.png`.
- Windows quick-start literally ran `psf-guard-linux-x64` on Windows.
- Documented the NSIS installer shipping `psf-guard-cli.exe` on PATH (releases after v0.3.0, from #154) and linked `docs/STATISTICAL_GRADING.md` (previously orphaned).

## Verification

- Every relative link/image resolves (14 paths checked against the tree).
- Every external URL returns 200 (curl, including the three `latest/download` CLI links post-metadata-fix).
- Every documented CLI invocation spot-checked against `--help` output; REST payload checked against `UpdateGradeRequest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up folded in: fix the dead `--host` flag

Fact-checking the README surfaced that `server --host` was **completely ignored**: `cli_main.rs` destructured it into `_host`, while clap advertised `[default: 127.0.0.1]` — so the server always bound the config default `0.0.0.0`, even for users who explicitly asked for (or trusted the help text about) localhost-only. Security-relevant, so it's fixed here rather than left documented-but-broken:

- `--host` is now `Option<String>` with no false clap default; help documents the real default (`0.0.0.0`).
- Threaded through `merge_with_cli` like `port`; CLI overrides config, absent → config default stands (Docker/NAS unaffected).
- Tauri desktop unchanged (still deliberately binds `127.0.0.1`).
- Tests cover both cases; **verified live with lsof**: `--host 127.0.0.1` binds `127.0.0.1:PORT`, no flag binds `*:PORT`.
