### PR TITLE
fix(release): NSIS installer asset silently dropped by quoting bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,10 +197,13 @@ jobs:
           windows-latest)
             # Copy .msi installers
             find target/release/bundle/msi -name "*.msi" -exec cp {} release-assets/ \; 2>/dev/null || echo "No .msi files found"
-            # Copy NSIS installers
-            find target/release/bundle/nsis -name "*.exe" | while read -r file; do
-              cp "$file" release-assets/$(basename "$file" .exe)-installer.exe 2>/dev/null || echo "No NSIS .exe files found"
-            done
+            # Copy NSIS installers. -exec is space-safe: the old
+            # `cp "$file" release-assets/$(basename ...)-installer.exe` pipeline
+            # word-split on the space in "PSF Guard_..." and silently copied
+            # nothing (why v0.3.0/v0.4.0 releases initially lacked the NSIS
+            # asset). Keep the original "-setup.exe" name — it's what the docs
+            # reference.
+            find target/release/bundle/nsis -name "*.exe" -exec cp {} release-assets/ \; 2>/dev/null || echo "No NSIS .exe files found"
             ;;
           macos-latest)
             # Copy .dmg installers


### PR DESCRIPTION
The v0.4.0 release published **without its NSIS `-setup.exe`** even though the Windows job log shows the bundler built it (`Finished 2 bundles ... PSF Guard_0.4.0_x64-setup.exe`), followed by `No NSIS .exe files found`.

## Root cause

```bash
cp "$file" release-assets/$(basename "$file" .exe)-installer.exe 2>/dev/null || echo "No NSIS .exe files found"
```

The destination is **unquoted**, and Tauri's installer name contains a space (`PSF Guard_0.4.0_x64-setup.exe`) — the substitution word-splits, `cp` gets three arguments and errors, and `2>/dev/null || echo` swallows the failure. v0.3.0 was affected the same way (it has no NSIS asset either) — this has never worked.

## Fix

Use the same space-safe form as the other bundle types, and keep the original `-setup.exe` filename (it's what the README/site reference):

```bash
find target/release/bundle/nsis -name "*.exe" -exec cp {} release-assets/ \; 2>/dev/null || echo "No NSIS .exe files found"
```

## v0.4.0 remediation (already done)

The tag commit `b56e59e` is identical to the main commit CI built, so I downloaded the `psf-guard-tauri-windows-x64` artifact from that green CI run, verified the installer contains the bundled binaries, and uploaded `PSF.Guard_0.4.0_x64-setup.exe` to the release — **v0.4.0 now has all 11 expected assets**, including the NSIS installer with `psf-guard-cli` on PATH and the first prebuilt Fedora RPMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)