### PR TITLE
Release PSF Guard 0.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,13 @@ jobs:
     - name: Install OpenCV dependencies (macOS)
       if: matrix.os == 'macos-latest'
       run: |
-        brew install opencv
+        # opencv-rust 0.99 targets OpenCV 4. Homebrew's unversioned formula now
+        # installs OpenCV 5, whose moved types break binding generation.
+        brew install opencv@4
+        OPENCV_PREFIX="$(brew --prefix opencv@4)"
+        echo "PKG_CONFIG_PATH=${OPENCV_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
+        echo "OPENCV_PKGCONFIG_NAME=opencv4" >> "$GITHUB_ENV"
+        echo "OpenCV 4 installed via Homebrew"
 
         # Set up libclang path for macOS to avoid dyld errors
         # Try both XCode and Command Line Tools paths

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3811,7 +3811,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -11,7 +11,7 @@
 %global debug_package %{nil}
 
 Name:           psf-guard
-Version:        0.4.2
+Version:        0.5.0
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -115,6 +115,10 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Sun Jul 19 2026 Yann Ramin <github@theatr.us> - 0.5.0-1
+- Add Seiza plate solving, astrometry overlays and evidence, off-target
+  sequence grading, and astrometry-aware regrading
+
 * Sun Jul 12 2026 Yann Ramin <github@theatr.us> - 0.4.2-1
 - Update to 0.4.2: FITS reading, header parsing, and image statistics now go
   through seiza-fits, substantially speeding up every FITS-backed operation

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
## Summary
- bump the Cargo package version to 0.5.0
- keep Cargo.lock and the Tauri bundle version in sync

## Validation
- cargo metadata --locked --no-deps
- cargo fmt --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked (331 passed, 5 ignored)