### PR TITLE
ci(docker): build arm64 natively (drop QEMU), split into build + merge

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,16 +18,39 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  # Build each architecture on its own native runner (no QEMU). On push/tag
+  # each build pushes an untagged, by-digest image; the merge job below then
+  # assembles the multi-arch manifest and applies the tags. On PRs each arch is
+  # just built (native, fast) as validation — nothing is pushed and the merge
+  # job is skipped.
+  build:
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
+      - name: Prepare platform slug
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Extract labels
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -40,44 +63,84 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Per-platform cache scope so amd64 and arm64 don't overwrite each
+          # other. Only write cache on push events — PRs writing cache would
+          # evict the shared repo cache and break other PRs' reads.
+          cache-from: type=gha,scope=docker-${{ env.PLATFORM_PAIR }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=gha,mode=max,scope=docker-{0}', env.PLATFORM_PAIR) || '' }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests into one multi-arch manifest and tag it.
+  # Skipped on PRs (nothing was pushed).
+  merge:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract metadata (tags)
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix={{branch}}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
         with:
-          context: .
-          # PRs validate the amd64 build only. Building linux/arm64 here means
-          # a full Rust+OpenCV compile under QEMU emulation (~60+ min), which
-          # (a) is slow and (b) overflows GitHub's ~10 GB Actions cache with
-          # mode=max, so blobs get LRU-evicted mid-build and the run dies with
-          # "cache entry no longer exists". Both arches are still built+pushed
-          # on main/tags below.
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          # Only write cache on push events. Letting PRs write cache (two arches,
-          # mode=max) evicts main's blobs from the shared repo cache, which then
-          # breaks other PRs' cache-from reads. PRs still read main's cache.
-          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Generate artifact attestation
-#        if: github.event_name != 'pull_request'
-#        uses: actions/attest-build-provenance@v1
-#        with:
-#          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-#          subject-digest: ${{ steps.push.outputs.digest }}
-#          push-to-registry: true
+      - name: Create and push multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect the published image
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Follow-up to #158. Instead of building `linux/arm64` under **QEMU emulation** (a full Rust+OpenCV compile that made `main`'s Docker build take **1–2 hours**), build each arch on its **own native runner** and merge the results into one manifest.

## Structure (canonical Docker multi-runner pattern)

- **`build`** matrix — one job per arch on its native runner:
  - `linux/amd64` → `ubuntu-24.04`
  - `linux/arm64` → `ubuntu-24.04-arm` (GitHub-hosted arm64 runner, **free for public repos**)
  - On push/tag: pushes an **untagged, by-digest** image and uploads the digest as an artifact.
  - On PR: builds natively as validation, **pushes nothing**.
- **`merge`** (skipped on PRs) — downloads the per-arch digests and runs `docker buildx imagetools create` to assemble the **multi-arch manifest** and apply all the tags (`latest`, branch, semver, sha).

## What this fixes / improves

- **No QEMU** → `main`'s multi-arch build drops from ~1–2 h to roughly the time of a single native compile per arch (in parallel).
- **PRs now validate *both* arches** natively and cheaply (before #158 they flaked; #158 made them amd64-only — this restores arm64 coverage without the emulation cost).
- **Per-platform cache scope** (`docker-linux-amd64` / `docker-linux-arm64`) so the arches stop clobbering each other's GHA cache; `cache-to` still only runs on push (keeps #158's eviction fix).

## No change to what ships

`main`/tags still publish a `linux/amd64` + `linux/arm64` manifest to `ghcr.io/theatrus/psf-guard` — the `merge` job even `imagetools inspect`s it at the end to prove the manifest has both platforms.

## Notes

- Job names change from `build-and-push` to `build` / `merge`; `main` has no branch protection / required checks, so nothing depends on the old name.
- The Dockerfile is arch-agnostic (plain `rust` base + apt + `cargo build`, no `--platform` pins), so native arm64 builds the same image the QEMU path did.

The Docker checks on this PR are the verification — both `build (linux/amd64)` and `build (linux/arm64)` should pass natively and fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)