### PR TITLE
Use published Seiza crates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,8 +122,8 @@ Implementation tracker and design rationale: [MULTI_DB_PLAN.md](./MULTI_DB_PLAN.
   persistent reload, rendered object overlay, and keyboard toggling.
 
 ### Satellite track prediction (2026-07)
-- **Boundary**: `src/satellites.rs` uses Seiza 0.11.2 and
-  `seiza-satellites 0.4.1` to predict named orbital crossings through one solved
+- **Boundary**: `src/satellites.rs` uses Seiza 0.12.0 and
+  `seiza-satellites 0.4.2` to predict named orbital crossings through one solved
   exposure. `association = predicted_not_pixel_detected` is intentional:
   never present a catalog prediction as a trail found in image pixels.
 - **Inputs**: a solved WCS, UTC shutter bounds (`DATE-BEG`/`DATE-OBS` plus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4693,7 +4693,8 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "seiza"
 version = "0.12.0"
-source = "git+https://github.com/theatrus/seiza?rev=5bb77362a2028ef9819687b9db19cc53728bd3da#5bb77362a2028ef9819687b9db19cc53728bd3da"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692368a038b482ccdd1eda4af18dd57a4703eb96e11ef15aeb722ee344d4c0ee"
 dependencies = [
  "directories",
  "image",
@@ -4713,7 +4714,8 @@ dependencies = [
 [[package]]
 name = "seiza-background"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza?rev=5bb77362a2028ef9819687b9db19cc53728bd3da#5bb77362a2028ef9819687b9db19cc53728bd3da"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0415eddd60c1bdfc01778c3563cb669fac86809587bee35f12aee9d4d316977"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -4724,7 +4726,8 @@ dependencies = [
 [[package]]
 name = "seiza-deconvolution"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza?rev=5bb77362a2028ef9819687b9db19cc53728bd3da#5bb77362a2028ef9819687b9db19cc53728bd3da"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaceca0f83c0e33737d4180166c0a50ac0af4b17c3621f44346872f134871cd0"
 dependencies = [
  "rayon",
  "serde",
@@ -4753,7 +4756,8 @@ dependencies = [
 [[package]]
 name = "seiza-fits"
 version = "0.2.0"
-source = "git+https://github.com/theatrus/seiza?rev=5bb77362a2028ef9819687b9db19cc53728bd3da#5bb77362a2028ef9819687b9db19cc53728bd3da"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f9f198ba3b87cd50c90f7f87e70ad1de615b0c5b2f87324705af5f64d8b133"
 dependencies = [
  "multiversion",
  "seiza-stretch",
@@ -4788,7 +4792,8 @@ dependencies = [
 [[package]]
 name = "seiza-stacking"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza?rev=5bb77362a2028ef9819687b9db19cc53728bd3da#5bb77362a2028ef9819687b9db19cc53728bd3da"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef95b239b9df2eb4819692c9f06562289e0ec186796e2f0b4798cd83655335f"
 dependencies = [
  "rayon",
  "seiza",
@@ -4803,12 +4808,14 @@ dependencies = [
 [[package]]
 name = "seiza-stats"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza?rev=5bb77362a2028ef9819687b9db19cc53728bd3da#5bb77362a2028ef9819687b9db19cc53728bd3da"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02427eea0eebef160eba79502519b73272924ccea855462292006af2320ef9e2"
 
 [[package]]
 name = "seiza-stretch"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza?rev=5bb77362a2028ef9819687b9db19cc53728bd3da#5bb77362a2028ef9819687b9db19cc53728bd3da"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0b6b7172999270f4b4a4446179fcf29be4d289406ef362a6a2b83acb9889de"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -4819,7 +4826,8 @@ dependencies = [
 [[package]]
 name = "seiza-xisf"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza?rev=5bb77362a2028ef9819687b9db19cc53728bd3da#5bb77362a2028ef9819687b9db19cc53728bd3da"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c58629034c4197cf415a86ad91fc044dbf9f1ea892ec5617d611e530af990c"
 dependencies = [
  "flate2",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,13 +35,10 @@ seiza = "0.12.0"
 seiza-imgproc = "0.2.0"
 seiza-fits = "=0.2.0"
 seiza-satellites = { version = "0.4.2", features = ["serde"] }
-# Temporary pins to Seiza main for stacking, color composition, background
-# extraction, deconvolution, and interactive stretching until these support
-# crates are published.
-seiza-stacking = { git = "https://github.com/theatrus/seiza", rev = "5bb77362a2028ef9819687b9db19cc53728bd3da" }
-seiza-stretch = { git = "https://github.com/theatrus/seiza", rev = "5bb77362a2028ef9819687b9db19cc53728bd3da" }
-seiza-background = { git = "https://github.com/theatrus/seiza", rev = "5bb77362a2028ef9819687b9db19cc53728bd3da" }
-seiza-deconvolution = { git = "https://github.com/theatrus/seiza", rev = "5bb77362a2028ef9819687b9db19cc53728bd3da" }
+seiza-stacking = "0.1.0"
+seiza-stretch = "0.1.0"
+seiza-background = "0.1.0"
+seiza-deconvolution = "0.1.0"
 sha2 = "0.11"
 rayon = "1"
 bumpalo = { version = "3.20", features = ["collections"] }
@@ -101,12 +98,3 @@ overflow-checks = false
 
 [build-dependencies]
 tauri-build = { version = "2.6.2", features = [] }
-
-# Interim source unification for the unreleased seiza-stacking crate. Its
-# workspace path dependencies otherwise introduce second copies of these
-# released crates from Git, which cargo vendor cannot represent alongside the
-# crates.io packages with the same name and version. Remove this patch when
-# seiza-stacking is published.
-[patch.crates-io]
-seiza = { git = "https://github.com/theatrus/seiza", rev = "5bb77362a2028ef9819687b9db19cc53728bd3da" }
-seiza-fits = { git = "https://github.com/theatrus/seiza", rev = "5bb77362a2028ef9819687b9db19cc53728bd3da" }

--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ toggles the overlay instead of solving again.
 
 ### Install the Seiza catalogs
 
-PSF Guard embeds Seiza 0.11.2's solver but does not bundle its multi-gigabyte
+PSF Guard embeds Seiza 0.12.0's solver but does not bundle its multi-gigabyte
 catalog data. Install the `seiza` CLI from the
 [Seiza releases](https://github.com/theatrus/seiza/releases) or with
-`cargo install seiza-cli --version 0.11.2`, then download a bundle once:
+`cargo install seiza-cli --version 0.12.0`, then download a bundle once:
 
 ```bash
 # Recommended: choose a bundle interactively and install it in Seiza's

--- a/docs/SATELLITES.md
+++ b/docs/SATELLITES.md
@@ -7,8 +7,8 @@ clipped orbital path inside the sensor, searches the nearby FITS pixels for a
 matching linear trail, and labels the candidate with the satellite name and
 NORAD identity supplied by the orbital catalog.
 
-The current integration uses `seiza 0.11.2`, `seiza-fits 0.1.6`, and
-`seiza-satellites 0.4.1`.
+The current integration uses `seiza 0.12.0`, `seiza-fits 0.2.0`, and
+`seiza-satellites 0.4.2`.
 
 ## Evidence boundary
 

--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -10,8 +10,8 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-pub const SEIZA_VERSION: &str = "0.11.2";
-pub const SEIZA_FITS_VERSION: &str = "0.1.6";
+pub const SEIZA_VERSION: &str = "0.12.0";
+pub const SEIZA_FITS_VERSION: &str = "0.2.0";
 
 pub type AstrometryResourcePath = Result<Option<PathBuf>, seiza::data_paths::DataPathError>;
 

--- a/src/satellites.rs
+++ b/src/satellites.rs
@@ -26,7 +26,7 @@ use crate::astrometry::{
 use crate::astrometry_headers::FitsAstrometryHeaders;
 use crate::FitsImage;
 
-pub const SEIZA_SATELLITES_VERSION: &str = "0.4.1";
+pub const SEIZA_SATELLITES_VERSION: &str = "0.4.2";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -41,7 +41,7 @@ use crate::server::extract::DbContext;
 use crate::server::handlers::AppError;
 use crate::server::state::AppState;
 
-pub const SEIZA_STACKING_VERSION: &str = "0.1.0-git-b9bdcd1";
+pub const SEIZA_STACKING_VERSION: &str = "0.1.0";
 /// Bump whenever stack admission, rendering, or persisted artifact semantics
 /// change. This deliberately versions PSF Guard policy separately from Seiza.
 const STACK_PREVIEW_CACHE_VERSION: u32 = 5;

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -42,7 +42,7 @@ use crate::server::state::AppState;
 
 const STACK_COLOR_CACHE_VERSION: u32 = 5;
 const COLOR_INPUT_CACHE_VERSION: u32 = 1;
-const SEIZA_BACKGROUND_VERSION: &str = "0.1.0-git-b9bdcd1";
+const SEIZA_BACKGROUND_VERSION: &str = "0.1.0";
 const MAX_REGISTRATION_RMS_PIXELS: f64 = 2.0;
 const COLOR_BYTES_PER_PIXEL: u64 = 64;
 const COLOR_DECONVOLUTION_BYTES_PER_PIXEL: u64 = 40;

--- a/src/server/stack_preview/stretch.rs
+++ b/src/server/stack_preview/stretch.rs
@@ -44,7 +44,7 @@ const STRETCH_BYTES_PER_SAMPLE: u64 = 16;
 const DECONVOLUTION_BYTES_PER_SAMPLE: u64 = 40;
 const LINEAR_BLACK_PERCENTILE: f64 = 0.001;
 const LINEAR_WHITE_PERCENTILE: f64 = 0.999;
-pub(super) const SEIZA_STRETCH_VERSION: &str = "0.1.0-git-b9bdcd1";
+pub(super) const SEIZA_STRETCH_VERSION: &str = "0.1.0";
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StackDeconvolutionResult {

--- a/static/e2e/astrometry-capabilities.spec.ts
+++ b/static/e2e/astrometry-capabilities.spec.ts
@@ -9,8 +9,8 @@ test('partial data directory reports usable and missing Seiza resources', async 
   const body = await response.json();
   expect(body.success).toBe(true);
   expect(body.data).toMatchObject({
-    seiza_version: '0.11.2',
-    seiza_fits_version: '0.1.6',
+    seiza_version: '0.12.0',
+    seiza_fits_version: '0.2.0',
     features: {
       object_association: true,
       object_name_search: false,

--- a/static/e2e/image-astrometry.spec.ts
+++ b/static/e2e/image-astrometry.spec.ts
@@ -129,7 +129,7 @@ test('keeps catalog-only association distinct when a real FITS file has no WCS',
     mode: 'hinted',
     catalog_scope: 'solved_footprint',
     solver_provenance: {
-      seiza_version: '0.11.2',
+      seiza_version: '0.12.0',
       detection_backend: 'mtf_u8',
       star_catalog: { format: 'SEIZAST2' },
     },

--- a/tests/integration_astrometry_capabilities.rs
+++ b/tests/integration_astrometry_capabilities.rs
@@ -95,8 +95,8 @@ async fn capabilities_and_validation_report_a_partial_data_directory() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["data"]["seiza_version"], "0.11.2");
-    assert_eq!(body["data"]["seiza_fits_version"], "0.1.6");
+    assert_eq!(body["data"]["seiza_version"], "0.12.0");
+    assert_eq!(body["data"]["seiza_fits_version"], "0.2.0");
     assert_eq!(
         body["data"]["resources"]["objects"]["status"],
         serde_json::to_value(AstrometryResourceStatus::Available).unwrap()

--- a/tests/integration_spatial_scan.rs
+++ b/tests/integration_spatial_scan.rs
@@ -337,7 +337,7 @@ async fn cached_astrometry_reduces_score_and_marks_regrade_reason() {
             "modified_subsec_nanos": source_modified.subsec_nanos()
         },
         "solver_provenance": {
-            "seiza_version": "0.11.2", "detection_backend": "mtf_u8",
+            "seiza_version": "0.12.0", "detection_backend": "mtf_u8",
             "star_catalog": {
                 "name": "stars", "path": "/data/stars.bin", "format": "test",
                 "size_bytes": 1, "modified_unix_seconds": 1


### PR DESCRIPTION
## Summary

- replace the remaining Seiza support-crate Git pins with published `seiza-stacking`, `seiza-stretch`, `seiza-background`, and `seiza-deconvolution` 0.1.0 crates
- remove the temporary crates.io patch block while keeping `main`'s `seiza-imgproc` dependency and exact `seiza-fits` pin
- update cache provenance, API version reports, tests, and user docs for Seiza 0.12.0, `seiza-fits` 0.2.0, and `seiza-satellites` 0.4.2

## Why

The support crates are now published. Registry dependencies remove the interim source split and let package builders resolve one checksummed crates.io source for each Seiza crate.

## Validation

- `cargo check --locked --no-default-features`
- `cargo test --locked --no-default-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npm test` — 91 passed
- `npm run lint`
- `npm run build`
- focused Playwright astrometry and stack-preview suite — 8 passed
- `git diff --check`
