### PR TITLE
[codex] Skip macOS signing on CI pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
 
 
     - name: Import Apple Developer Certificate (macOS)
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-latest' && github.event_name != 'pull_request'
       env:
         APPLE_CERTIFICATE: ${{ secrets.APPLE_BUILD_CERTIFICATE }}
         APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_BUILD_CERTIFICATE_PASSWORD }}
@@ -293,7 +293,7 @@ jobs:
 
         echo $APPLE_API_KEY_PRIVATE | base64 --decode > AuthKey_$APPLE_API_KEY.p8
     - name: Verify Certificate (macOS)
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-latest' && github.event_name != 'pull_request'
       run: |
         CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID")
         CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
@@ -409,8 +409,12 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: cargo tauri build --verbose --config tauri.bundle-windows.json
 
-    - name: Build Tauri desktop app (macOS)
-      if: matrix.os == 'macos-latest'
+    - name: Build Tauri desktop app (macOS, unsigned PR)
+      if: matrix.os == 'macos-latest' && github.event_name == 'pull_request'
+      run: bash scripts/build-macos.sh tauri build --no-bundle
+
+    - name: Build Tauri desktop app (macOS, signed and notarized)
+      if: matrix.os == 'macos-latest' && github.event_name != 'pull_request'
       env:
         APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
@@ -439,7 +443,7 @@ jobs:
           target/release/psf-guard.exe
           target/release/psf-guard-cli.exe
     - name: Upload Tauri artifacts (macOS)
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-latest' && github.event_name != 'pull_request'
       uses: actions/upload-artifact@v7
       with:
         name: psf-guard-tauri-macos-x64

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,6 @@
+[tools]
+actionlint = "1.7.12"
+
+[tasks.actionlint]
+description = "Lint GitHub Actions workflows"
+run = "actionlint .github/workflows/*.yml"


### PR DESCRIPTION
## Summary

- Skip Apple certificate import and verification during CI pull request runs.
- Split macOS Tauri CI into an unsigned PR build and a signed/notarized build for trusted non-PR runs.
- Add a repo-local mise config pinning `actionlint` 1.7.12 with an `actionlint` task.

## Why

Dependabot-triggered workflows do not receive normal GitHub Actions secrets, so the macOS certificate import step gets empty signing credentials and fails before the dependency update can be validated. CI pull requests should still compile the macOS Tauri target, but signing and notarization should remain limited to trusted runs with Actions secrets.

## Validation

- `mise run actionlint`
- `git diff --check`