### PR TITLE
Resolve historical satellite catalogs on demand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,20 +87,21 @@ Implementation tracker and design rationale: [MULTI_DB_PLAN.md](./MULTI_DB_PLAN.
   persistent reload, rendered object overlay, and keyboard toggling.
 
 ### Satellite track prediction (2026-07)
-- **Boundary**: `src/satellites.rs` uses Seiza 0.10 and
-  `seiza-satellites 0.2` to predict named orbital crossings through one solved
+- **Boundary**: `src/satellites.rs` uses Seiza 0.11.1 and
+  `seiza-satellites 0.3.1` to predict named orbital crossings through one solved
   exposure. `association = predicted_not_pixel_detected` is intentional:
   never present a catalog prediction as a trail found in image pixels.
 - **Inputs**: a solved WCS, UTC shutter bounds (`DATE-BEG`/`DATE-OBS` plus
   `DATE-END` or `EXPTIME`), and a topocentric site from FITS headers.
-- **Network/cache**: only `POST /api/db/{id}/images/{image_id}/satellites`
-  may refresh CelesTrak. Quality scans and CLI regrading use
-  `cached_for_exposure()` and never download: Seiza selects the durable
-  timestamped snapshot nearest each shutter interval. Shared elements live at
-  `<cache>/satellites`, persist up to the dependency's 5 GiB default bound,
-  and carry a payload SHA-256 into each result. Per-image predictions live at
-  `<cache>/<db>/satellites/<image_id>.json` and are invalidated by source
-  fingerprint, exact WCS, or dependency/alignment version.
+- **Network/cache**: explicit user-triggered server actions — per-image
+  `POST /api/db/{id}/images/{image_id}/satellites` and **Scan Quality** — may
+  resolve and durably cache current or historical elements. Read-only sequence
+  requests and CLI regrading use `cached_for_exposure()` and never download.
+  Seiza selects the timestamped snapshot nearest each shutter interval. Shared
+  elements live at `<cache>/satellites`, persist up to the dependency's 5 GiB
+  default bound, and carry a payload SHA-256 into each result. Per-image
+  predictions live at `<cache>/<db>/satellites/<image_id>.json` and are
+  invalidated by source fingerprint, exact WCS, or dependency/alignment version.
 - **Pixel evidence**: use `seiza_satellites::trail_alignment`; do not recreate
   the matcher in PSF Guard. It evaluates the complete clipped polyline in
   physical ADU and distinguishes `not_detected` from `not_evaluated` when less

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,9 +4674,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seiza"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3883b769cc60cbd4de66a26105333ac081c31295ae1ae11663251c392c88ce"
+checksum = "ae60585486f1a7014b9742aed92355945d7c230a8c6efc41f78f812c40f5830e"
 dependencies = [
  "directories",
  "image",
@@ -4703,9 +4703,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-satellites"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7874481df8b4534220a875077ead798ec2025fdacbb6d8085da4ac154d943ae0"
+checksum = "70209e084b6ad9695971609523e7f43e37c6543c76e155d016c5a07d60d9592b"
 dependencies = [
  "directories",
  "fs2",
@@ -4717,6 +4717,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.16",
  "tokio",
+ "zstd",
 ]
 
 [[package]]
@@ -7449,6 +7450,34 @@ name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4675,8 +4675,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "seiza"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd7998989f2c11becf073e3bd1e33b9973f31fead3eb060c5caf472077086fd"
+source = "git+https://github.com/theatrus/seiza.git?rev=5299dd23d6d2cf3d4b5f0782bbc7949aca837e73#5299dd23d6d2cf3d4b5f0782bbc7949aca837e73"
 dependencies = [
  "directories",
  "image",
@@ -4704,8 +4703,7 @@ dependencies = [
 [[package]]
 name = "seiza-satellites"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860d73841db0a90882d490b9b14c129482952a39178e3ee1e33812633c79f963"
+source = "git+https://github.com/theatrus/seiza.git?rev=5299dd23d6d2cf3d4b5f0782bbc7949aca837e73#5299dd23d6d2cf3d4b5f0782bbc7949aca837e73"
 dependencies = [
  "directories",
  "fs2",
@@ -4713,6 +4711,7 @@ dependencies = [
  "satkit",
  "seiza",
  "serde",
+ "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.16",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4674,8 +4674,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seiza"
-version = "0.10.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=5299dd23d6d2cf3d4b5f0782bbc7949aca837e73#5299dd23d6d2cf3d4b5f0782bbc7949aca837e73"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd3883b769cc60cbd4de66a26105333ac081c31295ae1ae11663251c392c88ce"
 dependencies = [
  "directories",
  "image",
@@ -4702,8 +4703,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-satellites"
-version = "0.2.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=5299dd23d6d2cf3d4b5f0782bbc7949aca837e73#5299dd23d6d2cf3d4b5f0782bbc7949aca837e73"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7874481df8b4534220a875077ead798ec2025fdacbb6d8085da4ac154d943ae0"
 dependencies = [
  "directories",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ anyhow = "1.0"
 chrono = "0.4"
 regex = "1.12"
 byteorder = "1.5"
-seiza = "0.10.0"
+seiza = { git = "https://github.com/theatrus/seiza.git", rev = "5299dd23d6d2cf3d4b5f0782bbc7949aca837e73" }
 seiza-fits = "=0.1.6"
-seiza-satellites = { version = "0.2.0", features = ["serde"] }
+seiza-satellites = { git = "https://github.com/theatrus/seiza.git", rev = "5299dd23d6d2cf3d4b5f0782bbc7949aca837e73", features = ["serde"] }
 bumpalo = { version = "3.20", features = ["collections"] }
 image = "0.25"
 imageproc = "0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ anyhow = "1.0"
 chrono = "0.4"
 regex = "1.12"
 byteorder = "1.5"
-seiza = { git = "https://github.com/theatrus/seiza.git", rev = "5299dd23d6d2cf3d4b5f0782bbc7949aca837e73" }
+seiza = "0.11.0"
 seiza-fits = "=0.1.6"
-seiza-satellites = { git = "https://github.com/theatrus/seiza.git", rev = "5299dd23d6d2cf3d4b5f0782bbc7949aca837e73", features = ["serde"] }
+seiza-satellites = { version = "0.3.0", features = ["serde"] }
 bumpalo = { version = "3.20", features = ["collections"] }
 image = "0.25"
 imageproc = "0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ anyhow = "1.0"
 chrono = "0.4"
 regex = "1.12"
 byteorder = "1.5"
-seiza = "0.11.0"
+seiza = "0.11.1"
 seiza-fits = "=0.1.6"
-seiza-satellites = { version = "0.3.0", features = ["serde"] }
+seiza-satellites = { version = "0.3.1", features = ["serde"] }
 bumpalo = { version = "3.20", features = ["collections"] }
 image = "0.25"
 imageproc = "0.27"

--- a/README.md
+++ b/README.md
@@ -273,23 +273,28 @@ FITS file, relevant catalog, or Seiza version changes.
 
 Open an image's **Satellite tracks** panel and choose **Identify satellite
 tracks**, or press `T`. PSF Guard ensures the frame has a pixel WCS, loads the
-active satellite elements through `seiza-satellites 0.2`, and projects every
-crossing during the shutter-open interval. It then searches a narrow corridor
-around each prediction for a matching linear trail in the FITS pixels. The
-overlay keeps risk-colored orbital paths dashed and draws detected pixel paths
-in solid green. Labels retain the candidate name and NORAD identity; selecting
-a named result opens its external satellite information page.
+appropriate satellite elements through the resolver in `seiza-satellites`,
+and projects every crossing during the shutter-open interval. Recent exposures
+use CelesTrak's active catalog. Historical exposures use a nearby durable cache
+entry, the Seiza rolling mirror, or the public IAU SatChecker fallback. PSF
+Guard does not reproduce that provider policy. It then searches a narrow
+corridor around each prediction for a matching linear trail in the FITS
+pixels. The overlay keeps risk-colored orbital paths dashed and draws detected
+pixel paths in solid green. Labels retain the candidate name and NORAD
+identity; selecting a named result opens its external satellite information
+page.
 
 The FITS header must contain either explicit UTC exposure bounds, a UTC
 midpoint (`DATE-AVG`) plus duration, or a UTC start plus duration, and an
 observing site (`SITELAT`/`SITELONG`, `OBSGEO-B`/`OBSGEO-L`, or their
 documented aliases). On-demand prediction is the only workflow that may
-refresh CelesTrak's active-satellite data. The quality scan and
-`screen-fits --regrade-db` never download orbital data: when a snapshot is
-already cached, they select the retained snapshot closest to each exposure and
-persist per-image predictions under `<cache>/<db-slug>/satellites/`. Timestamped
-snapshots remain available for historical re-tracing up to a 5 GiB default
-cache bound, and each result records the exact orbital-payload fingerprint.
+refresh CelesTrak data or resolve historical data from the Seiza mirror/IAU
+fallback. The quality scan and `screen-fits --regrade-db` never download
+orbital data: when a suitable snapshot is already cached, they reuse it and
+persist per-image predictions under `<cache>/<db-slug>/satellites/`. Current
+and historical snapshots share the same 5 GiB default cache bound, and each
+result records the provider and exact orbital-payload fingerprint. Historical
+results also record the requested catalog epoch separately from download time.
 
 Bright-trail risk is a conservative geometry/illumination heuristic based on
 sunlight, range, elevation, and path length. It is not an apparent magnitude.

--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ toggles the overlay instead of solving again.
 
 ### Install the Seiza catalogs
 
-PSF Guard embeds Seiza 0.10.0's solver but does not bundle its multi-gigabyte
+PSF Guard embeds Seiza 0.11.0's solver but does not bundle its multi-gigabyte
 catalog data. Install the `seiza` CLI from the
 [Seiza releases](https://github.com/theatrus/seiza/releases) or with
-`cargo install seiza-cli --version 0.10.0`, then download a bundle once:
+`cargo install seiza-cli --version 0.11.0`, then download a bundle once:
 
 ```bash
 # Recommended: choose a bundle interactively and install it in Seiza's

--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ toggles the overlay instead of solving again.
 
 ### Install the Seiza catalogs
 
-PSF Guard embeds Seiza 0.11.0's solver but does not bundle its multi-gigabyte
+PSF Guard embeds Seiza 0.11.1's solver but does not bundle its multi-gigabyte
 catalog data. Install the `seiza` CLI from the
 [Seiza releases](https://github.com/theatrus/seiza/releases) or with
-`cargo install seiza-cli --version 0.11.0`, then download a bundle once:
+`cargo install seiza-cli --version 0.11.1`, then download a bundle once:
 
 ```bash
 # Recommended: choose a bundle interactively and install it in Seiza's
@@ -287,14 +287,15 @@ page.
 The FITS header must contain either explicit UTC exposure bounds, a UTC
 midpoint (`DATE-AVG`) plus duration, or a UTC start plus duration, and an
 observing site (`SITELAT`/`SITELONG`, `OBSGEO-B`/`OBSGEO-L`, or their
-documented aliases). On-demand prediction is the only workflow that may
-refresh CelesTrak data or resolve historical data from the Seiza mirror/IAU
-fallback. The quality scan and `screen-fits --regrade-db` never download
-orbital data: when a suitable snapshot is already cached, they reuse it and
-persist per-image predictions under `<cache>/<db-slug>/satellites/`. Current
-and historical snapshots share the same 5 GiB default cache bound, and each
-result records the provider and exact orbital-payload fingerprint. Historical
-results also record the requested catalog epoch separately from download time.
+documented aliases). Both on-demand prediction and the user-triggered server
+quality scan may refresh CelesTrak data or resolve historical data from the
+Seiza mirror/IAU fallback. Merely viewing Sequence Analysis and running
+`screen-fits --regrade-db` never download orbital data. The latter reuses a
+suitable cached snapshot when one exists and otherwise abstains. Per-image
+predictions persist under `<cache>/<db-slug>/satellites/`. Current and
+historical snapshots share the same 5 GiB default cache bound, and each result
+records the provider and exact orbital-payload fingerprint. Historical results
+also record the requested catalog epoch separately from download time.
 
 Bright-trail risk is a conservative geometry/illumination heuristic based on
 sunlight, range, elevation, and path length. It is not an apparent magnitude.

--- a/docs/SATELLITES.md
+++ b/docs/SATELLITES.md
@@ -7,8 +7,8 @@ clipped orbital path inside the sensor, searches the nearby FITS pixels for a
 matching linear trail, and labels the candidate with the satellite name and
 NORAD identity supplied by the orbital catalog.
 
-The current integration uses `seiza 0.11.0`, `seiza-fits 0.1.6`, and
-`seiza-satellites 0.3.0`.
+The current integration uses `seiza 0.11.1`, `seiza-fits 0.1.6`, and
+`seiza-satellites 0.3.1`.
 
 ## Evidence boundary
 
@@ -64,10 +64,11 @@ abstain; it does not turn missing evidence into a clean-frame claim.
 
 ## Orbital-element cache
 
-The explicit on-demand action chooses the orbital source from the exposure
-time through `seiza-satellites::OrbitalCatalogSource`; PSF Guard does not own a
-parallel age cutoff or provider list. Recent images use CelesTrak's active-
-satellite catalog. Historical images try a nearby durable cache entry, the
+The explicit **Show tracks** action and server **Scan Quality** action choose
+the orbital source from the exposure time through
+`seiza-satellites::OrbitalCatalogSource`; PSF Guard does not own a parallel age
+cutoff or provider list. Recent images use CelesTrak's active-satellite
+catalog. Historical images try a nearby durable cache entry, the
 content-addressed Seiza rolling mirror, and finally the public IAU SatChecker
 endpoint `/tools/tles-at-epoch/?epoch=<julian-date>&format=txt`, using the
 shutter midpoint. A nearby validated historical response is reused for the
@@ -77,7 +78,9 @@ Current and historical responses share one durable cache. They remain
 available for re-tracing until that cache reaches its 5 GiB default upper
 bound; then the oldest downloads are pruned while the newest is always kept.
 Historical provenance records the provider, requested epoch, and download time.
-Cache-only quality scans and regrades never call either network service.
+The server quality scan may populate a missing snapshot because it is an
+explicit background action. Read-only sequence requests and CLI regrades never
+call either network service.
 Shared orbital data lives under `<cache>/satellites/`, with retrieval, locking,
 validation, and pruning handled by `seiza-satellites`.
 The mirror schema, twice-daily publisher, S3 transaction, retention, and
@@ -99,7 +102,11 @@ Per-image results are written atomically to
 `<cache>/<db-slug>/satellites/<image-id>.json`. They carry the exact orbital
 payload SHA-256 and are accepted only when the FITS fingerprint, exact WCS,
 Seiza version, seiza-satellites version, and pixel-alignment version still
-match.
+match. A normal quality scan reuses that evidence. Shift-click **Scan Quality**
+to recompute all cached quality evidence, including every satellite prediction,
+against the orbital snapshot the current cache now prefers. This forced scan is
+allowed to refresh or download orbital data when the Seiza resolver needs it.
+API clients can force only this part with `{"force_satellites":true}`.
 
 ## Bright-trail risk and grading
 
@@ -161,10 +168,15 @@ associations rather than asserted identities.
 
 ## Background and CLI behavior
 
-Quality scans and `screen-fits --regrade-db` are cache-only consumers: they
-never download orbital data. If a configured or previously downloaded
-snapshot exists, they compute and persist exposure predictions alongside the
-fresh plate solution. Otherwise satellite grading simply abstains.
+The server's user-triggered **Scan Quality** action seeds missing current or
+historical orbital snapshots, then computes and persists exposure predictions
+alongside each plate solution. Merely opening Sequence Analysis remains
+read-only and never causes a download.
+
+`screen-fits --regrade-db` is still a cache-only consumer. If a configured or
+previously downloaded snapshot exists, it uses it; otherwise satellite grading
+abstains. This keeps unattended CLI regrades deterministic and prevents a
+directory scan from unexpectedly performing network work.
 
 When CLI and server share the default `./cache`, no extra option is needed. If
 the server uses another cache root, give `screen-fits` the same path:

--- a/docs/SATELLITES.md
+++ b/docs/SATELLITES.md
@@ -61,15 +61,25 @@ abstain; it does not turn missing evidence into a clean-frame claim.
 
 ## Orbital-element cache
 
-The explicit on-demand action loads CelesTrak's active-satellite catalog via
-`seiza-satellites`. A fresh local snapshot is reused; when refresh is needed,
-that action may download a new timestamped snapshot and may fall back to stale
-cached data according to the library's cache policy. Snapshots are retained
-for historical re-tracing until the shared cache reaches its 5 GiB default
-upper bound; then the oldest snapshots are pruned while the newest is always
-kept. Cache-only quality scans and regrades select the retained snapshot whose
-retrieval time is closest to each exposure. Shared orbital data lives under
-`<cache>/satellites/`, with locking and pruning handled by the dependency.
+The explicit on-demand action chooses the orbital source from the exposure
+time through `seiza-satellites::OrbitalCatalogSource`; PSF Guard does not own a
+parallel age cutoff or provider list. Recent images use CelesTrak's active-
+satellite catalog. Historical images try a nearby durable cache entry, the
+content-addressed Seiza rolling mirror, and finally the public IAU SatChecker
+endpoint `/tools/tles-at-epoch/?epoch=<julian-date>&format=txt`, using the
+shutter midpoint. A nearby validated historical response is reused for the
+same observing night rather than issuing another large query.
+
+Current and historical responses share one durable cache. They remain
+available for re-tracing until that cache reaches its 5 GiB default upper
+bound; then the oldest downloads are pruned while the newest is always kept.
+Historical provenance records the provider, requested epoch, and download time.
+Cache-only quality scans and regrades never call either network service.
+Shared orbital data lives under `<cache>/satellites/`, with retrieval, locking,
+validation, and pruning handled by `seiza-satellites`.
+The mirror schema, twice-daily publisher, S3 transaction, retention, and
+backfill procedure are documented in the
+[Seiza satellite mirror runbook](https://github.com/theatrus/seiza/blob/main/docs/SATELLITE_MIRROR.md).
 
 For reproducible or offline work, set `astrometry.satellite_elements` in the
 JSON registry to a local OMM JSON or TLE file. Relative paths resolve below

--- a/docs/SATELLITES.md
+++ b/docs/SATELLITES.md
@@ -7,6 +7,9 @@ clipped orbital path inside the sensor, searches the nearby FITS pixels for a
 matching linear trail, and labels the candidate with the satellite name and
 NORAD identity supplied by the orbital catalog.
 
+The current integration uses `seiza 0.11.0`, `seiza-fits 0.1.6`, and
+`seiza-satellites 0.3.0`.
+
 ## Evidence boundary
 
 Satellite results begin as orbital predictions: “which cataloged objects
@@ -135,8 +138,9 @@ the recorded midpoint. Historical elements came from the
 [IAU SatChecker archive](https://satchecker.readthedocs.io/en/latest/tools_tle.html)
 near each exposure epoch.
 
-For the brighter frame, Seiza 0.10 solved 101 matched stars at 1.90 arcsec RMS.
-`seiza-satellites 0.2` projected four high-risk crossings, but pixel alignment
+These recorded reference metrics were produced with Seiza 0.10 and
+`seiza-satellites 0.2`. The brighter frame solved 101 matched stars at 1.90
+arcsec RMS. Four high-risk crossings were projected, but pixel alignment
 found only the two trails visible in the frame: **CZ-4B R/B [48624]** at 57.8
 sigma and **STARLINK-3093 [49141]** at 4.2 sigma. Their fitted paths are about
 30 and 76 sensor pixels from the raw orbital projections, with more than 98%

--- a/docs/SCREENING.md
+++ b/docs/SCREENING.md
@@ -89,11 +89,11 @@ scatter. Use **Select Clouded**, **Select Off Target**, **Select Unsolved**, or
 **Select Recommended**; rejecting a recommendation always opens a per-image
 review before anything is written.
 
-If orbital elements were previously populated from an image's **Satellite
-tracks** panel, the scan also caches exposure-specific crossings. Potentially
-bright predictions warn; only a high-risk prediction with a matching pixel
-trail creates a reviewed rejection recommendation. The scan itself never
-refreshes or downloads orbital data.
+The user-triggered scan resolves and durably caches suitable orbital elements
+for each exposure, then caches exposure-specific crossings. Potentially bright
+predictions warn; only a high-risk prediction with a matching pixel trail
+creates a reviewed rejection recommendation. Merely opening Sequence Analysis
+does not download anything, and CLI regrading remains cache-only.
 See [Satellite track prediction](SATELLITES.md).
 
 ## Reading the diagnostics

--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -10,7 +10,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-pub const SEIZA_VERSION: &str = "0.10.0";
+pub const SEIZA_VERSION: &str = "0.11.0";
 pub const SEIZA_FITS_VERSION: &str = "0.1.6";
 
 pub type AstrometryResourcePath = Result<Option<PathBuf>, seiza::data_paths::DataPathError>;

--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -10,7 +10,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-pub const SEIZA_VERSION: &str = "0.11.0";
+pub const SEIZA_VERSION: &str = "0.11.1";
 pub const SEIZA_FITS_VERSION: &str = "0.1.6";
 
 pub type AstrometryResourcePath = Result<Option<PathBuf>, seiza::data_paths::DataPathError>;

--- a/src/satellites.rs
+++ b/src/satellites.rs
@@ -26,7 +26,7 @@ use crate::astrometry::{
 use crate::astrometry_headers::FitsAstrometryHeaders;
 use crate::FitsImage;
 
-pub const SEIZA_SATELLITES_VERSION: &str = "0.2.0";
+pub const SEIZA_SATELLITES_VERSION: &str = "0.3.0";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/satellites.rs
+++ b/src/satellites.rs
@@ -26,7 +26,7 @@ use crate::astrometry::{
 use crate::astrometry_headers::FitsAstrometryHeaders;
 use crate::FitsImage;
 
-pub const SEIZA_SATELLITES_VERSION: &str = "0.3.0";
+pub const SEIZA_SATELLITES_VERSION: &str = "0.3.1";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -71,9 +71,9 @@ pub struct SatelliteCatalogSnapshot {
 }
 
 /// Shared orbital-element source. The network is touched only by
-/// [`load_for_exposure`](Self::load_for_exposure), which is called by the
-/// explicit on-demand endpoint. Provider selection belongs to
-/// `seiza-satellites`; sequence grading remains cache-only.
+/// [`load_for_exposure`](Self::load_for_exposure), which is called by explicit
+/// user-triggered server work. Provider selection belongs to
+/// `seiza-satellites`; CLI regrading remains cache-only.
 pub struct SatelliteContext {
     source: OrbitalCatalogSource,
     configured_elements: Option<PathBuf>,

--- a/src/satellites.rs
+++ b/src/satellites.rs
@@ -14,9 +14,9 @@ use seiza_satellites::trail_alignment::{
     PIXEL_TRAIL_ALIGNMENT_VERSION,
 };
 use seiza_satellites::{
-    BrightTrailRiskLevel, BrightTrailRiskOptions, CacheState, CelesTrakLoad, CelesTrakSource,
-    ExposureProvenance, ObserverLocation, SatelliteCatalog, SingleExposure, TrackOptions,
-    UtcTimestamp,
+    BrightTrailRiskLevel, BrightTrailRiskOptions, CacheState, ExposureProvenance, ObserverLocation,
+    OrbitalCatalogLoad, OrbitalCatalogProvider, OrbitalCatalogSource, SatelliteCatalog,
+    SingleExposure, TrackOptions, UtcTimestamp,
 };
 use serde::{Deserialize, Serialize};
 
@@ -41,6 +41,8 @@ pub enum SatelliteCatalogState {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SatelliteCatalogProvenance {
     pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<OrbitalCatalogProvider>,
     pub state: SatelliteCatalogState,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_path: Option<String>,
@@ -50,6 +52,10 @@ pub struct SatelliteCatalogProvenance {
     pub modified_unix_seconds: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retrieved_at: Option<String>,
+    /// Epoch requested from a historical catalog service. This is distinct
+    /// from the time at which the response was downloaded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query_epoch: Option<String>,
     /// Exact identity of the orbital-element payload, independent of its
     /// filename or retrieval timestamp.
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -65,17 +71,18 @@ pub struct SatelliteCatalogSnapshot {
 }
 
 /// Shared orbital-element source. The network is touched only by
-/// [`refresh_active`](Self::refresh_active), which is called by the explicit
-/// on-demand endpoint. Sequence grading uses [`cached_only`](Self::cached_only).
+/// [`load_for_exposure`](Self::load_for_exposure), which is called by the
+/// explicit on-demand endpoint. Provider selection belongs to
+/// `seiza-satellites`; sequence grading remains cache-only.
 pub struct SatelliteContext {
-    source: CelesTrakSource,
+    source: OrbitalCatalogSource,
     configured_elements: Option<PathBuf>,
     refresh_mutex: tokio::sync::Mutex<()>,
 }
 
 impl SatelliteContext {
     pub fn new(cache_dir: PathBuf, configured_elements: Option<PathBuf>) -> Result<Self, String> {
-        let source = CelesTrakSource::new(cache_dir).map_err(|error| error.to_string())?;
+        let source = OrbitalCatalogSource::new(cache_dir).map_err(|error| error.to_string())?;
         Ok(Self {
             source,
             configured_elements,
@@ -91,52 +98,32 @@ impl SatelliteContext {
         self.configured_elements
             .as_deref()
             .is_some_and(Path::is_file)
-            || self
-                .source
-                .cached_snapshots()
-                .is_ok_and(|snapshots| !snapshots.is_empty())
+            || self.source.has_cached_catalogs().unwrap_or(false)
     }
 
-    /// Load a configured historical file, or refresh the shared CelesTrak
-    /// active-satellite snapshot. This is the only network-capable path.
-    pub async fn refresh_active(&self) -> Result<SatelliteCatalogSnapshot, String> {
+    /// Load a configured file or resolve orbital elements appropriate to this
+    /// exposure. This is the only network-capable path; provider choice and
+    /// durable retention are delegated to `seiza-satellites`.
+    pub async fn load_for_exposure(&self, path: &Path) -> Result<SatelliteCatalogSnapshot, String> {
         let _guard = self.refresh_mutex.lock().await;
         if let Some(path) = self.configured_elements.as_deref() {
             return load_local_catalog(path, SatelliteCatalogState::Configured, None);
         }
+        let headers = FitsAstrometryHeaders::from_path(path)
+            .map_err(|error| format!("failed to read FITS exposure headers: {error}"))?;
+        let (exposure, _) = single_exposure(&headers)?;
 
         let load = self
             .source
-            .load_active()
+            .load_for_exposure(&exposure)
             .await
             .map_err(|error| error.to_string())?;
-        let state = match load.state {
-            CacheState::Fresh => SatelliteCatalogState::Fresh,
-            CacheState::Downloaded => SatelliteCatalogState::Downloaded,
-            CacheState::StaleFallback => SatelliteCatalogState::StaleFallback,
-            CacheState::Cached => SatelliteCatalogState::Cached,
-        };
-        Ok(snapshot_from_celestrak_load(load, state))
-    }
-
-    /// Return orbital elements without downloading. A configured file wins;
-    /// otherwise use Seiza's newest valid cached snapshot. Cache discovery,
-    /// validation, locking, and size-bound pruning belong to the dependency.
-    pub fn cached_only(&self) -> Result<Option<SatelliteCatalogSnapshot>, String> {
-        if let Some(path) = self.configured_elements.as_deref() {
-            return load_local_catalog(path, SatelliteCatalogState::Configured, None).map(Some);
-        }
-        self.source
-            .load_cached()
-            .map_err(|error| error.to_string())
-            .map(|load| {
-                load.map(|load| snapshot_from_celestrak_load(load, SatelliteCatalogState::Cached))
-            })
+        Ok(snapshot_from_orbital_load(load))
     }
 
     /// Return the durable cached snapshot closest to this exposure without
     /// downloading. This keeps historical regrades reproducible as newer
-    /// CelesTrak snapshots accumulate.
+    /// orbital snapshots accumulate.
     pub fn cached_for_exposure(
         &self,
         path: &Path,
@@ -148,28 +135,30 @@ impl SatelliteContext {
             .map_err(|error| format!("failed to read FITS exposure headers: {error}"))?;
         let (exposure, _) = single_exposure(&headers)?;
         self.source
-            .load_cached_for(exposure.midpoint())
+            .load_cached_for_exposure(&exposure)
             .map_err(|error| error.to_string())
-            .map(|load| {
-                load.map(|load| snapshot_from_celestrak_load(load, SatelliteCatalogState::Cached))
-            })
+            .map(|load| load.map(snapshot_from_orbital_load))
     }
 }
 
-fn snapshot_from_celestrak_load(
-    load: CelesTrakLoad,
-    state: SatelliteCatalogState,
-) -> SatelliteCatalogSnapshot {
+fn snapshot_from_orbital_load(load: OrbitalCatalogLoad) -> SatelliteCatalogSnapshot {
     let content_sha256 = load.catalog.fingerprint().content_sha256;
     let (size_bytes, modified_unix_seconds) = file_identity(&load.cache_path);
     SatelliteCatalogSnapshot {
         provenance: SatelliteCatalogProvenance {
             source: load.catalog.source().to_string(),
-            state,
+            provider: Some(load.snapshot.provider),
+            state: match load.state {
+                CacheState::Downloaded => SatelliteCatalogState::Downloaded,
+                CacheState::Cached => SatelliteCatalogState::Cached,
+                CacheState::Fresh => SatelliteCatalogState::Fresh,
+                CacheState::StaleFallback => SatelliteCatalogState::StaleFallback,
+            },
             cache_path: Some(load.cache_path.display().to_string()),
             size_bytes,
             modified_unix_seconds,
             retrieved_at: load.catalog.retrieved_at().map(UtcTimestamp::to_rfc3339),
+            query_epoch: load.snapshot.query_time.map(UtcTimestamp::to_rfc3339),
             content_sha256,
             warning: load.warning,
         },
@@ -195,11 +184,13 @@ fn load_local_catalog(
     Ok(SatelliteCatalogSnapshot {
         provenance: SatelliteCatalogProvenance {
             source: path.display().to_string(),
+            provider: None,
             state,
             cache_path: Some(path.display().to_string()),
             size_bytes,
             modified_unix_seconds,
             retrieved_at: retrieved_at.map(UtcTimestamp::to_rfc3339),
+            query_epoch: None,
             content_sha256,
             warning: None,
         },

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -364,13 +364,15 @@ pub struct SequenceAnalysisResponse {
 pub struct SpatialScanRequest {
     pub target_id: i32,
     pub filter_name: Option<String>,
-    /// Recompute images that already have cached metrics.
+    /// Recompute all cached quality evidence, including satellite predictions.
     #[serde(default)]
     pub force: bool,
     #[serde(default)]
     pub force_spatial: bool,
     #[serde(default)]
     pub force_astrometry: bool,
+    #[serde(default)]
+    pub force_satellites: bool,
 }
 
 /// Status returned by both the scan-start and scan-progress endpoints.

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -2623,12 +2623,10 @@ pub async fn start_spatial_scan(
 
     scan::ensure_loaded(&ctx.spatial_metrics, &ctx.cache_dir_path);
 
-    // A quality scan never performs network I/O. If orbital elements were
-    // previously downloaded by the on-demand action (or explicitly
-    // configured), reuse that snapshot to predict tracks while each frame's
-    // solved WCS is already in hand.
+    // This is an explicit user-triggered background action, so it may seed the
+    // durable orbital cache for an exposure. Read-only sequence queries and
+    // CLI regrading remain cache-only.
     let satellite_context = Arc::clone(&state.satellites);
-    let satellite_cache_available = satellite_context.has_cached_elements();
 
     // Collect this target's images together with schema-adaptive intended
     // framing. Unsupported coordinate epochs are deliberately omitted from
@@ -2669,12 +2667,13 @@ pub async fn start_spatial_scan(
         candidates
     };
 
-    // Keep the union of spatial and astrometry work. One side may already be
-    // cached while the other still needs computation.
+    // Keep the union of spatial, astrometry, and satellite work. One side may
+    // already be cached while another still needs computation.
     let mut work = Vec::new();
     let mut skipped_cached = 0usize;
     let force_spatial = req.force || req.force_spatial;
     let force_astrometry = req.force || req.force_astrometry;
+    let force_satellites = req.force || req.force_satellites;
     for (img, target_name, expected) in candidates {
         let Some(file_only) = filename_from_metadata(&img.metadata) else {
             continue;
@@ -2700,8 +2699,8 @@ pub async fn start_spatial_scan(
                     == Some(file_only.as_str())
             });
         let astrometry_cached = cached_astrometry.is_some();
-        let satellite_cached = !satellite_cache_available
-            || cached_astrometry.as_ref().is_some_and(|analysis| {
+        let satellite_cached = !force_satellites
+            && cached_astrometry.as_ref().is_some_and(|analysis| {
                 crate::satellites::persisted_analysis(&ctx.cache_dir_path, img.id, analysis)
                     .is_some()
             });
@@ -2754,6 +2753,7 @@ pub async fn start_spatial_scan(
     let target_id = req.target_id;
     let worker_policy = state.worker_policy();
     let astrometry = Arc::clone(&state.astrometry);
+    let runtime_handle = tokio::runtime::Handle::current();
     // Mark this as an interactive job for its whole lifetime so background
     // pre-generation yields cores + memory to it. Moved into the blocking task
     // and dropped when the scan returns (or panics).
@@ -2888,8 +2888,10 @@ pub async fn start_spatial_scan(
                                     None
                                 };
                             if *need_satellite && solved {
-                                match satellite_context.cached_for_exposure(&item.fits_path) {
-                                    Ok(Some(snapshot)) => {
+                                match runtime_handle
+                                    .block_on(satellite_context.load_for_exposure(&item.fits_path))
+                                {
+                                    Ok(snapshot) => {
                                         if let Err(error) = crate::satellites::predict_tracks(
                                             item.image_id,
                                             &item.fits_path,
@@ -2909,9 +2911,8 @@ pub async fn start_spatial_scan(
                                             );
                                         }
                                     }
-                                    Ok(None) => {}
                                     Err(error) => tracing::warn!(
-                                        "Cached satellite elements unavailable for {}: {}",
+                                        "Satellite elements unavailable for {}: {}",
                                         item.filename,
                                         error
                                     ),

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -243,7 +243,7 @@ pub async fn predict_image_satellites(
 
     state
         .satellites
-        .refresh_active()
+        .load_for_exposure(&fits_path)
         .await
         .map_err(AppError::BadRequest)?;
     let satellite_context = Arc::clone(&state.satellites);

--- a/static/e2e/astrometry-capabilities.spec.ts
+++ b/static/e2e/astrometry-capabilities.spec.ts
@@ -9,7 +9,7 @@ test('partial data directory reports usable and missing Seiza resources', async 
   const body = await response.json();
   expect(body.success).toBe(true);
   expect(body.data).toMatchObject({
-    seiza_version: '0.11.0',
+    seiza_version: '0.11.1',
     seiza_fits_version: '0.1.6',
     features: {
       object_association: true,

--- a/static/e2e/astrometry-capabilities.spec.ts
+++ b/static/e2e/astrometry-capabilities.spec.ts
@@ -9,7 +9,7 @@ test('partial data directory reports usable and missing Seiza resources', async 
   const body = await response.json();
   expect(body.success).toBe(true);
   expect(body.data).toMatchObject({
-    seiza_version: '0.10.0',
+    seiza_version: '0.11.0',
     seiza_fits_version: '0.1.6',
     features: {
       object_association: true,

--- a/static/e2e/image-astrometry.spec.ts
+++ b/static/e2e/image-astrometry.spec.ts
@@ -129,7 +129,7 @@ test('keeps catalog-only association distinct when a real FITS file has no WCS',
     mode: 'hinted',
     catalog_scope: 'solved_footprint',
     solver_provenance: {
-      seiza_version: '0.11.0',
+      seiza_version: '0.11.1',
       detection_backend: 'mtf_u8',
       star_catalog: { format: 'SEIZAST2' },
     },

--- a/static/e2e/image-astrometry.spec.ts
+++ b/static/e2e/image-astrometry.spec.ts
@@ -129,7 +129,7 @@ test('keeps catalog-only association distinct when a real FITS file has no WCS',
     mode: 'hinted',
     catalog_scope: 'solved_footprint',
     solver_provenance: {
-      seiza_version: '0.10.0',
+      seiza_version: '0.11.0',
       detection_backend: 'mtf_u8',
       star_catalog: { format: 'SEIZAST2' },
     },

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -528,6 +528,7 @@ export interface SpatialScanRequest {
   force?: boolean;
   force_spatial?: boolean;
   force_astrometry?: boolean;
+  force_satellites?: boolean;
 }
 
 export interface SequenceSummary {

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -198,11 +198,13 @@ export interface SatelliteAnalysis {
   };
   catalog: {
     source: string;
+    provider?: 'celes_trak_active' | 'seiza_mirror' | 'iau_sat_checker';
     state: 'configured' | 'fresh' | 'downloaded' | 'stale_fallback' | 'cached';
     cache_path?: string;
     size_bytes?: number;
     modified_unix_seconds?: number;
     retrieved_at?: string;
+    query_epoch?: string;
     content_sha256?: string;
     warning?: string;
   };

--- a/static/src/components/SatellitePanel.tsx
+++ b/static/src/components/SatellitePanel.tsx
@@ -23,6 +23,13 @@ export default function SatellitePanel({
 }: SatellitePanelProps) {
   const analysis = status?.analysis;
   const risk = analysis?.risk;
+  const providerLabel = analysis?.catalog.provider === 'celes_trak_active'
+    ? 'CelesTrak active'
+    : analysis?.catalog.provider === 'seiza_mirror'
+      ? 'Seiza mirror'
+      : analysis?.catalog.provider === 'iau_sat_checker'
+        ? 'IAU SatChecker'
+        : undefined;
 
   return (
     <section className="info-section astrometry-section" data-testid="satellite-panel">
@@ -78,6 +85,18 @@ export default function SatellitePanel({
           <dd>{risk.pixel_alignment_attempted ? risk.pixel_aligned_count : 'Unavailable'}</dd>
           <dt>Exposure</dt>
           <dd>{analysis.exposure.duration_seconds.toFixed(1)}s</dd>
+          {providerLabel && (
+            <>
+              <dt>Element source</dt>
+              <dd>{providerLabel}</dd>
+            </>
+          )}
+          {analysis.catalog.query_epoch && (
+            <>
+              <dt>Elements for</dt>
+              <dd>{new Date(analysis.catalog.query_epoch).toLocaleString()}</dd>
+            </>
+          )}
         </dl>
       )}
 

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -283,9 +283,9 @@ export default function SequenceView() {
             </button>
             <button
               className="header-button"
-              onClick={() => spatialScan.start(undefined)}
+              onClick={(event) => spatialScan.start(event.shiftKey || undefined)}
               disabled={spatialScan.isStarting || spatialScan.isRunning}
-              title="Analyze FITS pixels for occlusion, photometry, plate solutions, target offset, and tracking loss. Runs in the background and reuses cached results."
+              title="Analyze FITS pixels for occlusion, photometry, plate solutions, target offset, tracking loss, and satellite trails. Shift-click to recompute all cached evidence from the current catalogs."
             >
               {spatialScan.isRunning
                 ? `${spatialScan.status?.progress.stage === 'astrometry' ? 'Solving' : 'Scanning'} ${spatialScan.status?.progress.processed ?? 0}/${spatialScan.status?.progress.total ?? 0}...`

--- a/static/src/components/__tests__/SatellitePanel.test.tsx
+++ b/static/src/components/__tests__/SatellitePanel.test.tsx
@@ -76,4 +76,48 @@ describe('SatellitePanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /Identify satellite tracks/ }));
     expect(onPredict).toHaveBeenCalledOnce();
   });
+
+  it('shows the requested epoch for a historical catalog response', () => {
+    const status = {
+      orbital_elements_cached: true,
+      analysis: {
+        association: 'predicted_not_pixel_detected',
+        catalog: {
+          source: 'https://satchecker.cps.iau.org/tools/tles-at-epoch/',
+          provider: 'seiza_mirror',
+          state: 'downloaded',
+          query_epoch: '2025-10-18T12:52:12.790Z',
+        },
+        exposure: { duration_seconds: 60 },
+        tracks: [],
+        risk: {
+          track_count: 0,
+          potentially_bright_count: 0,
+          high_risk_count: 0,
+          maximum_bright_trail_risk: 0,
+          pixel_alignment_attempted: true,
+          pixel_aligned_count: 0,
+          pixel_aligned_high_risk_count: 0,
+          reject_recommended: false,
+        },
+      },
+    } as unknown as SatelliteAnalysisStatus;
+
+    render(
+      <SatellitePanel
+        status={status}
+        isLoading={false}
+        isPredicting={false}
+        overlayVisible={false}
+        onToggleOverlay={vi.fn()}
+        onPredict={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Elements for')).toBeInTheDocument();
+    expect(screen.getByText('Element source')).toBeInTheDocument();
+    expect(screen.getByText('Seiza mirror')).toBeInTheDocument();
+    expect(screen.getByText(new Date('2025-10-18T12:52:12.790Z').toLocaleString()))
+      .toBeInTheDocument();
+  });
 });

--- a/static/src/hooks/__tests__/useSpatialScan.test.tsx
+++ b/static/src/hooks/__tests__/useSpatialScan.test.tsx
@@ -84,13 +84,13 @@ describe('useSpatialScan', () => {
     const { result } = renderHook(() => useSpatialScan('test', 42, 'R'), { wrapper });
 
     act(() => {
-      result.current.start(undefined);
+      result.current.start(true);
     });
 
     await waitFor(() => {
       expect(result.current.isRunning).toBe(true);
     });
-    expect(postedBody).toMatchObject({ target_id: 42, filter_name: 'R' });
+    expect(postedBody).toMatchObject({ target_id: 42, filter_name: 'R', force: true });
     expect(result.current.status?.progress.total).toBe(12);
   });
 

--- a/static/src/hooks/useSpatialScan.ts
+++ b/static/src/hooks/useSpatialScan.ts
@@ -4,8 +4,8 @@ import { apiClient } from '../api/client';
 import type { SpatialScanStatus } from '../api/types';
 
 /**
- * Trigger and monitor the server-side quality scan (spatial metrics plus
- * pixel-derived astrometry).
+ * Trigger and monitor the server-side quality scan (spatial metrics,
+ * pixel-derived astrometry, and cached satellite catalogs).
  *
  * The scan reads every FITS file of the target and runs star detection, so it
  * takes seconds per frame; the server runs it in the background and this hook

--- a/tests/integration_astrometry_capabilities.rs
+++ b/tests/integration_astrometry_capabilities.rs
@@ -95,7 +95,7 @@ async fn capabilities_and_validation_report_a_partial_data_directory() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["data"]["seiza_version"], "0.10.0");
+    assert_eq!(body["data"]["seiza_version"], "0.11.1");
     assert_eq!(body["data"]["seiza_fits_version"], "0.1.6");
     assert_eq!(
         body["data"]["resources"]["objects"]["status"],

--- a/tests/integration_spatial_scan.rs
+++ b/tests/integration_spatial_scan.rs
@@ -337,7 +337,7 @@ async fn cached_astrometry_reduces_score_and_marks_regrade_reason() {
             "modified_subsec_nanos": source_modified.subsec_nanos()
         },
         "solver_provenance": {
-            "seiza_version": "0.10.0", "detection_backend": "mtf_u8",
+            "seiza_version": "0.11.1", "detection_backend": "mtf_u8",
             "star_catalog": {
                 "name": "stars", "path": "/data/stars.bin", "format": "test",
                 "size_bytes": 1, "modified_unix_seconds": 1


### PR DESCRIPTION
## Summary

- delegate current-vs-historical and cache/mirror/origin selection entirely to `seiza_satellites::OrbitalCatalogSource`
- use the published `seiza 0.11.1` and `seiza-satellites 0.3.1` crates, retaining `seiza-fits 0.1.6`
- let both the image-detail action and the explicit server quality scan seed current or historical orbital data on demand
- keep read-only sequence requests and CLI regrade workflows cache-only
- make forced quality scans rebuild satellite predictions from the currently preferred snapshot; expose `force_satellites` for targeted API invalidation
- persist and expose typed provider provenance plus the historical query epoch
- show the element source and historical epoch in the image-detail satellite panel
- bump persisted astrometry/satellite version fingerprints and test contracts so old cached results are invalidated correctly
- update application, screening, satellite, and maintainer documentation

## Validation

- `cargo check --lib --no-default-features`
- `cargo test --lib --no-default-features` (299 passed, 5 ignored; existing feature-disabled OpenCV warnings remain)
- full default-feature `cargo test` (303 library tests and 35 integration tests passed; 5 ignored)
- frontend ESLint
- frontend Vitest suite (85 passed)
- frontend production build
- local release-mode Playwright astrometry suite (6 passed), including real FITS solving, cached reload, overlay rendering, zoom, and pan

The temporary git pins are gone; Cargo.lock resolves the published crates.io releases and checksums.