### PR TITLE
[codex] Fix async preview fallback layering and lint

### DIFF
--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3197,7 +3197,13 @@
   text-align: center;
   color: var(--color-text-secondary, #888);
   background: var(--color-bg-primary, #1a1a1a);
-  z-index: 1;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.preview-image-hidden {
+  opacity: 0 !important;
+  pointer-events: none;
 }
 
 .preview-status-label {

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { AxiosInstance } from 'axios';
 import { getServerUrl } from '../utils/tauri';
 import type {
   ApiResponse,
@@ -26,16 +27,8 @@ import type {
   GenerationStatus,
 } from './types';
 
-// Default API instance (used as fallback)
-const api = axios.create({
-  baseURL: '/api',
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
-
 // Store the initialized API instance and server URL
-let initializedApi: typeof api | null = null;
+let initializedApi: AxiosInstance | null = null;
 let cachedServerUrl: string | null = null;
 
 // Initialize the API client

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -250,7 +250,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
       }
       prevGroupingMode.current = groupingMode;
     }
-  }, [groupingMode, imageGroups.length, setExpandedGroups]); // Depend on length, not content
+  }, [groupingMode, imageGroups, setExpandedGroups]);
 
   // Flatten images for navigation
   const flatImages = useMemo(() => {
@@ -313,7 +313,13 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
     setSelectedGroupIndex(newItem.groupIndex);
     setSelectedImageIndex(newItem.indexInGroup);
     setSelectedImageId(newItem.image.id); // Set immediately, don't wait for useEffect
-  }, [flatImages, selectedGroupIndex, selectedImageIndex]);
+  }, [
+    flatImages,
+    selectedGroupIndex,
+    selectedImageIndex,
+    setSelectedGroupIndex,
+    setSelectedImageIndex,
+  ]);
 
   const gradeImage = useCallback(async (status: 'accepted' | 'rejected' | 'pending') => {
     if (!selectedImageId) return;
@@ -384,7 +390,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
       setSelectedImageId(imageId);
       setLastSelectedImageId(imageId);
     }
-  }, [flatImages, lastSelectedImageId, updateParams]);
+  }, [flatImages, lastSelectedImageId, setSelectedImages, updateParams]);
 
   // Batch grading functions
   const gradeBatch = useCallback(async (status: 'accepted' | 'rejected' | 'pending') => {
@@ -399,7 +405,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
     } catch (error) {
       console.error('Batch grading failed:', error);
     }
-  }, [selectedImages, grading]);
+  }, [selectedImages, grading, setSelectedImages]);
 
   // Switch to appropriate grouping mode when changing between single/multi-project
   const prevProjectId = useRef(projectId);
@@ -423,10 +429,17 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
   }, [projectId, setGroupingMode]);
   
   // Clear date filters when project/target changes to avoid "no results" scenarios
+  const filtersRef = useRef(filters);
+  const updateFiltersRef = useRef(updateFilters);
+  useEffect(() => {
+    filtersRef.current = filters;
+    updateFiltersRef.current = updateFilters;
+  }, [filters, updateFilters]);
+
   useEffect(() => {
     // Only clear dates if they exist, to avoid infinite loops
-    if (filters.dateRange.start || filters.dateRange.end) {
-      updateFilters({
+    if (filtersRef.current.dateRange.start || filtersRef.current.dateRange.end) {
+      updateFiltersRef.current({
         dateStart: '',
         dateEnd: '',
       });
@@ -441,7 +454,14 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
   useEffect(() => {
     setSelectedImages(new Set());
     setLastSelectedImageId(null);
-  }, [filters.status, filters.filterName, filters.dateRange.start, filters.dateRange.end, filters.searchTerm]);
+  }, [
+    filters.status,
+    filters.filterName,
+    filters.dateRange.start,
+    filters.dateRange.end,
+    filters.searchTerm,
+    setSelectedImages,
+  ]);
 
   // Keyboard shortcuts
   useHotkeys('k', () => navigateImages('next'), [navigateImages]);

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -268,7 +268,7 @@ export default function ImageComparisonView({
       }, 300);
     }
     // Never switch back from original to large
-  }, [leftZoom, leftImageId, showStars, leftImage, leftOriginalLoaded]);
+  }, [leftZoom, leftImageId, showStars, leftImage, leftOriginalLoaded, dbId, maxStars]);
   
   // Load original dimensions from metadata if available
   useEffect(() => {
@@ -341,7 +341,16 @@ export default function ImageComparisonView({
       }, 300);
     }
     // Never switch back from original to large
-  }, [rightZoom, rightImageId, showStars, rightImage, rightOriginalLoaded, useLeftOriginal]);
+  }, [
+    rightZoom,
+    rightImageId,
+    showStars,
+    rightImage,
+    rightOriginalLoaded,
+    useLeftOriginal,
+    dbId,
+    maxStars,
+  ]);
   
   // Effect to make right image follow left image's resolution choice
   useEffect(() => {

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -228,7 +228,7 @@ export default function ImageDetailView({
       }, 300);
     }
     // Never switch back from original to large
-  }, [zoom, imageId, showStars, showPsf, image, isOriginalLoaded]);
+  }, [zoom, imageId, showStars, showPsf, image, isOriginalLoaded, dbId, maxStars]);
   
   // Reset preload state when image changes
   useEffect(() => {

--- a/static/src/components/PreviewImage.tsx
+++ b/static/src/components/PreviewImage.tsx
@@ -43,6 +43,19 @@ export default function PreviewImage({
   }, [img.state]);
 
   const pending = img.state === 'loading' || img.state === 'generating';
+  const imageVisible = img.state === 'ready';
+  const imageClassName = [className, !imageVisible ? 'preview-image-hidden' : null]
+    .filter(Boolean)
+    .join(' ');
+  const imageStyle: React.CSSProperties = {
+    ...imgStyle,
+    ...(imageVisible
+      ? {}
+      : {
+          opacity: 0,
+          pointerEvents: 'none',
+        }),
+  };
 
   return (
     <>
@@ -57,16 +70,16 @@ export default function PreviewImage({
       {img.state === 'error' && (fallback ?? <PreviewError />)}
       {/* The img stays in layout (never display:none) so it actually loads —
           a lazy + display:none image has no box and the browser never fetches
-          it, so onError/onLoad would never fire. While pending/error the
-          opaque .preview-status-box above covers it; when ready it shows. */}
+          it, so onError/onLoad would never fire. While pending/error it is
+          transparent and the opaque .preview-status-box above owns the view. */}
       <img
         src={img.src}
         alt={alt}
         loading={loading}
         onLoad={img.onLoad}
         onError={img.onError}
-        className={className}
-        style={imgStyle}
+        className={imageClassName || undefined}
+        style={imageStyle}
       />
     </>
   );

--- a/static/src/types/grouping.ts
+++ b/static/src/types/grouping.ts
@@ -78,7 +78,7 @@ export function isMultiProjectMode(mode: GroupingMode): mode is typeof MULTI_PRO
  * Get the next grouping mode in cycle for single-project view
  */
 export function getNextSingleProjectMode(current: GroupingMode): GroupingMode {
-  const currentIndex = SINGLE_PROJECT_MODES.indexOf(current as any);
+  const currentIndex = SINGLE_PROJECT_MODES.indexOf(current);
   const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % SINGLE_PROJECT_MODES.length;
   return SINGLE_PROJECT_MODES[nextIndex];
 }
@@ -87,7 +87,7 @@ export function getNextSingleProjectMode(current: GroupingMode): GroupingMode {
  * Get the next grouping mode in cycle for multi-project view  
  */
 export function getNextMultiProjectMode(current: GroupingMode): GroupingMode {
-  const currentIndex = MULTI_PROJECT_MODES.indexOf(current as any);
+  const currentIndex = MULTI_PROJECT_MODES.indexOf(current);
   const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % MULTI_PROJECT_MODES.length;
   return MULTI_PROJECT_MODES[nextIndex];
 }

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -23,7 +23,6 @@ export const isTauriApp = (): boolean => {
 export const getServerUrl = async (): Promise<string> => {
   if (isTauriApp()) {
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       return await invoke('get_server_url');
     } catch (error) {
@@ -80,7 +79,6 @@ export const tauriFileSystem = {
     if (!isTauriApp()) return null;
     
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       return await invoke('pick_database_file');
     } catch (error) {
@@ -94,7 +92,6 @@ export const tauriFileSystem = {
     if (!isTauriApp()) return null;
     
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       return await invoke('pick_image_directory');
     } catch (error) {
@@ -108,7 +105,6 @@ export const tauriFileSystem = {
     if (!isTauriApp()) return null;
     
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       return await invoke('get_default_nina_database_path');
     } catch (error) {
@@ -125,7 +121,6 @@ export const tauriConfig = {
     if (!isTauriApp()) return null;
 
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       return await invoke('get_current_configuration');
     } catch (error) {
@@ -139,7 +134,6 @@ export const tauriConfig = {
     if (!isTauriApp()) return false;
 
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       await invoke('save_configuration', { config });
       return true;
@@ -158,7 +152,6 @@ export const tauriConfig = {
     if (!isTauriApp()) return null;
 
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       return await invoke('add_database', { name, dbPath, imageDirs });
     } catch (error) {
@@ -172,7 +165,6 @@ export const tauriConfig = {
     if (!isTauriApp()) return false;
 
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       return await invoke('remove_database', { dbId });
     } catch (error) {
@@ -186,7 +178,6 @@ export const tauriConfig = {
     if (!isTauriApp()) return false;
     
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       await invoke('restart_application');
       return true;
@@ -201,7 +192,6 @@ export const tauriConfig = {
     if (!isTauriApp()) return false;
     
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       const result = await invoke('restart_server');
       console.log('Server restart result:', result);
@@ -217,7 +207,6 @@ export const tauriConfig = {
     if (!isTauriApp()) return false;
     
     try {
-      // @ts-ignore - Tauri API will be available at runtime
       const { invoke } = await import('@tauri-apps/api/core');
       return await invoke('is_configuration_valid');
     } catch (error) {


### PR DESCRIPTION
## Summary
- keep queued preview loading/error fallbacks visually above the hidden fetch image
- hide non-ready preview images without removing their layout box, preserving lazy loading behavior
- clean the broader frontend lint issues around unused API setup, hook deps, Tauri comments, and grouping casts

## Validation
- npm run lint
- npm run build
- npm test
- npm run test:e2e

Note: the first e2e attempt timed out while waiting for the initial Rust release build; the cached rerun completed with 15 passed tests.