### PR TITLE
Upgrade to Rust 2024 and Rust 1.97.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "psf-guard"
 version = "0.4.2"
-edition = "2021"
+edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not
 # the sidecar. Without this Tauri bundled psf-guard-cli as the app (WiX ICE30 on

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
 # Version should match rust-toolchain.toml
-FROM rust:1.95.0 AS builder
+FROM rust:1.97.1 AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/build.rs
+++ b/build.rs
@@ -263,12 +263,11 @@ fn is_dist_newer_than_sources(static_dir: &Path, dist_dir: &Path) -> bool {
     let src_dir = static_dir.join("src");
     if let Ok(entries) = fs::read_dir(&src_dir) {
         for entry in entries.flatten() {
-            if let Ok(metadata) = entry.metadata() {
-                if let Ok(modified) = metadata.modified() {
-                    if modified > dist_time {
-                        return false; // Source is newer, need to rebuild
-                    }
-                }
+            if let Ok(metadata) = entry.metadata()
+                && let Ok(modified) = metadata.modified()
+                && modified > dist_time
+            {
+                return false; // Source is newer, need to rebuild
             }
         }
     }
@@ -282,12 +281,11 @@ fn is_dist_newer_than_sources(static_dir: &Path, dist_dir: &Path) -> bool {
     ];
     for file in &config_files {
         let file_path = static_dir.join(file);
-        if let Ok(metadata) = fs::metadata(&file_path) {
-            if let Ok(modified) = metadata.modified() {
-                if modified > dist_time {
-                    return false; // Config file is newer, need to rebuild
-                }
-            }
+        if let Ok(metadata) = fs::metadata(&file_path)
+            && let Ok(modified) = metadata.modified()
+            && modified > dist_time
+        {
+            return false; // Config file is newer, need to rebuild
         }
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# Keep formatting stable while the language edition moves to Rust 2024.
+style_edition = "2021"

--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -1171,18 +1171,18 @@ fn load_cached<T>(
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "resource is not configured".to_string())?;
     let fingerprint = resource_fingerprint(&path)?;
-    if let Some(cached) = cache.read().unwrap().as_ref() {
-        if cached.fingerprint == fingerprint {
-            return Ok(cached.clone());
-        }
+    if let Some(cached) = cache.read().unwrap().as_ref()
+        && cached.fingerprint == fingerprint
+    {
+        return Ok(cached.clone());
     }
 
     let mut guard = cache.write().unwrap();
     let fingerprint = resource_fingerprint(&path)?;
-    if let Some(cached) = guard.as_ref() {
-        if cached.fingerprint == fingerprint {
-            return Ok(cached.clone());
-        }
+    if let Some(cached) = guard.as_ref()
+        && cached.fingerprint == fingerprint
+    {
+        return Ok(cached.clone());
     }
 
     let value = Arc::new(

--- a/src/commands/analyze_fits.rs
+++ b/src/commands/analyze_fits.rs
@@ -533,12 +533,11 @@ fn get_database_info(conn: &Connection, filename: &str) -> Result<Option<(i32, f
         // Try to parse the metadata
         if let Ok(metadata) = serde_json::from_str::<ImageMetadata>(&metadata_json) {
             // Check if filename matches
-            if let Some(meta_filename) = metadata.filename {
-                if meta_filename.contains(filename) || filename.contains(&meta_filename) {
-                    if let (Some(stars), Some(hfr)) = (metadata.detected_stars, metadata.hfr) {
-                        return Ok(Some((stars, hfr)));
-                    }
-                }
+            if let Some(meta_filename) = metadata.filename
+                && (meta_filename.contains(filename) || filename.contains(&meta_filename))
+                && let (Some(stars), Some(hfr)) = (metadata.detected_stars, metadata.hfr)
+            {
+                return Ok(Some((stars, hfr)));
             }
         }
     }

--- a/src/commands/reject_archive.rs
+++ b/src/commands/reject_archive.rs
@@ -585,25 +585,23 @@ pub fn move_rejects(
         // Already archived? Skip (idempotent re-runs). If the recorded
         // archive_path has gone missing, surface it for manual intervention
         // rather than masking a broken archive as a clean skip.
-        if archive_table_known {
-            if let Some(prior) = get_archive_record_by_guid(conn, guid)? {
-                if std::path::Path::new(&prior.archive_path).exists() {
-                    if options.verbose {
-                        println!("⏭️  {} already archived at {}", guid, prior.archive_path);
-                    }
-                    summary.already_archived += 1;
-                } else {
-                    eprintln!(
-                        "⚠️  Image id={} guid={} has a psf_guard_archive row pointing at \
+        if archive_table_known && let Some(prior) = get_archive_record_by_guid(conn, guid)? {
+            if std::path::Path::new(&prior.archive_path).exists() {
+                if options.verbose {
+                    println!("⏭️  {} already archived at {}", guid, prior.archive_path);
+                }
+                summary.already_archived += 1;
+            } else {
+                eprintln!(
+                    "⚠️  Image id={} guid={} has a psf_guard_archive row pointing at \
                          {} but that file is missing. Leaving the DB row in place; \
                          resolve manually (restore from backup, or delete the row to \
                          re-archive).",
-                        image.id, guid, prior.archive_path
-                    );
-                    summary.missing_archive += 1;
-                }
-                continue;
+                    image.id, guid, prior.archive_path
+                );
+                summary.missing_archive += 1;
             }
+            continue;
         }
 
         // Extract filename from the metadata JSON.
@@ -634,14 +632,12 @@ pub fn move_rejects(
                     break;
                 }
             }
-            if located.is_none() {
-                if let Some(Some(tree)) = trees.get(dir_idx) {
-                    if let Some(path) = tree.find_file_first(&filename) {
-                        if path.exists() {
-                            located = Some((dir.clone(), path.clone()));
-                        }
-                    }
-                }
+            if located.is_none()
+                && let Some(Some(tree)) = trees.get(dir_idx)
+                && let Some(path) = tree.find_file_first(&filename)
+                && path.exists()
+            {
+                located = Some((dir.clone(), path.clone()));
             }
             if located.is_some() {
                 break;

--- a/src/commands/screen_fits.rs
+++ b/src/commands/screen_fits.rs
@@ -226,15 +226,15 @@ fn annotate_flagged(
                     .unwrap_or_else(|| "-".into()),
             ),
         ];
-        if let Some(fall) = r.bg_cell_fall_fraction.filter(|&v| v > 0.0) {
-            if let Some(first) = caption.get_mut(1) {
-                first.push_str(&format!(" FALL={:.0}%", fall * 100.0));
-            }
+        if let Some(fall) = r.bg_cell_fall_fraction.filter(|&v| v > 0.0)
+            && let Some(first) = caption.get_mut(1)
+        {
+            first.push_str(&format!(" FALL={:.0}%", fall * 100.0));
         }
-        if let Some(glow) = r.bg_glow_max.filter(|&v| v > 0.0) {
-            if let Some(first) = caption.get_mut(1) {
-                first.push_str(&format!(" GLOW={:.1}%", glow * 100.0));
-            }
+        if let Some(glow) = r.bg_glow_max.filter(|&v| v > 0.0)
+            && let Some(first) = caption.get_mut(1)
+        {
+            first.push_str(&format!(" GLOW={:.1}%", glow * 100.0));
         }
         if let Some(details) = &r.details {
             caption.push(details.chars().take(110).collect());

--- a/src/commands/show_images.rs
+++ b/src/commands/show_images.rs
@@ -33,10 +33,10 @@ pub fn show_images(conn: &Connection, ids_str: &str) -> Result<()> {
         println!("Project ID: {}", image.project_id);
         println!("Target ID: {}", image.target_id);
 
-        if let Some(date) = image.acquired_date {
-            if let Some(dt) = chrono::DateTime::from_timestamp(date, 0) {
-                println!("Acquired Date: {}", dt.format("%Y-%m-%d %H:%M:%S"));
-            }
+        if let Some(date) = image.acquired_date
+            && let Some(dt) = chrono::DateTime::from_timestamp(date, 0)
+        {
+            println!("Acquired Date: {}", dt.format("%Y-%m-%d %H:%M:%S"));
         }
 
         println!("Filter: {}", image.filter_name);

--- a/src/commands/sync/grades.rs
+++ b/src/commands/sync/grades.rs
@@ -134,10 +134,10 @@ pub fn sync_grades(
         let mut stmt = src.prepare("SELECT guid FROM acquiredimage")?;
         let mut rows = stmt.query([])?;
         while let Some(r) = rows.next()? {
-            if let Some(g) = r.get::<_, Option<String>>(0)? {
-                if !g.is_empty() {
-                    *counts.entry(g).or_insert(0) += 1;
-                }
+            if let Some(g) = r.get::<_, Option<String>>(0)?
+                && !g.is_empty()
+            {
+                *counts.entry(g).or_insert(0) += 1;
             }
         }
         counts

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -40,10 +40,10 @@ pub fn parse_status(s: &str) -> Result<GradingStatus> {
 /// argument as a path to an existing `.sqlite` file. Image directories are
 /// irrelevant for sync, so raw paths need no registry entry.
 pub fn resolve_db_path(registry: Option<&DbRegistry>, arg: &str) -> Result<PathBuf> {
-    if let Some(reg) = registry {
-        if let Some(entry) = reg.find(arg) {
-            return Ok(PathBuf::from(&entry.db_path));
-        }
+    if let Some(reg) = registry
+        && let Some(entry) = reg.find(arg)
+    {
+        return Ok(PathBuf::from(&entry.db_path));
     }
     let path = PathBuf::from(arg);
     if path.is_file() {

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -155,10 +155,10 @@ fn source_dup_guids(src: &Connection, table: &str) -> Result<HashSet<String>> {
     let mut stmt = src.prepare(&format!("SELECT guid FROM {}", table))?;
     let mut rows = stmt.query([])?;
     while let Some(r) = rows.next()? {
-        if let Some(g) = r.get::<_, Option<String>>(0)? {
-            if !g.is_empty() {
-                *counts.entry(g).or_insert(0) += 1;
-            }
+        if let Some(g) = r.get::<_, Option<String>>(0)?
+            && !g.is_empty()
+        {
+            *counts.entry(g).or_insert(0) += 1;
         }
     }
     Ok(counts
@@ -192,16 +192,16 @@ fn dest_guid_map(
         let vals: Vec<Value> = (0..n)
             .map(|i| row.get::<_, Value>(i + 1))
             .collect::<rusqlite::Result<_>>()?;
-        if let Value::Text(g) = &vals[guid_w] {
-            if !g.is_empty() {
-                if dups.contains(g) {
-                    continue;
-                }
-                if map.remove(g).is_some() {
-                    dups.insert(g.clone());
-                } else {
-                    map.insert(g.clone(), (dest_id, vals));
-                }
+        if let Value::Text(g) = &vals[guid_w]
+            && !g.is_empty()
+        {
+            if dups.contains(g) {
+                continue;
+            }
+            if map.remove(g).is_some() {
+                dups.insert(g.clone());
+            } else {
+                map.insert(g.clone(), (dest_id, vals));
             }
         }
     }
@@ -308,10 +308,10 @@ fn upsert_guid_table(
             Some(n) => n,
             None => continue,
         };
-        if let Some(allowed) = allowed_src_ids {
-            if !allowed.contains(&src_id) {
-                continue;
-            }
+        if let Some(allowed) = allowed_src_ids
+            && !allowed.contains(&src_id)
+        {
+            continue;
         }
         let guid = match &all_vals[guid_pos] {
             Value::Text(g) if !g.is_empty() => g.clone(),
@@ -468,10 +468,10 @@ fn upsert_acquired_images(
         }
         // exposureId is a soft reference to exposureplan.Id; if unmatched, write
         // 0 (the "no plan" sentinel) — never retain the source id.
-        if let Some(p) = expo_w {
-            if let Value::Integer(src_plan) = write_values[p] {
-                write_values[p] = Value::Integer(plan_map.get(&src_plan).copied().unwrap_or(0));
-            }
+        if let Some(p) = expo_w
+            && let Value::Integer(src_plan) = write_values[p]
+        {
+            write_values[p] = Value::Integer(plan_map.get(&src_plan).copied().unwrap_or(0));
         }
 
         match dest_map.get(&guid) {
@@ -651,10 +651,10 @@ fn child_ids(
     while let Some(r) = rows.next()? {
         let id: i64 = r.get(0)?;
         let fk: Option<i64> = r.get(1)?;
-        if let Some(fk) = fk {
-            if parents.contains(&fk) {
-                set.insert(id);
-            }
+        if let Some(fk) = fk
+            && parents.contains(&fk)
+        {
+            set.insert(id);
         }
     }
     Ok(set)

--- a/src/commands/visualize_psf/star_selection.rs
+++ b/src/commands/visualize_psf/star_selection.rs
@@ -277,15 +277,15 @@ fn select_custom(
         .into_iter()
         .filter(|s| {
             // HFR filter
-            if let Some(min) = min_hfr {
-                if s.hfr < min {
-                    return false;
-                }
+            if let Some(min) = min_hfr
+                && s.hfr < min
+            {
+                return false;
             }
-            if let Some(max) = max_hfr {
-                if s.hfr > max {
-                    return false;
-                }
+            if let Some(max) = max_hfr
+                && s.hfr > max
+            {
+                return false;
             }
 
             // R² filter

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,10 +140,10 @@ impl Config {
         }
 
         // CLI image directories override config (legacy; server mode ignores this)
-        if let Some(dirs) = image_dirs {
-            if !dirs.is_empty() {
-                self.images = Some(ImagesConfig { directories: dirs });
-            }
+        if let Some(dirs) = image_dirs
+            && !dirs.is_empty()
+        {
+            self.images = Some(ImagesConfig { directories: dirs });
         }
 
         // CLI port overrides config

--- a/src/db.rs
+++ b/src/db.rs
@@ -26,12 +26,12 @@ impl SchemaCapabilities {
 
     fn table_has_column(conn: &Connection, table: &str, column: &str) -> bool {
         let query = format!("PRAGMA table_info({})", table);
-        if let Ok(mut stmt) = conn.prepare(&query) {
-            if let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(1)) {
-                for col_name in rows.flatten() {
-                    if col_name.eq_ignore_ascii_case(column) {
-                        return true;
-                    }
+        if let Ok(mut stmt) = conn.prepare(&query)
+            && let Ok(rows) = stmt.query_map([], |row| row.get::<_, String>(1))
+        {
+            for col_name in rows.flatten() {
+                if col_name.eq_ignore_ascii_case(column) {
+                    return true;
                 }
             }
         }

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -194,12 +194,11 @@ impl DbRegistry {
             if entry.db_path == db_path {
                 return Some(entry);
             }
-            if let Some(target) = &canon_target {
-                if let Ok(canon_entry) = std::fs::canonicalize(&entry.db_path) {
-                    if canon_entry == *target {
-                        return Some(entry);
-                    }
-                }
+            if let Some(target) = &canon_target
+                && let Ok(canon_entry) = std::fs::canonicalize(&entry.db_path)
+                && canon_entry == *target
+            {
+                return Some(entry);
             }
         }
         None
@@ -330,10 +329,10 @@ impl DbRegistry {
             dedup.push(entry);
         }
         self.databases = dedup;
-        if let Some(active) = &self.active_db_id {
-            if !self.databases.iter().any(|d| d.id == *active) {
-                self.active_db_id = None;
-            }
+        if let Some(active) = &self.active_db_id
+            && !self.databases.iter().any(|d| d.id == *active)
+        {
+            self.active_db_id = None;
         }
         Ok(())
     }

--- a/src/photometry.rs
+++ b/src/photometry.rs
@@ -490,10 +490,11 @@ pub fn split_sessions(timestamps: &[Option<i64>], gap_seconds: i64) -> Vec<Vec<u
     let mut current: Vec<usize> = Vec::new();
     let mut last_ts: Option<i64> = None;
     for (i, ts) in timestamps.iter().enumerate() {
-        if let (Some(t), Some(prev)) = (ts, last_ts) {
-            if t - prev > gap_seconds && !current.is_empty() {
-                sessions.push(std::mem::take(&mut current));
-            }
+        if let (Some(t), Some(prev)) = (ts, last_ts)
+            && t - prev > gap_seconds
+            && !current.is_empty()
+        {
+            sessions.push(std::mem::take(&mut current));
         }
         current.push(i);
         if ts.is_some() {
@@ -736,10 +737,10 @@ fn fit_plane_masked(values: &[f64], cols: usize, rows: usize, mask: Option<&[boo
     for gy in 0..rows {
         for gx in 0..cols {
             let c = gy * cols + gx;
-            if let Some(m) = mask {
-                if !m[c] {
-                    continue;
-                }
+            if let Some(m) = mask
+                && !m[c]
+            {
+                continue;
             }
             let v = values[c];
             let (x, y) = (gx as f64, gy as f64);

--- a/src/server/cache.rs
+++ b/src/server/cache.rs
@@ -45,11 +45,11 @@ impl CacheManager {
             let entry = entry?;
             let path = entry.path();
 
-            if let Ok(age) = self.get_cache_age(&path) {
-                if age > max_age_seconds {
-                    std::fs::remove_file(&path)?;
-                    removed_count += 1;
-                }
+            if let Ok(age) = self.get_cache_age(&path)
+                && age > max_age_seconds
+            {
+                std::fs::remove_file(&path)?;
+                removed_count += 1;
             }
         }
 

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -419,14 +419,14 @@ impl DatabaseContext {
             let _build_guard = lock_recover(ctx.tree_build_lock.as_ref());
             {
                 let cache = ctx.directory_tree_cache.read().unwrap();
-                if let Some(ref tree) = *cache {
-                    if !tree.is_older_than(Duration::from_secs(300)) {
-                        tracing::debug!(
-                            "🌳 Background directory tree rebuild skipped for db={}; another scan refreshed it",
-                            ctx.id
-                        );
-                        return;
-                    }
+                if let Some(ref tree) = *cache
+                    && !tree.is_older_than(Duration::from_secs(300))
+                {
+                    tracing::debug!(
+                        "🌳 Background directory tree rebuild skipped for db={}; another scan refreshed it",
+                        ctx.id
+                    );
+                    return;
                 }
             }
 
@@ -504,10 +504,10 @@ impl DatabaseContext {
         let _guard = lock_recover(self.tree_build_lock.as_ref());
         {
             let cache = self.directory_tree_cache.read().unwrap();
-            if let Some(ref tree) = *cache {
-                if !tree.is_older_than(Duration::from_secs(300)) {
-                    return Ok(Arc::new(tree.clone()));
-                }
+            if let Some(ref tree) = *cache
+                && !tree.is_older_than(Duration::from_secs(300))
+            {
+                return Ok(Arc::new(tree.clone()));
             }
         }
         self.rebuild_directory_tree_internal()
@@ -807,11 +807,11 @@ impl DatabaseContext {
     async fn refresh_directory_tree_with_progress(&self) -> Result<Arc<DirectoryTree>> {
         {
             let cache = self.directory_tree_cache.read().unwrap();
-            if let Some(ref tree) = *cache {
-                if !tree.is_older_than(Duration::from_secs(300)) {
-                    tracing::debug!("🌳 Directory tree cache is fresh, skipping rebuild");
-                    return Ok(Arc::new(tree.clone()));
-                }
+            if let Some(ref tree) = *cache
+                && !tree.is_older_than(Duration::from_secs(300))
+            {
+                tracing::debug!("🌳 Directory tree cache is fresh, skipping rebuild");
+                return Ok(Arc::new(tree.clone()));
             }
         }
 
@@ -845,10 +845,10 @@ impl DatabaseContext {
             let _build_guard = lock_recover(tree_build_lock.as_ref());
             {
                 let cache = directory_tree_cache.read().unwrap();
-                if let Some(ref tree) = *cache {
-                    if !tree.is_older_than(Duration::from_secs(300)) {
-                        return Ok((tree.clone(), false));
-                    }
+                if let Some(ref tree) = *cache
+                    && !tree.is_older_than(Duration::from_secs(300))
+                {
+                    return Ok((tree.clone(), false));
                 }
             }
 

--- a/src/server/embedded_static.rs
+++ b/src/server/embedded_static.rs
@@ -62,22 +62,22 @@ pub async fn serve_embedded_file(uri: Uri) -> impl IntoResponse {
         response_builder.body(body).unwrap().into_response()
     } else {
         // For SPA, fall back to index.html for non-API routes
-        if !path.starts_with("api/") {
-            if let Some(index_file) = STATIC_DIR.get_file("index.html") {
-                let mut headers = HeaderMap::new();
-                headers.insert(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_static("text/html; charset=utf-8"),
-                );
-                headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+        if !path.starts_with("api/")
+            && let Some(index_file) = STATIC_DIR.get_file("index.html")
+        {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("text/html; charset=utf-8"),
+            );
+            headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
 
-                let body = Body::from(index_file.contents());
-                return Response::builder()
-                    .status(StatusCode::OK)
-                    .body(body)
-                    .unwrap()
-                    .into_response();
-            }
+            let body = Body::from(index_file.contents());
+            return Response::builder()
+                .status(StatusCode::OK)
+                .body(body)
+                .unwrap()
+                .into_response();
         }
 
         // Return 404 for missing files

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -880,11 +880,11 @@ pub async fn get_image(
     };
 
     // Merge statistics into metadata if available
-    if let (Some(stats), Some(metadata_obj)) = (fits_stats, metadata.as_object_mut()) {
-        if let Some(stats_obj) = stats.as_object() {
-            for (key, value) in stats_obj {
-                metadata_obj.insert(key.clone(), value.clone());
-            }
+    if let (Some(stats), Some(metadata_obj)) = (fits_stats, metadata.as_object_mut())
+        && let Some(stats_obj) = stats.as_object()
+    {
+        for (key, value) in stats_obj {
+            metadata_obj.insert(key.clone(), value.clone());
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -493,10 +493,10 @@ fn probe_pregen_frame_pixels(
 ) -> Option<usize> {
     let tree = ctx.get_directory_tree().ok()?;
     for (_image_id, file_only, _target_name) in images {
-        if let Some(path) = tree.find_file_first(file_only) {
-            if let Some(px) = crate::concurrency::probe_frame_pixels(path) {
-                return Some(px);
-            }
+        if let Some(path) = tree.find_file_first(file_only)
+            && let Some(px) = crate::concurrency::probe_frame_pixels(path)
+        {
+            return Some(px);
         }
     }
     None
@@ -564,16 +564,16 @@ async fn get_all_images_for_pregeneration(
 
     for (image, _project_name, target_name) in images {
         // Extract filename from metadata
-        if let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&image.metadata) {
-            if let Some(filename_path) = metadata["FileName"].as_str() {
-                let file_only = filename_path
-                    .split(&['\\', '/'][..])
-                    .next_back()
-                    .unwrap_or(filename_path)
-                    .to_string();
+        if let Ok(metadata) = serde_json::from_str::<serde_json::Value>(&image.metadata)
+            && let Some(filename_path) = metadata["FileName"].as_str()
+        {
+            let file_only = filename_path
+                .split(&['\\', '/'][..])
+                .next_back()
+                .unwrap_or(filename_path)
+                .to_string();
 
-                result.push((image.id, file_only, target_name));
-            }
+            result.push((image.id, file_only, target_name));
         }
     }
 
@@ -629,17 +629,17 @@ async fn pregenerate_preview(
     let cache_path = cache_manager.get_cached_path("previews", &cache_key, "png");
 
     // Skip if already cached and not expired
-    if cache_manager.is_cached(&cache_path) {
-        if let Ok(metadata) = tokio::fs::metadata(&cache_path).await {
-            let age = metadata.modified()?.elapsed().unwrap_or_default();
-            if age < state.pregeneration_config.cache_expiry {
-                tracing::trace!(
-                    "⏭️ Skipping pre-generation for image {} ({}): already cached",
-                    image_id,
-                    size
-                );
-                return Ok(false); // Skipped, not generated
-            }
+    if cache_manager.is_cached(&cache_path)
+        && let Ok(metadata) = tokio::fs::metadata(&cache_path).await
+    {
+        let age = metadata.modified()?.elapsed().unwrap_or_default();
+        if age < state.pregeneration_config.cache_expiry {
+            tracing::trace!(
+                "⏭️ Skipping pre-generation for image {} ({}): already cached",
+                image_id,
+                size
+            );
+            return Ok(false); // Skipped, not generated
         }
     }
 
@@ -722,16 +722,16 @@ async fn pregenerate_annotated(
     let cache_path = cache_manager.get_cached_path("annotated", &cache_key, "png");
 
     // Skip if already cached and not expired
-    if cache_manager.is_cached(&cache_path) {
-        if let Ok(metadata) = tokio::fs::metadata(&cache_path).await {
-            let age = metadata.modified()?.elapsed().unwrap_or_default();
-            if age < state.pregeneration_config.cache_expiry {
-                tracing::trace!(
-                    "⏭️ Skipping annotated pre-generation for image {}: already cached",
-                    image_id
-                );
-                return Ok(false); // Skipped, not generated
-            }
+    if cache_manager.is_cached(&cache_path)
+        && let Ok(metadata) = tokio::fs::metadata(&cache_path).await
+    {
+        let age = metadata.modified()?.elapsed().unwrap_or_default();
+        if age < state.pregeneration_config.cache_expiry {
+            tracing::trace!(
+                "⏭️ Skipping annotated pre-generation for image {}: already cached",
+                image_id
+            );
+            return Ok(false); // Skipped, not generated
         }
     }
 

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -352,10 +352,10 @@ async fn restart_server(
 
     {
         let mut shutdown_guard = state.server_shutdown.lock().unwrap();
-        if let Some(shutdown_tx) = shutdown_guard.take() {
-            if shutdown_tx.send(()).is_err() {
-                tracing::warn!("Failed to send shutdown signal");
-            }
+        if let Some(shutdown_tx) = shutdown_guard.take()
+            && shutdown_tx.send(()).is_err()
+        {
+            tracing::warn!("Failed to send shutdown signal");
         }
     }
 


### PR DESCRIPTION
## Summary

- adopt the Rust 2024 language edition
- pin the development, CI, release, and security toolchain to Rust 1.97.1
- update the Docker builder to the matching `rust:1.97.1` image
- preserve the existing rustfmt style edition to avoid unrelated formatting churn
- apply the Rust 1.97 Clippy let-chain migrations required by the repository's `-D warnings` policy

The existing `rust-version = "1.89.0"` MSRV and RPM requirement remain unchanged; those describe minimum compiler compatibility rather than the selected development toolchain. GitHub Actions already reads `rust-toolchain.toml`, so the CI, release, and security workflows stay synchronized with this pin.

## Why

The crate still declared edition 2021 and pinned Rust 1.95.0. This moves the project to edition 2024 and the current stable patched compiler release without unnecessarily dropping supported RPM build environments.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` — 313 passed, 5 ignored, 0 failed
- `cargo metadata --no-deps --format-version 1` confirms all Rust targets use edition 2024
