### PR TITLE
Adopt Seiza 0.8.0 data path resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4412,8 +4412,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seiza"
-version = "0.7.3"
-source = "git+https://github.com/theatrus/seiza?rev=184aef6a65e826d7e62c864c7f8de222fec1d3e4#184aef6a65e826d7e62c864c7f8de222fec1d3e4"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae20be7b2b87b9d5d737f05c3d222818b8d164a2b406675f381386758f44694"
 dependencies = [
  "directories",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4403,10 +4412,10 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seiza"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da417b380c0918cccf6a93d2452a0113a35fde6b35b786b782f5a26632e141b9"
+version = "0.7.3"
+source = "git+https://github.com/theatrus/seiza?rev=184aef6a65e826d7e62c864c7f8de222fec1d3e4#184aef6a65e826d7e62c864c7f8de222fec1d3e4"
 dependencies = [
+ "directories",
  "image",
  "memmap2",
  "multiversion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,7 @@ anyhow = "1.0"
 chrono = "0.4"
 regex = "1.12"
 byteorder = "1.5"
-# crates.io's immutable 0.7.3 package omitted `data_paths`; pin the official
-# v0.7.3 tag commit that contains the advertised embedding API.
-seiza = { version = "=0.7.3", git = "https://github.com/theatrus/seiza", rev = "184aef6a65e826d7e62c864c7f8de222fec1d3e4" }
+seiza = "=0.8.0"
 seiza-fits = "=0.1.6"
 bumpalo = { version = "3.20", features = ["collections"] }
 image = "0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ anyhow = "1.0"
 chrono = "0.4"
 regex = "1.12"
 byteorder = "1.5"
-seiza = "=0.7.2"
+# crates.io's immutable 0.7.3 package omitted `data_paths`; pin the official
+# v0.7.3 tag commit that contains the advertised embedding API.
+seiza = { version = "=0.7.3", git = "https://github.com/theatrus/seiza", rev = "184aef6a65e826d7e62c864c7f8de222fec1d3e4" }
 seiza-fits = "=0.1.6"
 bumpalo = { version = "3.20", features = ["collections"] }
 image = "0.25"

--- a/SEIZA_INTEGRATION_PLAN.md
+++ b/SEIZA_INTEGRATION_PLAN.md
@@ -3,7 +3,7 @@
 Status: **Phase 0 complete; first Phase 1 and Seiza v4 overlay UI slice implemented**
 Owner: psf-guard maintainers
 Last updated: 2026-07-18
-Baseline: PSF Guard 0.4.2; Seiza 0.7.3; seiza-fits 0.1.6;
+Baseline: PSF Guard 0.4.2; Seiza 0.8.0; seiza-fits 0.1.6;
 `@seiza/astro-overlay` 0.3.0
 
 ## 1. Goal
@@ -35,19 +35,16 @@ FITS hint, and derived solution as separate values with explicit provenance.
 - Do not make pointing classifications affect quality scores or grades until
   thresholds have been validated against real sequences and dithers.
 
-## 3. Seiza 0.7.3 baseline
+## 3. Seiza 0.8.0 baseline
 
-PSF Guard pins the current Rust integration versions. The crates.io 0.7.3
-package omitted the release's `data_paths` module, so the Seiza dependency is
-temporarily pinned to the exact official v0.7.3 tag commit:
+PSF Guard pins the current published Rust integration versions. Seiza 0.8.0
+includes the `data_paths` module in its crates.io package, so the dependency
+uses the registry again rather than the temporary v0.7.3 Git revision pin:
 
 ```toml
-seiza = { version = "=0.7.3", git = "https://github.com/theatrus/seiza", rev = "184aef6a65e826d7e62c864c7f8de222fec1d3e4" }
+seiza = "=0.8.0"
 seiza-fits = "=0.1.6"
 ```
-
-Return Seiza to a registry pin once a package containing the v0.7.3
-`data_paths` API is published.
 
 ### 3.1 Changes that directly improve this integration
 
@@ -64,7 +61,7 @@ separate performance task; no custom compatibility layer is expected.
 
 #### Indexed object catalog v4
 
-Seiza 0.7.3's `SEIZAOB4` object catalog retains the memory-mapped spatial and
+Seiza 0.8.0's `SEIZAOB4` object catalog retains the memory-mapped spatial and
 normalized-name indexes and adds source-qualified geometry, including catalog
 outline sets. Ordinary cone, footprint, exact-name, and prefix queries
 materialize only returned records instead of eagerly decoding the entire
@@ -105,7 +102,7 @@ review step of back-catalog import instead of adding a second name index.
 
 The optional `SEIZASI1` stellar identifier sidecar resolves identifiers and
 names such as TYC, HIP, HR, HD, SAO, FK5, IAU proper names, variables, and WDS
-designations. In Seiza 0.7.3 it supports exact and prefix lookup, but not a
+designations. In Seiza 0.8.0 it supports exact and prefix lookup, but not a
 spatial cone or footprint query. Therefore:
 
 - use it initially for search, target resolution, and inspecting a known
@@ -116,7 +113,7 @@ spatial cone or footprint query. Therefore:
 
 #### Coherent hosted catalog bundle
 
-Seiza 0.7.3 uses one complete catalog bundle at `/data/v2/manifest.json`. It
+Seiza 0.8.0 uses one complete catalog bundle at `/data/v2/manifest.json`. It
 covers solver tiles, the blind index,
 stellar identifier sidecar, object and transient catalogs, and minor bodies.
 Local downloads remain flat and retain the canonical filenames.
@@ -169,7 +166,7 @@ an overlapping ladder ordered by common astrophotography scales rather than
 numerically. PSF Guard can improve on its sidecar input by deriving the known
 scale from FITS headers and equipment metadata.
 
-Backend adapters must use the Seiza 0.7.3 owned-result and fallible-query APIs.
+Backend adapters must use the Seiza 0.8.0 owned-result and fallible-query APIs.
 This avoids embedding an obsolete compatibility layer just to mirror the two
 downstream applications.
 
@@ -530,7 +527,7 @@ configuration block rather than under each database:
 }
 ```
 
-The paths are optional and resolved relative to `data_dir`. Seiza 0.7.3 owns
+The paths are optional and resolved relative to `data_dir`. Seiza 0.8.0 owns
 bundle filename selection and its standard environment, executable-adjacent,
 and platform data conventions through `seiza::data_paths`; PSF Guard passes
 the one directory through and retains explicit per-resource overrides. Adding
@@ -590,9 +587,9 @@ remain bounded. Focused contract tests cover absent/missing/malformed catalogs
 plus legacy-v1, indexed-v3, and extensible-v4 object catalogs.
 
 - Bump `seiza-fits` to 0.1.6 and verify streamed decoding through PSF Guard.
-- Add `seiza` 0.7.3.
+- Add `seiza` 0.8.0.
 - Add centralized FITS astrometry-header parsing and provenance.
-- Define shared API types with Seiza 0.7.3 stable object metadata.
+- Define shared API types with Seiza 0.8.0 stable object metadata.
 - Add global catalog configuration, capability reporting, lazy open, and
   explicit validation.
 - Model catalog signatures as hosted bundle version plus per-file hash, or as

--- a/SEIZA_INTEGRATION_PLAN.md
+++ b/SEIZA_INTEGRATION_PLAN.md
@@ -3,7 +3,7 @@
 Status: **Phase 0 complete; first Phase 1 and Seiza v4 overlay UI slice implemented**
 Owner: psf-guard maintainers
 Last updated: 2026-07-18
-Baseline: PSF Guard 0.4.2; Seiza 0.7.2; seiza-fits 0.1.6;
+Baseline: PSF Guard 0.4.2; Seiza 0.7.3; seiza-fits 0.1.6;
 `@seiza/astro-overlay` 0.3.0
 
 ## 1. Goal
@@ -35,14 +35,19 @@ FITS hint, and derived solution as separate values with explicit provenance.
 - Do not make pointing classifications affect quality scores or grades until
   thresholds have been validated against real sequences and dithers.
 
-## 3. Seiza 0.7.2 baseline
+## 3. Seiza 0.7.3 baseline
 
-PSF Guard pins the current published Rust integration versions:
+PSF Guard pins the current Rust integration versions. The crates.io 0.7.3
+package omitted the release's `data_paths` module, so the Seiza dependency is
+temporarily pinned to the exact official v0.7.3 tag commit:
 
 ```toml
-seiza = "=0.7.2"
+seiza = { version = "=0.7.3", git = "https://github.com/theatrus/seiza", rev = "184aef6a65e826d7e62c864c7f8de222fec1d3e4" }
 seiza-fits = "=0.1.6"
 ```
+
+Return Seiza to a registry pin once a package containing the v0.7.3
+`data_paths` API is published.
 
 ### 3.1 Changes that directly improve this integration
 
@@ -59,7 +64,7 @@ separate performance task; no custom compatibility layer is expected.
 
 #### Indexed object catalog v4
 
-Seiza 0.7.2's `SEIZAOB4` object catalog retains the memory-mapped spatial and
+Seiza 0.7.3's `SEIZAOB4` object catalog retains the memory-mapped spatial and
 normalized-name indexes and adds source-qualified geometry, including catalog
 outline sets. Ordinary cone, footprint, exact-name, and prefix queries
 materialize only returned records instead of eagerly decoding the entire
@@ -100,7 +105,7 @@ review step of back-catalog import instead of adding a second name index.
 
 The optional `SEIZASI1` stellar identifier sidecar resolves identifiers and
 names such as TYC, HIP, HR, HD, SAO, FK5, IAU proper names, variables, and WDS
-designations. In Seiza 0.7.2 it supports exact and prefix lookup, but not a
+designations. In Seiza 0.7.3 it supports exact and prefix lookup, but not a
 spatial cone or footprint query. Therefore:
 
 - use it initially for search, target resolution, and inspecting a known
@@ -111,7 +116,7 @@ spatial cone or footprint query. Therefore:
 
 #### Coherent hosted catalog bundle
 
-Seiza 0.7.2 uses one complete catalog bundle at `/data/v2/manifest.json`. It
+Seiza 0.7.3 uses one complete catalog bundle at `/data/v2/manifest.json`. It
 covers solver tiles, the blind index,
 stellar identifier sidecar, object and transient catalogs, and minor bodies.
 Local downloads remain flat and retain the canonical filenames.
@@ -164,7 +169,7 @@ an overlapping ladder ordered by common astrophotography scales rather than
 numerically. PSF Guard can improve on its sidecar input by deriving the known
 scale from FITS headers and equipment metadata.
 
-Backend adapters must use the Seiza 0.7.2 owned-result and fallible-query APIs.
+Backend adapters must use the Seiza 0.7.3 owned-result and fallible-query APIs.
 This avoids embedding an obsolete compatibility layer just to mirror the two
 downstream applications.
 
@@ -525,11 +530,12 @@ configuration block rather than under each database:
 }
 ```
 
-The paths are optional and resolved relative to `data_dir`. Auto-discover the
-canonical Seiza filenames and environment conventions used by seiza-server,
-then allow explicit overrides. Adding the optional block is backward-
-compatible with the current registry parser; the source-kind migration is
-reserved for registry v3.
+The paths are optional and resolved relative to `data_dir`. Seiza 0.7.3 owns
+bundle filename selection and its standard environment, executable-adjacent,
+and platform data conventions through `seiza::data_paths`; PSF Guard passes
+the one directory through and retains explicit per-resource overrides. Adding
+the optional block is backward-compatible with the current registry parser;
+the source-kind migration is reserved for registry v3.
 
 For a PSF Guard-managed directory, persist installation state beside the data:
 
@@ -584,9 +590,9 @@ remain bounded. Focused contract tests cover absent/missing/malformed catalogs
 plus legacy-v1, indexed-v3, and extensible-v4 object catalogs.
 
 - Bump `seiza-fits` to 0.1.6 and verify streamed decoding through PSF Guard.
-- Add `seiza` 0.7.2.
+- Add `seiza` 0.7.3.
 - Add centralized FITS astrometry-header parsing and provenance.
-- Define shared API types with Seiza 0.7.2 stable object metadata.
+- Define shared API types with Seiza 0.7.3 stable object metadata.
 - Add global catalog configuration, capability reporting, lazy open, and
   explicit validation.
 - Model catalog signatures as hosted bundle version plus per-file hash, or as

--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -10,7 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-pub const SEIZA_VERSION: &str = "0.7.3";
+pub const SEIZA_VERSION: &str = "0.8.0";
 pub const SEIZA_FITS_VERSION: &str = "0.1.6";
 
 pub type AstrometryResourcePath = Result<Option<PathBuf>, seiza::data_paths::DataPathError>;

--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -10,22 +10,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-pub const SEIZA_VERSION: &str = "0.7.2";
+pub const SEIZA_VERSION: &str = "0.7.3";
 pub const SEIZA_FITS_VERSION: &str = "0.1.6";
 
-const OBJECTS_FILE: &str = "objects.bin";
-const STARS_FILE: &str = "stars-gaia.bin";
-const STAR_IDENTIFIERS_FILE: &str = "stars-lite-tycho2.ids.bin";
-const BLIND_INDEX_FILE: &str = "blind-gaia16.idx";
-const TRANSIENTS_FILE: &str = "transients.bin";
-const MINOR_BODIES_FILE: &str = "minor-bodies.bin";
+pub type AstrometryResourcePath = Result<Option<PathBuf>, seiza::data_paths::DataPathError>;
 
 /// Process-global paths to Seiza's offline data files.
 ///
-/// An explicit relative filename is resolved below `data_dir`. When a field is
-/// absent but `data_dir` is present, the canonical Seiza bundle filename is
-/// auto-discovered. With neither a directory nor an explicit path, that
-/// capability is not configured.
+/// `data_dir` is enough to configure an entire Seiza bundle. Explicit resource
+/// paths override it, with relative paths resolved below the directory. When
+/// neither is set, Seiza's standard environment, executable-adjacent, and
+/// platform data locations are searched.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AstrometryConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -45,47 +40,63 @@ pub struct AstrometryConfig {
 }
 
 impl AstrometryConfig {
-    fn resolve(&self, explicit: &Option<String>, canonical: &str) -> Option<PathBuf> {
-        match explicit {
+    fn resolver_input(&self, explicit: &Option<String>) -> Option<PathBuf> {
+        let data_dir = self
+            .data_dir
+            .as_deref()
+            .filter(|path| !path.is_empty())
+            .map(PathBuf::from);
+        match explicit.as_deref().filter(|path| !path.is_empty()) {
             Some(path) => {
                 let path = PathBuf::from(path);
                 if path.is_absolute() {
                     Some(path)
-                } else if let Some(data_dir) = &self.data_dir {
-                    Some(PathBuf::from(data_dir).join(path))
+                } else if let Some(data_dir) = data_dir {
+                    Some(data_dir.join(path))
                 } else {
                     Some(path)
                 }
             }
-            None => self
-                .data_dir
-                .as_ref()
-                .map(|directory| PathBuf::from(directory).join(canonical)),
+            None => data_dir,
         }
     }
 
-    pub fn objects_path(&self) -> Option<PathBuf> {
-        self.resolve(&self.objects, OBJECTS_FILE)
+    fn resolve_required(
+        &self,
+        explicit: &Option<String>,
+        resolve: impl FnOnce(Option<&Path>) -> Result<PathBuf, seiza::data_paths::DataPathError>,
+    ) -> AstrometryResourcePath {
+        let input = self.resolver_input(explicit);
+        match resolve(input.as_deref()) {
+            Ok(path) => Ok(Some(path)),
+            Err(seiza::data_paths::DataPathError::NoDefault { .. }) => Ok(None),
+            Err(error) => Err(error),
+        }
     }
 
-    pub fn stars_path(&self) -> Option<PathBuf> {
-        self.resolve(&self.stars, STARS_FILE)
+    pub fn objects_path(&self) -> AstrometryResourcePath {
+        self.resolve_required(&self.objects, seiza::data_paths::objects)
     }
 
-    pub fn star_identifiers_path(&self) -> Option<PathBuf> {
-        self.resolve(&self.star_identifiers, STAR_IDENTIFIERS_FILE)
+    pub fn stars_path(&self) -> AstrometryResourcePath {
+        self.resolve_required(&self.stars, seiza::data_paths::star_data)
     }
 
-    pub fn blind_index_path(&self) -> Option<PathBuf> {
-        self.resolve(&self.blind_index, BLIND_INDEX_FILE)
+    pub fn star_identifiers_path(&self) -> AstrometryResourcePath {
+        self.resolve_required(&self.star_identifiers, seiza::data_paths::star_identifiers)
     }
 
-    pub fn transients_path(&self) -> Option<PathBuf> {
-        self.resolve(&self.transients, TRANSIENTS_FILE)
+    pub fn blind_index_path(&self) -> AstrometryResourcePath {
+        let input = self.resolver_input(&self.blind_index);
+        seiza::data_paths::blind_index(input.as_deref())
     }
 
-    pub fn minor_bodies_path(&self) -> Option<PathBuf> {
-        self.resolve(&self.minor_bodies, MINOR_BODIES_FILE)
+    pub fn transients_path(&self) -> AstrometryResourcePath {
+        self.resolve_required(&self.transients, seiza::data_paths::transients)
+    }
+
+    pub fn minor_bodies_path(&self) -> AstrometryResourcePath {
+        self.resolve_required(&self.minor_bodies, seiza::data_paths::minor_bodies)
     }
 }
 
@@ -1153,10 +1164,12 @@ impl Drop for AstrometryValidationGuard<'_> {
 
 fn load_cached<T>(
     cache: &ResourceCache<T>,
-    path: Option<PathBuf>,
+    path: AstrometryResourcePath,
     open: impl FnOnce(&Path) -> Result<T, String>,
 ) -> Result<LoadedResource<T>, String> {
-    let path = path.ok_or_else(|| "resource is not configured".to_string())?;
+    let path = path
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "resource is not configured".to_string())?;
     let fingerprint = resource_fingerprint(&path)?;
     if let Some(cached) = cache.read().unwrap().as_ref() {
         if cached.fingerprint == fingerprint {
@@ -1191,20 +1204,35 @@ fn load_cached<T>(
 
 fn capability(
     name: &str,
-    path: Option<PathBuf>,
+    path: AstrometryResourcePath,
     opened: Result<ResourceFingerprint, String>,
 ) -> AstrometryResourceCapability {
-    let Some(path) = path else {
-        return AstrometryResourceCapability {
-            name: name.to_string(),
-            status: AstrometryResourceStatus::NotConfigured,
-            path: None,
-            format: None,
-            size_bytes: None,
-            modified_unix_seconds: None,
-            modified_subsec_nanos: None,
-            error: None,
-        };
+    let path = match path {
+        Ok(Some(path)) => path,
+        Ok(None) => {
+            return AstrometryResourceCapability {
+                name: name.to_string(),
+                status: AstrometryResourceStatus::NotConfigured,
+                path: None,
+                format: None,
+                size_bytes: None,
+                modified_unix_seconds: None,
+                modified_subsec_nanos: None,
+                error: None,
+            };
+        }
+        Err(error) => {
+            return AstrometryResourceCapability {
+                name: name.to_string(),
+                status: AstrometryResourceStatus::Missing,
+                path: data_path_error_path(&error),
+                format: None,
+                size_bytes: None,
+                modified_unix_seconds: None,
+                modified_subsec_nanos: None,
+                error: Some(error.to_string()),
+            };
+        }
     };
     let path_string = path.to_string_lossy().into_owned();
     if !path.is_file() {
@@ -1251,6 +1279,17 @@ fn capability(
                 error: Some(error),
             }
         }
+    }
+}
+
+fn data_path_error_path(error: &seiza::data_paths::DataPathError) -> Option<String> {
+    use seiza::data_paths::DataPathError;
+
+    match error {
+        DataPathError::NotFoundInDirectory { path, .. }
+        | DataPathError::Missing { path, .. }
+        | DataPathError::EnvVar { path, .. } => Some(path.to_string_lossy().into_owned()),
+        _ => None,
     }
 }
 
@@ -1324,17 +1363,29 @@ fn read_magic(path: &Path) -> std::io::Result<String> {
 
 fn validate_resource(
     name: &str,
-    path: Option<PathBuf>,
+    path: AstrometryResourcePath,
     validate: impl FnOnce() -> Result<(), String>,
 ) -> AstrometryResourceValidation {
-    let Some(path) = path else {
-        return AstrometryResourceValidation {
-            name: name.to_string(),
-            status: AstrometryResourceStatus::NotConfigured,
-            path: None,
-            validated: false,
-            error: None,
-        };
+    let path = match path {
+        Ok(Some(path)) => path,
+        Ok(None) => {
+            return AstrometryResourceValidation {
+                name: name.to_string(),
+                status: AstrometryResourceStatus::NotConfigured,
+                path: None,
+                validated: false,
+                error: None,
+            };
+        }
+        Err(error) => {
+            return AstrometryResourceValidation {
+                name: name.to_string(),
+                status: AstrometryResourceStatus::Missing,
+                path: data_path_error_path(&error),
+                validated: false,
+                error: Some(error.to_string()),
+            };
+        }
     };
     let path_string = path.to_string_lossy().into_owned();
     if !path.is_file() {
@@ -1394,7 +1445,7 @@ mod tests {
     #[test]
     fn v4_outlines_project_with_provenance_and_unknown_angle() {
         let directory = tempfile::tempdir().unwrap();
-        let objects_path = directory.path().join(OBJECTS_FILE);
+        let objects_path = directory.path().join("objects.bin");
         let mut object = test_object();
         object.kind = ObjectKind::Nebula;
         object.ra = 10.0;
@@ -1458,29 +1509,83 @@ mod tests {
     }
 
     #[test]
-    fn canonical_paths_resolve_below_data_dir() {
+    fn seiza_resolvers_select_bundle_resources_below_data_dir() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("objects.bin"), b"objects").unwrap();
+        std::fs::write(directory.path().join("stars-lite-tycho2.bin"), b"lite").unwrap();
+        std::fs::write(directory.path().join("stars-gaia.bin"), b"gaia").unwrap();
+        std::fs::write(directory.path().join("custom-blind.idx"), b"index").unwrap();
+        std::fs::write(
+            directory.path().join("stars-lite-tycho2.ids.bin"),
+            b"identifiers",
+        )
+        .unwrap();
+        std::fs::write(directory.path().join("transients.bin"), b"transients").unwrap();
+        std::fs::write(directory.path().join("minor-bodies.bin"), b"minor bodies").unwrap();
+
         let config = AstrometryConfig {
-            data_dir: Some("/catalogs".to_string()),
-            objects: None,
+            data_dir: Some(directory.path().to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        assert_eq!(
+            config.objects_path().unwrap().unwrap(),
+            directory.path().join("objects.bin")
+        );
+        assert_eq!(
+            config.stars_path().unwrap().unwrap(),
+            directory.path().join("stars-gaia.bin"),
+            "Seiza should select the deepest catalog in the directory"
+        );
+        assert_eq!(
+            config.blind_index_path().unwrap().unwrap(),
+            directory.path().join("custom-blind.idx")
+        );
+        assert_eq!(
+            config.star_identifiers_path().unwrap().unwrap(),
+            directory.path().join("stars-lite-tycho2.ids.bin")
+        );
+        assert_eq!(
+            config.transients_path().unwrap().unwrap(),
+            directory.path().join("transients.bin")
+        );
+        assert_eq!(
+            config.minor_bodies_path().unwrap().unwrap(),
+            directory.path().join("minor-bodies.bin")
+        );
+
+        std::fs::write(directory.path().join("custom-stars.bin"), b"custom").unwrap();
+        let overridden = AstrometryConfig {
+            data_dir: config.data_dir.clone(),
             stars: Some("custom-stars.bin".to_string()),
             ..Default::default()
         };
         assert_eq!(
-            config.objects_path().unwrap(),
-            PathBuf::from("/catalogs/objects.bin")
-        );
-        assert_eq!(
-            config.stars_path().unwrap(),
-            PathBuf::from("/catalogs/custom-stars.bin")
+            overridden.stars_path().unwrap().unwrap(),
+            directory.path().join("custom-stars.bin"),
+            "relative overrides remain relative to data_dir"
         );
     }
 
     #[test]
-    fn no_configuration_reports_no_capabilities() {
-        let capabilities = AstrometryContext::default().capabilities();
+    fn missing_data_directory_is_reported_as_missing() {
+        let directory = tempfile::tempdir().unwrap();
+        let missing = directory.path().join("missing-catalogs");
+        let capabilities = AstrometryContext::new(AstrometryConfig {
+            data_dir: Some(missing.to_string_lossy().into_owned()),
+            ..Default::default()
+        })
+        .capabilities();
         assert_eq!(
             capabilities.resources.objects.status,
-            AstrometryResourceStatus::NotConfigured
+            AstrometryResourceStatus::Missing
+        );
+        assert_eq!(
+            capabilities.resources.objects.path.as_deref(),
+            Some(missing.to_string_lossy().as_ref())
+        );
+        assert!(
+            capabilities.resources.objects.error.is_some(),
+            "the upstream resolver error should remain visible"
         );
         assert!(!capabilities.features.object_association);
         assert!(!capabilities.features.hinted_solve);
@@ -1502,7 +1607,7 @@ mod tests {
     #[test]
     fn indexed_v4_object_catalog_is_available_and_validates() {
         let directory = tempfile::tempdir().unwrap();
-        let objects_path = directory.path().join(OBJECTS_FILE);
+        let objects_path = directory.path().join("objects.bin");
         ObjectCatalog::new(vec![test_object()])
             .write_to(&objects_path)
             .unwrap();
@@ -1590,7 +1695,7 @@ mod tests {
     #[test]
     fn malformed_object_catalog_is_reported_as_invalid() {
         let directory = tempfile::tempdir().unwrap();
-        let objects_path = directory.path().join(OBJECTS_FILE);
+        let objects_path = directory.path().join("objects.bin");
         std::fs::write(&objects_path, b"not a seiza catalog").unwrap();
 
         let context = AstrometryContext::new(AstrometryConfig {
@@ -1632,14 +1737,14 @@ mod tests {
         let cache: ResourceCache<String> = RwLock::new(None);
         std::fs::write(&path, "first").unwrap();
 
-        let first = load_cached(&cache, Some(path.clone()), |path| {
+        let first = load_cached(&cache, Ok(Some(path.clone())), |path| {
             std::fs::read_to_string(path).map_err(|error| error.to_string())
         })
         .unwrap();
         assert_eq!(first.value.as_str(), "first");
 
         std::fs::write(&path, "replacement with a different size").unwrap();
-        let second = load_cached(&cache, Some(path), |path| {
+        let second = load_cached(&cache, Ok(Some(path)), |path| {
             std::fs::read_to_string(path).map_err(|error| error.to_string())
         })
         .unwrap();

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -73,8 +73,8 @@ pub struct DbRegistry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_db_id: Option<String>,
     /// Process-global Seiza catalog configuration shared by every database.
-    /// Additive within registry v2: an absent block means astrometry data is
-    /// not configured and every related capability is disabled.
+    /// Additive within registry v2: an absent block lets Seiza search its
+    /// standard environment, executable-adjacent, and platform data paths.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub astrometry: Option<crate::astrometry::AstrometryConfig>,
 }

--- a/static/e2e/astrometry-capabilities.spec.ts
+++ b/static/e2e/astrometry-capabilities.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('catalog-only configuration reports the exact usable Seiza capabilities', async ({
+test('partial data directory reports usable and missing Seiza resources', async ({
   request,
 }) => {
   const response = await request.get('/api/astrometry/capabilities');
@@ -9,7 +9,7 @@ test('catalog-only configuration reports the exact usable Seiza capabilities', a
   const body = await response.json();
   expect(body.success).toBe(true);
   expect(body.data).toMatchObject({
-    seiza_version: '0.7.2',
+    seiza_version: '0.7.3',
     seiza_fits_version: '0.1.6',
     features: {
       object_association: true,
@@ -26,11 +26,11 @@ test('catalog-only configuration reports the exact usable Seiza capabilities', a
         status: 'available',
         format: 'SEIZAOB4',
       },
-      stars: { status: 'not_configured' },
-      star_identifiers: { status: 'not_configured' },
-      blind_index: { status: 'not_configured' },
-      transients: { status: 'not_configured' },
-      minor_bodies: { status: 'not_configured' },
+      stars: { status: 'missing' },
+      star_identifiers: { status: 'missing' },
+      blind_index: { status: 'missing' },
+      transients: { status: 'missing' },
+      minor_bodies: { status: 'missing' },
     },
   });
   expect(body.data.resources.objects.path).toMatch(/objects\.bin$/);
@@ -45,7 +45,7 @@ test('explicit validation opens and exhaustively validates the installed catalog
 
   const body = await response.json();
   expect(body.success).toBe(true);
-  expect(body.data.all_configured_valid).toBe(true);
+  expect(body.data.all_configured_valid).toBe(false);
 
   const resources = body.data.resources as Array<{
     name: string;
@@ -62,7 +62,7 @@ test('explicit validation opens and exhaustively validates the installed catalog
       .filter((resource) => resource.name !== 'objects')
       .every(
         (resource) =>
-          resource.status === 'not_configured' && resource.validated === false
+          resource.status === 'missing' && resource.validated === false
       )
   ).toBe(true);
 });

--- a/static/e2e/astrometry-capabilities.spec.ts
+++ b/static/e2e/astrometry-capabilities.spec.ts
@@ -9,7 +9,7 @@ test('partial data directory reports usable and missing Seiza resources', async 
   const body = await response.json();
   expect(body.success).toBe(true);
   expect(body.data).toMatchObject({
-    seiza_version: '0.7.3',
+    seiza_version: '0.8.0',
     seiza_fits_version: '0.1.6',
     features: {
       object_association: true,

--- a/static/e2e/fixtures/astrometry.ts
+++ b/static/e2e/fixtures/astrometry.ts
@@ -6,7 +6,7 @@ import * as zlib from 'zlib';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * Install the tiny real SEIZAOB4 fixture and an isolated catalog-only
+ * Install the tiny real SEIZAOB4 fixture and an isolated partial-bundle
  * registry. Playwright config calls this before the web server starts; global
  * setup calls it again after resetting the remainder of the per-run fixture.
  */
@@ -28,7 +28,7 @@ export function installAstrometryFixture(tmpBase: string): string {
       {
         schema_version: 2,
         databases: [],
-        astrometry: { objects: objectsPath },
+        astrometry: { data_dir: astrometryDir },
       },
       null,
       2

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -61,8 +61,9 @@ export interface DbEntry {
   reject_archive?: RejectArchiveOverrides;
 }
 
-// Process-global Seiza catalog paths. Relative filenames resolve below
-// data_dir; omitted filenames use Seiza's canonical bundle names.
+// Process-global Seiza catalog paths. data_dir configures a complete bundle;
+// relative overrides resolve below it. Without either, Seiza searches its
+// standard environment, executable-adjacent, and platform data locations.
 export interface AstrometryConfig {
   data_dir?: string;
   objects?: string;

--- a/tests/integration_astrometry_capabilities.rs
+++ b/tests/integration_astrometry_capabilities.rs
@@ -95,7 +95,7 @@ async fn capabilities_and_validation_report_a_partial_data_directory() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["data"]["seiza_version"], "0.7.3");
+    assert_eq!(body["data"]["seiza_version"], "0.8.0");
     assert_eq!(body["data"]["seiza_fits_version"], "0.1.6");
     assert_eq!(
         body["data"]["resources"]["objects"]["status"],

--- a/tests/integration_astrometry_capabilities.rs
+++ b/tests/integration_astrometry_capabilities.rs
@@ -66,7 +66,7 @@ fn write_object_catalog(path: &std::path::Path) {
 }
 
 #[tokio::test]
-async fn capabilities_and_validation_report_a_configured_object_catalog() {
+async fn capabilities_and_validation_report_a_partial_data_directory() {
     let directory = tempdir().unwrap();
     let objects_path = directory.path().join("objects.bin");
     write_object_catalog(&objects_path);
@@ -81,7 +81,7 @@ async fn capabilities_and_validation_report_a_configured_object_catalog() {
                 .into_owned(),
             psf_guard::cli::PregenerationConfig::default(),
             Some(AstrometryConfig {
-                objects: Some(objects_path.to_string_lossy().into_owned()),
+                data_dir: Some(directory.path().to_string_lossy().into_owned()),
                 ..Default::default()
             }),
         )
@@ -95,7 +95,7 @@ async fn capabilities_and_validation_report_a_configured_object_catalog() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["data"]["seiza_version"], "0.7.2");
+    assert_eq!(body["data"]["seiza_version"], "0.7.3");
     assert_eq!(body["data"]["seiza_fits_version"], "0.1.6");
     assert_eq!(
         body["data"]["resources"]["objects"]["status"],
@@ -109,6 +109,7 @@ async fn capabilities_and_validation_report_a_configured_object_catalog() {
     assert_eq!(body["data"]["features"]["blind_solve"], false);
     assert_eq!(body["data"]["features"]["transient_annotations"], false);
     assert_eq!(body["data"]["features"]["minor_body_annotations"], false);
+    assert_eq!(body["data"]["resources"]["stars"]["status"], "missing");
 
     let (status, body) = request(
         build_app(state),
@@ -117,7 +118,7 @@ async fn capabilities_and_validation_report_a_configured_object_catalog() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["data"]["all_configured_valid"], true);
+    assert_eq!(body["data"]["all_configured_valid"], false);
     let objects = body["data"]["resources"]
         .as_array()
         .unwrap()
@@ -126,6 +127,14 @@ async fn capabilities_and_validation_report_a_configured_object_catalog() {
         .unwrap();
     assert_eq!(objects["validated"], true);
     assert_eq!(objects["status"], "available");
+    let stars = body["data"]["resources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|resource| resource["name"] == "stars")
+        .unwrap();
+    assert_eq!(stars["validated"], false);
+    assert_eq!(stars["status"], "missing");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- upgrade PSF Guard to the published Seiza 0.8.0 crate and delegate catalog/index discovery to `seiza::data_paths`
- let one `astrometry.data_dir` select objects, the deepest star catalog, identifiers, blind indexes, transients, and minor bodies while preserving explicit relative and absolute overrides
- search Seiza's standard environment, executable-adjacent, and platform data locations when no PSF Guard path is configured
- preserve typed resolver failures in capability and validation responses, including honest partial-bundle diagnostics
- exercise the directory-only configuration through Rust HTTP integration tests and the real `SEIZAOB4` Playwright fixture
- keep `CLAUDE.md` as the canonical repository guidance and expose it through the `AGENTS.md` symlink

## Release provenance

Seiza 0.8.0 fixes the v0.7.3 packaging omission: the published crates.io artifact contains `src/data_paths.rs`, exports `seiza::data_paths`, and declares the `directories` dependency. PSF Guard therefore uses the exact registry dependency `seiza = "=0.8.0"`; the temporary Git revision pin is gone.

## Validation

- `cargo fmt --all --check`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (313 passed, 5 intentionally ignored)
- `cargo audit` (no vulnerabilities; existing allowed warnings only)
- `npm run test:e2e -- astrometry-capabilities.spec.ts` (2 passed against a freshly rebuilt release server)

The prior head also passed the complete frontend unit/lint/build suite and all 25 Playwright tests; GitHub CI is re-running the full matrix for this dependency-only follow-up.
