### PR TITLE
Preserve detail zoom during original preview load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,24 @@ PNG (the pregen paths in `mod.rs` do the same now).
   zoom transforms), and `ensurePreviewReady` replaces the `new Image()` zoom-
   switch preloads + `useImagePreloader` warming so an uncached 'original'
   actually generates before the zoom swaps to it.
+- **Detail-view zoom model (2026-07)**: `useImageZoom` keeps `stateDimsRef` —
+  the dimensions the transform is *calibrated against* — and constrains pans
+  and fits against that, never the live `<img>.naturalWidth` (which lags a src
+  swap; clamping original-image offsets against the old preview's dims is what
+  threw the viewport to the top-left mid-gesture). `ImageDetailView` tracks a
+  `'fit' | 'user'` view mode via the hook's `onViewModeChange` (wheel / +/- /
+  100% / pan → `'user'`; F / Fit / 0 → `'fit'`; no time-based cooldown
+  heuristics). Every `onLoad` reports through `applyBitmapDimensions(w, h,
+  mode)`: `'fit'` refits centered; `'preserve'` keeps the state EXACTLY when
+  dims are unchanged (arrow-key navigation ⇒ identical scale/offsets/percent)
+  and remaps to the same displayed size + center when they differ (preview ↔
+  original swaps). The original switch triggers on RAW scale (`>0.8` preload,
+  once per image; `>=1.0` swap) — raw `scale > 1` means the current bitmap is
+  upscaled past its native pixels, whichever size is showing. The zoom
+  percentage is relative to the ORIGINAL's pixels (learned from metadata or
+  the first original load; falls back to raw until known). ImageComparisonView
+  keeps its own working preservation logic — the hook API it uses is
+  unchanged, so don't "unify" it into this model without re-testing both.
 
 ### Two-DB sync (2026-06)
 Lives in `src/commands/sync/` (`mod.rs` shared helpers + `grades.rs` + `pull.rs`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,17 @@ PNG (the pregen paths in `mod.rs` do the same now).
 - **Cache keys**: `preview_cache_key` / `annotated_cache_key` in `handlers.rs`
   are shared by the artifact handler, the status endpoint, and pregen so all
   address the same file.
+- **Slow-storage isolation (2026-07)**: measured against an SMB-mounted
+  scheduler DB (274MB, journal=delete) where every SQLite transaction pays
+  network lock round-trips (30-80s/query observed). Two rules keep the
+  request path responsive there: (1) the background file-check refresh runs
+  all its queries on a **dedicated connection** (one `get_images_by_project_id`
+  per project, per-target tallies grouped in memory — never the old
+  full-table scan per target), so the shared request-connection mutex is
+  never held by a slow refresh query; (2) `get_directory_tree` **never scans
+  in the request path** when any tree exists — a stale (>5min) tree is served
+  immediately while one deduped background thread revalidates; only a cold
+  start blocks, and concurrent cold callers share a single scan.
 - **Frontend** (`static/src`): optimistic `<img>` + poll-on-error. `hooks/previewPoll.ts`
   is a singleton coordinator that batches pending descriptors (per DB) into one
   `getGenerationStatus` POST every ~800ms; `hooks/useAsyncImage.ts` drives an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,8 +289,12 @@ PNG (the pregen paths in `mod.rs` do the same now).
   upscaled past its native pixels, whichever size is showing. The zoom
   percentage is relative to the ORIGINAL's pixels (learned from metadata or
   the first original load; falls back to raw until known). ImageComparisonView
-  keeps its own working preservation logic — the hook API it uses is
-  unchanged, so don't "unify" it into this model without re-testing both.
+  keeps its own working preservation logic — don't "unify" it into this model
+  without re-testing both — but every loaded bitmap MUST be reported to the
+  hook (comparison calls `notifyBitmapDimensions` in its onLoads; detail goes
+  through `applyBitmapDimensions`): constraints follow `stateDimsRef`, not the
+  live `<img>`, so an unreported load leaves pans clamped against the previous
+  image's dimensions.
 
 ### Two-DB sync (2026-06)
 Lives in `src/commands/sync/` (`mod.rs` shared helpers + `grades.rs` + `pull.rs`).

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -14,6 +14,7 @@ use crate::server::state::{FileCheckCache, RefreshProgress, RefreshStage, Refres
 use anyhow::Result;
 use rusqlite::{Connection, OpenFlags};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 use tokio::sync::Mutex as TokioMutex;
@@ -80,6 +81,16 @@ fn lock_recover<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     m.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+struct TreeRebuildInflight {
+    flag: Arc<AtomicBool>,
+}
+
+impl Drop for TreeRebuildInflight {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::SeqCst);
+    }
+}
+
 /// Whether a rusqlite error is the specific signature of a connection whose
 /// backing file was replaced with different (or non-database) bytes underneath
 /// it. Deliberately narrow: only `SQLITE_CORRUPT` and `SQLITE_NOTADB`, the two
@@ -135,8 +146,8 @@ pub struct DatabaseContext {
     /// Serializes cold directory-tree builds so N concurrent requests on an
     /// empty cache share one filesystem scan instead of starting N.
     tree_build_lock: Arc<Mutex<()>>,
-    /// True while a background (stale-revalidation) tree rebuild is running.
-    tree_rebuild_inflight: Arc<std::sync::atomic::AtomicBool>,
+    /// True while a stale-revalidation/progress tree rebuild is scheduled or running.
+    tree_rebuild_inflight: Arc<AtomicBool>,
     pub refresh_mutex: Arc<TokioMutex<()>>,
     /// Per-DB spatial (occlusion) metrics store + scan progress; persisted
     /// under `cache_dir` as spatial_metrics.json.
@@ -201,7 +212,7 @@ impl DatabaseContext {
             file_check_cache: Arc::new(RwLock::new(FileCheckCache::new())),
             directory_tree_cache: Arc::new(RwLock::new(None)),
             tree_build_lock: Arc::new(Mutex::new(())),
-            tree_rebuild_inflight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            tree_rebuild_inflight: Arc::new(AtomicBool::new(false)),
             refresh_mutex: Arc::new(TokioMutex::new(())),
             spatial_metrics: Arc::new(RwLock::new(Default::default())),
         })
@@ -376,22 +387,26 @@ impl DatabaseContext {
     /// Kick a deduplicated background rebuild of the directory tree. No-op if
     /// one is already running.
     fn spawn_directory_tree_rebuild(&self) {
-        use std::sync::atomic::Ordering;
-
-        if self.tree_rebuild_inflight.swap(true, Ordering::SeqCst) {
+        let Some(inflight) = self.try_mark_directory_tree_rebuild() else {
             return;
-        }
+        };
         let ctx = self.clone();
         std::thread::spawn(move || {
-            // Reset the flag even if the scan errors or panics, so a failed
-            // rebuild doesn't pin the stale tree forever.
-            struct Reset(Arc<std::sync::atomic::AtomicBool>);
-            impl Drop for Reset {
-                fn drop(&mut self) {
-                    self.0.store(false, Ordering::SeqCst);
+            let _inflight = inflight;
+            let _build_guard = lock_recover(ctx.tree_build_lock.as_ref());
+            {
+                let cache = ctx.directory_tree_cache.read().unwrap();
+                if let Some(ref tree) = *cache {
+                    if !tree.is_older_than(Duration::from_secs(300)) {
+                        tracing::debug!(
+                            "🌳 Background directory tree rebuild skipped for db={}; another scan refreshed it",
+                            ctx.id
+                        );
+                        return;
+                    }
                 }
             }
-            let _reset = Reset(ctx.tree_rebuild_inflight.clone());
+
             if let Err(e) = ctx.rebuild_directory_tree_internal() {
                 tracing::warn!(
                     "⚠️ Background directory tree rebuild failed for db={}: {}",
@@ -400,6 +415,16 @@ impl DatabaseContext {
                 );
             }
         });
+    }
+
+    fn try_mark_directory_tree_rebuild(&self) -> Option<TreeRebuildInflight> {
+        if self.tree_rebuild_inflight.swap(true, Ordering::SeqCst) {
+            None
+        } else {
+            Some(TreeRebuildInflight {
+                flag: Arc::clone(&self.tree_rebuild_inflight),
+            })
+        }
     }
 
     fn rebuild_directory_tree_internal(&self) -> Result<Arc<DirectoryTree>> {
@@ -451,6 +476,15 @@ impl DatabaseContext {
                     "🌳 Directory tree cache is empty for db={}, building",
                     self.id
                 );
+            }
+        }
+        let _guard = lock_recover(self.tree_build_lock.as_ref());
+        {
+            let cache = self.directory_tree_cache.read().unwrap();
+            if let Some(ref tree) = *cache {
+                if !tree.is_older_than(Duration::from_secs(300)) {
+                    return Ok(Arc::new(tree.clone()));
+                }
             }
         }
         self.rebuild_directory_tree_internal()
@@ -571,6 +605,7 @@ impl DatabaseContext {
             let mut per_target: std::collections::HashMap<i32, (usize, usize)> =
                 std::collections::HashMap::new();
             for (image, _project_name, _target_name) in &images {
+                let entry = per_target.entry(image.target_id).or_insert((0, 0));
                 let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&image.metadata)
                 else {
                     continue;
@@ -582,7 +617,6 @@ impl DatabaseContext {
                     .split(&['\\', '/'][..])
                     .next_back()
                     .unwrap_or(filename_path);
-                let entry = per_target.entry(image.target_id).or_insert((0, 0));
                 if directory_tree.find_file_first(filename).is_some() {
                     entry.0 += 1;
                 } else {
@@ -758,6 +792,8 @@ impl DatabaseContext {
             }
         }
 
+        let _inflight = self.try_mark_directory_tree_rebuild();
+
         tracing::info!(
             "🌳 Building directory tree cache for db={} ({} directories) with progress tracking",
             self.id,
@@ -780,7 +816,19 @@ impl DatabaseContext {
         });
 
         let image_dir_paths = self.image_dir_paths.clone();
-        let tree_result = tokio::task::spawn_blocking(move || {
+        let directory_tree_cache = Arc::clone(&self.directory_tree_cache);
+        let tree_build_lock = Arc::clone(&self.tree_build_lock);
+        let tree_result = tokio::task::spawn_blocking(move || -> Result<(DirectoryTree, bool)> {
+            let _build_guard = lock_recover(tree_build_lock.as_ref());
+            {
+                let cache = directory_tree_cache.read().unwrap();
+                if let Some(ref tree) = *cache {
+                    if !tree.is_older_than(Duration::from_secs(300)) {
+                        return Ok((tree.clone(), false));
+                    }
+                }
+            }
+
             let roots: Vec<&std::path::Path> =
                 image_dir_paths.iter().map(|p| p.as_path()).collect();
 
@@ -793,33 +841,53 @@ impl DatabaseContext {
                     ));
                 };
 
-            crate::directory_tree::DirectoryTree::build_multiple_with_progress(
+            let tree = crate::directory_tree::DirectoryTree::build_multiple_with_progress(
                 &roots,
                 &mut progress_callback,
-            )
+            )?;
+
+            {
+                let mut cache = directory_tree_cache.write().unwrap();
+                *cache = Some(tree.clone());
+            }
+
+            Ok((tree, true))
         })
         .await??;
 
-        {
+        let (tree_result, built_tree) = tree_result;
+
+        if built_tree {
             let mut cache = self.file_check_cache.write().unwrap();
             cache.refresh_progress.complete_directory();
+        } else {
+            tracing::debug!(
+                "🌳 Directory tree cache became fresh while refresh waited for db={}",
+                self.id
+            );
         }
 
         progress_task.abort();
 
         let stats = tree_result.stats();
-        tracing::info!(
-            "✅ Directory tree built for db={} with progress tracking: {} files, {} directories across {} roots (age: {})",
-            self.id,
-            stats.total_files,
-            stats.total_directories,
-            stats.roots.len(),
-            stats.format_age()
-        );
-
-        {
-            let mut cache = self.directory_tree_cache.write().unwrap();
-            *cache = Some(tree_result.clone());
+        if built_tree {
+            tracing::info!(
+                "✅ Directory tree built for db={} with progress tracking: {} files, {} directories across {} roots (age: {})",
+                self.id,
+                stats.total_files,
+                stats.total_directories,
+                stats.roots.len(),
+                stats.format_age()
+            );
+        } else {
+            tracing::debug!(
+                "🌳 Reusing directory tree for db={}: {} files, {} directories across {} roots (age: {})",
+                self.id,
+                stats.total_files,
+                stats.total_directories,
+                stats.roots.len(),
+                stats.format_age()
+            );
         }
 
         Ok(Arc::new(tree_result))
@@ -843,7 +911,7 @@ impl DatabaseContext {
             file_check_cache: Arc::new(RwLock::new(FileCheckCache::new())),
             directory_tree_cache: Arc::new(RwLock::new(None)),
             tree_build_lock: Arc::new(Mutex::new(())),
-            tree_rebuild_inflight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            tree_rebuild_inflight: Arc::new(AtomicBool::new(false)),
             refresh_mutex: Arc::new(TokioMutex::new(())),
             spatial_metrics: Arc::new(RwLock::new(Default::default())),
         }
@@ -886,6 +954,51 @@ mod tests {
         conn.execute(
             "INSERT INTO project (Id, name) VALUES (1, ?1)",
             [project_name],
+        )
+        .unwrap();
+    }
+
+    fn make_file_refresh_db(path: &std::path::Path) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE project (
+                Id INTEGER PRIMARY KEY,
+                profileId TEXT,
+                name TEXT NOT NULL,
+                description TEXT
+            );
+            CREATE TABLE target (
+                Id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                active INTEGER,
+                ra REAL,
+                dec REAL,
+                projectid INTEGER
+            );
+            CREATE TABLE acquiredimage (
+                Id INTEGER PRIMARY KEY,
+                projectId INTEGER,
+                targetId INTEGER,
+                acquireddate INTEGER,
+                filtername TEXT,
+                gradingStatus INTEGER,
+                metadata TEXT,
+                rejectreason TEXT,
+                profileId TEXT
+            );
+            INSERT INTO project (Id, profileId, name, description)
+                VALUES (1, 'default', 'Project', NULL);
+            INSERT INTO target (Id, name, active, ra, dec, projectid)
+                VALUES
+                    (10, 'Has File', 1, NULL, NULL, 1),
+                    (20, 'No Filename', 1, NULL, NULL, 1),
+                    (30, 'Bad Metadata', 1, NULL, NULL, 1);
+            INSERT INTO acquiredimage
+                (Id, projectId, targetId, acquireddate, filtername, gradingStatus, metadata, rejectreason, profileId)
+                VALUES
+                    (100, 1, 10, 1000, 'L', 0, '{\"FileName\":\"/remote/present.fit\"}', NULL, 'default'),
+                    (200, 1, 20, 2000, 'L', 0, '{}', NULL, 'default'),
+                    (300, 1, 30, 3000, 'L', 0, 'not json', NULL, 'default');",
         )
         .unwrap();
     }
@@ -937,6 +1050,27 @@ mod tests {
             dir.join("cache").to_string_lossy().into_owned(),
         )
         .unwrap()
+    }
+
+    #[tokio::test]
+    async fn refresh_cache_records_targets_without_usable_filename_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("sched.sqlite");
+        make_file_refresh_db(&db_path);
+        let image_dir = tmp.path().join("images");
+        std::fs::create_dir_all(&image_dir).unwrap();
+        std::fs::write(image_dir.join("present.fit"), b"fits").unwrap();
+        let ctx = build_ctx(tmp.path(), &db_path);
+
+        let (checked, found, missing, _) = ctx.refresh_cache_unified_internal().await.unwrap();
+
+        assert_eq!((checked, found, missing), (4, 2, 2));
+        let cache = ctx.file_check_cache.read().unwrap();
+        assert_eq!(cache.projects_with_files.get(&1), Some(&true));
+        assert_eq!(cache.targets_with_files.len(), 3);
+        assert_eq!(cache.targets_with_files.get(&10), Some(&true));
+        assert_eq!(cache.targets_with_files.get(&20), Some(&false));
+        assert_eq!(cache.targets_with_files.get(&30), Some(&false));
     }
 
     // Unix-only: the proactive reopen this exercises is itself `#[cfg(unix)]`

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -26,6 +26,29 @@ fn db_open_flags() -> OpenFlags {
     OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX
 }
 
+/// How long a connection waits on SQLITE_BUSY before giving up. The scheduler
+/// DB is rollback-journal SQLite, so a write (grade update) needs the
+/// exclusive lock at commit and conflicts with any in-flight read on ANOTHER
+/// connection. We create that contention OURSELVES: the background file-check
+/// refresh runs on its own dedicated connection (so its slow queries never
+/// hold the request mutex), and each of its streaming reads holds a shared
+/// lock for the statement's duration — 30-80s per project on an SMB-mounted
+/// DB. Without a busy handler, a grade written during a refresh surfaces
+/// instantly as "database is locked" → HTTP 500; with one, the writer waits
+/// out the current refresh statement and wins the gap between statements.
+/// Sized to cover the worst observed single-query duration. (External writers
+/// like N.I.N.A. on a network share get the same courtesy.)
+const DB_BUSY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The one way to open a scheduler DB connection in the server: flags above +
+/// busy timeout. Every open site (initial, both reopen paths, the refresh
+/// connection) must go through here so none silently loses the busy handler.
+fn open_scheduler_connection(path: &str) -> rusqlite::Result<Connection> {
+    let conn = Connection::open_with_flags(path, db_open_flags())?;
+    conn.busy_timeout(DB_BUSY_TIMEOUT)?;
+    Ok(conn)
+}
+
 /// Identity of the on-disk database file: the `(device, inode)` pair on unix.
 ///
 /// This is deliberately file *identity*, not file *content*. When another
@@ -195,7 +218,7 @@ impl DatabaseContext {
         })?;
         let cache_dir = cache_dir_path.to_string_lossy().into_owned();
 
-        let conn = Connection::open_with_flags(&db_path, db_open_flags())?;
+        let conn = open_scheduler_connection(&db_path)?;
         let fingerprint = fingerprint_path(&db_path);
 
         Ok(Self {
@@ -297,7 +320,7 @@ impl DatabaseContext {
 
         // Open outside the connection/fingerprint locks so a slow open doesn't
         // block queries.
-        match Connection::open_with_flags(&self.database_path, db_open_flags()) {
+        match open_scheduler_connection(&self.database_path) {
             Ok(new_conn) => {
                 *lock_recover(&self.db_connection) = new_conn;
                 *lock_recover(&self.db_fingerprint) = Some(new_fp);
@@ -324,7 +347,7 @@ impl DatabaseContext {
     /// queries are not blocked.
     fn force_reopen(&self) {
         let _reopen = lock_recover(&self.reopen_lock);
-        match Connection::open_with_flags(&self.database_path, db_open_flags()) {
+        match open_scheduler_connection(&self.database_path) {
             Ok(new_conn) => {
                 *lock_recover(&self.db_connection) = new_conn;
                 *lock_recover(&self.db_fingerprint) = fingerprint_path(&self.database_path);
@@ -550,7 +573,7 @@ impl DatabaseContext {
         // lock round-trips) transactions never hold the shared request
         // connection's mutex. API handlers keep answering while this walks the
         // database; two readers coexist at the SQLite level.
-        let refresh_conn = Connection::open_with_flags(&self.database_path, db_open_flags())
+        let refresh_conn = open_scheduler_connection(&self.database_path)
             .map_err(|e| anyhow::anyhow!("Opening refresh connection: {}", e))?;
 
         let projects = {

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -132,6 +132,11 @@ pub struct DatabaseContext {
     reopen_lock: Arc<Mutex<()>>,
     pub file_check_cache: Arc<RwLock<FileCheckCache>>,
     pub directory_tree_cache: Arc<RwLock<Option<DirectoryTree>>>,
+    /// Serializes cold directory-tree builds so N concurrent requests on an
+    /// empty cache share one filesystem scan instead of starting N.
+    tree_build_lock: Arc<Mutex<()>>,
+    /// True while a background (stale-revalidation) tree rebuild is running.
+    tree_rebuild_inflight: Arc<std::sync::atomic::AtomicBool>,
     pub refresh_mutex: Arc<TokioMutex<()>>,
     /// Per-DB spatial (occlusion) metrics store + scan progress; persisted
     /// under `cache_dir` as spatial_metrics.json.
@@ -195,6 +200,8 @@ impl DatabaseContext {
             reopen_lock: Arc::new(Mutex::new(())),
             file_check_cache: Arc::new(RwLock::new(FileCheckCache::new())),
             directory_tree_cache: Arc::new(RwLock::new(None)),
+            tree_build_lock: Arc::new(Mutex::new(())),
+            tree_rebuild_inflight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             refresh_mutex: Arc::new(TokioMutex::new(())),
             spatial_metrics: Arc::new(RwLock::new(Default::default())),
         })
@@ -336,16 +343,63 @@ impl DatabaseContext {
         self.image_dir_paths[0].join(relative_path)
     }
 
+    /// Get the directory tree for file lookups. Never lets the request path
+    /// pay for a full filesystem scan when *any* tree exists: a fresh tree is
+    /// served as-is, a stale one is served immediately while one background
+    /// thread revalidates (on a slow network mount a scan can take a minute —
+    /// blocking requests on it starves the UI). Only a cold cache (no tree at
+    /// all) blocks, and then all concurrent callers share a single scan.
     pub fn get_directory_tree(&self) -> Result<Arc<DirectoryTree>> {
         {
             let cache = self.directory_tree_cache.read().unwrap();
             if let Some(ref tree) = *cache {
-                if !tree.is_older_than(Duration::from_secs(300)) {
-                    return Ok(Arc::new(tree.clone()));
+                let stale = tree.is_older_than(Duration::from_secs(300));
+                let tree = Arc::new(tree.clone());
+                if stale {
+                    self.spawn_directory_tree_rebuild();
                 }
+                return Ok(tree);
+            }
+        }
+
+        // Cold cache: one caller scans; the rest wait here and reuse the result.
+        let _guard = lock_recover(&self.tree_build_lock);
+        {
+            let cache = self.directory_tree_cache.read().unwrap();
+            if let Some(ref tree) = *cache {
+                return Ok(Arc::new(tree.clone()));
             }
         }
         self.rebuild_directory_tree_internal()
+    }
+
+    /// Kick a deduplicated background rebuild of the directory tree. No-op if
+    /// one is already running.
+    fn spawn_directory_tree_rebuild(&self) {
+        use std::sync::atomic::Ordering;
+
+        if self.tree_rebuild_inflight.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let ctx = self.clone();
+        std::thread::spawn(move || {
+            // Reset the flag even if the scan errors or panics, so a failed
+            // rebuild doesn't pin the stale tree forever.
+            struct Reset(Arc<std::sync::atomic::AtomicBool>);
+            impl Drop for Reset {
+                fn drop(&mut self) {
+                    self.0.store(false, Ordering::SeqCst);
+                }
+            }
+            let _reset = Reset(ctx.tree_rebuild_inflight.clone());
+            if let Err(e) = ctx.rebuild_directory_tree_internal() {
+                tracing::warn!(
+                    "⚠️ Background directory tree rebuild failed for db={}: {}",
+                    ctx.id,
+                    e
+                );
+            }
+        });
     }
 
     fn rebuild_directory_tree_internal(&self) -> Result<Arc<DirectoryTree>> {
@@ -457,12 +511,16 @@ impl DatabaseContext {
                 .set_stage(RefreshStage::LoadingProjects);
         }
 
+        // All refresh queries run on a dedicated connection so their (possibly
+        // slow — e.g. a network-mounted sqlite where every transaction pays
+        // lock round-trips) transactions never hold the shared request
+        // connection's mutex. API handlers keep answering while this walks the
+        // database; two readers coexist at the SQLite level.
+        let refresh_conn = Connection::open_with_flags(&self.database_path, db_open_flags())
+            .map_err(|e| anyhow::anyhow!("Opening refresh connection: {}", e))?;
+
         let projects = {
-            let conn = self.db();
-            let conn = conn
-                .lock()
-                .map_err(|_| anyhow::anyhow!("Database lock failed"))?;
-            let db = crate::db::Database::new(&conn);
+            let db = crate::db::Database::new(&refresh_conn);
             db.get_projects_with_images()
                 .map_err(|e| anyhow::anyhow!("Failed to get projects: {}", e))?
         };
@@ -477,13 +535,16 @@ impl DatabaseContext {
             projects.len()
         );
 
+        let directory_tree = self.get_directory_tree().map_err(|e| {
+            tracing::error!("Failed to get directory tree cache: {}", e);
+            anyhow::anyhow!("Directory cache error: {}", e)
+        })?;
+
         let mut project_cache_updates = std::collections::HashMap::new();
         let mut target_cache_updates = std::collections::HashMap::new();
         let mut projects_with_files = 0;
         let mut targets_with_files = 0;
         let mut total_targets = 0;
-        let mut _total_files_found = 0;
-        let mut _total_files_missing = 0;
 
         for project in &projects {
             {
@@ -497,51 +558,64 @@ impl DatabaseContext {
                 project.id
             );
 
-            let (project_has_files, project_files_found, project_files_missing) =
-                self.check_project_files_with_details(project.id).await?;
-
-            if project_has_files {
-                projects_with_files += 1;
-            }
-            _total_files_found += project_files_found;
-            _total_files_missing += project_files_missing;
-            project_cache_updates.insert(project.id, project_has_files);
-
-            let project_targets = {
-                let conn = self.db();
-                let conn = conn
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("Database lock failed"))?;
-                let db = crate::db::Database::new(&conn);
-                db.get_targets_with_images(project.id).map_err(|e| {
-                    anyhow::anyhow!("Failed to get targets for project {}: {}", project.id, e)
+            // One query per project; per-target tallies are grouped in memory
+            // so the refresh never rescans the whole image table per target.
+            let images = {
+                let db = crate::db::Database::new(&refresh_conn);
+                db.get_images_by_project_id(project.id).map_err(|e| {
+                    anyhow::anyhow!("Failed to get images for project {}: {}", project.id, e)
                 })?
             };
 
-            {
-                let mut cache = self.file_check_cache.write().unwrap();
-                cache
-                    .refresh_progress
-                    .set_targets_info(project_targets.len());
+            // target_id -> (files found, files missing)
+            let mut per_target: std::collections::HashMap<i32, (usize, usize)> =
+                std::collections::HashMap::new();
+            for (image, _project_name, _target_name) in &images {
+                let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&image.metadata)
+                else {
+                    continue;
+                };
+                let Some(filename_path) = metadata["FileName"].as_str() else {
+                    continue;
+                };
+                let filename = filename_path
+                    .split(&['\\', '/'][..])
+                    .next_back()
+                    .unwrap_or(filename_path);
+                let entry = per_target.entry(image.target_id).or_insert((0, 0));
+                if directory_tree.find_file_first(filename).is_some() {
+                    entry.0 += 1;
+                } else {
+                    entry.1 += 1;
+                }
             }
 
-            total_targets += project_targets.len();
-            for (target, _, _, _) in project_targets {
-                let (target_has_files, target_files_found, target_files_missing) =
-                    self.check_target_files_with_details(target.id).await?;
+            let project_files_found: usize = per_target.values().map(|(f, _)| f).sum();
+            let project_files_missing: usize = per_target.values().map(|(_, m)| m).sum();
+            let project_has_files = project_files_found > 0;
+            if project_has_files {
+                projects_with_files += 1;
+            }
+            project_cache_updates.insert(project.id, project_has_files);
 
+            {
+                let mut cache = self.file_check_cache.write().unwrap();
+                cache.refresh_progress.set_targets_info(per_target.len());
+            }
+
+            total_targets += per_target.len();
+            for (target_id, (found, missing)) in per_target {
+                let target_has_files = found > 0;
                 if target_has_files {
                     targets_with_files += 1;
                 }
-                target_cache_updates.insert(target.id, target_has_files);
+                target_cache_updates.insert(target_id, target_has_files);
 
                 {
                     let mut cache = self.file_check_cache.write().unwrap();
-                    cache.refresh_progress.complete_target(
-                        target_has_files,
-                        target_files_found,
-                        target_files_missing,
-                    );
+                    cache
+                        .refresh_progress
+                        .complete_target(target_has_files, found, missing);
                 }
             }
 
@@ -640,109 +714,6 @@ impl DatabaseContext {
         } else {
             RefreshStatus::InProgressWait
         }
-    }
-
-    async fn check_project_files_with_details(
-        &self,
-        project_id: i32,
-    ) -> Result<(bool, usize, usize), anyhow::Error> {
-        use crate::db::Database;
-
-        let directory_tree = self.get_directory_tree().map_err(|e| {
-            tracing::error!("Failed to get directory tree cache: {}", e);
-            anyhow::anyhow!("Directory cache error: {}", e)
-        })?;
-
-        let all_images = {
-            let conn = self.db();
-            let conn = conn
-                .lock()
-                .map_err(|_| anyhow::anyhow!("Database lock error"))?;
-            let db = Database::new(&conn);
-            db.get_images_by_project_id(project_id)
-                .map_err(|e| anyhow::anyhow!("Database error: {}", e))?
-        };
-
-        if all_images.is_empty() {
-            return Ok((false, 0, 0));
-        }
-
-        let mut files_found = 0;
-        let mut files_missing = 0;
-        let mut has_any_files = false;
-
-        for (image, _project_name, _target_name) in &all_images {
-            if let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&image.metadata) {
-                if let Some(filename_path) = metadata["FileName"].as_str() {
-                    let filename = filename_path
-                        .split(&['\\', '/'][..])
-                        .next_back()
-                        .unwrap_or(filename_path);
-
-                    if directory_tree.find_file_first(filename).is_some() {
-                        files_found += 1;
-                        has_any_files = true;
-                    } else {
-                        files_missing += 1;
-                    }
-                }
-            }
-        }
-
-        Ok((has_any_files, files_found, files_missing))
-    }
-
-    async fn check_target_files_with_details(
-        &self,
-        target_id: i32,
-    ) -> Result<(bool, usize, usize), anyhow::Error> {
-        use crate::db::Database;
-
-        let directory_tree = self.get_directory_tree().map_err(|e| {
-            tracing::error!("Failed to get directory tree cache: {}", e);
-            anyhow::anyhow!("Directory cache error: {}", e)
-        })?;
-
-        let all_images = {
-            let conn = self.db();
-            let conn = conn
-                .lock()
-                .map_err(|_| anyhow::anyhow!("Database lock error"))?;
-            let db = Database::new(&conn);
-            db.query_images(None, None, None, None)
-                .map_err(|e| anyhow::anyhow!("Database error: {}", e))?
-                .into_iter()
-                .filter(|(img, _, _)| img.target_id == target_id)
-                .collect::<Vec<_>>()
-        };
-
-        if all_images.is_empty() {
-            return Ok((false, 0, 0));
-        }
-
-        let mut files_found = 0;
-        let mut files_missing = 0;
-        let mut has_any_files = false;
-
-        for (image, _project_name, _target_name) in &all_images {
-            if let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&image.metadata) {
-                if let Some(filename_path) = metadata["FileName"].as_str() {
-                    let filename = filename_path
-                        .split(&['\\', '/'][..])
-                        .next_back()
-                        .unwrap_or(filename_path);
-
-                    if directory_tree.find_file_first(filename).is_some() {
-                        files_found += 1;
-                        has_any_files = true;
-                    } else {
-                        files_missing += 1;
-                    }
-                }
-            }
-        }
-
-        Ok((has_any_files, files_found, files_missing))
     }
 
     pub fn get_cache_refresh_progress(&self) -> Option<RefreshProgress> {
@@ -871,6 +842,8 @@ impl DatabaseContext {
             reopen_lock: Arc::new(Mutex::new(())),
             file_check_cache: Arc::new(RwLock::new(FileCheckCache::new())),
             directory_tree_cache: Arc::new(RwLock::new(None)),
+            tree_build_lock: Arc::new(Mutex::new(())),
+            tree_rebuild_inflight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             refresh_mutex: Arc::new(TokioMutex::new(())),
             spatial_metrics: Arc::new(RwLock::new(Default::default())),
         }
@@ -892,6 +865,8 @@ impl Clone for DatabaseContext {
             reopen_lock: self.reopen_lock.clone(),
             file_check_cache: self.file_check_cache.clone(),
             directory_tree_cache: self.directory_tree_cache.clone(),
+            tree_build_lock: self.tree_build_lock.clone(),
+            tree_rebuild_inflight: self.tree_rebuild_inflight.clone(),
             refresh_mutex: self.refresh_mutex.clone(),
             spatial_metrics: self.spatial_metrics.clone(),
         }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -508,15 +508,13 @@ pub async fn list_projects(
     // Get ALL projects with profile info from database (not just those with files)
     let (projects, profile_count) = {
         let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
         let projects = db
             .get_projects_with_images_and_profile_info()
-            .map_err(|_| AppError::DatabaseError)?;
-        let profile_count = db
-            .get_profile_count()
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
+        let profile_count = db.get_profile_count().map_err(AppError::db)?;
 
         (projects, profile_count)
     };
@@ -595,11 +593,11 @@ pub async fn list_targets(
     // Get ALL targets from database (not just those with files)
     let targets = {
         let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
         db.get_targets_with_images(project_id)
-            .map_err(|_| AppError::DatabaseError)?
+            .map_err(AppError::db)?
     };
 
     let response: Vec<TargetResponse> = targets
@@ -637,13 +635,11 @@ pub async fn get_images(
     Query(params): Query<ImageQuery>,
 ) -> Result<Json<ApiResponse<Vec<ImageResponse>>>, AppError> {
     let conn = ctx.db();
-    let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+    let conn = conn.lock().map_err(AppError::db)?;
     let db = Database::new(&conn);
 
     // Get profile count to determine display format
-    let profile_count = db
-        .get_profile_count()
-        .map_err(|_| AppError::DatabaseError)?;
+    let profile_count = db.get_profile_count().map_err(AppError::db)?;
     let show_profile = profile_count > 1;
 
     // Convert status string to GradingStatus enum
@@ -656,7 +652,7 @@ pub async fn get_images(
 
     let images = db
         .query_images(status_filter, None, None, None)
-        .map_err(|_| AppError::DatabaseError)?;
+        .map_err(AppError::db)?;
 
     // Filter by project_id and target_id if provided
     let filtered_images: Vec<_> = images
@@ -715,25 +711,21 @@ pub async fn get_image(
     // Get image data from database first (before any async operations)
     let (image, proj_name, target_name, mut metadata, show_profile) = {
         let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
         // Get profile count to determine display format
-        let profile_count = db
-            .get_profile_count()
-            .map_err(|_| AppError::DatabaseError)?;
+        let profile_count = db.get_profile_count().map_err(AppError::db)?;
         let show_profile = profile_count > 1;
 
-        let images = db
-            .get_images_by_ids(&[image_id])
-            .map_err(|_| AppError::DatabaseError)?;
+        let images = db.get_images_by_ids(&[image_id]).map_err(AppError::db)?;
 
         let image = images.into_iter().next().ok_or(AppError::NotFound)?;
 
         // Get project and target names
         let all_images = db
             .query_images(None, None, None, None)
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
 
         let (_, proj_name, target_name) = all_images
             .into_iter()
@@ -861,7 +853,7 @@ pub async fn update_image_grade(
     Json(request): Json<UpdateGradeRequest>,
 ) -> Result<Json<ApiResponse<()>>, AppError> {
     let conn = ctx.db();
-    let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+    let conn = conn.lock().map_err(AppError::db)?;
     let db = Database::new(&conn);
 
     let status = match request.status.as_str() {
@@ -872,7 +864,7 @@ pub async fn update_image_grade(
     };
 
     db.update_grading_status(image_id, status, request.reason.as_deref())
-        .map_err(|_| AppError::DatabaseError)?;
+        .map_err(AppError::db)?;
 
     Ok(Json(ApiResponse::success(())))
 }
@@ -884,19 +876,19 @@ fn resolve_image_meta(
     image_id: i32,
 ) -> Result<(crate::models::AcquiredImage, String, String), AppError> {
     let conn = ctx.db();
-    let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+    let conn = conn.lock().map_err(AppError::db)?;
     let db = Database::new(&conn);
 
     let image = db
         .get_images_by_ids(&[image_id])
-        .map_err(|_| AppError::DatabaseError)?
+        .map_err(AppError::db)?
         .into_iter()
         .next()
         .ok_or(AppError::NotFound)?;
 
     let target = db
         .get_targets_by_ids(&[image.target_id])
-        .map_err(|_| AppError::DatabaseError)?
+        .map_err(AppError::db)?
         .into_iter()
         .next()
         .ok_or(AppError::NotFound)?;
@@ -1175,19 +1167,17 @@ pub async fn get_image_stars(
     // Get image metadata from database
     let (image, file_only, target_name) = {
         let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
-        let images = db
-            .get_images_by_ids(&[image_id])
-            .map_err(|_| AppError::DatabaseError)?;
+        let images = db.get_images_by_ids(&[image_id]).map_err(AppError::db)?;
 
         let image = images.into_iter().next().ok_or(AppError::NotFound)?;
 
         // Get target name
         let targets = db
             .get_targets_by_ids(&[image.target_id])
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
 
         let target = targets.into_iter().next().ok_or(AppError::NotFound)?;
         let target_name = target.name.clone();
@@ -1392,15 +1382,11 @@ pub async fn post_generation_status(
         HashMap<i32, String>,
     ) = {
         let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
-        let images = db
-            .get_images_by_ids(&ids)
-            .map_err(|_| AppError::DatabaseError)?;
+        let images = db.get_images_by_ids(&ids).map_err(AppError::db)?;
         let target_ids: Vec<i32> = images.iter().map(|i| i.target_id).collect();
-        let targets = db
-            .get_targets_by_ids(&target_ids)
-            .map_err(|_| AppError::DatabaseError)?;
+        let targets = db.get_targets_by_ids(&target_ids).map_err(AppError::db)?;
         (
             images.into_iter().map(|i| (i.id, i)).collect(),
             targets.into_iter().map(|t| (t.id, t.name)).collect(),
@@ -1530,19 +1516,17 @@ pub async fn get_psf_visualization(
     // Get image metadata from database
     let (image, file_only, target_name) = {
         let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
-        let images = db
-            .get_images_by_ids(&[image_id])
-            .map_err(|_| AppError::DatabaseError)?;
+        let images = db.get_images_by_ids(&[image_id]).map_err(AppError::db)?;
 
         let image = images.into_iter().next().ok_or(AppError::NotFound)?;
 
         // Get target name
         let targets = db
             .get_targets_by_ids(&[image.target_id])
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
 
         let target = targets.into_iter().next().ok_or(AppError::NotFound)?;
         let target_name = target.name.clone();
@@ -1674,18 +1658,16 @@ pub async fn get_projects_overview(
     tracing::debug!("📋 Getting projects overview");
 
     let conn = ctx.db();
-    let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+    let conn = conn.lock().map_err(AppError::db)?;
     let db = Database::new(&conn);
 
     // Get all projects with images and profile info
     let projects = db
         .get_projects_with_images_and_profile_info()
-        .map_err(|_| AppError::DatabaseError)?;
+        .map_err(AppError::db)?;
 
     // Get profile count to determine display format
-    let profile_count = db
-        .get_profile_count()
-        .map_err(|_| AppError::DatabaseError)?;
+    let profile_count = db.get_profile_count().map_err(AppError::db)?;
 
     // Get file existence map
     let file_existence_map: std::collections::HashMap<i32, bool> = {
@@ -1701,7 +1683,7 @@ pub async fn get_projects_overview(
         // Get detailed stats for this project
         let stats = db
             .get_project_overview_stats(project.id)
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
 
         // Get desired values for this project
         let desired_stats =
@@ -1716,7 +1698,7 @@ pub async fn get_projects_overview(
 
         let target_count = db
             .get_target_count_for_project(project.id)
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
 
         // Get basic file statistics (simplified for performance)
         let files_found = if file_existence_map
@@ -1781,13 +1763,13 @@ pub async fn get_targets_overview(
     tracing::debug!("🎯 Getting targets overview");
 
     let conn = ctx.db();
-    let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+    let conn = conn.lock().map_err(AppError::db)?;
     let db = Database::new(&conn);
 
     // Get all targets with project info and stats including desired values
     let targets_data = db
         .get_all_targets_with_desired_stats()
-        .map_err(|_| AppError::DatabaseError)?;
+        .map_err(AppError::db)?;
 
     // Get file existence map
     let file_existence_map: std::collections::HashMap<i32, bool> = {
@@ -1802,23 +1784,23 @@ pub async fn get_targets_overview(
         let (earliest, latest, filters) = {
             let mut stmt = conn.prepare(
                 "SELECT MIN(acquireddate), MAX(acquireddate) FROM acquiredimage WHERE targetId = ?",
-            ).map_err(|_| AppError::DatabaseError)?;
+            ).map_err(AppError::db)?;
 
             let (earliest, latest): (Option<i64>, Option<i64>) = stmt
                 .query_row([target_data.target.id], |row| {
                     Ok((row.get(0)?, row.get(1)?))
                 })
-                .map_err(|_| AppError::DatabaseError)?;
+                .map_err(AppError::db)?;
 
             let mut filter_stmt = conn.prepare(
                 "SELECT DISTINCT filtername FROM acquiredimage WHERE targetId = ? AND filtername IS NOT NULL ORDER BY filtername",
-            ).map_err(|_| AppError::DatabaseError)?;
+            ).map_err(AppError::db)?;
 
             let filters: Vec<String> = filter_stmt
                 .query_map([target_data.target.id], |row| row.get(0))
-                .map_err(|_| AppError::DatabaseError)?
+                .map_err(AppError::db)?
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| AppError::DatabaseError)?;
+                .map_err(AppError::db)?;
 
             (earliest, latest, filters)
         };
@@ -1881,12 +1863,10 @@ pub async fn get_overall_stats(
     tracing::debug!("📊 Getting overall statistics");
 
     let conn = ctx.db();
-    let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+    let conn = conn.lock().map_err(AppError::db)?;
     let db = Database::new(&conn);
 
-    let stats = db
-        .get_overall_statistics()
-        .map_err(|_| AppError::DatabaseError)?;
+    let stats = db.get_overall_statistics().map_err(AppError::db)?;
 
     // Get overall desired statistics
     let desired_stats = db
@@ -1964,13 +1944,11 @@ pub async fn analyze_sequence(
     // Fetch images from database
     let (images_data, target_name) = {
         let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
         // Get target name
-        let targets = db
-            .get_targets_by_ids(&[target_id])
-            .map_err(|_| AppError::DatabaseError)?;
+        let targets = db.get_targets_by_ids(&[target_id]).map_err(AppError::db)?;
         let target = targets
             .into_iter()
             .next()
@@ -1980,7 +1958,7 @@ pub async fn analyze_sequence(
         // Query images for this target
         let all_images = db
             .query_images(None, None, None, None)
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
 
         let filtered: Vec<_> = all_images
             .into_iter()
@@ -2096,25 +2074,23 @@ pub async fn get_image_quality(
     // Get the target image and its context from database
     let (target_image, all_filter_images, target_name) = {
         let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
-        let images = db
-            .get_images_by_ids(&[image_id])
-            .map_err(|_| AppError::DatabaseError)?;
+        let images = db.get_images_by_ids(&[image_id]).map_err(AppError::db)?;
         let target_image = images.into_iter().next().ok_or(AppError::NotFound)?;
 
         // Get target name
         let targets = db
             .get_targets_by_ids(&[target_image.target_id])
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
         let target = targets.into_iter().next().ok_or(AppError::NotFound)?;
         let target_name = target.name.clone();
 
         // Get all images for the same target + filter
         let all_images = db
             .query_images(None, None, None, None)
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
 
         let filter_images: Vec<_> = all_images
             .into_iter()
@@ -2353,12 +2329,12 @@ pub async fn start_spatial_scan(
     // Collect this target's images.
     let candidates = {
         let conn = ctx.db();
-        let conn = conn.lock().map_err(|_| AppError::DatabaseError)?;
+        let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
         let targets = db
             .get_targets_by_ids(&[req.target_id])
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
         let target = targets
             .into_iter()
             .next()
@@ -2367,7 +2343,7 @@ pub async fn start_spatial_scan(
 
         let all_images = db
             .query_images(None, None, None, None)
-            .map_err(|_| AppError::DatabaseError)?;
+            .map_err(AppError::db)?;
 
         all_images
             .into_iter()
@@ -2525,11 +2501,21 @@ pub async fn get_spatial_scan_progress(
 #[derive(Debug)]
 pub enum AppError {
     NotFound,
-    DatabaseError,
+    DatabaseError(String),
     BadRequest(String),
     Forbidden(String),
     InternalError(String),
     NotImplemented,
+}
+
+impl AppError {
+    /// Wrap any database-layer failure, preserving its message —
+    /// `map_err(AppError::db)`. Losing the underlying rusqlite error (as the
+    /// old unit `DatabaseError` did) made lock contention ("database is
+    /// locked") indistinguishable from corruption or I/O failures in the logs.
+    fn db(err: impl std::fmt::Display) -> Self {
+        AppError::DatabaseError(err.to_string())
+    }
 }
 
 impl IntoResponse for AppError {
@@ -2539,9 +2525,13 @@ impl IntoResponse for AppError {
                 tracing::warn!("🔍 Resource not found");
                 (StatusCode::NOT_FOUND, "Resource not found")
             }
-            AppError::DatabaseError => {
-                tracing::error!("💾 Database error occurred");
-                (StatusCode::INTERNAL_SERVER_ERROR, "Database error")
+            AppError::DatabaseError(msg) => {
+                tracing::error!("💾 Database error: {}", msg);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ApiResponse::<()>::error(format!("Database error: {}", msg))),
+                )
+                    .into_response();
             }
             AppError::BadRequest(msg) => {
                 tracing::warn!("❌ Bad request: {}", msg);

--- a/static/e2e/image-detail.spec.ts
+++ b/static/e2e/image-detail.spec.ts
@@ -375,6 +375,174 @@ test('detail view keeps the viewport anchored while swapping to original resolut
   }
 });
 
+test('detail view preserves zoom and pan exactly across arrow-key navigation', async ({
+  page,
+}) => {
+  test.setTimeout(90_000);
+
+  await page.goto(`/#/detail/1?db=${encodeURIComponent(dbId)}&project=1`);
+
+  const container = page.locator('.zoom-container').first();
+  const img = container.locator('img.detail-main-image').first();
+  await expect(img).toBeVisible({ timeout: 15_000 });
+  await page.waitForFunction(
+    (el) => el instanceof HTMLImageElement && el.complete && el.naturalWidth > 0,
+    await img.elementHandle(),
+    { timeout: 30_000 }
+  );
+
+  const box = await container.boundingBox();
+  expect(box).not.toBeNull();
+  const centerX = box!.x + box!.width / 2;
+  const centerY = box!.y + box!.height / 2;
+
+  // Zoom to a target below raw 1.0 so the original-resolution swap stays out
+  // of the picture — this test is about EXACT persistence of the transform.
+  const fitScale = (await readDetailViewportAnchor(page)).scale;
+  const targetScale = Math.min(0.9, fitScale + 0.4);
+  expect(targetScale).toBeGreaterThan(fitScale);
+  await page.mouse.move(centerX, centerY);
+  // handleWheel: newScale = scale - deltaY * 0.001
+  await page.mouse.wheel(0, -(targetScale - fitScale) / 0.001);
+  await page.mouse.down();
+  await page.mouse.move(centerX - 90, centerY - 60, { steps: 5 });
+  await page.mouse.up();
+
+  const before = await readDetailViewportAnchor(page);
+  expect(before.scale).toBeLessThan(1.0);
+  expect(before.scale).toBeGreaterThan(fitScale + 0.01);
+  const beforePercent = await page
+    .locator('.zoom-percentage-compact')
+    .textContent();
+
+  await page.keyboard.press('ArrowRight');
+  await expect(page).toHaveURL(/\/detail\/2/);
+
+  // The main <img> is keyed by image id and REMOUNTS on navigation — an
+  // element handle grabbed now may bind the detached old node, so re-query
+  // the DOM on every poll instead.
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector('.zoom-container img.detail-main-image');
+      return (
+        el instanceof HTMLImageElement &&
+        el.complete &&
+        el.naturalWidth > 0 &&
+        (el.currentSrc || el.src).includes('/images/2/')
+      );
+    },
+    undefined,
+    { timeout: 60_000 }
+  );
+  await expect(img).not.toHaveClass(/detail-image-hidden/, { timeout: 10_000 });
+  await expect(page.locator('.image-loading-overlay')).toHaveCount(0, {
+    timeout: 10_000,
+  });
+
+  const after = await readDetailViewportAnchor(page);
+  expect(after.src).toContain('/images/2/');
+  // Identical bitmap dimensions in the sequence ⇒ the transform must carry
+  // over EXACTLY: same scale, same offsets, same displayed percentage.
+  expect(after.naturalWidth).toBe(before.naturalWidth);
+  expect(after.scale).toBeCloseTo(before.scale, 5);
+  expect(Math.abs(after.offsetX - before.offsetX)).toBeLessThan(0.5);
+  expect(Math.abs(after.offsetY - before.offsetY)).toBeLessThan(0.5);
+  const afterPercent = await page
+    .locator('.zoom-percentage-compact')
+    .textContent();
+  expect(afterPercent).toBe(beforePercent);
+});
+
+test('detail view keeps the anchored region across navigation while zoomed past 100%', async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+
+  await page.goto(`/#/detail/1?db=${encodeURIComponent(dbId)}&project=1`);
+
+  const container = page.locator('.zoom-container').first();
+  const img = container.locator('img.detail-main-image').first();
+  await expect(img).toBeVisible({ timeout: 15_000 });
+  await page.waitForFunction(
+    (el) => el instanceof HTMLImageElement && el.complete && el.naturalWidth > 0,
+    await img.elementHandle(),
+    { timeout: 30_000 }
+  );
+
+  const box = await container.boundingBox();
+  expect(box).not.toBeNull();
+  const centerX = box!.x + box!.width / 2;
+  const centerY = box!.y + box!.height / 2;
+
+  // Zoom well past raw 1.0 and pan off-center; the view should upgrade to
+  // the original-resolution artifact on its own.
+  await page.mouse.move(centerX, centerY);
+  await page.mouse.wheel(0, -1400);
+  await page.mouse.down();
+  await page.mouse.move(centerX - 120, centerY - 80, { steps: 6 });
+  await page.mouse.up();
+
+  await page.waitForFunction(
+    (el) =>
+      el instanceof HTMLImageElement &&
+      el.complete &&
+      el.naturalWidth > 0 &&
+      (el.currentSrc || el.src).includes('size=original'),
+    await img.elementHandle(),
+    { timeout: 60_000 }
+  );
+  await expect(page.locator('.image-loading-overlay')).toHaveCount(0, {
+    timeout: 10_000,
+  });
+
+  const before = await readDetailViewportAnchor(page);
+  const beforeDisplayedWidth = before.scale * before.naturalWidth;
+  const beforePercent = await page
+    .locator('.zoom-percentage-compact')
+    .textContent();
+
+  await page.keyboard.press('ArrowRight');
+  await expect(page).toHaveURL(/\/detail\/2/);
+
+  // The next image must come back at the SAME anchored region and displayed
+  // size, and re-upgrade to its own original-resolution artifact. Re-query
+  // the DOM each poll — the keyed <img> remounts on navigation.
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector('.zoom-container img.detail-main-image');
+      const src = el instanceof HTMLImageElement ? el.currentSrc || el.src : '';
+      return (
+        el instanceof HTMLImageElement &&
+        el.complete &&
+        el.naturalWidth > 0 &&
+        src.includes('/images/2/') &&
+        src.includes('size=original')
+      );
+    },
+    undefined,
+    { timeout: 60_000 }
+  );
+  await expect(page.locator('.image-loading-overlay')).toHaveCount(0, {
+    timeout: 10_000,
+  });
+
+  const after = await readDetailViewportAnchor(page);
+  expect(after.naturalWidth).toBe(before.naturalWidth);
+  const afterDisplayedWidth = after.scale * after.naturalWidth;
+  expect(
+    Math.abs(afterDisplayedWidth - beforeDisplayedWidth) / beforeDisplayedWidth
+  ).toBeLessThan(0.01);
+  expect(Math.abs(after.centerRatioX - before.centerRatioX)).toBeLessThan(0.02);
+  expect(Math.abs(after.centerRatioY - before.centerRatioY)).toBeLessThan(0.02);
+  // No top-left collapse: the anchored region stays away from the corner.
+  expect(after.centerRatioX).toBeGreaterThan(0.1);
+  expect(after.centerRatioY).toBeGreaterThan(0.1);
+  const afterPercent = await page
+    .locator('.zoom-percentage-compact')
+    .textContent();
+  expect(afterPercent).toBe(beforePercent);
+});
+
 test('detail view shows the image after the 202-generating path reloads with a cache-buster', async ({
   page,
 }) => {

--- a/static/e2e/image-detail.spec.ts
+++ b/static/e2e/image-detail.spec.ts
@@ -374,3 +374,63 @@ test('detail view keeps the viewport anchored while swapping to original resolut
     await page.unroute('**/images/1/preview**');
   }
 });
+
+test('detail view shows the image after the 202-generating path reloads with a cache-buster', async ({
+  page,
+}) => {
+  // Force the first large-preview GET to answer 202 exactly like an uncached
+  // artifact, regardless of server cache state. The frontend must ride
+  // generating → status poll → ready → reload with a `v=` cache-buster — and
+  // then actually reveal the image. Regression test: the `v=` reload used to
+  // fail the "is this src current?" identity check (busted URL vs pristine
+  // URL) and the loaded image stayed at opacity 0 with no overlay.
+  let served202 = false;
+  await page.route('**/images/1/preview**', async (route) => {
+    const url = new URL(route.request().url());
+    if (
+      url.searchParams.get('size') !== 'large' ||
+      url.searchParams.has('v') ||
+      served202
+    ) {
+      await route.continue();
+      return;
+    }
+    served202 = true;
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      headers: { 'cache-control': 'no-store' },
+      body: JSON.stringify({
+        success: true,
+        data: { state: 'generating' },
+        error: null,
+      }),
+    });
+  });
+
+  try {
+    await page.goto(`/#/detail/1?db=${encodeURIComponent(dbId)}&project=1`);
+
+    const img = page.locator('.zoom-container img.detail-main-image').first();
+    // The post-ready reload carries the cache-buster and must fully load.
+    await page.waitForFunction(
+      (el) =>
+        el instanceof HTMLImageElement &&
+        el.complete &&
+        el.naturalWidth > 0 &&
+        new URL(el.currentSrc || el.src).searchParams.has('v'),
+      await img.elementHandle(),
+      { timeout: 60_000 }
+    );
+
+    await expect(img).not.toHaveClass(/detail-image-hidden/, {
+      timeout: 10_000,
+    });
+    await expect(img).toHaveCSS('opacity', '1');
+    await expect(page.locator('.image-loading-overlay')).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  } finally {
+    await page.unroute('**/images/1/preview**');
+  }
+});

--- a/static/e2e/image-detail.spec.ts
+++ b/static/e2e/image-detail.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import {
   registerFixtureDb,
   resetDatabases,
@@ -6,16 +6,46 @@ import {
 } from './helpers';
 
 let dbId: string;
+let slugCounter = 0;
 
 test.beforeEach(async ({ request }) => {
   await resetDatabases(request);
+  slugCounter += 1;
   const entry = await registerFixtureDb(request, {
-    name: 'Imaging Rig e2e',
-    slug: 'imaging-rig-e2e',
+    name: `Imaging Rig e2e ${slugCounter}`,
+    slug: `imaging-rig-e2e-${slugCounter}`,
   });
   dbId = entry.id;
   await waitForCacheReady(request, dbId);
 });
+
+async function readDetailViewportAnchor(page: Page) {
+  return page.locator('.zoom-container img.detail-main-image').first().evaluate((img) => {
+    const container = img.closest('.zoom-container');
+    if (!(container instanceof HTMLElement)) {
+      throw new Error('Missing zoom container');
+    }
+
+    const matrix = new DOMMatrixReadOnly(getComputedStyle(img).transform);
+    const rect = container.getBoundingClientRect();
+    const viewportCenterX = rect.width / 2;
+    const viewportCenterY = rect.height / 2;
+    const scale = matrix.a || 1;
+    const imageX = (viewportCenterX - matrix.e) / scale;
+    const imageY = (viewportCenterY - matrix.f) / scale;
+
+    return {
+      src: (img as HTMLImageElement).currentSrc || (img as HTMLImageElement).src,
+      naturalWidth: (img as HTMLImageElement).naturalWidth,
+      naturalHeight: (img as HTMLImageElement).naturalHeight,
+      scale,
+      offsetX: matrix.e,
+      offsetY: matrix.f,
+      centerRatioX: imageX / (img as HTMLImageElement).naturalWidth,
+      centerRatioY: imageY / (img as HTMLImageElement).naturalHeight,
+    };
+  });
+}
 
 test('preview images load with per-DB-nested URLs and render pixels', async ({
   page,
@@ -64,9 +94,31 @@ test('preview endpoint returns a 200 for a registered image', async ({
   // we wrote into the fixture image dir, end-to-end through the per-DB
   // routing and find_fits_file lookup. This decouples "preview works" from
   // any frontend rendering quirks.
-  const res = await request.get(
+  let res = await request.get(
     `/api/db/${encodeURIComponent(dbId)}/images/1/preview?size=screen`
   );
+  if (res.status() === 202) {
+    await expect
+      .poll(
+        async () => {
+          const status = await request.post(
+            `/api/db/${encodeURIComponent(dbId)}/images/generation-status`,
+            {
+              data: {
+                requests: [{ image_id: 1, kind: 'preview', size: 'screen' }],
+              },
+            }
+          );
+          return (await status.json()).data.statuses[0].state;
+        },
+        { timeout: 30_000, intervals: [500] }
+      )
+      .toBe('ready');
+
+    res = await request.get(
+      `/api/db/${encodeURIComponent(dbId)}/images/1/preview?size=screen`
+    );
+  }
   expect(res.status(), `body: ${await res.text().catch(() => '<unread>')}`).toBe(200);
   expect(res.headers()['content-type']).toMatch(/^image\//);
   const buf = await res.body();
@@ -100,4 +152,182 @@ test('detail view loads the large preview and renders pixels', async ({
   }));
   expect(dims.natW).toBeGreaterThan(500);
   expect(dims.natH).toBeGreaterThan(500);
+});
+
+test('detail view hides the pending image while arrow-key navigation generates it', async ({
+  page,
+}) => {
+  let releaseNextImageResponse!: () => void;
+  let markNextImageHeld!: () => void;
+  const releasePromise = new Promise<void>((resolve) => {
+    releaseNextImageResponse = resolve;
+  });
+  const nextImageHeldPromise = new Promise<void>((resolve) => {
+    markNextImageHeld = resolve;
+  });
+  let nextImageHeld = false;
+
+  await page.route('**/images/2/preview**', async (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get('size') !== 'large') {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    if (response.status() === 200 && !nextImageHeld) {
+      nextImageHeld = true;
+      markNextImageHeld();
+      await releasePromise;
+    }
+    await route.fulfill({ response });
+  });
+
+  try {
+    await page.goto(`/#/detail/1?db=${encodeURIComponent(dbId)}&project=1`);
+
+    const img = page.locator('.zoom-container img.detail-main-image').first();
+    await expect(img).toBeVisible({ timeout: 15_000 });
+    await page.waitForFunction(
+      (el) => el instanceof HTMLImageElement && el.complete && el.naturalWidth > 0,
+      await img.elementHandle(),
+      { timeout: 30_000 }
+    );
+
+    await page.keyboard.press('ArrowRight');
+
+    await Promise.race([
+      nextImageHeldPromise,
+      page.waitForTimeout(45_000).then(() => {
+        throw new Error('Timed out waiting for generated next detail image');
+      }),
+    ]);
+
+    await expect(page).toHaveURL(/\/detail\/2/);
+    await expect(page.locator('.image-loading-overlay')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(img).toHaveCSS('opacity', '0');
+    await expect(img).toHaveClass(/detail-image-hidden/);
+
+    releaseNextImageResponse();
+
+    await page.waitForFunction(
+      (el) =>
+        el instanceof HTMLImageElement &&
+        el.complete &&
+        el.naturalWidth > 0 &&
+        (el.currentSrc || el.src).includes('/images/2/preview'),
+      await img.elementHandle(),
+      { timeout: 30_000 }
+    );
+    await expect(page.locator('.image-loading-overlay')).toHaveCount(0, {
+      timeout: 10_000,
+    });
+    await expect(img).not.toHaveClass(/detail-image-hidden/);
+  } finally {
+    releaseNextImageResponse();
+    await page.unroute('**/images/2/preview**');
+  }
+});
+
+test('detail view keeps the viewport anchored while swapping to original resolution', async ({
+  page,
+}) => {
+  test.setTimeout(90_000);
+
+  let releaseOriginalResponse!: () => void;
+  let markOriginalHeld!: () => void;
+  const releasePromise = new Promise<void>((resolve) => {
+    releaseOriginalResponse = resolve;
+  });
+  const originalHeldPromise = new Promise<void>((resolve) => {
+    markOriginalHeld = resolve;
+  });
+  let originalHeld = false;
+
+  await page.route('**/images/1/preview**', async (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get('size') !== 'original') {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    if (response.status() === 200 && !originalHeld) {
+      originalHeld = true;
+      markOriginalHeld();
+      await releasePromise;
+    }
+    await route.fulfill({ response });
+  });
+
+  try {
+    await page.goto(`/#/detail/1?db=${encodeURIComponent(dbId)}&project=1`);
+
+    const container = page.locator('.zoom-container').first();
+    const img = container.locator('img.detail-main-image').first();
+    await expect(img).toBeVisible({ timeout: 15_000 });
+    await page.waitForFunction(
+      (el) =>
+        el instanceof HTMLImageElement && el.complete && el.naturalWidth > 0,
+      await img.elementHandle(),
+      { timeout: 30_000 }
+    );
+
+    const box = await container.boundingBox();
+    expect(box).not.toBeNull();
+    const centerX = box!.x + box!.width / 2;
+    const centerY = box!.y + box!.height / 2;
+
+    await page.mouse.move(centerX, centerY);
+    await page.mouse.wheel(0, -1400);
+    await page.mouse.down();
+    await page.mouse.move(centerX - 120, centerY - 80, { steps: 6 });
+    await page.mouse.up();
+
+    const before = await readDetailViewportAnchor(page);
+    expect(before.src).toContain('size=large');
+
+    await Promise.race([
+      originalHeldPromise,
+      page.waitForTimeout(45_000).then(() => {
+        throw new Error('Timed out waiting for original preview request');
+      }),
+    ]);
+
+    await expect(page.locator('.image-loading-overlay')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const during = await readDetailViewportAnchor(page);
+    expect(during.src).toContain('size=large');
+    expect(Math.abs(during.centerRatioX - before.centerRatioX)).toBeLessThan(0.001);
+    expect(Math.abs(during.centerRatioY - before.centerRatioY)).toBeLessThan(0.001);
+
+    releaseOriginalResponse();
+
+    await page.waitForFunction(
+      ([el, minWidth]) =>
+        el instanceof HTMLImageElement &&
+        el.complete &&
+        el.naturalWidth > Number(minWidth) &&
+        (el.currentSrc || el.src).includes('size=original'),
+      [await img.elementHandle(), before.naturalWidth],
+      { timeout: 30_000 }
+    );
+
+    await expect(page.locator('.image-loading-overlay')).toHaveCount(0, {
+      timeout: 10_000,
+    });
+
+    const after = await readDetailViewportAnchor(page);
+    expect(after.src).toContain('size=original');
+    expect(after.naturalWidth).toBeGreaterThan(before.naturalWidth);
+    expect(Math.abs(after.centerRatioX - before.centerRatioX)).toBeLessThan(0.02);
+    expect(Math.abs(after.centerRatioY - before.centerRatioY)).toBeLessThan(0.02);
+  } finally {
+    releaseOriginalResponse();
+    await page.unroute('**/images/1/preview**');
+  }
 });

--- a/static/e2e/image-detail.spec.ts
+++ b/static/e2e/image-detail.spec.ts
@@ -47,6 +47,39 @@ async function readDetailViewportAnchor(page: Page) {
   });
 }
 
+async function readDetailFitState(page: Page) {
+  return page.locator('.zoom-container img.detail-main-image').first().evaluate((img) => {
+    const container = img.closest('.zoom-container');
+    if (!(container instanceof HTMLElement)) {
+      throw new Error('Missing zoom container');
+    }
+
+    const image = img as HTMLImageElement;
+    const matrix = new DOMMatrixReadOnly(getComputedStyle(image).transform);
+    const containerRect = container.getBoundingClientRect();
+    const expectedFitScale = Math.min(
+      (containerRect.width - 20) / image.naturalWidth,
+      (containerRect.height - 20) / image.naturalHeight
+    );
+    const renderedCenterX = matrix.e + (image.naturalWidth * matrix.a) / 2;
+    const renderedCenterY = matrix.f + (image.naturalHeight * matrix.d) / 2;
+
+    return {
+      className: image.className,
+      currentSrc: image.currentSrc || image.src,
+      expectedFitScale,
+      naturalHeight: image.naturalHeight,
+      naturalWidth: image.naturalWidth,
+      opacity: getComputedStyle(image).opacity,
+      renderedCenterX,
+      renderedCenterY,
+      scale: matrix.a || 1,
+      viewportCenterX: containerRect.width / 2,
+      viewportCenterY: containerRect.height / 2,
+    };
+  });
+}
+
 test('preview images load with per-DB-nested URLs and render pixels', async ({
   page,
 }) => {
@@ -225,6 +258,16 @@ test('detail view hides the pending image while arrow-key navigation generates i
       timeout: 10_000,
     });
     await expect(img).not.toHaveClass(/detail-image-hidden/);
+    await expect(img).toHaveCSS('opacity', '1', { timeout: 10_000 });
+
+    const fit = await readDetailFitState(page);
+    expect(fit.currentSrc).toContain('/images/2/preview');
+    expect(fit.className).not.toContain('detail-image-hidden');
+    expect(fit.opacity).toBe('1');
+    expect(fit.naturalWidth).toBeGreaterThan(0);
+    expect(Math.abs(fit.scale - fit.expectedFitScale)).toBeLessThan(0.05);
+    expect(Math.abs(fit.renderedCenterX - fit.viewportCenterX)).toBeLessThan(2);
+    expect(Math.abs(fit.renderedCenterY - fit.viewportCenterY)).toBeLessThan(2);
   } finally {
     releaseNextImageResponse();
     await page.unroute('**/images/2/preview**');

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -1164,10 +1164,6 @@
   transform-origin: 0 0 !important;
 }
 
-.detail-image img.loading {
-  opacity: 0.5;
-}
-
 .detail-image-hidden {
   opacity: 0 !important;
   pointer-events: none;

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -1173,6 +1173,11 @@
   pointer-events: none;
 }
 
+.comparison-image-hidden {
+  opacity: 0 !important;
+  pointer-events: none;
+}
+
 .detail-image-preload {
   width: 1px !important;
   height: 1px !important;

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -1168,6 +1168,18 @@
   opacity: 0.5;
 }
 
+.detail-image-hidden {
+  opacity: 0 !important;
+  pointer-events: none;
+}
+
+.detail-image-preload {
+  width: 1px !important;
+  height: 1px !important;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .detail-info {
   width: 320px;
   padding: 1.25rem;

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -550,6 +550,10 @@ export default function ImageComparisonView({
                       // Update image dimensions in zoom hook
                       const isShowingOriginal = useLeftOriginal || (leftOriginalLoaded && targetLeftZoomRef.current !== null && targetLeftZoomRef.current > 1.0);
                       leftZoom.setImageDimensions(newWidth, newHeight, isShowingOriginal);
+                      // Recalibrate pan constraints to the loaded bitmap even on
+                      // the paths below that adjust nothing (preserved zoom on a
+                      // new image) — constraints follow stateDims, not the <img>.
+                      leftZoom.notifyBitmapDimensions(newWidth, newHeight);
 
                       // Check if dimensions actually changed
                       const dimensionsChanged = oldWidth > 0 && (Math.abs(newWidth - oldWidth) > 10 || Math.abs(newHeight - oldHeight) > 10);
@@ -718,6 +722,10 @@ export default function ImageComparisonView({
                             // Update image dimensions in zoom hook
                             const isShowingOriginal = useRightOriginal || (rightOriginalLoaded && targetRightZoomRef.current !== null && targetRightZoomRef.current > 1.0);
                             rightZoom.setImageDimensions(newWidth, newHeight, isShowingOriginal);
+                            // Recalibrate pan constraints to the loaded bitmap
+                            // even when nothing below adjusts (preserved zoom on
+                            // a new image) — constraints follow stateDims.
+                            rightZoom.notifyBitmapDimensions(newWidth, newHeight);
 
                             // Check if dimensions actually changed
                             const dimensionsChanged = oldWidth > 0 && (Math.abs(newWidth - oldWidth) > 10 || Math.abs(newHeight - oldHeight) > 10);

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { apiClient } from '../api/client';
@@ -43,6 +43,8 @@ export default function ImageComparisonView({
   // Track image loading
   const [leftImageLoaded, setLeftImageLoaded] = useState(false);
   const [rightImageLoaded, setRightImageLoaded] = useState(false);
+  const [loadedLeftSrc, setLoadedLeftSrc] = useState<string | null>(null);
+  const [loadedRightSrc, setLoadedRightSrc] = useState<string | null>(null);
   
   // Track original image preloading
   const [leftOriginalLoaded, setLeftOriginalLoaded] = useState(false);
@@ -139,6 +141,8 @@ export default function ImageComparisonView({
     ? { imageId: rightIdForUrl, kind: 'annotated', size: rightSize, maxStars }
     : { imageId: rightIdForUrl, kind: 'preview', size: rightSize };
   const asyncRight = useAsyncImage(dbId, rightSrc, rightDescriptor);
+  const hideLeftImage = asyncLeft.state !== 'ready' || loadedLeftSrc !== asyncLeft.src;
+  const hideRightImage = asyncRight.state !== 'ready' || loadedRightSrc !== asyncRight.src;
 
   // Capture zoom intent before image change
   useEffect(() => {
@@ -246,11 +250,6 @@ export default function ImageComparisonView({
         if (currentState === 'large' && currentVisualScale > 1.0) {
           leftImageStateRef.current = 'switching-to-original';
           setUseLeftOriginal(true);
-          setTimeout(() => {
-            if (leftImageStateRef.current === 'switching-to-original') {
-              leftImageStateRef.current = 'original';
-            }
-          }, 300);
         }
       });
     }
@@ -260,12 +259,6 @@ export default function ImageComparisonView({
       // Switch to original
       leftImageStateRef.current = 'switching-to-original';
       setUseLeftOriginal(true);
-      // Delay state update to allow render
-      setTimeout(() => {
-        if (leftImageStateRef.current === 'switching-to-original') {
-          leftImageStateRef.current = 'original';
-        }
-      }, 300);
     }
     // Never switch back from original to large
   }, [leftZoom, leftImageId, showStars, leftImage, leftOriginalLoaded, dbId, maxStars]);
@@ -319,11 +312,6 @@ export default function ImageComparisonView({
         if (currentState === 'large' && (currentVisualScale > 1.0 || useLeftOriginal)) {
           rightImageStateRef.current = 'switching-to-original';
           setUseRightOriginal(true);
-          setTimeout(() => {
-            if (rightImageStateRef.current === 'switching-to-original') {
-              rightImageStateRef.current = 'original';
-            }
-          }, 300);
         }
       });
     }
@@ -333,12 +321,6 @@ export default function ImageComparisonView({
       // Switch to original
       rightImageStateRef.current = 'switching-to-original';
       setUseRightOriginal(true);
-      // Delay state update to allow render
-      setTimeout(() => {
-        if (rightImageStateRef.current === 'switching-to-original') {
-          rightImageStateRef.current = 'original';
-        }
-      }, 300);
     }
     // Never switch back from original to large
   }, [
@@ -357,27 +339,24 @@ export default function ImageComparisonView({
     if (useLeftOriginal && !useRightOriginal && rightOriginalLoaded && rightImageStateRef.current !== 'switching-to-original') {
       rightImageStateRef.current = 'switching-to-original';
       setUseRightOriginal(true);
-      setTimeout(() => {
-        if (rightImageStateRef.current === 'switching-to-original') {
-          rightImageStateRef.current = 'original';
-        }
-      }, 300);
     }
   }, [useLeftOriginal, useRightOriginal, rightOriginalLoaded]);
 
   // Reset preload state when images change
-  useEffect(() => {
+  useLayoutEffect(() => {
     setLeftOriginalLoaded(false);
     leftOriginalRef.current = null;
     setUseLeftOriginal(false);
+    setLoadedLeftSrc(null);
     leftDimensionsRef.current = { width: 0, height: 0 };
     leftImageStateRef.current = 'large';
   }, [leftImageId, showStars]);
   
-  useEffect(() => {
+  useLayoutEffect(() => {
     setRightOriginalLoaded(false);
     rightOriginalRef.current = null;
     setUseRightOriginal(false);
+    setLoadedRightSrc(null);
     rightDimensionsRef.current = { width: 0, height: 0 };
     rightImageStateRef.current = 'large';
   }, [rightImageId, showStars]);
@@ -554,46 +533,52 @@ export default function ImageComparisonView({
                   <img
                     ref={leftZoom.imageRef}
                     src={asyncLeft.src}
+                    className={hideLeftImage ? 'comparison-image-hidden' : undefined}
                     alt={`${leftImage.target_name} - ${leftImage.filter_name || 'No filter'}`}
                     onError={asyncLeft.onError}
                     onLoad={(e) => {
-                    asyncLeft.onLoad();
-                    setLeftImageLoaded(true);
+                      asyncLeft.onLoad();
+                      setLeftImageLoaded(true);
+                      setLoadedLeftSrc(asyncLeft.src);
 
-                    const img = e.currentTarget;
-                    const newWidth = img.naturalWidth;
-                    const newHeight = img.naturalHeight;
-                    const oldWidth = leftDimensionsRef.current.width;
-                    const oldHeight = leftDimensionsRef.current.height;
-                    
-                    // Update image dimensions in zoom hook
-                    const isShowingOriginal = useLeftOriginal || (leftOriginalLoaded && targetLeftZoomRef.current !== null && targetLeftZoomRef.current > 1.0);
-                    leftZoom.setImageDimensions(newWidth, newHeight, isShowingOriginal);
-                    
-                    // Check if dimensions actually changed
-                    const dimensionsChanged = oldWidth > 0 && (Math.abs(newWidth - oldWidth) > 10 || Math.abs(newHeight - oldHeight) > 10);
-                    
-                    if (dimensionsChanged) {
-                      const currentVisualScale = leftZoom.getVisualScale();
-                      
-                      // Adjust zoom in two cases:
-                      // 1. Switching to original image (preserve visual scale)
-                      // 2. Loading new regular image with preserved zoom from previous image
-                      if (leftImageStateRef.current === 'switching-to-original' || 
-                          (leftImageStateRef.current === 'large' && currentVisualScale > 1.2)) {
-                        // Adjust zoom to maintain visual continuity
-                        leftZoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
+                      const img = e.currentTarget;
+                      const newWidth = img.naturalWidth;
+                      const newHeight = img.naturalHeight;
+                      const oldWidth = leftDimensionsRef.current.width;
+                      const oldHeight = leftDimensionsRef.current.height;
+
+                      // Update image dimensions in zoom hook
+                      const isShowingOriginal = useLeftOriginal || (leftOriginalLoaded && targetLeftZoomRef.current !== null && targetLeftZoomRef.current > 1.0);
+                      leftZoom.setImageDimensions(newWidth, newHeight, isShowingOriginal);
+
+                      // Check if dimensions actually changed
+                      const dimensionsChanged = oldWidth > 0 && (Math.abs(newWidth - oldWidth) > 10 || Math.abs(newHeight - oldHeight) > 10);
+
+                      if (dimensionsChanged) {
+                        const currentVisualScale = leftZoom.getVisualScale();
+
+                        // Adjust zoom in two cases:
+                        // 1. Switching to original image (preserve visual scale)
+                        // 2. Loading new regular image with preserved zoom from previous image
+                        if (leftImageStateRef.current === 'switching-to-original' ||
+                            (leftImageStateRef.current === 'large' && currentVisualScale > 1.2)) {
+                          // Adjust zoom to maintain visual continuity
+                          leftZoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
+                        }
                       }
-                    }
-                    
-                    // Update stored dimensions
-                    leftDimensionsRef.current = { width: newWidth, height: newHeight };
-                  }}
-                  style={{
-                    transform: `translate(${leftZoom.zoomState.offsetX}px, ${leftZoom.zoomState.offsetY}px) scale(${leftZoom.zoomState.scale})`,
-                    cursor: leftZoom.zoomState.scale > 1 ? 'grab' : 'default',
-                  }}
-                  draggable={false}
+
+                      if (leftImageStateRef.current === 'switching-to-original') {
+                        leftImageStateRef.current = 'original';
+                      }
+
+                      // Update stored dimensions
+                      leftDimensionsRef.current = { width: newWidth, height: newHeight };
+                    }}
+                    style={{
+                      transform: `translate(${leftZoom.zoomState.offsetX}px, ${leftZoom.zoomState.offsetY}px) scale(${leftZoom.zoomState.scale})`,
+                      cursor: leftZoom.zoomState.scale > 1 ? 'grab' : 'default',
+                    }}
+                    draggable={false}
                   />
                 )}
                 {(asyncLeft.state === 'generating' || asyncLeft.state === 'loading') && (
@@ -716,40 +701,46 @@ export default function ImageComparisonView({
                         <img
                           ref={rightZoom.imageRef}
                           src={asyncRight.src}
-                        alt={`${rightImage.target_name} - ${rightImage.filter_name || 'No filter'}`}
-                        onError={asyncRight.onError}
-                        onLoad={(e) => {
-                        asyncRight.onLoad();
-                        setRightImageLoaded(true);
+                          className={hideRightImage ? 'comparison-image-hidden' : undefined}
+                          alt={`${rightImage.target_name} - ${rightImage.filter_name || 'No filter'}`}
+                          onError={asyncRight.onError}
+                          onLoad={(e) => {
+                            asyncRight.onLoad();
+                            setRightImageLoaded(true);
+                            setLoadedRightSrc(asyncRight.src);
 
-                        const img = e.currentTarget;
-                        const newWidth = img.naturalWidth;
-                        const newHeight = img.naturalHeight;
-                        const oldWidth = rightDimensionsRef.current.width;
-                        const oldHeight = rightDimensionsRef.current.height;
-                        
-                        // Update image dimensions in zoom hook
-                        const isShowingOriginal = useRightOriginal || (rightOriginalLoaded && targetRightZoomRef.current !== null && targetRightZoomRef.current > 1.0);
-                        rightZoom.setImageDimensions(newWidth, newHeight, isShowingOriginal);
-                        
-                        // Check if dimensions actually changed
-                        const dimensionsChanged = oldWidth > 0 && (Math.abs(newWidth - oldWidth) > 10 || Math.abs(newHeight - oldHeight) > 10);
-                        
-                        if (dimensionsChanged) {
-                          const currentVisualScale = rightZoom.getVisualScale();
-                          
-                          // Adjust zoom in two cases:
-                          // 1. Switching to original image (preserve visual scale)
-                          // 2. Loading new regular image with preserved zoom from previous image
-                          if (rightImageStateRef.current === 'switching-to-original' || 
-                              (rightImageStateRef.current === 'large' && currentVisualScale > 1.2)) {
-                            // Adjust zoom to maintain visual continuity
-                            rightZoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
-                          }
-                        }
-                        
-                        // Update stored dimensions
-                        rightDimensionsRef.current = { width: newWidth, height: newHeight };
+                            const img = e.currentTarget;
+                            const newWidth = img.naturalWidth;
+                            const newHeight = img.naturalHeight;
+                            const oldWidth = rightDimensionsRef.current.width;
+                            const oldHeight = rightDimensionsRef.current.height;
+
+                            // Update image dimensions in zoom hook
+                            const isShowingOriginal = useRightOriginal || (rightOriginalLoaded && targetRightZoomRef.current !== null && targetRightZoomRef.current > 1.0);
+                            rightZoom.setImageDimensions(newWidth, newHeight, isShowingOriginal);
+
+                            // Check if dimensions actually changed
+                            const dimensionsChanged = oldWidth > 0 && (Math.abs(newWidth - oldWidth) > 10 || Math.abs(newHeight - oldHeight) > 10);
+
+                            if (dimensionsChanged) {
+                              const currentVisualScale = rightZoom.getVisualScale();
+
+                              // Adjust zoom in two cases:
+                              // 1. Switching to original image (preserve visual scale)
+                              // 2. Loading new regular image with preserved zoom from previous image
+                              if (rightImageStateRef.current === 'switching-to-original' ||
+                                  (rightImageStateRef.current === 'large' && currentVisualScale > 1.2)) {
+                                // Adjust zoom to maintain visual continuity
+                                rightZoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
+                              }
+                            }
+
+                            if (rightImageStateRef.current === 'switching-to-original') {
+                              rightImageStateRef.current = 'original';
+                            }
+
+                            // Update stored dimensions
+                            rightDimensionsRef.current = { width: newWidth, height: newHeight };
                           }}
                           style={{
                             transform: `translate(${rightZoom.zoomState.offsetX}px, ${rightZoom.zoomState.offsetY}px) scale(${rightZoom.zoomState.scale})`,

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { apiClient } from '../api/client';
@@ -54,6 +54,7 @@ export default function ImageDetailView({
   
   // State machine to prevent feedback loops
   const imageStateRef = useRef<'large' | 'switching-to-original' | 'original'>('large');
+  const mainImageKey = `${dbId}:${imageId}:${showStars ? 'stars' : 'preview'}:${maxStars}`;
 
   // Initialize zoom functionality
   const zoom = useImageZoom({
@@ -83,15 +84,35 @@ export default function ImageDetailView({
   // endpoint and is not queued here). On a cache miss the server returns 202
   // and this drives a "Generating…" indicator, then reloads when ready.
   const mainSize: 'large' | 'original' = useOriginalImage ? 'original' : 'large';
-  const nonPsfSrc = showStars
-    ? apiClient.getAnnotatedUrl(dbId, imageId, mainSize, maxStars)
-    : apiClient.getPreviewUrl(dbId, imageId, { size: mainSize });
+  const largeNonPsfSrc = showStars
+    ? apiClient.getAnnotatedUrl(dbId, imageId, 'large', maxStars)
+    : apiClient.getPreviewUrl(dbId, imageId, { size: 'large' });
+  const originalNonPsfSrc = showStars
+    ? apiClient.getAnnotatedUrl(dbId, imageId, 'original', maxStars)
+    : apiClient.getPreviewUrl(dbId, imageId, { size: 'original' });
+  const nonPsfSrc = mainSize === 'original' ? originalNonPsfSrc : largeNonPsfSrc;
   const nonPsfDescriptor: PreviewDescriptor = showStars
     ? { imageId, kind: 'annotated', size: mainSize, maxStars }
     : { imageId, kind: 'preview', size: mainSize };
   const asyncImg = useAsyncImage(dbId, nonPsfSrc, nonPsfDescriptor);
-  const [visibleMainSrc, setVisibleMainSrc] = useState(nonPsfSrc);
-  const [loadedMainSrc, setLoadedMainSrc] = useState<string | null>(null);
+  const [visibleMainImage, setVisibleMainImage] = useState<{
+    key: string;
+    src: string;
+    loadedSrc: string | null;
+  }>(() => ({
+    key: mainImageKey,
+    src: nonPsfSrc,
+    loadedSrc: null,
+  }));
+  const visibleMainSrc =
+    visibleMainImage.key === mainImageKey ? visibleMainImage.src : nonPsfSrc;
+  const loadedMainSrc =
+    visibleMainImage.key === mainImageKey ? visibleMainImage.loadedSrc : null;
+  const currentMainSrcIsLoaded =
+    visibleMainSrc === loadedMainSrc;
+  const currentNonPsfSources = [largeNonPsfSrc, originalNonPsfSrc];
+  const visibleMainSrcIsCurrent =
+    currentNonPsfSources.includes(visibleMainSrc);
 
   // Fetch image details
   const { data: image, isLoading, isFetching } = useQuery({
@@ -227,19 +248,14 @@ export default function ImageDetailView({
   }, [zoom, imageId, showStars, showPsf, image, isOriginalLoaded, dbId, maxStars]);
   
   // Reset preload state when image changes
-  useEffect(() => {
+  useLayoutEffect(() => {
     setIsOriginalLoaded(false);
     setUseOriginalImage(false);
-    setVisibleMainSrc(
-      showStars
-        ? apiClient.getAnnotatedUrl(dbId, imageId, 'large', maxStars)
-        : apiClient.getPreviewUrl(dbId, imageId, { size: 'large' })
-    );
-    setLoadedMainSrc(null);
+    setVisibleMainImage({ key: mainImageKey, src: largeNonPsfSrc, loadedSrc: null });
     imageDimensionsRef.current = { width: 0, height: 0 };
     imageStateRef.current = 'large';
     setImageError(false);
-  }, [dbId, imageId, showStars, maxStars]);
+  }, [dbId, imageId, showStars, maxStars, mainImageKey, largeNonPsfSrc]);
 
   // Show loading state only on initial load
   if (!image && isLoading) {
@@ -278,8 +294,9 @@ export default function ImageDetailView({
 
   const hideMainImage =
     !showPsf &&
-    visibleMainSrc === asyncImg.src &&
-    (asyncImg.state !== 'ready' || loadedMainSrc !== visibleMainSrc);
+    (!visibleMainSrcIsCurrent ||
+      (visibleMainSrc === asyncImg.src &&
+        (asyncImg.state !== 'ready' || !currentMainSrcIsLoaded)));
 
   return (
     <div className="image-detail-overlay" onClick={onClose}>
@@ -375,8 +392,11 @@ export default function ImageDetailView({
                       }
 
                       imageDimensionsRef.current = { width: newWidth, height: newHeight };
-                      setLoadedMainSrc(asyncImg.src);
-                      setVisibleMainSrc(asyncImg.src);
+                      setVisibleMainImage({
+                        key: mainImageKey,
+                        src: asyncImg.src,
+                        loadedSrc: asyncImg.src,
+                      });
                     }}
                     draggable={false}
                   />
@@ -423,6 +443,10 @@ export default function ImageDetailView({
                     asyncImg.onLoad();
                   }
 
+                  if (!showPsf && !visibleMainSrcIsCurrent) {
+                    return;
+                  }
+
                   const img = e.currentTarget;
                   const newWidth = img.naturalWidth;
                   const newHeight = img.naturalHeight;
@@ -440,18 +464,20 @@ export default function ImageDetailView({
                       // Adjust zoom to maintain visual continuity
                       zoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
                     }
-                    imageStateRef.current = 'original';
+                  imageStateRef.current = 'original';
                   } else if (imageDimensionsRef.current.width === 0) {
-                    // Only zoom to fit on initial load
-                    setTimeout(() => {
-                      zoom.zoomToFit();
-                    }, 50);
+                    // Queue fit before revealing the newly loaded image.
+                    zoom.zoomToFit();
                   }
                   
                   // Update stored dimensions
                   imageDimensionsRef.current = { width: newWidth, height: newHeight };
                   if (!showPsf) {
-                    setLoadedMainSrc(visibleMainSrc);
+                    setVisibleMainImage((current) =>
+                      current.key === mainImageKey && current.src === visibleMainSrc
+                        ? { ...current, loadedSrc: visibleMainSrc }
+                        : current
+                    );
                   }
                   }}
                   draggable={false}

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -90,6 +90,8 @@ export default function ImageDetailView({
     ? { imageId, kind: 'annotated', size: mainSize, maxStars }
     : { imageId, kind: 'preview', size: mainSize };
   const asyncImg = useAsyncImage(dbId, nonPsfSrc, nonPsfDescriptor);
+  const [visibleMainSrc, setVisibleMainSrc] = useState(nonPsfSrc);
+  const [loadedMainSrc, setLoadedMainSrc] = useState<string | null>(null);
 
   // Fetch image details
   const { data: image, isLoading, isFetching } = useQuery({
@@ -220,12 +222,6 @@ export default function ImageDetailView({
       // Switch to original
       imageStateRef.current = 'switching-to-original';
       setUseOriginalImage(true);
-      // Delay state update to allow render
-      setTimeout(() => {
-        if (imageStateRef.current === 'switching-to-original') {
-          imageStateRef.current = 'original';
-        }
-      }, 300);
     }
     // Never switch back from original to large
   }, [zoom, imageId, showStars, showPsf, image, isOriginalLoaded, dbId, maxStars]);
@@ -234,10 +230,16 @@ export default function ImageDetailView({
   useEffect(() => {
     setIsOriginalLoaded(false);
     setUseOriginalImage(false);
+    setVisibleMainSrc(
+      showStars
+        ? apiClient.getAnnotatedUrl(dbId, imageId, 'large', maxStars)
+        : apiClient.getPreviewUrl(dbId, imageId, { size: 'large' })
+    );
+    setLoadedMainSrc(null);
     imageDimensionsRef.current = { width: 0, height: 0 };
     imageStateRef.current = 'large';
     setImageError(false);
-  }, [imageId, showStars]);
+  }, [dbId, imageId, showStars, maxStars]);
 
   // Show loading state only on initial load
   if (!image && isLoading) {
@@ -273,6 +275,11 @@ export default function ImageDetailView({
     if (!timestamp) return 'Unknown';
     return new Date(timestamp * 1000).toLocaleString();
   };
+
+  const hideMainImage =
+    !showPsf &&
+    visibleMainSrc === asyncImg.src &&
+    (asyncImg.state !== 'ready' || loadedMainSrc !== visibleMainSrc);
 
   return (
     <div className="image-detail-overlay" onClick={onClose}>
@@ -336,10 +343,52 @@ export default function ImageDetailView({
                   </div>
                 </div>
               ) : (
+                <>
+                {!showPsf && visibleMainSrc !== asyncImg.src && asyncImg.state !== 'error' && (
+                  <img
+                    className="detail-image-preload"
+                    src={asyncImg.src}
+                    alt=""
+                    aria-hidden="true"
+                    loading="eager"
+                    onError={asyncImg.onError}
+                    onLoad={(e) => {
+                      asyncImg.onLoad();
+
+                      const img = e.currentTarget;
+                      const newWidth = img.naturalWidth;
+                      const newHeight = img.naturalHeight;
+                      const oldWidth = imageDimensionsRef.current.width;
+                      const oldHeight = imageDimensionsRef.current.height;
+                      const dimensionsChanged =
+                        oldWidth > 0 &&
+                        (Math.abs(newWidth - oldWidth) > 10 ||
+                          Math.abs(newHeight - oldHeight) > 10);
+
+                      zoom.setImageDimensions(newWidth, newHeight, useOriginalImage);
+
+                      if (imageStateRef.current === 'switching-to-original') {
+                        if (dimensionsChanged) {
+                          zoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
+                        }
+                        imageStateRef.current = 'original';
+                      }
+
+                      imageDimensionsRef.current = { width: newWidth, height: newHeight };
+                      setLoadedMainSrc(asyncImg.src);
+                      setVisibleMainSrc(asyncImg.src);
+                    }}
+                    draggable={false}
+                  />
+                )}
                 <img
                   ref={zoom.imageRef}
                   key={`${imageId}-${showStars ? 'stars' : showPsf ? 'psf' : 'normal'}`}
-                  className={isFetching ? 'loading' : ''}
+                  className={[
+                    'detail-main-image',
+                    isFetching ? 'loading' : null,
+                    hideMainImage ? 'detail-image-hidden' : null,
+                  ].filter(Boolean).join(' ')}
                   src={
                     showPsf
                       ? apiClient.getPsfUrl(dbId, imageId, {
@@ -348,7 +397,7 @@ export default function ImageDetailView({
                           sort_by: 'r2',
                           selection: 'top-n',
                         })
-                      : asyncImg.src
+                      : visibleMainSrc
                   }
                   alt={`${image.target_name} - ${image.filter_name || 'No filter'}`}
                   style={{
@@ -356,7 +405,13 @@ export default function ImageDetailView({
                     cursor: zoom.zoomState.scale > 1 ? 'grab' : 'default',
                     transformOrigin: '0 0',
                   }}
-                  onError={showPsf ? () => setImageError(true) : asyncImg.onError}
+                  onError={
+                    showPsf
+                      ? () => setImageError(true)
+                      : visibleMainSrc === asyncImg.src
+                        ? asyncImg.onError
+                        : undefined
+                  }
                   onLoad={(e) => {
                   // Remove loading class when image loads
                   e.currentTarget.classList.remove('loading');
@@ -364,7 +419,7 @@ export default function ImageDetailView({
                   // Clear PSF loading state / mark the async image ready.
                   if (showPsf) {
                     setPsfImageLoading(false);
-                  } else {
+                  } else if (visibleMainSrc === asyncImg.src) {
                     asyncImg.onLoad();
                   }
 
@@ -380,9 +435,12 @@ export default function ImageDetailView({
                   // Check if dimensions actually changed (indicating size switch)
                   const dimensionsChanged = oldWidth > 0 && (Math.abs(newWidth - oldWidth) > 10 || Math.abs(newHeight - oldHeight) > 10);
                   
-                  if (dimensionsChanged && imageStateRef.current === 'switching-to-original') {
-                    // Adjust zoom to maintain visual continuity
-                    zoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
+                  if (imageStateRef.current === 'switching-to-original') {
+                    if (dimensionsChanged) {
+                      // Adjust zoom to maintain visual continuity
+                      zoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
+                    }
+                    imageStateRef.current = 'original';
                   } else if (imageDimensionsRef.current.width === 0) {
                     // Only zoom to fit on initial load
                     setTimeout(() => {
@@ -392,9 +450,13 @@ export default function ImageDetailView({
                   
                   // Update stored dimensions
                   imageDimensionsRef.current = { width: newWidth, height: newHeight };
+                  if (!showPsf) {
+                    setLoadedMainSrc(visibleMainSrc);
+                  }
                   }}
                   draggable={false}
                 />
+                </>
               )}
               {!showPsf &&
                 (asyncImg.state === 'generating' || asyncImg.state === 'loading') && (

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -96,24 +96,31 @@ export default function ImageDetailView({
     ? { imageId, kind: 'annotated', size: mainSize, maxStars }
     : { imageId, kind: 'preview', size: mainSize };
   const asyncImg = useAsyncImage(dbId, nonPsfSrc, nonPsfDescriptor);
+  // `src` is what the <img> renders (may carry a `v=` cache-buster after a
+  // generation-triggered reload); `baseSrc` is the stable identity used to
+  // decide whether the visible artifact still belongs to this image/size.
   const [visibleMainImage, setVisibleMainImage] = useState<{
     key: string;
     src: string;
+    baseSrc: string;
     loadedSrc: string | null;
   }>(() => ({
     key: mainImageKey,
     src: nonPsfSrc,
+    baseSrc: nonPsfSrc,
     loadedSrc: null,
   }));
   const visibleMainSrc =
     visibleMainImage.key === mainImageKey ? visibleMainImage.src : nonPsfSrc;
+  const visibleMainBaseSrc =
+    visibleMainImage.key === mainImageKey ? visibleMainImage.baseSrc : nonPsfSrc;
   const loadedMainSrc =
     visibleMainImage.key === mainImageKey ? visibleMainImage.loadedSrc : null;
   const currentMainSrcIsLoaded =
     visibleMainSrc === loadedMainSrc;
   const currentNonPsfSources = [largeNonPsfSrc, originalNonPsfSrc];
   const visibleMainSrcIsCurrent =
-    currentNonPsfSources.includes(visibleMainSrc);
+    currentNonPsfSources.includes(visibleMainBaseSrc);
 
   // Fetch image details
   const { data: image, isLoading } = useQuery({
@@ -252,7 +259,12 @@ export default function ImageDetailView({
   useLayoutEffect(() => {
     setIsOriginalLoaded(false);
     setUseOriginalImage(false);
-    setVisibleMainImage({ key: mainImageKey, src: largeNonPsfSrc, loadedSrc: null });
+    setVisibleMainImage({
+      key: mainImageKey,
+      src: largeNonPsfSrc,
+      baseSrc: largeNonPsfSrc,
+      loadedSrc: null,
+    });
     imageDimensionsRef.current = { width: 0, height: 0 };
     imageStateRef.current = 'large';
     setImageError(false);
@@ -294,11 +306,11 @@ export default function ImageDetailView({
     return new Date(timestamp * 1000).toLocaleString();
   };
 
+  // Hide until the visible src has actually loaded AND still belongs to this
+  // image/size — never show a stale or errored <img> (e.g. one whose original
+  // request 202'd while its regenerated copy loads under a `v=` buster).
   const hideMainImage =
-    !showPsf &&
-    (!visibleMainSrcIsCurrent ||
-      (visibleMainSrc === asyncImg.src &&
-        (asyncImg.state !== 'ready' || !currentMainSrcIsLoaded)));
+    !showPsf && (!visibleMainSrcIsCurrent || !currentMainSrcIsLoaded);
 
   return (
     <div className="image-detail-overlay" onClick={onClose}>
@@ -399,6 +411,7 @@ export default function ImageDetailView({
                       setVisibleMainImage({
                         key: mainImageKey,
                         src: asyncImg.src,
+                        baseSrc: nonPsfSrc,
                         loadedSrc: asyncImg.src,
                       });
                     }}

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -49,19 +49,30 @@ export default function ImageDetailView({
   const [imageSize, setImageSize] = useState<'screen' | 'large' | 'original'>('large');
   const [isOriginalLoaded, setIsOriginalLoaded] = useState(false);
   const [useOriginalImage, setUseOriginalImage] = useState(false);
-  const imageDimensionsRef = useRef<{ width: number; height: number }>({ width: 0, height: 0 });
   const [imageError, setImageError] = useState(false);
-  
+
   // State machine to prevent feedback loops
   const imageStateRef = useRef<'large' | 'switching-to-original' | 'original'>('large');
+  // Guard: request original-resolution generation at most once per image.
+  const originalRequestedRef = useRef(false);
   const mainImageKey = `${dbId}:${imageId}:${showStars ? 'stars' : 'preview'}:${maxStars}`;
+  const mainImageKeyRef = useRef(mainImageKey);
+  mainImageKeyRef.current = mainImageKey;
+
+  // 'fit': the view follows the image (refit whenever a new one loads).
+  // 'user': the user owns the view — zoom percent and position are preserved
+  // exactly across arrow-key navigation and preview↔original bitmap swaps,
+  // until an explicit Fit/reset returns to 'fit'.
+  const viewModeRef = useRef<'fit' | 'user'>('fit');
 
   // Initialize zoom functionality
   const zoom = useImageZoom({
     minScale: 0.1,
     maxScale: 10.0,
+    onViewModeChange: (mode) => {
+      viewModeRef.current = mode;
+    },
   });
-  const resetZoomInitialization = zoom.resetInitialization;
 
   // Check if image has overflow (is larger than container)
   const hasOverflow = zoom.zoomState.scale > 1 || 
@@ -167,47 +178,6 @@ export default function ImageDetailView({
   useHotkeys('1', () => zoom.zoomTo100(), [zoom.zoomTo100]);
   useHotkeys('f', () => zoom.zoomToFit(), [zoom.zoomToFit]);
 
-  // Track zoom state to detect user interactions
-  const previousZoomState = useRef(zoom.zoomState);
-  const lastUserZoomRef = useRef<number>(0);
-  const lastImageIdRef = useRef<number>(imageId);
-  const USER_ZOOM_COOLDOWN = 2000; // 2 seconds
-  
-  // Track user zoom interactions by monitoring zoom state changes
-  useEffect(() => {
-    const currentZoom = zoom.zoomState;
-    const prevZoom = previousZoomState.current;
-    
-    // Check if zoom changed and it wasn't from an image change
-    const zoomChanged = currentZoom.scale !== prevZoom.scale || 
-                       currentZoom.offsetX !== prevZoom.offsetX || 
-                       currentZoom.offsetY !== prevZoom.offsetY;
-    
-    const imageChanged = imageId !== lastImageIdRef.current;
-    
-    // If zoom changed but image didn't change, it was a user interaction
-    if (zoomChanged && !imageChanged) {
-      lastUserZoomRef.current = Date.now();
-    }
-    
-    previousZoomState.current = currentZoom;
-    lastImageIdRef.current = imageId;
-  }, [zoom.zoomState, imageId]);
-
-  // Reset zoom only when image ID changes and user hasn't zoomed recently
-  useEffect(() => {
-    const timeSinceUserZoom = Date.now() - lastUserZoomRef.current;
-    
-    // Only auto-fit if user hasn't zoomed recently
-    if (timeSinceUserZoom > USER_ZOOM_COOLDOWN) {
-      const timer = setTimeout(() => {
-        zoom.zoomToFit();
-      }, 300);
-      
-      return () => clearTimeout(timer);
-    }
-  }, [imageId, zoom.zoomToFit]); // eslint-disable-line react-hooks/exhaustive-deps
-  
   // Load original dimensions from metadata if available
   useEffect(() => {
     // Try different possible field names for image dimensions
@@ -223,17 +193,21 @@ export default function ImageDetailView({
     }
   }, [image, zoom]);
   
-  // Combined effect for image preloading and switching
+  // Combined effect for image preloading and switching. Triggers on the RAW
+  // scale of the displayed bitmap: scale > 1 means the current bitmap is
+  // being magnified past its native pixels (blurry) and the original-
+  // resolution artifact is needed, whichever preview size is showing.
   useEffect(() => {
     if (!image || showPsf) return;
-    
-    const visualScale = zoom.getVisualScale();
+
+    const scale = zoom.zoomState.scale;
     const state = imageStateRef.current;
-    
-    // Preload when visual zoom > 80%. Route through the interactive queue so an
-    // uncached 'original' is actually generated (its 202 is not a failure);
-    // only flip to it once generation completes.
-    if (visualScale > 0.8 && !isOriginalLoaded && state === 'large') {
+
+    // Preload near 1:1. Route through the interactive queue so an uncached
+    // 'original' is actually generated (its 202 is not a failure); only flip
+    // to it once generation completes.
+    if (scale > 0.8 && state === 'large' && !isOriginalLoaded && !originalRequestedRef.current) {
+      originalRequestedRef.current = true;
       const originalUrl = showStars
         ? apiClient.getAnnotatedUrl(dbId, imageId, 'original', maxStars)
         : apiClient.getPreviewUrl(dbId, imageId, { size: 'original' });
@@ -241,35 +215,68 @@ export default function ImageDetailView({
         ? { imageId, kind: 'annotated', size: 'original', maxStars }
         : { imageId, kind: 'preview', size: 'original' };
 
+      const requestedKey = mainImageKey;
       void ensurePreviewReady(dbId, originalUrl, originalDescriptor).then((ok) => {
-        if (ok) setIsOriginalLoaded(true);
+        // With zoom persisting across navigation these requests fire on every
+        // image; ignore resolutions that arrive after we moved on.
+        if (mainImageKeyRef.current !== requestedKey) return;
+        if (ok) {
+          setIsOriginalLoaded(true);
+        } else {
+          // Transient generation failure — clear the guard so the next zoom
+          // change retries instead of leaving this image stuck on the preview.
+          originalRequestedRef.current = false;
+        }
       });
     }
-    
-    // State machine transitions based on visual scale - only switch to original, never back
-    if (state === 'large' && visualScale > 1.0 && isOriginalLoaded) {
+
+    // State machine transitions - only switch to original, never back
+    if (state === 'large' && scale >= 1.0 && isOriginalLoaded) {
       // Switch to original
       imageStateRef.current = 'switching-to-original';
       setUseOriginalImage(true);
     }
     // Never switch back from original to large
-  }, [zoom, imageId, showStars, showPsf, image, isOriginalLoaded, dbId, maxStars]);
+  }, [zoom, imageId, showStars, showPsf, image, isOriginalLoaded, dbId, maxStars, mainImageKey]);
   
-  // Reset preload state when image changes
+  // Reset preload state when image changes. Deliberately does NOT touch the
+  // zoom state: in 'user' view mode the zoom/pan carries over to the next
+  // image (reportBitmapLoaded reconciles it against the incoming bitmap).
   useLayoutEffect(() => {
     setIsOriginalLoaded(false);
     setUseOriginalImage(false);
+    originalRequestedRef.current = false;
     setVisibleMainImage({
       key: mainImageKey,
       src: largeNonPsfSrc,
       baseSrc: largeNonPsfSrc,
       loadedSrc: null,
     });
-    imageDimensionsRef.current = { width: 0, height: 0 };
     imageStateRef.current = 'large';
     setImageError(false);
-    resetZoomInitialization();
-  }, [dbId, imageId, showStars, maxStars, mainImageKey, largeNonPsfSrc, resetZoomInitialization]);
+  }, [dbId, imageId, showStars, maxStars, mainImageKey, largeNonPsfSrc]);
+
+  // A bitmap finished loading into one of the <img> elements. Hand its
+  // dimensions to the zoom hook: fit when the view is in 'fit' mode, keep the
+  // view (exactly, or remapped across a size change) when the user owns it or
+  // when this load is the large→original swap.
+  const reportBitmapLoaded = (img: HTMLImageElement) => {
+    const width = img.naturalWidth;
+    const height = img.naturalHeight;
+    if (!width || !height) return;
+
+    zoom.setImageDimensions(width, height, useOriginalImage);
+
+    const switching = imageStateRef.current === 'switching-to-original';
+    zoom.applyBitmapDimensions(
+      width,
+      height,
+      switching || viewModeRef.current === 'user' ? 'preserve' : 'fit'
+    );
+    if (switching) {
+      imageStateRef.current = 'original';
+    }
+  };
 
   // Show loading state only on initial load
   if (!image && isLoading) {
@@ -385,29 +392,7 @@ export default function ImageDetailView({
                     onError={asyncImg.onError}
                     onLoad={(e) => {
                       asyncImg.onLoad();
-
-                      const img = e.currentTarget;
-                      const newWidth = img.naturalWidth;
-                      const newHeight = img.naturalHeight;
-                      const oldWidth = imageDimensionsRef.current.width;
-                      const oldHeight = imageDimensionsRef.current.height;
-                      const dimensionsChanged =
-                        oldWidth > 0 &&
-                        (Math.abs(newWidth - oldWidth) > 10 ||
-                          Math.abs(newHeight - oldHeight) > 10);
-
-                      zoom.setImageDimensions(newWidth, newHeight, useOriginalImage);
-
-                      if (imageStateRef.current === 'switching-to-original') {
-                        if (dimensionsChanged) {
-                          zoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
-                        }
-                        imageStateRef.current = 'original';
-                      } else if (oldWidth === 0) {
-                        zoom.zoomToFitDimensions(newWidth, newHeight);
-                      }
-
-                      imageDimensionsRef.current = { width: newWidth, height: newHeight };
+                      reportBitmapLoaded(e.currentTarget);
                       setVisibleMainImage({
                         key: mainImageKey,
                         src: asyncImg.src,
@@ -449,49 +434,27 @@ export default function ImageDetailView({
                         : undefined
                   }
                   onLoad={(e) => {
-                  // Clear PSF loading state / mark the async image ready.
-                  if (showPsf) {
-                    setPsfImageLoading(false);
-                  } else if (visibleMainSrc === asyncImg.src) {
-                    asyncImg.onLoad();
-                  }
-
-                  if (!showPsf && !visibleMainSrcIsCurrent) {
-                    return;
-                  }
-
-                  const img = e.currentTarget;
-                  const newWidth = img.naturalWidth;
-                  const newHeight = img.naturalHeight;
-                  const oldWidth = imageDimensionsRef.current.width;
-                  const oldHeight = imageDimensionsRef.current.height;
-                  
-                  // Update image dimensions in zoom hook
-                  zoom.setImageDimensions(newWidth, newHeight, useOriginalImage);
-                  
-                  // Check if dimensions actually changed (indicating size switch)
-                  const dimensionsChanged = oldWidth > 0 && (Math.abs(newWidth - oldWidth) > 10 || Math.abs(newHeight - oldHeight) > 10);
-                  
-                  if (imageStateRef.current === 'switching-to-original') {
-                    if (dimensionsChanged) {
-                      // Adjust zoom to maintain visual continuity
-                      zoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
+                    // The PSF diagnostic image never feeds the zoom
+                    // calibration — its dimensions are unrelated to the
+                    // preview/original bitmaps.
+                    if (showPsf) {
+                      setPsfImageLoading(false);
+                      return;
                     }
-                    imageStateRef.current = 'original';
-                  } else if (imageDimensionsRef.current.width === 0) {
-                    // Queue fit before revealing the newly loaded image.
-                    zoom.zoomToFitDimensions(newWidth, newHeight);
-                  }
-                  
-                  // Update stored dimensions
-                  imageDimensionsRef.current = { width: newWidth, height: newHeight };
-                  if (!showPsf) {
+
+                    if (visibleMainSrc === asyncImg.src) {
+                      asyncImg.onLoad();
+                    }
+                    if (!visibleMainSrcIsCurrent) {
+                      return;
+                    }
+
+                    reportBitmapLoaded(e.currentTarget);
                     setVisibleMainImage((current) =>
                       current.key === mainImageKey && current.src === visibleMainSrc
                         ? { ...current, loadedSrc: visibleMainSrc }
                         : current
                     );
-                  }
                   }}
                   draggable={false}
                 />

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -61,6 +61,7 @@ export default function ImageDetailView({
     minScale: 0.1,
     maxScale: 10.0,
   });
+  const resetZoomInitialization = zoom.resetInitialization;
 
   // Check if image has overflow (is larger than container)
   const hasOverflow = zoom.zoomState.scale > 1 || 
@@ -115,7 +116,7 @@ export default function ImageDetailView({
     currentNonPsfSources.includes(visibleMainSrc);
 
   // Fetch image details
-  const { data: image, isLoading, isFetching } = useQuery({
+  const { data: image, isLoading } = useQuery({
     queryKey: ['db', dbId, 'image', imageId],
     queryFn: () => apiClient.getImage(dbId, imageId),
     placeholderData: (previousData) => previousData, // Keep showing previous image while loading new one
@@ -255,7 +256,8 @@ export default function ImageDetailView({
     imageDimensionsRef.current = { width: 0, height: 0 };
     imageStateRef.current = 'large';
     setImageError(false);
-  }, [dbId, imageId, showStars, maxStars, mainImageKey, largeNonPsfSrc]);
+    resetZoomInitialization();
+  }, [dbId, imageId, showStars, maxStars, mainImageKey, largeNonPsfSrc, resetZoomInitialization]);
 
   // Show loading state only on initial load
   if (!image && isLoading) {
@@ -389,6 +391,8 @@ export default function ImageDetailView({
                           zoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
                         }
                         imageStateRef.current = 'original';
+                      } else if (oldWidth === 0) {
+                        zoom.zoomToFitDimensions(newWidth, newHeight);
                       }
 
                       imageDimensionsRef.current = { width: newWidth, height: newHeight };
@@ -406,7 +410,6 @@ export default function ImageDetailView({
                   key={`${imageId}-${showStars ? 'stars' : showPsf ? 'psf' : 'normal'}`}
                   className={[
                     'detail-main-image',
-                    isFetching ? 'loading' : null,
                     hideMainImage ? 'detail-image-hidden' : null,
                   ].filter(Boolean).join(' ')}
                   src={
@@ -433,9 +436,6 @@ export default function ImageDetailView({
                         : undefined
                   }
                   onLoad={(e) => {
-                  // Remove loading class when image loads
-                  e.currentTarget.classList.remove('loading');
-
                   // Clear PSF loading state / mark the async image ready.
                   if (showPsf) {
                     setPsfImageLoading(false);
@@ -464,10 +464,10 @@ export default function ImageDetailView({
                       // Adjust zoom to maintain visual continuity
                       zoom.adjustZoomForNewImage(oldWidth, oldHeight, newWidth, newHeight);
                     }
-                  imageStateRef.current = 'original';
+                    imageStateRef.current = 'original';
                   } else if (imageDimensionsRef.current.width === 0) {
                     // Queue fit before revealing the newly loaded image.
-                    zoom.zoomToFit();
+                    zoom.zoomToFitDimensions(newWidth, newHeight);
                   }
                   
                   // Update stored dimensions

--- a/static/src/hooks/__tests__/useAsyncImage.test.tsx
+++ b/static/src/hooks/__tests__/useAsyncImage.test.tsx
@@ -1,0 +1,32 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useAsyncImage } from '../useAsyncImage';
+import type { PreviewDescriptor } from '../../api/types';
+
+function preview(imageId: number): PreviewDescriptor {
+  return { imageId, kind: 'preview', size: 'screen' };
+}
+
+describe('useAsyncImage', () => {
+  it('does not carry ready state across source changes', () => {
+    const firstSrc = '/api/db/test/images/1/preview?size=screen';
+    const secondSrc = '/api/db/test/images/2/preview?size=screen';
+    const { result, rerender } = renderHook(
+      ({ src, descriptor }) => useAsyncImage('test', src, descriptor),
+      {
+        initialProps: {
+          src: firstSrc,
+          descriptor: preview(1),
+        },
+      }
+    );
+
+    act(() => result.current.onLoad());
+    expect(result.current.state).toBe('ready');
+
+    rerender({ src: secondSrc, descriptor: preview(2) });
+
+    expect(result.current.src).toBe(secondSrc);
+    expect(result.current.state).toBe('loading');
+  });
+});

--- a/static/src/hooks/__tests__/useImageZoom.test.tsx
+++ b/static/src/hooks/__tests__/useImageZoom.test.tsx
@@ -190,6 +190,36 @@ describe('useImageZoom applyBitmapDimensions', () => {
   });
 });
 
+describe('useImageZoom notifyBitmapDimensions', () => {
+  it('recalibrates pan constraints to the loaded bitmap without touching the transform', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit');
+    });
+    act(() => result.current.zoomIn());
+    act(() => result.current.zoomIn());
+    act(() => result.current.zoomIn());
+    const before = result.current.zoomState;
+
+    // Comparison-view preserved-zoom navigation: a LARGER bitmap loads but
+    // nothing adjusts the transform — only the calibration must move over.
+    act(() => {
+      result.current.notifyBitmapDimensions(6000, 3999);
+    });
+
+    expect(result.current.zoomState.scale).toBe(before.scale);
+    expect(result.current.zoomState.offsetX).toBe(before.offsetX);
+    expect(result.current.zoomState.offsetY).toBe(before.offsetY);
+
+    // Pans must now clamp against the 6000px bitmap's bounds; against the
+    // stale 2000px dims this pan would be clamped to ~(-1380, -846).
+    panBy(result, -2500, -1500);
+    expect(result.current.zoomState.offsetX).toBeLessThan(-2000);
+    expect(result.current.zoomState.offsetY).toBeLessThan(-1000);
+  });
+});
+
 describe('useImageZoom view-mode notifications', () => {
   it('reports user intent on zoom/pan and fit intent on zoomToFit', () => {
     const onViewModeChange = vi.fn();

--- a/static/src/hooks/__tests__/useImageZoom.test.tsx
+++ b/static/src/hooks/__tests__/useImageZoom.test.tsx
@@ -1,0 +1,237 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useImageZoom } from '../useImageZoom';
+
+// Container mocked at 820x620 → fit padding (-20) leaves 800x600.
+const CONTAINER = { width: 820, height: 620 };
+
+function makeContainer(): HTMLDivElement {
+  const el = document.createElement('div');
+  el.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: CONTAINER.width,
+      bottom: CONTAINER.height,
+      width: CONTAINER.width,
+      height: CONTAINER.height,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return el;
+}
+
+function makeImg(naturalWidth: number, naturalHeight: number): HTMLImageElement {
+  // complete:false keeps the hook's mount auto-fit effect out of the way so
+  // each test drives state transitions explicitly.
+  return { naturalWidth, naturalHeight, complete: false } as HTMLImageElement;
+}
+
+function setup(onViewModeChange?: (mode: 'fit' | 'user') => void) {
+  const hook = renderHook(() =>
+    useImageZoom({ minScale: 0.1, maxScale: 10.0, onViewModeChange })
+  );
+  hook.result.current.containerRef.current = makeContainer();
+  return hook;
+}
+
+function panBy(
+  result: { current: ReturnType<typeof useImageZoom> },
+  dx: number,
+  dy: number
+) {
+  const down = {
+    button: 0,
+    clientX: 400,
+    clientY: 300,
+    preventDefault: () => {},
+  } as React.MouseEvent;
+  const move = {
+    clientX: 400 + dx,
+    clientY: 300 + dy,
+    preventDefault: () => {},
+  } as React.MouseEvent;
+  act(() => {
+    result.current.handleMouseDown(down);
+    result.current.handleMouseMove(move);
+    result.current.handleMouseUp(move);
+  });
+}
+
+describe('useImageZoom applyBitmapDimensions', () => {
+  it("fit mode centers the bitmap at the container's fit scale", () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit');
+    });
+
+    // fit = min(800/2000, 600/1333) = 0.4, centered.
+    expect(result.current.zoomState.scale).toBeCloseTo(0.4, 5);
+    expect(result.current.zoomState.offsetX).toBeCloseTo(
+      (CONTAINER.width - 2000 * 0.4) / 2,
+      5
+    );
+    expect(result.current.zoomState.offsetY).toBeCloseTo(
+      (CONTAINER.height - 1333 * 0.4) / 2,
+      5
+    );
+  });
+
+  it('preserve mode keeps the state EXACTLY when dimensions match (arrow-key navigation)', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit');
+    });
+    act(() => {
+      result.current.zoomIn();
+    });
+    panBy(result, -120, -80);
+    const before = result.current.zoomState;
+
+    // Next image in the sequence loads with identical bitmap dimensions.
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'preserve');
+    });
+
+    expect(result.current.zoomState.scale).toBe(before.scale);
+    expect(result.current.zoomState.offsetX).toBe(before.offsetX);
+    expect(result.current.zoomState.offsetY).toBe(before.offsetY);
+  });
+
+  it('preserve mode keeps displayed size and center across a bitmap size change', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit');
+    });
+    // Zoom to raw 1.0 on the preview bitmap.
+    act(() => result.current.zoomIn());
+    act(() => result.current.zoomIn());
+    act(() => result.current.zoomIn());
+    const before = result.current.zoomState;
+    expect(before.scale).toBeCloseTo(1.0, 5);
+
+    const beforeDisplayedWidth = 2000 * before.scale;
+    const beforeCenterRatioX =
+      (CONTAINER.width / 2 - before.offsetX) / before.scale / 2000;
+    const beforeCenterRatioY =
+      (CONTAINER.height / 2 - before.offsetY) / before.scale / 1333;
+
+    // The original-resolution bitmap (3x) replaces the preview.
+    act(() => {
+      result.current.applyBitmapDimensions(6000, 3999, 'preserve');
+    });
+
+    const after = result.current.zoomState;
+    expect(6000 * after.scale).toBeCloseTo(beforeDisplayedWidth, 3);
+    expect(
+      (CONTAINER.width / 2 - after.offsetX) / after.scale / 6000
+    ).toBeCloseTo(beforeCenterRatioX, 5);
+    expect(
+      (CONTAINER.height / 2 - after.offsetY) / after.scale / 3999
+    ).toBeCloseTo(beforeCenterRatioY, 5);
+  });
+
+  it('constrains pans against the state-calibrated dims, not a stale <img> (top-left jump regression)', () => {
+    const { result } = setup();
+
+    // The <img> element still holds the OLD preview bitmap for the whole
+    // swap window — constraints must ignore it.
+    result.current.imageRef.current = makeImg(2000, 1333);
+
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit');
+    });
+    act(() => result.current.zoomIn());
+    act(() => result.current.zoomIn());
+    act(() => result.current.zoomIn());
+    act(() => {
+      result.current.applyBitmapDimensions(6000, 3999, 'preserve');
+    });
+    // State is now calibrated to 6000x3999 at scale ~1/3; the stale <img>
+    // (2000px) would make the scaled size ~667px < container and every
+    // constraint recenters toward the small-image bounds.
+    const scale = result.current.zoomState.scale;
+    expect(6000 * scale).toBeGreaterThan(CONTAINER.width);
+
+    panBy(result, -500, -300);
+
+    const { offsetX, offsetY } = result.current.zoomState;
+    // Against the correct dims the pan lands well inside bounds; against the
+    // stale <img> dims it would have been recentered to (76.7, 88.4).
+    expect(offsetX).toBeLessThan(-400);
+    expect(offsetY).toBeLessThan(-200);
+  });
+
+  it('zoomToFit without a loaded <img> falls back to the state dims instead of a top-left reset', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit');
+    });
+    act(() => result.current.zoomIn());
+    const zoomed = result.current.zoomState;
+    expect(zoomed.scale).toBeGreaterThan(0.4);
+
+    // No usable <img> (src swap in flight) — fit must still target the
+    // calibrated bitmap, not collapse to scale 1 at (0,0).
+    act(() => {
+      result.current.zoomToFit();
+    });
+
+    expect(result.current.zoomState.scale).toBeCloseTo(0.4, 5);
+    expect(result.current.zoomState.offsetX).toBeCloseTo(
+      (CONTAINER.width - 2000 * 0.4) / 2,
+      5
+    );
+  });
+});
+
+describe('useImageZoom view-mode notifications', () => {
+  it('reports user intent on zoom/pan and fit intent on zoomToFit', () => {
+    const onViewModeChange = vi.fn();
+    const { result } = setup(onViewModeChange);
+
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit');
+    });
+    // Programmatic fit/apply never notifies.
+    expect(onViewModeChange).not.toHaveBeenCalled();
+
+    act(() => result.current.zoomIn());
+    expect(onViewModeChange).toHaveBeenLastCalledWith('user');
+
+    panBy(result, -50, 0);
+    expect(onViewModeChange).toHaveBeenLastCalledWith('user');
+
+    act(() => result.current.zoomToFit());
+    expect(onViewModeChange).toHaveBeenLastCalledWith('fit');
+
+    act(() => result.current.zoomTo100());
+    expect(onViewModeChange).toHaveBeenLastCalledWith('user');
+  });
+});
+
+describe('useImageZoom zoomTo100', () => {
+  it('targets 1:1 of the ORIGINAL pixels when showing a downscaled preview', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.setImageDimensions(6000, 3999, true); // metadata
+    });
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit'); // preview bitmap
+    });
+
+    act(() => {
+      result.current.zoomTo100();
+    });
+
+    // scale 3.0 upscales the preview to the original's pixel grid — which is
+    // what flips the detail view over to the original artifact.
+    expect(result.current.zoomState.scale).toBeCloseTo(3.0, 5);
+  });
+});

--- a/static/src/hooks/useAsyncImage.ts
+++ b/static/src/hooks/useAsyncImage.ts
@@ -12,6 +12,12 @@ export interface AsyncImageResult {
   onError: () => void;
 }
 
+interface AsyncImageRecord {
+  baseSrc: string;
+  state: AsyncImageState;
+  reloadTick: number;
+}
+
 /**
  * Optimistic image loading with batched poll-on-error.
  *
@@ -28,8 +34,11 @@ export function useAsyncImage(
   src: string,
   descriptor: PreviewDescriptor
 ): AsyncImageResult {
-  const [state, setState] = useState<AsyncImageState>('loading');
-  const [reloadTick, setReloadTick] = useState(0);
+  const [record, setRecord] = useState<AsyncImageRecord>(() => ({
+    baseSrc: src,
+    state: 'loading',
+    reloadTick: 0,
+  }));
   const unregisterRef = useRef<null | (() => void)>(null);
   // Latest descriptor without making `onError` depend on its object identity.
   const descRef = useRef(descriptor);
@@ -37,8 +46,11 @@ export function useAsyncImage(
 
   // Reset when the underlying src changes (new image / size / stars toggle).
   useEffect(() => {
-    setState('loading');
-    setReloadTick(0);
+    setRecord((current) =>
+      current.baseSrc === src
+        ? current
+        : { baseSrc: src, state: 'loading', reloadTick: 0 }
+    );
     return () => {
       unregisterRef.current?.();
       unregisterRef.current = null;
@@ -48,30 +60,51 @@ export function useAsyncImage(
   const onLoad = useCallback(() => {
     unregisterRef.current?.();
     unregisterRef.current = null;
-    setState('ready');
-  }, []);
+    setRecord((current) => ({
+      baseSrc: src,
+      state: 'ready',
+      reloadTick: current.baseSrc === src ? current.reloadTick : 0,
+    }));
+  }, [src]);
 
   const onError = useCallback(() => {
     unregisterRef.current?.();
     if (!dbId) {
       unregisterRef.current = null;
-      setState('error');
+      setRecord((current) => ({
+        baseSrc: src,
+        state: 'error',
+        reloadTick: current.baseSrc === src ? current.reloadTick : 0,
+      }));
       return;
     }
-    setState('generating');
+    setRecord((current) => ({
+      baseSrc: src,
+      state: 'generating',
+      reloadTick: current.baseSrc === src ? current.reloadTick : 0,
+    }));
     unregisterRef.current = registerPending(dbId, descRef.current, {
       onReady: () => {
         unregisterRef.current = null;
-        setState('loading');
-        setReloadTick((t) => t + 1); // force <img> to re-fetch (now cached)
+        setRecord((current) => ({
+          baseSrc: src,
+          state: 'loading',
+          reloadTick: (current.baseSrc === src ? current.reloadTick : 0) + 1,
+        })); // force <img> to re-fetch (now cached)
       },
       onError: () => {
         unregisterRef.current = null;
-        setState('error');
+        setRecord((current) => ({
+          baseSrc: src,
+          state: 'error',
+          reloadTick: current.baseSrc === src ? current.reloadTick : 0,
+        }));
       },
     });
-  }, [dbId]);
+  }, [dbId, src]);
 
+  const state = record.baseSrc === src ? record.state : 'loading';
+  const reloadTick = record.baseSrc === src ? record.reloadTick : 0;
   const displaySrc =
     reloadTick > 0 ? withParam(src, 'v', String(reloadTick)) : src;
   return { src: displaySrc, state, onLoad, onError };

--- a/static/src/hooks/useImageZoom.ts
+++ b/static/src/hooks/useImageZoom.ts
@@ -24,6 +24,7 @@ export interface UseImageZoomReturn {
   zoomIn: () => void;
   zoomOut: () => void;
   zoomToFit: () => void;
+  zoomToFitDimensions: (width: number, height: number) => void;
   zoomTo100: () => void;
   resetZoom: () => void;
   getZoomPercentage: () => number;
@@ -65,6 +66,24 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
   const originalDimensionsRef = useRef<{ width: number; height: number } | null>(null);
   const currentImageIsOriginalRef = useRef(false);
 
+  const calculateFitScaleForDimensions = useCallback((width: number, height: number) => {
+    const container = containerRef.current;
+
+    if (!container || !width || !height) {
+      return 1;
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    const containerWidth = containerRect.width - 20; // Minimal padding
+    const containerHeight = containerRect.height - 20;
+
+    const scaleX = containerWidth / width;
+    const scaleY = containerHeight / height;
+    
+    // Use the smaller scale to ensure the image fits entirely, but allow scaling up for small images
+    return Math.min(scaleX, scaleY);
+  }, []);
+
   // Calculate the fit-to-screen scale when image loads
   const calculateFitScale = useCallback(() => {
     const container = containerRef.current;
@@ -74,54 +93,44 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
       return 1;
     }
 
-    const containerRect = container.getBoundingClientRect();
-    const containerWidth = containerRect.width - 20; // Minimal padding
-    const containerHeight = containerRect.height - 20;
-    
-    const scaleX = containerWidth / image.naturalWidth;
-    const scaleY = containerHeight / image.naturalHeight;
-    
-    // Use the smaller scale to ensure the image fits entirely, but allow scaling up for small images
-    return Math.min(scaleX, scaleY);
-  }, []);
+    return calculateFitScaleForDimensions(image.naturalWidth, image.naturalHeight);
+  }, [calculateFitScaleForDimensions]);
 
-  // Reset to fit-to-screen when image changes
-  const zoomToFit = useCallback(() => {
+  const zoomToFitDimensions = useCallback((width: number, height: number) => {
     const container = containerRef.current;
-    const image = imageRef.current;
-    
-    if (!container || !image || !image.naturalWidth || !image.naturalHeight) {
+
+    if (!container || !width || !height) {
       setZoomState({
         scale: 1,
         offsetX: 0,
         offsetY: 0,
+        visualScale: 1,
       });
       return;
     }
 
-    const fitScale = calculateFitScale();
+    const fitScale = calculateFitScaleForDimensions(width, height);
     initialFitScaleRef.current = fitScale;
-    
+
     // Calculate the centered position for the image
     const containerRect = container.getBoundingClientRect();
     const containerWidth = containerRect.width;
     const containerHeight = containerRect.height;
-    
-    const scaledImageWidth = image.naturalWidth * fitScale;
-    const scaledImageHeight = image.naturalHeight * fitScale;
-    
+
+    const scaledImageWidth = width * fitScale;
+    const scaledImageHeight = height * fitScale;
+
     // Calculate offsets to center the image in the container
     const offsetX = (containerWidth - scaledImageWidth) / 2;
     const offsetY = (containerHeight - scaledImageHeight) / 2;
-    
+
     // Calculate visual scale based on original dimensions if available
     let visualScale = fitScale;
     if (originalDimensionsRef.current && !currentImageIsOriginalRef.current) {
-      const currentWidth = image.naturalWidth;
-      const ratio = currentWidth / originalDimensionsRef.current.width;
+      const ratio = width / originalDimensionsRef.current.width;
       visualScale = fitScale * ratio;
     }
-    
+
     setZoomState({
       scale: fitScale,
       offsetX: offsetX,
@@ -131,7 +140,19 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     
     // Mark as initialized when we manually fit
     hasInitializedRef.current = true;
-  }, [calculateFitScale]);
+  }, [calculateFitScaleForDimensions]);
+
+  // Reset to fit-to-screen when image changes
+  const zoomToFit = useCallback(() => {
+    const image = imageRef.current;
+
+    if (!image || !image.naturalWidth || !image.naturalHeight) {
+      zoomToFitDimensions(0, 0);
+      return;
+    }
+
+    zoomToFitDimensions(image.naturalWidth, image.naturalHeight);
+  }, [zoomToFitDimensions]);
 
   // Zoom to 100% (actual size)
   const zoomTo100 = useCallback(() => {
@@ -520,6 +541,7 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     zoomIn,
     zoomOut,
     zoomToFit,
+    zoomToFitDimensions,
     zoomTo100,
     resetZoom,
     getZoomPercentage,

--- a/static/src/hooks/useImageZoom.ts
+++ b/static/src/hooks/useImageZoom.ts
@@ -44,6 +44,7 @@ export interface UseImageZoomReturn {
   setZoomState: React.Dispatch<React.SetStateAction<ZoomState>>;
   adjustZoomForNewImage: (oldWidth: number, oldHeight: number, newWidth: number, newHeight: number) => void;
   applyBitmapDimensions: (width: number, height: number, mode: 'fit' | 'preserve') => void;
+  notifyBitmapDimensions: (width: number, height: number) => void;
   setImageDimensions: (width: number, height: number, isOriginal: boolean) => void;
   getVisualScale: () => number;
   hasOverflow: boolean;
@@ -585,6 +586,18 @@ export function useImageZoom(options: UseImageZoomOptions = DEFAULT_BOUNDS): Use
     [zoomToFitDimensions, adjustZoomForNewImage]
   );
 
+  // The <img> now renders a bitmap of these dimensions — recalibrate pan
+  // constraints and fit fallbacks against it WITHOUT touching the transform.
+  // For callers that keep their own zoom-preservation logic (comparison view)
+  // and don't route loads through applyBitmapDimensions: since constrainPan
+  // prefers stateDimsRef over the live <img>, every loaded bitmap must be
+  // reported through one of these paths or constraints clamp against the
+  // previous image's dimensions.
+  const notifyBitmapDimensions = useCallback((width: number, height: number) => {
+    if (!width || !height) return;
+    stateDimsRef.current = { width, height };
+  }, []);
+
   // Initialize fit scale when component mounts or image changes
   useEffect(() => {
     const container = containerRef.current;
@@ -639,6 +652,7 @@ export function useImageZoom(options: UseImageZoomOptions = DEFAULT_BOUNDS): Use
     setZoomState,
     adjustZoomForNewImage,
     applyBitmapDimensions,
+    notifyBitmapDimensions,
     setImageDimensions,
     getVisualScale,
     hasOverflow,

--- a/static/src/hooks/useImageZoom.ts
+++ b/static/src/hooks/useImageZoom.ts
@@ -438,9 +438,10 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
       const oldImageY = (viewportCenterY - prevState.offsetY) / prevState.scale;
       
       // Scale the image coordinates by the size change ratio
-      const sizeChangeRatio = newWidth / oldWidth;
-      const newImageX = oldImageX * sizeChangeRatio;
-      const newImageY = oldImageY * sizeChangeRatio;
+      const widthChangeRatio = newWidth / oldWidth;
+      const heightChangeRatio = newHeight / oldHeight;
+      const newImageX = oldImageX * widthChangeRatio;
+      const newImageY = oldImageY * heightChangeRatio;
       
       // Calculate new offsets to keep the same point at the center
       const newOffsetX = viewportCenterX - (newImageX * newScale);

--- a/static/src/hooks/useImageZoom.ts
+++ b/static/src/hooks/useImageZoom.ts
@@ -12,6 +12,18 @@ interface ZoomBounds {
   maxScale: number;
 }
 
+export type ZoomViewMode = 'fit' | 'user';
+
+export interface UseImageZoomOptions extends ZoomBounds {
+  /**
+   * Notified when the view intent changes: 'user' after any explicit zoom or
+   * pan, 'fit' after an explicit fit/reset. Programmatic dimension updates
+   * (applyBitmapDimensions / adjustZoomForNewImage) never fire this, so the
+   * caller can use it to decide whether to preserve the view on image loads.
+   */
+  onViewModeChange?: (mode: ZoomViewMode) => void;
+}
+
 export interface UseImageZoomReturn {
   zoomState: ZoomState;
   containerRef: React.RefObject<HTMLDivElement | null>;
@@ -31,6 +43,7 @@ export interface UseImageZoomReturn {
   resetInitialization: () => void;
   setZoomState: React.Dispatch<React.SetStateAction<ZoomState>>;
   adjustZoomForNewImage: (oldWidth: number, oldHeight: number, newWidth: number, newHeight: number) => void;
+  applyBitmapDimensions: (width: number, height: number, mode: 'fit' | 'preserve') => void;
   setImageDimensions: (width: number, height: number, isOriginal: boolean) => void;
   getVisualScale: () => number;
   hasOverflow: boolean;
@@ -44,14 +57,15 @@ const DEFAULT_BOUNDS: ZoomBounds = {
 const ZOOM_STEP = 0.1;
 const KEYBOARD_ZOOM_STEP = 0.2;
 
-export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomReturn {
+export function useImageZoom(options: UseImageZoomOptions = DEFAULT_BOUNDS): UseImageZoomReturn {
+  const bounds: ZoomBounds = options;
   const [zoomState, setZoomState] = useState<ZoomState>({
     scale: 1,
     offsetX: 0,
     offsetY: 0,
     visualScale: 1,
   });
-  
+
   // Flag to prevent auto-fit interference with intentional zoom operations
   const intentionalZoomRef = useRef(false);
   const hasInitializedRef = useRef(false);
@@ -61,7 +75,19 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
   const isPanningRef = useRef(false);
   const lastMousePosRef = useRef({ x: 0, y: 0 });
   const initialFitScaleRef = useRef(1);
-  
+
+  // Latest onViewModeChange without forcing callers to memoize it.
+  const onViewModeChangeRef = useRef(options.onViewModeChange);
+  onViewModeChangeRef.current = options.onViewModeChange;
+
+  // Dimensions of the bitmap the CURRENT zoom state (scale/offsets) is
+  // calibrated against. This is the source of truth for pan constraints and
+  // fits — never the live <img>.naturalWidth, which lags the state during a
+  // src swap (large → original) and used to clamp original-image offsets
+  // against the old preview's dimensions, throwing the viewport to the
+  // top-left corner mid-gesture.
+  const stateDimsRef = useRef<{ width: number; height: number } | null>(null);
+
   // Track original image dimensions
   const originalDimensionsRef = useRef<{ width: number; height: number } | null>(null);
   const currentImageIsOriginalRef = useRef(false);
@@ -111,6 +137,7 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
 
     const fitScale = calculateFitScaleForDimensions(width, height);
     initialFitScaleRef.current = fitScale;
+    stateDimsRef.current = { width, height };
 
     // Calculate the centered position for the image
     const containerRect = container.getBoundingClientRect();
@@ -144,51 +171,19 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
 
   // Reset to fit-to-screen when image changes
   const zoomToFit = useCallback(() => {
+    onViewModeChangeRef.current?.('fit');
+
     const image = imageRef.current;
+    const width = image?.naturalWidth || stateDimsRef.current?.width || 0;
+    const height = image?.naturalHeight || stateDimsRef.current?.height || 0;
 
-    if (!image || !image.naturalWidth || !image.naturalHeight) {
-      zoomToFitDimensions(0, 0);
-      return;
-    }
+    // No dimensions known yet — keep the current state rather than hard
+    // resetting to a top-left scale-1 view; the 'fit' intent above makes the
+    // next load fit instead.
+    if (!width || !height) return;
 
-    zoomToFitDimensions(image.naturalWidth, image.naturalHeight);
+    zoomToFitDimensions(width, height);
   }, [zoomToFitDimensions]);
-
-  // Zoom to 100% (actual size)
-  const zoomTo100 = useCallback(() => {
-    // Mark this as an intentional zoom operation
-    intentionalZoomRef.current = true;
-    
-    const container = containerRef.current;
-    const image = imageRef.current;
-    
-    if (!container || !image || !image.naturalWidth || !image.naturalHeight) {
-      setZoomState({
-        scale: 1,
-        offsetX: 0,
-        offsetY: 0,
-      });
-      return;
-    }
-
-    // Calculate the centered position for 100% zoom
-    const containerRect = container.getBoundingClientRect();
-    const containerWidth = containerRect.width;
-    const containerHeight = containerRect.height;
-    
-    const imageWidth = image.naturalWidth; // 1:1 scale
-    const imageHeight = image.naturalHeight;
-    
-    // Always center at 100% - don't apply constraints here as we want actual 100% zoom
-    const offsetX = (containerWidth - imageWidth) / 2;
-    const offsetY = (containerHeight - imageHeight) / 2;
-    
-    setZoomState({
-      scale: 1,
-      offsetX: offsetX,
-      offsetY: offsetY,
-    });
-  }, []);
 
   // Reset zoom (alias for zoomToFit)
   const resetZoom = useCallback(() => {
@@ -211,8 +206,13 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     const container = containerRef.current;
     const image = imageRef.current;
 
-    const naturalWidth = imageWidth ?? image?.naturalWidth;
-    const naturalHeight = imageHeight ?? image?.naturalHeight;
+    // Prefer the dimensions the zoom state is calibrated against over the
+    // live <img> — during a bitmap swap the element still reports the OLD
+    // image's size and would clamp the new state's offsets wrongly.
+    const naturalWidth =
+      imageWidth ?? stateDimsRef.current?.width ?? image?.naturalWidth;
+    const naturalHeight =
+      imageHeight ?? stateDimsRef.current?.height ?? image?.naturalHeight;
 
     if (!container || !naturalWidth || !naturalHeight) {
       return { offsetX, offsetY };
@@ -251,19 +251,70 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     return { offsetX, offsetY };
   }, []);
 
+  // Zoom to 100% (actual size)
+  const zoomTo100 = useCallback(() => {
+    // Mark this as an intentional zoom operation
+    intentionalZoomRef.current = true;
+    onViewModeChangeRef.current?.('user');
+
+    const container = containerRef.current;
+    const image = imageRef.current;
+    const bitmapWidth =
+      stateDimsRef.current?.width || image?.naturalWidth || 0;
+
+    if (!container || !bitmapWidth) {
+      setZoomState({
+        scale: 1,
+        offsetX: 0,
+        offsetY: 0,
+      });
+      return;
+    }
+
+    // 100% means one ORIGINAL image pixel per screen pixel. When the current
+    // bitmap is a downscaled preview this lands at scale > 1 — exactly what
+    // triggers the swap to the original-resolution artifact.
+    const targetScale = clampScale(
+      originalDimensionsRef.current
+        ? originalDimensionsRef.current.width / bitmapWidth
+        : 1
+    );
+
+    const containerRect = container.getBoundingClientRect();
+    const viewportCenterX = containerRect.width / 2;
+    const viewportCenterY = containerRect.height / 2;
+
+    setZoomState(prevState => {
+      // Keep the image point currently at the viewport center fixed.
+      const imageX = (viewportCenterX - prevState.offsetX) / prevState.scale;
+      const imageY = (viewportCenterY - prevState.offsetY) / prevState.scale;
+      const constrained = constrainPan(
+        viewportCenterX - imageX * targetScale,
+        viewportCenterY - imageY * targetScale,
+        targetScale
+      );
+      return {
+        scale: targetScale,
+        offsetX: constrained.offsetX,
+        offsetY: constrained.offsetY,
+      };
+    });
+  }, [clampScale, constrainPan]);
+
   // Handle mouse wheel zoom
   const handleWheel = useCallback((e: React.WheelEvent) => {
     e.preventDefault();
-    
+
     const container = containerRef.current;
     if (!container) return;
 
     const rect = container.getBoundingClientRect();
     const mouseX = e.clientX - rect.left;
     const mouseY = e.clientY - rect.top;
-    
+
     // Mark this as an intentional zoom operation
     intentionalZoomRef.current = true;
+    onViewModeChangeRef.current?.('user');
 
     setZoomState(prevState => {
       const delta = -e.deltaY * 0.01;
@@ -305,6 +356,10 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     const deltaX = e.clientX - lastMousePosRef.current.x;
     const deltaY = e.clientY - lastMousePosRef.current.y;
 
+    if (deltaX !== 0 || deltaY !== 0) {
+      onViewModeChangeRef.current?.('user');
+    }
+
     setZoomState(prevState => {
       const newOffsetX = prevState.offsetX + deltaX;
       const newOffsetY = prevState.offsetY + deltaY;
@@ -329,7 +384,8 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
   const zoomIn = useCallback(() => {
     // Mark this as an intentional zoom operation
     intentionalZoomRef.current = true;
-    
+    onViewModeChangeRef.current?.('user');
+
     setZoomState(prevState => {
       const newScale = clampScale(prevState.scale + KEYBOARD_ZOOM_STEP);
       const constrained = constrainPan(prevState.offsetX, prevState.offsetY, newScale);
@@ -345,7 +401,8 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
   const zoomOut = useCallback(() => {
     // Mark this as an intentional zoom operation
     intentionalZoomRef.current = true;
-    
+    onViewModeChangeRef.current?.('user');
+
     setZoomState(prevState => {
       const newScale = clampScale(prevState.scale - KEYBOARD_ZOOM_STEP);
       const constrained = constrainPan(prevState.offsetX, prevState.offsetY, newScale);
@@ -385,10 +442,16 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     }
   }, [zoomIn, zoomOut, resetZoom, zoomTo100]);
 
-  // Get zoom percentage (visual scale)
+  // Get zoom percentage relative to the ORIGINAL image's pixels: 100% = one
+  // original pixel per screen pixel, whichever bitmap (preview or original)
+  // is currently displayed. This keeps the number stable across bitmap swaps
+  // and across navigation.
   const getZoomPercentage = useCallback((): number => {
-    return Math.round((zoomState.visualScale || zoomState.scale) * 100);
-  }, [zoomState.scale, zoomState.visualScale]);
+    const dims = stateDimsRef.current;
+    const original = originalDimensionsRef.current;
+    const ratio = dims && original ? dims.width / original.width : 1;
+    return Math.round(zoomState.scale * ratio * 100);
+  }, [zoomState.scale]);
   
   // Get visual scale
   const getVisualScale = useCallback((): number => {
@@ -404,11 +467,20 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
   // Set image dimensions and update visual scale
   const setImageDimensions = useCallback((width: number, height: number, isOriginal: boolean) => {
     const isFirstTime = !originalDimensionsRef.current;
-    
-    if (isOriginal && !originalDimensionsRef.current) {
-      originalDimensionsRef.current = { width, height };
+
+    if (isOriginal) {
+      const prev = originalDimensionsRef.current;
+      // Update when meaningfully different so navigating to a target shot on
+      // different gear doesn't keep a stale original size forever.
+      if (
+        !prev ||
+        Math.abs(prev.width - width) > 10 ||
+        Math.abs(prev.height - height) > 10
+      ) {
+        originalDimensionsRef.current = { width, height };
+      }
     }
-    
+
     // Update which image we're currently viewing
     currentImageIsOriginalRef.current = isOriginal;
     
@@ -427,14 +499,19 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
   
   // Adjust zoom when switching between different image sizes
   const adjustZoomForNewImage = useCallback((oldWidth: number, oldHeight: number, newWidth: number, newHeight: number) => {
-    if (oldWidth === 0 || oldHeight === 0 || !originalDimensionsRef.current) return;
-    
+    if (oldWidth === 0 || oldHeight === 0 || newWidth === 0 || newHeight === 0) return;
+
     const container = containerRef.current;
     if (!container) return;
-    
+
     // Determine which image we're NOW viewing (not updated yet)
-    const isNowOriginal = Math.abs(newWidth - originalDimensionsRef.current.width) < 10;
-    
+    const isNowOriginal = originalDimensionsRef.current
+      ? Math.abs(newWidth - originalDimensionsRef.current.width) < 10
+      : currentImageIsOriginalRef.current;
+
+    // The state below is calibrated against the NEW bitmap from here on.
+    stateDimsRef.current = { width: newWidth, height: newHeight };
+
     setZoomState(prevState => {
       // The key insight: we need to maintain the same DISPLAYED pixel size
       // If we were showing a 2000px image at scale 3.0 (displaying 6000px)
@@ -482,6 +559,32 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     currentImageIsOriginalRef.current = isNowOriginal;
   }, [constrainPan]);
 
+  // Report the dimensions of a bitmap that just finished loading into the
+  // <img>. In 'fit' mode the view refits (centered); in 'preserve' mode the
+  // view is kept EXACTLY when the dimensions match the state's calibration
+  // (the arrow-key navigation case) and mapped to the same visual size and
+  // center when they differ (preview ↔ original swaps, cross-size loads).
+  const applyBitmapDimensions = useCallback(
+    (width: number, height: number, mode: 'fit' | 'preserve') => {
+      if (!width || !height) return;
+
+      const prev = stateDimsRef.current;
+      if (mode === 'fit' || !prev) {
+        zoomToFitDimensions(width, height);
+        return;
+      }
+
+      const changed =
+        Math.abs(width - prev.width) > 10 || Math.abs(height - prev.height) > 10;
+      if (changed) {
+        adjustZoomForNewImage(prev.width, prev.height, width, height);
+      } else {
+        stateDimsRef.current = { width, height };
+      }
+    },
+    [zoomToFitDimensions, adjustZoomForNewImage]
+  );
+
   // Initialize fit scale when component mounts or image changes
   useEffect(() => {
     const container = containerRef.current;
@@ -489,28 +592,15 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     if (container && image && image.complete && image.naturalWidth > 0) {
       const fitScale = calculateFitScale();
       initialFitScaleRef.current = fitScale;
-      
+
       // Only auto-fit if we haven't initialized yet
       if (!hasInitializedRef.current && zoomState.scale === 1 && !intentionalZoomRef.current) {
-        // Visual scale is always based on original dimensions
-        let visualScale = fitScale;
-        if (originalDimensionsRef.current && !currentImageIsOriginalRef.current) {
-          const ratio = image.naturalWidth / originalDimensionsRef.current.width;
-          visualScale = fitScale * ratio;
-        }
-        
-        setZoomState({
-          scale: fitScale,
-          offsetX: 0,
-          offsetY: 0,
-          visualScale: visualScale,
-        });
-        hasInitializedRef.current = true;
+        zoomToFitDimensions(image.naturalWidth, image.naturalHeight);
       }
       // Reset the intentional flag after any potential auto-fit
       intentionalZoomRef.current = false;
     }
-  }, [calculateFitScale, zoomState.scale]);
+  }, [calculateFitScale, zoomToFitDimensions, zoomState.scale]);
 
   // Calculate whether the image overflows the container
   const hasOverflow = (() => {
@@ -548,6 +638,7 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     resetInitialization,
     setZoomState,
     adjustZoomForNewImage,
+    applyBitmapDimensions,
     setImageDimensions,
     getVisualScale,
     hasOverflow,

--- a/static/src/hooks/useImageZoom.ts
+++ b/static/src/hooks/useImageZoom.ts
@@ -69,7 +69,7 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
   const calculateFitScale = useCallback(() => {
     const container = containerRef.current;
     const image = imageRef.current;
-    
+
     if (!container || !image || !image.naturalWidth || !image.naturalHeight) {
       return 1;
     }
@@ -180,11 +180,20 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
   }, [bounds]);
 
   // Constrain pan offsets to keep image mostly visible
-  const constrainPan = useCallback((offsetX: number, offsetY: number, scale: number): { offsetX: number; offsetY: number } => {
+  const constrainPan = useCallback((
+    offsetX: number,
+    offsetY: number,
+    scale: number,
+    imageWidth?: number,
+    imageHeight?: number
+  ): { offsetX: number; offsetY: number } => {
     const container = containerRef.current;
     const image = imageRef.current;
-    
-    if (!container || !image || !image.naturalWidth || !image.naturalHeight) {
+
+    const naturalWidth = imageWidth ?? image?.naturalWidth;
+    const naturalHeight = imageHeight ?? image?.naturalHeight;
+
+    if (!container || !naturalWidth || !naturalHeight) {
       return { offsetX, offsetY };
     }
 
@@ -192,8 +201,8 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
     const containerWidth = containerRect.width;
     const containerHeight = containerRect.height;
     
-    const scaledImageWidth = image.naturalWidth * scale;
-    const scaledImageHeight = image.naturalHeight * scale;
+    const scaledImageWidth = naturalWidth * scale;
+    const scaledImageHeight = naturalHeight * scale;
     
     // Allow a small margin (10% of image size) to pan slightly past edges
     const marginX = scaledImageWidth * 0.1;
@@ -396,8 +405,7 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
   }, []);
   
   // Adjust zoom when switching between different image sizes
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const adjustZoomForNewImage = useCallback((oldWidth: number, oldHeight: number, newWidth: number, _newHeight: number) => {
+  const adjustZoomForNewImage = useCallback((oldWidth: number, oldHeight: number, newWidth: number, newHeight: number) => {
     if (oldWidth === 0 || oldHeight === 0 || !originalDimensionsRef.current) return;
     
     const container = containerRef.current;
@@ -438,7 +446,7 @@ export function useImageZoom(bounds: ZoomBounds = DEFAULT_BOUNDS): UseImageZoomR
       const newOffsetX = viewportCenterX - (newImageX * newScale);
       const newOffsetY = viewportCenterY - (newImageY * newScale);
       
-      const constrained = constrainPan(newOffsetX, newOffsetY, newScale);
+      const constrained = constrainPan(newOffsetX, newOffsetY, newScale, newWidth, newHeight);
       
       return {
         scale: newScale,


### PR DESCRIPTION
## Summary
- keep the current large detail preview visible while an uncached original-resolution preview generates and decodes
- swap to the original image only after it is ready, preserving the viewport anchor across the size change
- hide pending detail-view image sources until the exact current src has decoded, including arrow-key navigation to an uncached image
- add Playwright regression coverage for both the uncached original-image zoom path and the arrow-key navigation loading path

## Root cause
The detail view switched the visible image source to a not-yet-ready URL immediately and marked the original-resolution transition complete after a fixed timeout. When the requested image was uncached, the browser could paint its broken-image fallback behind the loading spinner, and the later image load could skip the continuity adjustment.

## Validation
- npm run lint
- npm run build
- npm test
- npx playwright test e2e/image-detail.spec.ts (5 passed)
- npm run test:e2e (17 passed)