### PR TITLE
Update Seiza dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Implementation tracker and design rationale: [MULTI_DB_PLAN.md](./MULTI_DB_PLAN.
 
 ### Satellite track prediction (2026-07)
 - **Boundary**: `src/satellites.rs` uses Seiza 0.11.2 and
-  `seiza-satellites 0.4.0` to predict named orbital crossings through one solved
+  `seiza-satellites 0.4.1` to predict named orbital crossings through one solved
   exposure. `association = predicted_not_pixel_detected` is intentional:
   never present a catalog prediction as a trail found in image pixels.
 - **Inputs**: a solved WCS, UTC shutter bounds (`DATE-BEG`/`DATE-OBS` plus

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,8 @@ Implementation tracker and design rationale: [MULTI_DB_PLAN.md](./MULTI_DB_PLAN.
   persistent reload, rendered object overlay, and keyboard toggling.
 
 ### Satellite track prediction (2026-07)
-- **Boundary**: `src/satellites.rs` uses Seiza 0.11.1 and
-  `seiza-satellites 0.3.1` to predict named orbital crossings through one solved
+- **Boundary**: `src/satellites.rs` uses Seiza 0.11.2 and
+  `seiza-satellites 0.4.0` to predict named orbital crossings through one solved
   exposure. `association = predicted_not_pixel_detected` is intentional:
   never present a catalog prediction as a trail found in image pixels.
 - **Inputs**: a solved WCS, UTC shutter bounds (`DATE-BEG`/`DATE-OBS` plus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,13 +174,12 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.33"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c1f86859c1af3d514fa19e8323147ff10ea98684e6c7b307912509f50e67b2"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
- "futures-core",
  "pin-project-lite",
  "tokio",
 ]
@@ -734,13 +733,15 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.32"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680dc087785c5230f8e8843e2e57ac7c1c90488b6a91b88caa265410568f441b"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
  "memchr",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -1118,7 +1119,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1400,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2886,7 +2887,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.16",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4021,7 +4022,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4534,7 +4535,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4674,9 +4675,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seiza"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae60585486f1a7014b9742aed92355945d7c230a8c6efc41f78f812c40f5830e"
+checksum = "fd14e5e6e43bd886cd1405b264bad730e473f20f5398ec5bd262aad6ae2cfff2"
 dependencies = [
  "directories",
  "image",
@@ -4693,6 +4694,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "seiza-download"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adbf5e69a4f516d755283941e1d6734191e6223456d3b4605a1d95c5f1b6753"
+dependencies = [
+ "async-compression",
+ "directories",
+ "fs2",
+ "futures-util",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "seiza-fits"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4703,21 +4723,21 @@ dependencies = [
 
 [[package]]
 name = "seiza-satellites"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70209e084b6ad9695971609523e7f43e37c6543c76e155d016c5a07d60d9592b"
+checksum = "012cbba788bd95bd9a846500ed48312b8b75698ea5b080e1cbd3b076944a2ee6"
 dependencies = [
  "directories",
  "fs2",
  "reqwest 0.12.28",
  "satkit",
  "seiza",
+ "seiza-download",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.16",
  "tokio",
- "zstd",
 ]
 
 [[package]]
@@ -5622,7 +5642,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5805,9 +5825,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6118,7 +6138,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.16",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2887,7 +2887,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.16",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4022,7 +4022,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4535,7 +4535,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4723,9 +4723,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-satellites"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012cbba788bd95bd9a846500ed48312b8b75698ea5b080e1cbd3b076944a2ee6"
+checksum = "4ebec6e24911c969ddba9f55d8b527773217f539f53007ae74f87886658e54a3"
 dependencies = [
  "directories",
  "fs2",
@@ -5642,7 +5642,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6138,7 +6138,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.16",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ regex = "1.12"
 byteorder = "1.5"
 seiza = "0.11.2"
 seiza-fits = "=0.1.6"
-seiza-satellites = { version = "0.4.0", features = ["serde"] }
+seiza-satellites = { version = "0.4.1", features = ["serde"] }
 bumpalo = { version = "3.20", features = ["collections"] }
 image = "0.25"
 imageproc = "0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ anyhow = "1.0"
 chrono = "0.4"
 regex = "1.12"
 byteorder = "1.5"
-seiza = "0.11.1"
+seiza = "0.11.2"
 seiza-fits = "=0.1.6"
-seiza-satellites = { version = "0.3.1", features = ["serde"] }
+seiza-satellites = { version = "0.4.0", features = ["serde"] }
 bumpalo = { version = "3.20", features = ["collections"] }
 image = "0.25"
 imageproc = "0.27"

--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ toggles the overlay instead of solving again.
 
 ### Install the Seiza catalogs
 
-PSF Guard embeds Seiza 0.11.1's solver but does not bundle its multi-gigabyte
+PSF Guard embeds Seiza 0.11.2's solver but does not bundle its multi-gigabyte
 catalog data. Install the `seiza` CLI from the
 [Seiza releases](https://github.com/theatrus/seiza/releases) or with
-`cargo install seiza-cli --version 0.11.1`, then download a bundle once:
+`cargo install seiza-cli --version 0.11.2`, then download a bundle once:
 
 ```bash
 # Recommended: choose a bundle interactively and install it in Seiza's

--- a/docs/SATELLITES.md
+++ b/docs/SATELLITES.md
@@ -8,7 +8,7 @@ matching linear trail, and labels the candidate with the satellite name and
 NORAD identity supplied by the orbital catalog.
 
 The current integration uses `seiza 0.11.2`, `seiza-fits 0.1.6`, and
-`seiza-satellites 0.4.0`.
+`seiza-satellites 0.4.1`.
 
 ## Evidence boundary
 

--- a/docs/SATELLITES.md
+++ b/docs/SATELLITES.md
@@ -7,8 +7,8 @@ clipped orbital path inside the sensor, searches the nearby FITS pixels for a
 matching linear trail, and labels the candidate with the satellite name and
 NORAD identity supplied by the orbital catalog.
 
-The current integration uses `seiza 0.11.1`, `seiza-fits 0.1.6`, and
-`seiza-satellites 0.3.1`.
+The current integration uses `seiza 0.11.2`, `seiza-fits 0.1.6`, and
+`seiza-satellites 0.4.0`.
 
 ## Evidence boundary
 

--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -10,7 +10,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-pub const SEIZA_VERSION: &str = "0.11.1";
+pub const SEIZA_VERSION: &str = "0.11.2";
 pub const SEIZA_FITS_VERSION: &str = "0.1.6";
 
 pub type AstrometryResourcePath = Result<Option<PathBuf>, seiza::data_paths::DataPathError>;

--- a/src/satellites.rs
+++ b/src/satellites.rs
@@ -26,7 +26,7 @@ use crate::astrometry::{
 use crate::astrometry_headers::FitsAstrometryHeaders;
 use crate::FitsImage;
 
-pub const SEIZA_SATELLITES_VERSION: &str = "0.3.1";
+pub const SEIZA_SATELLITES_VERSION: &str = "0.4.0";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -73,11 +73,11 @@ pub struct SatelliteCatalogSnapshot {
 /// Shared orbital-element source. The network is touched only by
 /// [`load_for_exposure`](Self::load_for_exposure), which is called by explicit
 /// user-triggered server work. Provider selection belongs to
-/// `seiza-satellites`; CLI regrading remains cache-only.
+/// `seiza-satellites`; its shared advisory lock serializes cache publication,
+/// while CLI regrading remains cache-only.
 pub struct SatelliteContext {
     source: OrbitalCatalogSource,
     configured_elements: Option<PathBuf>,
-    refresh_mutex: tokio::sync::Mutex<()>,
 }
 
 impl SatelliteContext {
@@ -86,7 +86,6 @@ impl SatelliteContext {
         Ok(Self {
             source,
             configured_elements,
-            refresh_mutex: tokio::sync::Mutex::new(()),
         })
     }
 
@@ -104,18 +103,20 @@ impl SatelliteContext {
     /// Load a configured file or resolve orbital elements appropriate to this
     /// exposure. This is the only network-capable path; provider choice and
     /// durable retention are delegated to `seiza-satellites`.
-    pub async fn load_for_exposure(&self, path: &Path) -> Result<SatelliteCatalogSnapshot, String> {
-        let _guard = self.refresh_mutex.lock().await;
+    pub async fn load_for_exposure(
+        self: Arc<Self>,
+        path: PathBuf,
+    ) -> Result<SatelliteCatalogSnapshot, String> {
         if let Some(path) = self.configured_elements.as_deref() {
             return load_local_catalog(path, SatelliteCatalogState::Configured, None);
         }
-        let headers = FitsAstrometryHeaders::from_path(path)
+        let headers = FitsAstrometryHeaders::from_path(&path)
             .map_err(|error| format!("failed to read FITS exposure headers: {error}"))?;
         let (exposure, _) = single_exposure(&headers)?;
 
         let load = self
             .source
-            .load_for_exposure(&exposure)
+            .load_at(exposure.midpoint())
             .await
             .map_err(|error| error.to_string())?;
         Ok(snapshot_from_orbital_load(load))

--- a/src/satellites.rs
+++ b/src/satellites.rs
@@ -26,7 +26,7 @@ use crate::astrometry::{
 use crate::astrometry_headers::FitsAstrometryHeaders;
 use crate::FitsImage;
 
-pub const SEIZA_SATELLITES_VERSION: &str = "0.4.0";
+pub const SEIZA_SATELLITES_VERSION: &str = "0.4.1";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -103,20 +103,17 @@ impl SatelliteContext {
     /// Load a configured file or resolve orbital elements appropriate to this
     /// exposure. This is the only network-capable path; provider choice and
     /// durable retention are delegated to `seiza-satellites`.
-    pub async fn load_for_exposure(
-        self: Arc<Self>,
-        path: PathBuf,
-    ) -> Result<SatelliteCatalogSnapshot, String> {
+    pub async fn load_for_exposure(&self, path: &Path) -> Result<SatelliteCatalogSnapshot, String> {
         if let Some(path) = self.configured_elements.as_deref() {
             return load_local_catalog(path, SatelliteCatalogState::Configured, None);
         }
-        let headers = FitsAstrometryHeaders::from_path(&path)
+        let headers = FitsAstrometryHeaders::from_path(path)
             .map_err(|error| format!("failed to read FITS exposure headers: {error}"))?;
         let (exposure, _) = single_exposure(&headers)?;
 
         let load = self
             .source
-            .load_at(exposure.midpoint())
+            .load_for_exposure(&exposure)
             .await
             .map_err(|error| error.to_string())?;
         Ok(snapshot_from_orbital_load(load))

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -210,7 +210,7 @@ pub async fn predict_image_satellites(
         })?
         .map_err(AppError::BadRequest)?;
     let astrometry_analysis = {
-        let _solve_guard = ctx.astrometry_solve_mutex.lock().await;
+        let _solve_guard = Arc::clone(&ctx.astrometry_solve_mutex).lock_owned().await;
         let solve_path = fits_path.clone();
         let solve_cache = cache_dir.clone();
         tokio::task::spawn_blocking(move || {
@@ -241,11 +241,18 @@ pub async fn predict_image_satellites(
         .map_err(AppError::BadRequest)?
     };
 
-    state
-        .satellites
-        .load_for_exposure(&fits_path)
-        .await
-        .map_err(AppError::BadRequest)?;
+    let catalog_context = Arc::clone(&state.satellites);
+    let catalog_path = fits_path.clone();
+    let runtime_handle = tokio::runtime::Handle::current();
+    // Keep the provider cascade's borrowed response internals out of Axum's
+    // higher-ranked `Send` check. I/O still runs on the current Tokio runtime;
+    // the blocking worker only owns and drives that future to completion.
+    tokio::task::spawn_blocking(move || {
+        runtime_handle.block_on(catalog_context.load_for_exposure(catalog_path))
+    })
+    .await
+    .map_err(|error| AppError::InternalError(format!("Satellite catalog task failed: {error}")))?
+    .map_err(AppError::BadRequest)?;
     let satellite_context = Arc::clone(&state.satellites);
     let prediction_path = fits_path;
     let prediction_cache = cache_dir;
@@ -2888,9 +2895,10 @@ pub async fn start_spatial_scan(
                                     None
                                 };
                             if *need_satellite && solved {
-                                match runtime_handle
-                                    .block_on(satellite_context.load_for_exposure(&item.fits_path))
-                                {
+                                match runtime_handle.block_on(
+                                    Arc::clone(&satellite_context)
+                                        .load_for_exposure(item.fits_path.clone()),
+                                ) {
                                     Ok(snapshot) => {
                                         if let Err(error) = crate::satellites::predict_tracks(
                                             item.image_id,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -210,7 +210,7 @@ pub async fn predict_image_satellites(
         })?
         .map_err(AppError::BadRequest)?;
     let astrometry_analysis = {
-        let _solve_guard = Arc::clone(&ctx.astrometry_solve_mutex).lock_owned().await;
+        let _solve_guard = ctx.astrometry_solve_mutex.lock().await;
         let solve_path = fits_path.clone();
         let solve_cache = cache_dir.clone();
         tokio::task::spawn_blocking(move || {
@@ -241,18 +241,11 @@ pub async fn predict_image_satellites(
         .map_err(AppError::BadRequest)?
     };
 
-    let catalog_context = Arc::clone(&state.satellites);
-    let catalog_path = fits_path.clone();
-    let runtime_handle = tokio::runtime::Handle::current();
-    // Keep the provider cascade's borrowed response internals out of Axum's
-    // higher-ranked `Send` check. I/O still runs on the current Tokio runtime;
-    // the blocking worker only owns and drives that future to completion.
-    tokio::task::spawn_blocking(move || {
-        runtime_handle.block_on(catalog_context.load_for_exposure(catalog_path))
-    })
-    .await
-    .map_err(|error| AppError::InternalError(format!("Satellite catalog task failed: {error}")))?
-    .map_err(AppError::BadRequest)?;
+    state
+        .satellites
+        .load_for_exposure(&fits_path)
+        .await
+        .map_err(AppError::BadRequest)?;
     let satellite_context = Arc::clone(&state.satellites);
     let prediction_path = fits_path;
     let prediction_cache = cache_dir;
@@ -2895,10 +2888,9 @@ pub async fn start_spatial_scan(
                                     None
                                 };
                             if *need_satellite && solved {
-                                match runtime_handle.block_on(
-                                    Arc::clone(&satellite_context)
-                                        .load_for_exposure(item.fits_path.clone()),
-                                ) {
+                                match runtime_handle
+                                    .block_on(satellite_context.load_for_exposure(&item.fits_path))
+                                {
                                     Ok(snapshot) => {
                                         if let Err(error) = crate::satellites::predict_tracks(
                                             item.image_id,

--- a/static/e2e/astrometry-capabilities.spec.ts
+++ b/static/e2e/astrometry-capabilities.spec.ts
@@ -9,7 +9,7 @@ test('partial data directory reports usable and missing Seiza resources', async 
   const body = await response.json();
   expect(body.success).toBe(true);
   expect(body.data).toMatchObject({
-    seiza_version: '0.11.1',
+    seiza_version: '0.11.2',
     seiza_fits_version: '0.1.6',
     features: {
       object_association: true,

--- a/static/e2e/image-astrometry.spec.ts
+++ b/static/e2e/image-astrometry.spec.ts
@@ -129,7 +129,7 @@ test('keeps catalog-only association distinct when a real FITS file has no WCS',
     mode: 'hinted',
     catalog_scope: 'solved_footprint',
     solver_provenance: {
-      seiza_version: '0.11.1',
+      seiza_version: '0.11.2',
       detection_backend: 'mtf_u8',
       star_catalog: { format: 'SEIZAST2' },
     },

--- a/tests/integration_astrometry_capabilities.rs
+++ b/tests/integration_astrometry_capabilities.rs
@@ -95,7 +95,7 @@ async fn capabilities_and_validation_report_a_partial_data_directory() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["data"]["seiza_version"], "0.11.1");
+    assert_eq!(body["data"]["seiza_version"], "0.11.2");
     assert_eq!(body["data"]["seiza_fits_version"], "0.1.6");
     assert_eq!(
         body["data"]["resources"]["objects"]["status"],

--- a/tests/integration_spatial_scan.rs
+++ b/tests/integration_spatial_scan.rs
@@ -337,7 +337,7 @@ async fn cached_astrometry_reduces_score_and_marks_regrade_reason() {
             "modified_subsec_nanos": source_modified.subsec_nanos()
         },
         "solver_provenance": {
-            "seiza_version": "0.11.1", "detection_backend": "mtf_u8",
+            "seiza_version": "0.11.2", "detection_backend": "mtf_u8",
             "star_catalog": {
                 "name": "stars", "path": "/data/stars.bin", "format": "test",
                 "size_bytes": 1, "modified_unix_seconds": 1


### PR DESCRIPTION
## What

- Update Seiza from 0.11.1 to 0.11.2.
- Update seiza-satellites from 0.3.1 to 0.4.1.
- Refresh the lockfile, runtime provenance constants, documentation, and version assertions.
- Remove PSF Guard redundant refresh mutex now that cache publication is locked by the satellite crate.

## Why

seiza-satellites 0.4 centralizes its download and durable-cache behavior through seiza-download and owns cross-process advisory locking. PSF Guard should use that implementation directly instead of serializing catalog refreshes a second time.

Version 0.4.1 also makes the network-capable resolver futures Send and adds compile-time guards against regressions. PSF Guard can therefore await the provider directly in its Axum handler; no blocking-worker workaround is needed.

## Impact

- Existing astrometry and satellite cache entries are invalidated through the updated dependency provenance versions and will be recomputed on demand.
- Satellite predictions keep the same explicit on-demand and quality-scan behavior.
- No database schema or API shape changes.

## Checks

- cargo fmt --check
- cargo check --lib --no-default-features
- cargo check --lib
- cargo clippy --all-targets -- -D warnings
- cargo test
- cargo test --no-default-features
- npm run lint -- --max-warnings=0
- npm run test -- --run (85 tests)
- npm run build
- npm run test:e2e -- e2e/astrometry-capabilities.spec.ts e2e/image-astrometry.spec.ts (6 tests)