### PR TITLE
fix(ci): stop Docker build failing on every PR (GHA cache eviction)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,12 +58,21 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # PRs validate the amd64 build only. Building linux/arm64 here means
+          # a full Rust+OpenCV compile under QEMU emulation (~60+ min), which
+          # (a) is slow and (b) overflows GitHub's ~10 GB Actions cache with
+          # mode=max, so blobs get LRU-evicted mid-build and the run dies with
+          # "cache entry no longer exists". Both arches are still built+pushed
+          # on main/tags below.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Only write cache on push events. Letting PRs write cache (two arches,
+          # mode=max) evicts main's blobs from the shared repo cache, which then
+          # breaks other PRs' cache-from reads. PRs still read main's cache.
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
 
 #      - name: Generate artifact attestation
 #        if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Problem

The **Docker `build-and-push` job fails on every pull request** but succeeds on `main`. Every PR run ends with:

```
ERROR: blob sha256:… not found
ERROR: failed to build: failed to solve: failed to compute cache key: failed to copy: cache entry no longer exists
```

## Root cause

PRs build **`linux/amd64` + `linux/arm64`**, and arm64 runs through **QEMU emulation** — a full Rust+OpenCV compile that took **~78 minutes** on the failing run (a single crate compiled for 26 min). With `cache-to: type=gha,mode=max` across two arches, the cache export overflows GitHub's **~10 GB per-repo Actions cache**, so blobs get **LRU-evicted mid-build**; buildkit then can't import a layer whose blob is gone → *"cache entry no longer exists"*.

`main` passed because PRs read `main`'s cache scope and are the ones that get their referenced blobs evicted out from under them (often by a concurrent/subsequent `main` build writing a fresh two-arch `mode=max` cache).

## Fix

- **PRs build `linux/amd64` only** — fast validation (~15 min vs 78), no QEMU arm64. Both arches are still built **and pushed** on `main`/tags.
- **`cache-to` runs on push events only** — PRs writing two-arch `mode=max` cache is what evicts `main`'s blobs from the shared repo cache and breaks *other* PRs' `cache-from` reads. PRs still read `main`'s cache.

No change to what ships: `main`/tags still publish the multi-arch (amd64+arm64) image to GHCR.

## Follow-up (not in this PR)

Build arm64 on a native `ubuntu-24.04-arm` runner (matrix + `buildx imagetools` manifest merge) instead of QEMU — that would cut `main`'s current 1–2 h Docker build to minutes and drop emulation entirely. Happy to do this next if you want it.

The Docker check on this PR is itself the verification — it should now pass (amd64-only, no cache write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)