### PR TITLE
Make import merge into existing structure, with preview-confirm UI

### DIFF
--- a/CREATE_IMPORT_PLAN.md
+++ b/CREATE_IMPORT_PLAN.md
@@ -188,6 +188,31 @@ Import guesses; the user fixes them.
 
 ---
 
+## 8. Safety: merge-aware import + preview-confirm (2026-07-22) ☑
+
+Shipped after a real-world incident: the per-DB Import button ran a
+ground-zero import against an existing scheduler database, synthesizing
+duplicate projects/targets with no confirmation.
+
+- ☑ **Merge phase**: after basename dedup, frames attach to EXISTING targets
+  — exact (case-insensitive) OBJECT-name match first, else nearest target
+  within `match_radius_deg` (default 0.5°). Attached frames reuse the
+  target's project/profile, reuse the profile's exposure template, and reuse
+  a matching exposure plan (bumping `acquired`) or add one. Only unmatched
+  frames reach the ground-zero grouping. `--no-attach` restores the old
+  behavior deliberately.
+- ☑ A fully-attached import no longer resolves/creates an import profile —
+  multi-profile databases import cleanly when everything matches.
+- ☑ **UI preview-confirm**: the Import button now runs a dry-run first and
+  shows exactly what would happen (attached per existing target with match
+  kind, NEW projects, skip counts); nothing is written until the user
+  clicks "Import N frame(s)". Cancel writes nothing.
+- ☑ **Recovery**: `psf-guard remove-imported <db> [--dry-run]` deletes the
+  projects an import created (recognized by the `Imported by PSF Guard`
+  description marker) with their targets/plans/rule weights/images —
+  attached frames in pre-existing projects are never touched.
+- ☑ Backfill scans attached targets too (cached frames skip, cost ∝ new).
+
 ## Phasing
 
 1. **P0** §1 bootstrap module + golden-schema test. ☑

--- a/README.md
+++ b/README.md
@@ -493,7 +493,10 @@ psf-guard screen-fits ./lights --format json         # or table, csv
 
 # Create a new Target Scheduler database from folders of FITS lights
 psf-guard create-db new.sqlite ./lights1 ./lights2 [--name "My Rig"] [--dry-run]
-psf-guard import <slug-or-path> ./more-lights [--dry-run]   # top up later
+# Top up later: attaches to EXISTING targets (name/coordinate match); only
+# unmatched frames create new projects. Preview with --dry-run first.
+psf-guard import <slug-or-path> ./more-lights [--dry-run] [--no-attach]
+psf-guard remove-imported <slug-or-path> [--dry-run]  # undo an import's projects
 
 # Export ("take out") non-rejected lights for stacking — WBPP-style layout
 # <dest>/<target>/LIGHT/<filter>/; rejects are never exported

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,10 +81,11 @@ pub enum Commands {
 
     /// Import FITS folders into an existing Target Scheduler database.
     ///
-    /// Accepts a registry slug or a path to a .sqlite file. Grouping and
-    /// idempotency rules match `create-db`: frames whose basename is already
-    /// recorded in the database are skipped, so re-running after a new night
-    /// only adds the new subs.
+    /// Accepts a registry slug or a path to a .sqlite file. Frames whose
+    /// basename is already recorded are skipped; remaining frames attach to
+    /// EXISTING targets when the OBJECT name or coordinates match, and only
+    /// unmatched frames create new projects/targets. Use --dry-run first to
+    /// preview exactly what will happen.
     Import {
         /// Registry slug or path of the target database.
         db: String,
@@ -104,6 +105,37 @@ pub enum Commands {
         profile_id: Option<String>,
 
         /// Preview the plan and roll back without writing.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Do NOT attach frames to existing targets — synthesize new
+        /// structure for everything (ground-zero import).
+        #[arg(long)]
+        no_attach: bool,
+
+        /// Coordinate-match radius (degrees) for attaching to an existing
+        /// target.
+        #[arg(long, default_value_t = crate::commands::import::DEFAULT_MATCH_RADIUS_DEG)]
+        match_radius_deg: f64,
+
+        /// Path to the database registry JSON file (defaults to the platform
+        /// config directory).
+        #[arg(long)]
+        registry: Option<String>,
+    },
+
+    /// Remove everything a PSF Guard import created from a database.
+    ///
+    /// Deletes projects whose description carries the `Imported by PSF
+    /// Guard` marker, together with their targets, exposure plans, rule
+    /// weights, and acquired images. Frames that were ATTACHED to
+    /// pre-existing projects are not touched. Recovery hatch for an import
+    /// that should not have happened.
+    RemoveImported {
+        /// Registry slug or path of the database.
+        db: String,
+
+        /// Show what would be removed without writing.
         #[arg(long)]
         dry_run: bool,
 

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -28,6 +28,38 @@ pub fn main() -> Result<()> {
                 .with_context(|| format!("Failed to open database: {}", cli.database))?;
             list_projects(&conn)?;
         }
+        Commands::RemoveImported {
+            db,
+            dry_run,
+            registry,
+        } => {
+            use crate::db_registry::DbRegistry;
+            use rusqlite::OpenFlags;
+            use std::path::PathBuf;
+
+            let registry_path = match &registry {
+                Some(p) => PathBuf::from(p),
+                None => DbRegistry::default_path().context("resolving default registry path")?,
+            };
+            let reg = DbRegistry::load_or_init(&registry_path).ok();
+            let db_path = crate::commands::sync::resolve_db_path(reg.as_ref(), &db)?;
+            let mut conn = Connection::open_with_flags(
+                &db_path,
+                OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_URI,
+            )
+            .with_context(|| format!("opening database at {}", db_path.display()))?;
+
+            let (projects, targets, plans, images) =
+                crate::commands::import::remove_imported(&mut conn, dry_run)?;
+            println!(
+                "Remove-imported {}: {} project(s), {} target(s), {} plan(s), {} image row(s)",
+                if dry_run { "(dry-run)" } else { "(live)" },
+                projects,
+                targets,
+                plans,
+                images
+            );
+        }
         Commands::Export {
             db,
             dest,
@@ -141,6 +173,7 @@ pub fn main() -> Result<()> {
                 time_gap_days,
                 profile_id,
                 dry_run,
+                ..Default::default()
             };
             let outcome = import_frames(&mut conn, frames, &options)?;
             print_outcome(&outcome);
@@ -190,6 +223,8 @@ pub fn main() -> Result<()> {
             time_gap_days,
             profile_id,
             dry_run,
+            no_attach,
+            match_radius_deg,
             registry,
         } => {
             use crate::commands::import::{
@@ -227,6 +262,8 @@ pub fn main() -> Result<()> {
                 time_gap_days,
                 profile_id,
                 dry_run,
+                attach_existing: !no_attach,
+                match_radius_deg,
             };
             let outcome = import_frames(&mut conn, frames, &options)?;
             print_outcome(&outcome);

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -36,7 +36,18 @@ pub struct ImportOptions {
     pub profile_id: Option<String>,
     /// Build the plan and run every insert, then roll the transaction back.
     pub dry_run: bool,
+    /// Attach frames to EXISTING targets (matched by name, then by
+    /// coordinates) instead of synthesizing new structure for them. New
+    /// projects/targets are only created for frames nothing matches. This is
+    /// what keeps an import into a real scheduler database from duplicating
+    /// its projects — disable only for deliberate ground-zero imports.
+    pub attach_existing: bool,
+    /// Coordinate-match radius for attaching to an existing target, in
+    /// degrees of angular separation.
+    pub match_radius_deg: f64,
 }
+
+pub const DEFAULT_MATCH_RADIUS_DEG: f64 = 0.5;
 
 impl Default for ImportOptions {
     fn default() -> Self {
@@ -44,6 +55,8 @@ impl Default for ImportOptions {
             time_gap_days: DEFAULT_TIME_GAP_DAYS,
             profile_id: None,
             dry_run: false,
+            attach_existing: true,
+            match_radius_deg: DEFAULT_MATCH_RADIUS_DEG,
         }
     }
 }
@@ -56,6 +69,16 @@ pub struct ProjectSummary {
     pub frames: usize,
 }
 
+/// One existing target that received attached frames.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AttachSummary {
+    pub project: String,
+    pub target: String,
+    pub frames: usize,
+    /// `name` or `coordinates` — how the match was made.
+    pub matched_by: String,
+}
+
 #[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct ImportOutcome {
     pub scanned: usize,
@@ -63,6 +86,8 @@ pub struct ImportOutcome {
     pub non_light: usize,
     pub skipped_existing: usize,
     pub imported: usize,
+    /// Frames attached to targets that already existed in the database.
+    pub attached: usize,
     pub projects_created: usize,
     pub targets_created: usize,
     pub templates_created: usize,
@@ -71,9 +96,14 @@ pub struct ImportOutcome {
     pub profile_id: String,
     pub dry_run: bool,
     pub project_summaries: Vec<ProjectSummary>,
+    /// Existing targets that gained frames, for the preview/confirm UI.
+    pub attach_summaries: Vec<AttachSummary>,
     /// Target row ids created by this import (live runs only) — the server's
     /// post-import quality backfill iterates these.
     pub created_target_ids: Vec<i32>,
+    /// Existing target ids that gained frames (live runs only) — backfill
+    /// scans these too (cached frames are skipped, so cost ∝ new frames).
+    pub attached_target_ids: Vec<i32>,
 }
 
 /// Recursively collect `.fits` / `.fit` files (a bare file argument is
@@ -162,8 +192,54 @@ pub fn import_frames(
         }
     }
 
+    // Merge phase: attach frames to targets that already exist (matched by
+    // name, then coordinates). Only what's left falls through to the
+    // ground-zero grouping below. This is what keeps a re-import against a
+    // real scheduler database from duplicating its structure.
+    let mut fresh: Vec<FrameMeta> = Vec::new();
+    if options.attach_existing {
+        let existing_targets = load_existing_targets(&tx)?;
+        let mut attach: HashMap<usize, Vec<FrameMeta>> = HashMap::new();
+        let mut matched_by: HashMap<usize, &'static str> = HashMap::new();
+        for frame in lights {
+            match match_existing_target(&frame, &existing_targets, options.match_radius_deg) {
+                Some((idx, how)) => {
+                    attach.entry(idx).or_default().push(frame);
+                    matched_by.entry(idx).or_insert(how);
+                }
+                None => fresh.push(frame),
+            }
+        }
+
+        // Deterministic order for summaries and tests.
+        let mut attach: Vec<(usize, Vec<FrameMeta>)> = attach.into_iter().collect();
+        attach.sort_by_key(|(idx, _)| *idx);
+        for (idx, frames) in attach {
+            let target = &existing_targets[idx];
+            attach_frames_to_target(&tx, target, &frames, &mut outcome)?;
+            outcome.attached += frames.len();
+            outcome.attached_target_ids.push(target.id as i32);
+            outcome.attach_summaries.push(AttachSummary {
+                project: target.project_name.clone(),
+                target: target.name.clone(),
+                frames: frames.len(),
+                matched_by: matched_by.get(&idx).copied().unwrap_or("name").to_string(),
+            });
+        }
+    } else {
+        fresh = lights;
+    }
+    let lights = fresh;
+
     let plan = build_plan(&lights, options.time_gap_days);
-    let profile_id = resolve_profile(&tx, options)?;
+    // Only resolve (or create) an import profile when new structure is
+    // actually being created — a fully-attached import into a multi-profile
+    // database must not fail on profile ambiguity or add a profile row.
+    let profile_id = if plan.projects.is_empty() {
+        String::new()
+    } else {
+        resolve_profile(&tx, options)?
+    };
     let template_ids = ensure_templates(&tx, &plan, &profile_id, &mut outcome)?;
 
     for project in &plan.projects {
@@ -213,12 +289,259 @@ pub fn import_frames(
     if options.dry_run {
         tx.rollback().context("rolling back dry-run transaction")?;
         // Rolled-back row ids mean nothing to callers (backfill would scan
-        // targets that don't exist).
+        // rows that don't exist). Attached ids reference REAL targets, but
+        // the frames weren't kept, so clear those too.
         outcome.created_target_ids.clear();
+        outcome.attached_target_ids.clear();
     } else {
         tx.commit().context("committing import transaction")?;
     }
     Ok(outcome)
+}
+
+/// Remove every project this importer created (recognized by the
+/// `Imported by PSF Guard` description marker) together with its rule
+/// weights, targets, exposure plans, acquired images, and their thumbnail
+/// blobs. Recovery hatch for an import that should not have happened —
+/// imported rows only ever land in marker projects (attached frames go to
+/// pre-existing projects and are deliberately NOT touched).
+///
+/// Returns (projects, targets, plans, images) removed.
+pub fn remove_imported(
+    conn: &mut Connection,
+    dry_run: bool,
+) -> Result<(usize, usize, usize, usize)> {
+    let tx = conn.transaction()?;
+    let project_ids: Vec<i64> = {
+        let mut stmt =
+            tx.prepare("SELECT Id FROM project WHERE description LIKE 'Imported by PSF Guard%'")?;
+        stmt.query_map([], |row| row.get(0))?
+            .collect::<Result<_, _>>()?
+    };
+    if project_ids.is_empty() {
+        tx.rollback()?;
+        return Ok((0, 0, 0, 0));
+    }
+    let placeholders = vec!["?"; project_ids.len()].join(",");
+    let params: Vec<&dyn rusqlite::ToSql> = project_ids
+        .iter()
+        .map(|id| id as &dyn rusqlite::ToSql)
+        .collect();
+
+    let images = tx.execute(
+        &format!(
+            "DELETE FROM imagedata WHERE acquiredimageid IN
+             (SELECT Id FROM acquiredimage WHERE projectId IN ({placeholders}))"
+        ),
+        params.as_slice(),
+    )?;
+    let _ = images; // thumbnail rows; the acquiredimage count below is reported
+    let images = tx.execute(
+        &format!("DELETE FROM acquiredimage WHERE projectId IN ({placeholders})"),
+        params.as_slice(),
+    )?;
+    let plans = tx.execute(
+        &format!(
+            "DELETE FROM exposureplan WHERE targetid IN
+             (SELECT Id FROM target WHERE projectid IN ({placeholders}))"
+        ),
+        params.as_slice(),
+    )?;
+    let targets = tx.execute(
+        &format!("DELETE FROM target WHERE projectid IN ({placeholders})"),
+        params.as_slice(),
+    )?;
+    tx.execute(
+        &format!("DELETE FROM ruleweight WHERE projectid IN ({placeholders})"),
+        params.as_slice(),
+    )?;
+    let projects = tx.execute(
+        &format!("DELETE FROM project WHERE Id IN ({placeholders})"),
+        params.as_slice(),
+    )?;
+
+    if dry_run {
+        tx.rollback()?;
+    } else {
+        tx.commit()?;
+    }
+    Ok((projects, targets, plans, images))
+}
+
+/// An existing target row, loaded once per import for merge matching.
+#[derive(Debug)]
+struct ExistingTarget {
+    id: i64,
+    project_id: i64,
+    name: String,
+    /// Converted from the DB's decimal hours to degrees at load.
+    ra_deg: Option<f64>,
+    dec_deg: Option<f64>,
+    profile_id: String,
+    project_name: String,
+}
+
+fn load_existing_targets(conn: &Connection) -> Result<Vec<ExistingTarget>> {
+    let mut stmt = conn.prepare(
+        "SELECT t.Id, t.projectid, t.name, t.ra, t.dec, p.profileId, p.name
+         FROM target t JOIN project p ON p.Id = t.projectid
+         ORDER BY t.Id",
+    )?;
+    let targets = stmt
+        .query_map([], |row| {
+            Ok(ExistingTarget {
+                id: row.get(0)?,
+                project_id: row.get(1)?,
+                name: row.get::<_, String>(2)?,
+                ra_deg: row.get::<_, Option<f64>>(3)?.map(|hours| hours * 15.0),
+                dec_deg: row.get(4)?,
+                profile_id: row.get(5)?,
+                project_name: row.get(6)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(targets)
+}
+
+/// Angular separation in degrees (small-angle approximation — fine at the
+/// sub-degree radii used for target matching).
+fn angular_separation_deg(ra1: f64, dec1: f64, ra2: f64, dec2: f64) -> f64 {
+    let dra = ((ra1 - ra2 + 180.0).rem_euclid(360.0) - 180.0)
+        * dec1
+            .to_radians()
+            .cos()
+            .max(dec2.to_radians().cos().min(1.0));
+    let ddec = dec1 - dec2;
+    (dra * dra + ddec * ddec).sqrt()
+}
+
+/// Find the existing target a frame belongs to: exact (case-insensitive)
+/// OBJECT-name match wins; otherwise the nearest target whose coordinates
+/// are within `radius_deg`. Returns the index and how the match was made.
+fn match_existing_target(
+    frame: &FrameMeta,
+    targets: &[ExistingTarget],
+    radius_deg: f64,
+) -> Option<(usize, &'static str)> {
+    if let Some(object) = frame
+        .object
+        .as_deref()
+        .map(str::trim)
+        .filter(|o| !o.is_empty())
+    {
+        // Multiple targets can share a name (mosaic panels); pick the one
+        // nearest the frame, falling back to the first.
+        let mut named: Vec<usize> = targets
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| t.name.trim().eq_ignore_ascii_case(object))
+            .map(|(i, _)| i)
+            .collect();
+        if !named.is_empty() {
+            if let (Some(ra), Some(dec)) = (frame.ra_deg, frame.dec_deg) {
+                named.sort_by(|&a, &b| {
+                    let sep = |i: usize| match (targets[i].ra_deg, targets[i].dec_deg) {
+                        (Some(tra), Some(tdec)) => angular_separation_deg(ra, dec, tra, tdec),
+                        _ => f64::MAX,
+                    };
+                    sep(a).total_cmp(&sep(b))
+                });
+            }
+            return Some((named[0], "name"));
+        }
+    }
+
+    let (ra, dec) = (frame.ra_deg?, frame.dec_deg?);
+    targets
+        .iter()
+        .enumerate()
+        .filter_map(|(i, t)| {
+            let (tra, tdec) = (t.ra_deg?, t.dec_deg?);
+            let sep = angular_separation_deg(ra, dec, tra, tdec);
+            (sep <= radius_deg).then_some((i, sep))
+        })
+        .min_by(|a, b| a.1.total_cmp(&b.1))
+        .map(|(i, _)| (i, "coordinates"))
+}
+
+/// Insert frames into an EXISTING target: reuse (or create) the profile's
+/// exposure template, reuse a matching exposure plan on the target (bumping
+/// its acquired count) or add one, and land the images under the target's
+/// own project and profile.
+fn attach_frames_to_target(
+    conn: &Connection,
+    target: &ExistingTarget,
+    frames: &[FrameMeta],
+    outcome: &mut ImportOutcome,
+) -> Result<()> {
+    use rusqlite::OptionalExtension;
+
+    // Group by template + exposure, exactly like the ground-zero path.
+    let mut groups: std::collections::BTreeMap<(TemplateKey, i64), Vec<&FrameMeta>> =
+        std::collections::BTreeMap::new();
+    for frame in frames {
+        let key = TemplateKey::of(frame);
+        let exp_ms = frame
+            .exposure_s
+            .map(|e| (e * 1000.0).round() as i64)
+            .unwrap_or(0);
+        groups.entry((key, exp_ms)).or_default().push(frame);
+    }
+
+    for ((key, exp_ms), group) in groups {
+        let exposure_s = exp_ms as f64 / 1000.0;
+        let template_id =
+            find_or_create_template(conn, &key, &target.profile_id, exposure_s, outcome)?;
+
+        // Reuse the target's own plan for this template + exposure length.
+        let existing_plan: Option<i64> = conn
+            .query_row(
+                "SELECT Id FROM exposureplan
+                 WHERE targetid = ?1 AND exposureTemplateId = ?2
+                   AND ABS(IFNULL(exposure, -1) - ?3) < 0.001",
+                params![
+                    target.id,
+                    template_id,
+                    if exposure_s > 0.0 { exposure_s } else { -1.0 }
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let plan_id = match existing_plan {
+            Some(id) => {
+                conn.execute(
+                    "UPDATE exposureplan SET acquired = IFNULL(acquired, 0) + ?1 WHERE Id = ?2",
+                    params![group.len() as i64, id],
+                )?;
+                id
+            }
+            None => {
+                let id = insert_exposure_plan(
+                    conn,
+                    &target.profile_id,
+                    exposure_s,
+                    group.len(),
+                    target.id,
+                    template_id,
+                )?;
+                outcome.plans_created += 1;
+                id
+            }
+        };
+
+        for frame in group {
+            insert_acquired_image(
+                conn,
+                frame,
+                target.project_id,
+                target.id,
+                plan_id,
+                &target.profile_id,
+            )?;
+            outcome.imported += 1;
+        }
+    }
+    Ok(())
 }
 
 /// Basenames (lowercased) of every FileName already present in the DB.
@@ -365,29 +688,6 @@ fn ensure_templates(
     }
     let mut ids = HashMap::new();
     for key in plan.template_keys() {
-        let existing: Option<i64> = conn
-            .query_row(
-                "SELECT Id FROM exposuretemplate
-                 WHERE profileId = ?1 AND filtername = ?2
-                   AND IFNULL(gain, -1) = ?3 AND IFNULL(offset, -1) = ?4
-                   AND IFNULL(bin, 1) = ?5 AND IFNULL(readoutmode, -1) = ?6",
-                params![
-                    profile_id,
-                    key.filter,
-                    key.gain,
-                    key.offset,
-                    key.binning,
-                    key.readout
-                ],
-                |row| row.get(0),
-            )
-            .ok();
-        if let Some(id) = existing {
-            outcome.templates_reused += 1;
-            ids.insert(key, id);
-            continue;
-        }
-
         let default_exposure = frames_per_exposure
             .iter()
             .filter(|((k, _), _)| *k == key)
@@ -395,31 +695,72 @@ fn ensure_templates(
             .map(|((_, exp_ms), _)| *exp_ms as f64 / 1000.0)
             .filter(|e| *e > 0.0)
             .unwrap_or(60.0);
+        let id = find_or_create_template(conn, &key, profile_id, default_exposure, outcome)?;
+        ids.insert(key, id);
+    }
+    Ok(ids)
+}
 
-        conn.execute(
-            "INSERT INTO exposuretemplate (
-                profileId, name, filtername, gain, offset, bin, readoutmode,
-                twilightlevel, moonavoidanceenabled, moonavoidanceseparation,
-                moonavoidancewidth, maximumhumidity, defaultexposure,
-                moonrelaxscale, moonrelaxmaxaltitude, moonrelaxminaltitude,
-                moondownenabled, ditherevery, minutesOffset, guid
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, 0, 60, 7, 0, ?8, 0, 5, -15, 0, -1, 0, ?9)",
+/// Reuse the profile's template matching this key, or insert one with the
+/// plugin's constructor defaults. Shared by the ground-zero and the
+/// attach-to-existing paths.
+fn find_or_create_template(
+    conn: &Connection,
+    key: &TemplateKey,
+    profile_id: &str,
+    default_exposure: f64,
+    outcome: &mut ImportOutcome,
+) -> Result<i64> {
+    use rusqlite::OptionalExtension;
+
+    let existing: Option<i64> = conn
+        .query_row(
+            "SELECT Id FROM exposuretemplate
+             WHERE profileId = ?1 AND filtername = ?2
+               AND IFNULL(gain, -1) = ?3 AND IFNULL(offset, -1) = ?4
+               AND IFNULL(bin, 1) = ?5 AND IFNULL(readoutmode, -1) = ?6",
             params![
                 profile_id,
-                key.name(),
                 key.filter,
                 key.gain,
                 key.offset,
                 key.binning,
-                key.readout,
-                default_exposure,
-                new_guid(),
+                key.readout
             ],
-        )?;
-        outcome.templates_created += 1;
-        ids.insert(key, conn.last_insert_rowid());
+            |row| row.get(0),
+        )
+        .optional()?;
+    if let Some(id) = existing {
+        outcome.templates_reused += 1;
+        return Ok(id);
     }
-    Ok(ids)
+
+    conn.execute(
+        "INSERT INTO exposuretemplate (
+            profileId, name, filtername, gain, offset, bin, readoutmode,
+            twilightlevel, moonavoidanceenabled, moonavoidanceseparation,
+            moonavoidancewidth, maximumhumidity, defaultexposure,
+            moonrelaxscale, moonrelaxmaxaltitude, moonrelaxminaltitude,
+            moondownenabled, ditherevery, minutesOffset, guid
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, 0, 60, 7, 0, ?8, 0, 5, -15, 0, -1, 0, ?9)",
+        params![
+            profile_id,
+            key.name(),
+            key.filter,
+            key.gain,
+            key.offset,
+            key.binning,
+            key.readout,
+            if default_exposure > 0.0 {
+                default_exposure
+            } else {
+                60.0
+            },
+            new_guid(),
+        ],
+    )?;
+    outcome.templates_created += 1;
+    Ok(conn.last_insert_rowid())
 }
 
 /// Insert a project row with the plugin's constructor defaults
@@ -639,6 +980,9 @@ pub fn print_outcome(outcome: &ImportOutcome) {
         println!("  Already in DB:    {}", outcome.skipped_existing);
     }
     println!("  Imported:         {}", outcome.imported);
+    if outcome.attached > 0 {
+        println!("    → to existing:  {}", outcome.attached);
+    }
     println!(
         "  Projects: {}  Targets: {}  Exposure plans: {}  Templates: {} new / {} reused",
         outcome.projects_created,
@@ -647,10 +991,18 @@ pub fn print_outcome(outcome: &ImportOutcome) {
         outcome.templates_created,
         outcome.templates_reused,
     );
-    println!("  Profile: {}", outcome.profile_id);
+    if !outcome.profile_id.is_empty() {
+        println!("  Profile: {}", outcome.profile_id);
+    }
+    for attach in &outcome.attach_summaries {
+        println!(
+            "    ↳ existing {} / {} — +{} frame(s) (matched by {})",
+            attach.project, attach.target, attach.frames, attach.matched_by
+        );
+    }
     for summary in &outcome.project_summaries {
         println!(
-            "    {} — {} target(s), {} frame(s)",
+            "    NEW {} — {} target(s), {} frame(s)",
             summary.name, summary.targets, summary.frames
         );
     }
@@ -886,5 +1238,232 @@ mod tests {
             )
             .unwrap();
         assert_eq!((desired, acquired, accepted, enabled), (3, 3, 0, 1));
+    }
+
+    /// Seed an existing project + target (profile `p1`) the way a real TS
+    /// database would have them: RA stored in decimal hours.
+    fn seed_existing_target(conn: &Connection, name: &str, ra_deg: f64, dec_deg: f64) {
+        conn.execute_batch(&format!(
+            "INSERT INTO profilepreference (profileId, guid) VALUES ('p1', 'pp-guid');
+             INSERT INTO project (Id, profileId, name, description, guid)
+             VALUES (10, 'p1', 'Existing Project', 'real project', 'proj-guid');
+             INSERT INTO target (Id, name, active, ra, dec, epochcode, projectid, guid)
+             VALUES (20, '{name}', 1, {ra_hours}, {dec_deg}, 2, 10, 'tgt-guid');",
+            name = name,
+            ra_hours = ra_deg / 15.0,
+            dec_deg = dec_deg,
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    fn attaches_by_object_name_to_existing_target() {
+        let mut conn = fresh_conn();
+        seed_existing_target(&conn, "M31", 10.68, 41.27);
+
+        let outcome = import_frames(
+            &mut conn,
+            vec![light("M31", "Ha", 1_000)],
+            &ImportOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(outcome.attached, 1);
+        assert_eq!(outcome.projects_created, 0, "must not synthesize a project");
+        assert_eq!(outcome.targets_created, 0);
+        assert_eq!(outcome.attach_summaries.len(), 1);
+        assert_eq!(outcome.attach_summaries[0].matched_by, "name");
+        assert_eq!(outcome.attach_summaries[0].target, "M31");
+        assert_eq!(outcome.attached_target_ids, vec![20]);
+
+        let (project_id, target_id, profile): (i64, i64, String) = conn
+            .query_row(
+                "SELECT projectId, targetId, profileId FROM acquiredimage",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!((project_id, target_id, profile.as_str()), (10, 20, "p1"));
+        // The plan landed on the existing target under its profile.
+        let (plan_target, plan_profile): (i64, String) = conn
+            .query_row("SELECT targetid, profileId FROM exposureplan", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!((plan_target, plan_profile.as_str()), (20, "p1"));
+    }
+
+    #[test]
+    fn attaches_by_coordinates_when_name_differs() {
+        let mut conn = fresh_conn();
+        // Existing target named differently but at the frame's coordinates.
+        seed_existing_target(&conn, "Andromeda Panel 1", 10.68, 41.27);
+
+        let outcome = import_frames(
+            &mut conn,
+            vec![light("M31", "Ha", 1_000)],
+            &ImportOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(outcome.attached, 1);
+        assert_eq!(outcome.projects_created, 0);
+        assert_eq!(outcome.attach_summaries[0].matched_by, "coordinates");
+    }
+
+    #[test]
+    fn distant_unmatched_frames_still_create_new_structure() {
+        let mut conn = fresh_conn();
+        seed_existing_target(&conn, "M31", 10.68, 41.27);
+
+        // Unknown object 90 degrees away: nothing to attach to.
+        let mut frame = light("Unknown Nebula", "Ha", 1_000);
+        frame.ra_deg = Some(180.0);
+        frame.dec_deg = Some(-30.0);
+        let outcome = import_frames(&mut conn, vec![frame], &ImportOptions::default()).unwrap();
+        assert_eq!(outcome.attached, 0);
+        assert_eq!(outcome.projects_created, 1);
+        assert_eq!(outcome.targets_created, 1);
+    }
+
+    #[test]
+    fn attach_reuses_matching_plan_and_bumps_acquired() {
+        let mut conn = fresh_conn();
+        seed_existing_target(&conn, "M31", 10.68, 41.27);
+        conn.execute_batch(
+            "INSERT INTO exposuretemplate (Id, profileId, name, filtername, gain, offset, bin, readoutmode, guid)
+             VALUES (30, 'p1', 'Ha tmpl', 'Ha', 100, 30, 1, -1, 'tmpl-guid');
+             INSERT INTO exposureplan (Id, profileId, exposure, desired, acquired, accepted, targetid, exposureTemplateId, enabled, guid)
+             VALUES (40, 'p1', 300.0, 50, 7, 3, 20, 30, 1, 'plan-guid');",
+        )
+        .unwrap();
+
+        let outcome = import_frames(
+            &mut conn,
+            vec![light("M31", "Ha", 1_000), light("M31", "Ha", 2_000)],
+            &ImportOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(outcome.attached, 2);
+        assert_eq!(outcome.plans_created, 0, "existing plan reused");
+        assert_eq!(outcome.templates_created, 0);
+        assert_eq!(outcome.templates_reused, 1);
+
+        let (acquired, desired, plan_count): (i64, i64, i64) = conn
+            .query_row(
+                "SELECT acquired, desired, (SELECT COUNT(*) FROM exposureplan) FROM exposureplan WHERE Id = 40",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!((acquired, desired, plan_count), (9, 50, 1));
+        let exposure_ids: Vec<i64> = conn
+            .prepare("SELECT DISTINCT exposureId FROM acquiredimage")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(exposure_ids, vec![40]);
+    }
+
+    #[test]
+    fn no_attach_forces_ground_zero() {
+        let mut conn = fresh_conn();
+        seed_existing_target(&conn, "M31", 10.68, 41.27);
+        let outcome = import_frames(
+            &mut conn,
+            vec![light("M31", "Ha", 1_000)],
+            &ImportOptions {
+                attach_existing: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.attached, 0);
+        assert_eq!(outcome.projects_created, 1);
+    }
+
+    #[test]
+    fn fully_attached_import_ignores_profile_ambiguity() {
+        // A real DB with several profiles used to make import bail with
+        // "pass --profile-id" even when every frame attaches to existing
+        // targets and no new structure is needed.
+        let mut conn = fresh_conn();
+        seed_existing_target(&conn, "M31", 10.68, 41.27);
+        ensure_profile_preference(&conn, "p2").unwrap();
+
+        let outcome = import_frames(
+            &mut conn,
+            vec![light("M31", "Ha", 1_000)],
+            &ImportOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(outcome.attached, 1);
+        assert_eq!(outcome.profile_id, "", "no import profile resolved");
+    }
+
+    #[test]
+    fn attached_dry_run_writes_nothing_and_clears_ids() {
+        let mut conn = fresh_conn();
+        seed_existing_target(&conn, "M31", 10.68, 41.27);
+        let outcome = import_frames(
+            &mut conn,
+            vec![light("M31", "Ha", 1_000)],
+            &ImportOptions {
+                dry_run: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(outcome.attached, 1, "preview still reports the attach");
+        assert!(outcome.attached_target_ids.is_empty());
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM acquiredimage", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(rows, 0);
+    }
+
+    #[test]
+    fn remove_imported_deletes_only_marker_projects() {
+        let mut conn = fresh_conn();
+        seed_existing_target(&conn, "M31", 10.68, 41.27);
+
+        // One attached frame (goes to the pre-existing project) and one
+        // ground-zero frame (creates a marker project).
+        let mut far = light("Far Nebula", "Ha", 2_000);
+        far.ra_deg = Some(200.0);
+        far.dec_deg = Some(10.0);
+        import_frames(
+            &mut conn,
+            vec![light("M31", "Ha", 1_000), far],
+            &ImportOptions::default(),
+        )
+        .unwrap();
+
+        // Dry run counts, changes nothing.
+        let (p, t, _pl, i) = remove_imported(&mut conn, true).unwrap();
+        assert_eq!((p, t, i), (1, 1, 1));
+        let projects: i64 = conn
+            .query_row("SELECT COUNT(*) FROM project", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(projects, 2);
+
+        // Live run removes only the marker project and its rows.
+        let (p, t, _pl, i) = remove_imported(&mut conn, false).unwrap();
+        assert_eq!((p, t, i), (1, 1, 1));
+        let (projects, targets, images): (i64, i64, i64) = conn
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM project), (SELECT COUNT(*) FROM target),
+                        (SELECT COUNT(*) FROM acquiredimage)",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        // Pre-existing project/target survive, as does the ATTACHED frame.
+        assert_eq!((projects, targets, images), (1, 1, 1));
+        let name: String = conn
+            .query_row("SELECT name FROM project", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(name, "Existing Project");
     }
 }

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -307,6 +307,13 @@ pub struct ImportRequest {
     /// Run the post-import quality backfill (default true).
     #[serde(default)]
     pub backfill: Option<bool>,
+    /// Attach frames to existing targets (name/coordinate match) instead of
+    /// synthesizing new structure for them (default true).
+    #[serde(default)]
+    pub attach_existing: Option<bool>,
+    /// Coordinate-match radius in degrees (default 0.5).
+    #[serde(default)]
+    pub match_radius_deg: Option<f64>,
 }
 
 /// Status returned by both the import-start and import-progress endpoints.

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -853,6 +853,7 @@ pub async fn create_database_route(
             .unwrap_or(crate::commands::import::grouping::DEFAULT_TIME_GAP_DAYS),
         profile_id: req.profile_id.clone(),
         dry_run: false,
+        ..Default::default()
     };
     spawn_import_job(
         &state,
@@ -901,6 +902,10 @@ pub async fn start_import_route(
             .unwrap_or(crate::commands::import::grouping::DEFAULT_TIME_GAP_DAYS),
         profile_id: req.profile_id,
         dry_run: req.dry_run,
+        attach_existing: req.attach_existing.unwrap_or(true),
+        match_radius_deg: req
+            .match_radius_deg
+            .unwrap_or(crate::commands::import::DEFAULT_MATCH_RADIUS_DEG),
     };
     let started = spawn_import_job(
         &state,
@@ -1020,7 +1025,12 @@ fn spawn_import_job(
             outcome.targets_created,
             if outcome.dry_run { " (dry-run)" } else { "" }
         );
-        let target_ids = outcome.created_target_ids.clone();
+        let mut target_ids = outcome.created_target_ids.clone();
+        for id in &outcome.attached_target_ids {
+            if !target_ids.contains(id) {
+                target_ids.push(*id);
+            }
+        }
         job::set_outcome(&job_store, outcome);
 
         // New rows reference files the DB-based file cache hasn't seen; kick

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -625,6 +625,15 @@ export interface ImportProjectSummary {
   frames: number;
 }
 
+/** One existing target that received attached frames. */
+export interface ImportAttachSummary {
+  project: string;
+  target: string;
+  frames: number;
+  /** 'name' or 'coordinates' */
+  matched_by: string;
+}
+
 /** Result of one FITS import run (mirrors Rust `ImportOutcome`). */
 export interface ImportOutcome {
   scanned: number;
@@ -632,6 +641,8 @@ export interface ImportOutcome {
   non_light: number;
   skipped_existing: number;
   imported: number;
+  /** Frames attached to targets that already existed. */
+  attached: number;
   projects_created: number;
   targets_created: number;
   templates_created: number;
@@ -640,7 +651,9 @@ export interface ImportOutcome {
   profile_id: string;
   dry_run: boolean;
   project_summaries: ImportProjectSummary[];
+  attach_summaries: ImportAttachSummary[];
   created_target_ids: number[];
+  attached_target_ids: number[];
 }
 
 /** Progress of the singleton per-DB import job (poll ~1s while running). */
@@ -673,6 +686,9 @@ export interface ImportRequest {
   profile_id?: string;
   dry_run?: boolean;
   backfill?: boolean;
+  /** Attach to existing targets by name/coordinates (default true). */
+  attach_existing?: boolean;
+  match_radius_deg?: number;
 }
 
 /** Body of `POST /api/databases/create`. */

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -455,3 +455,8 @@
   padding-left: 18px;
   color: var(--color-text-secondary, #999);
 }
+
+.tauri-settings .import-confirm-buttons {
+  margin-top: 10px;
+  justify-content: flex-start;
+}

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -271,6 +271,11 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     }
   };
 
+  // Import is two-step: a dry-run PREVIEW first (rolled back server-side),
+  // then an explicit confirmation. Nothing touches the database until the
+  // user has seen exactly what would be attached vs newly created.
+  const [confirmImport, setConfirmImport] = useState<DbEntry | null>(null);
+
   const handleImport = async (entry: DbEntry) => {
     if (entry.image_dirs.length === 0) {
       setStatusMessage(
@@ -281,15 +286,32 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setIsApplying(true);
     setStatusMessage('');
     try {
-      const status = await apiClient.startImport(entry.id, {});
+      const status = await apiClient.startImport(entry.id, { dry_run: true, backfill: false });
       setImportDbId(entry.id);
+      setConfirmImport(entry);
       setStatusMessage(
         status.started
-          ? `Importing images into ${entry.name}…`
+          ? `Previewing import into ${entry.name}… nothing is written until you confirm.`
           : 'An import is already running for this database.'
       );
     } catch (err) {
-      console.error('import failed to start:', err);
+      console.error('import preview failed to start:', err);
+      const msg = err instanceof Error ? err.message : String(err);
+      setStatusMessage(`Failed to preview import: ${msg}`);
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  const handleConfirmImport = async () => {
+    if (!confirmImport) return;
+    const entry = confirmImport;
+    setConfirmImport(null);
+    setIsApplying(true);
+    try {
+      await apiClient.startImport(entry.id, { dry_run: false });
+      setStatusMessage(`Importing images into ${entry.name}…`);
+    } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setStatusMessage(`Failed to start import: ${msg}`);
     } finally {
@@ -466,17 +488,60 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
                   {importRunning && <span className="import-spinner">⏳ </span>}
                   {describeImportProgress(importProgress)}
                 </div>
-                {importProgress.stage === 'complete' &&
-                  importProgress.outcome &&
-                  importProgress.outcome.project_summaries.length > 0 && (
-                    <ul className="import-project-list">
-                      {importProgress.outcome.project_summaries.map((p) => (
-                        <li key={p.name}>
-                          {p.name} — {p.targets} target(s), {p.frames} frame(s)
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                {importProgress.stage === 'complete' && importProgress.outcome && (
+                  <>
+                    {importProgress.outcome.attach_summaries.length > 0 && (
+                      <ul className="import-project-list">
+                        {importProgress.outcome.attach_summaries.map((a) => (
+                          <li key={`${a.project}:${a.target}`}>
+                            ↳ existing {a.project} / {a.target} — +{a.frames} frame(s) (
+                            {a.matched_by} match)
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                    {importProgress.outcome.project_summaries.length > 0 && (
+                      <ul className="import-project-list">
+                        {importProgress.outcome.project_summaries.map((p) => (
+                          <li key={p.name}>
+                            NEW {p.name} — {p.targets} target(s), {p.frames} frame(s)
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                    {importProgress.outcome.dry_run &&
+                      confirmImport &&
+                      importDbId === confirmImport.id && (
+                        <div className="modal-buttons import-confirm-buttons">
+                          {importProgress.outcome.imported > 0 ? (
+                            <>
+                              <button
+                                className="save-button"
+                                onClick={handleConfirmImport}
+                                disabled={isApplying}
+                              >
+                                Import {importProgress.outcome.imported} frame(s)
+                              </button>
+                              <button
+                                className="cancel-button"
+                                onClick={() => {
+                                  setConfirmImport(null);
+                                  setStatusMessage('Import cancelled — nothing was written.');
+                                }}
+                                disabled={isApplying}
+                              >
+                                Cancel
+                              </button>
+                            </>
+                          ) : (
+                            <span className="muted">
+                              Nothing new to import — every frame is already in the database.
+                            </span>
+                          )}
+                        </div>
+                      )}
+                  </>
+                )}
               </div>
             )}
           </div>

--- a/static/src/hooks/useImportJob.ts
+++ b/static/src/hooks/useImportJob.ts
@@ -59,9 +59,15 @@ export function describeImportProgress(
       const o = progress.outcome;
       if (!o) return 'Import complete.';
       const skipped = o.skipped_existing > 0 ? `, ${o.skipped_existing} already present` : '';
+      const attached = o.attached > 0 ? `${o.attached} to existing target(s)` : '';
+      const fresh =
+        o.projects_created > 0
+          ? `${o.imported - o.attached} into ${o.projects_created} NEW project(s)`
+          : '';
+      const detail = [attached, fresh].filter(Boolean).join(', ') || 'nothing new';
       return o.dry_run
-        ? `Dry run: would import ${o.imported} frame(s) into ${o.projects_created} project(s)${skipped}.`
-        : `Imported ${o.imported} frame(s) into ${o.projects_created} project(s), ${o.targets_created} target(s)${skipped}.`;
+        ? `Preview: would import ${o.imported} frame(s) — ${detail}${skipped}.`
+        : `Imported ${o.imported} frame(s) — ${detail}${skipped}.`;
     }
     case 'error':
       return `Import failed: ${progress.error ?? 'unknown error'}`;

--- a/tests/integration_import.rs
+++ b/tests/integration_import.rs
@@ -782,3 +782,97 @@ async fn local_export_places_files_and_respects_management_gate() {
     .await;
     assert_eq!(status, StatusCode::FORBIDDEN);
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reimport_attaches_to_existing_targets_after_preview() {
+    let dir = tempdir().unwrap();
+    let images = dir.path().join("lights");
+    std::fs::create_dir_all(&images).unwrap();
+    write_fits(
+        &images.join("m31_ha_0001.fits"),
+        "M31",
+        "Ha",
+        "2026-01-15T04:00:00.000",
+        10.6847,
+    );
+
+    let state = state_with_management(dir.path());
+    let (status, body) = json_request(
+        build_app(state.clone()),
+        "POST",
+        "/api/databases/create",
+        Some(serde_json::json!({
+            "name": "MergeSafe",
+            "image_dirs": [images.to_string_lossy()],
+            "backfill": false,
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let slug = body["data"]["database"]["id"].as_str().unwrap().to_string();
+    let db_path = body["data"]["database"]["database_path"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    wait_for_import(&state, &slug).await;
+
+    // A new night lands more M31 subs (different basenames, same object).
+    write_fits(
+        &images.join("m31_ha_0002.fits"),
+        "M31",
+        "Ha",
+        "2026-01-16T04:00:00.000",
+        10.6851,
+    );
+
+    // Step 1: PREVIEW (dry run) — reports the attach, writes nothing.
+    let (status, _) = json_request(
+        build_app(state.clone()),
+        "POST",
+        &format!("/api/db/{slug}/import"),
+        Some(serde_json::json!({ "dry_run": true, "backfill": false })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let progress = wait_for_import(&state, &slug).await;
+    let outcome = &progress["outcome"];
+    assert_eq!(outcome["dry_run"], true);
+    assert_eq!(outcome["attached"], 1, "outcome: {outcome}");
+    assert_eq!(outcome["projects_created"], 0, "no duplicated structure");
+    assert_eq!(outcome["attach_summaries"][0]["target"], "M31");
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM acquiredimage", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(rows, 1, "preview must not write");
+    }
+
+    // Step 2: confirmed live import — attaches to the existing target.
+    let (status, _) = json_request(
+        build_app(state.clone()),
+        "POST",
+        &format!("/api/db/{slug}/import"),
+        Some(serde_json::json!({ "backfill": false })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let progress = wait_for_import(&state, &slug).await;
+    assert_eq!(progress["outcome"]["attached"], 1);
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let (projects, targets, images_n, distinct_targets): (i64, i64, i64, i64) = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM project), (SELECT COUNT(*) FROM target),
+                    (SELECT COUNT(*) FROM acquiredimage),
+                    (SELECT COUNT(DISTINCT targetId) FROM acquiredimage)",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        (projects, targets, images_n, distinct_targets),
+        (1, 1, 2, 1),
+        "both frames on the one existing target"
+    );
+}


### PR DESCRIPTION
Fixes a real-world incident: clicking **Import** on the DB panel ran a ground-zero import against an existing Target Scheduler database — synthesizing duplicate projects/targets for every frame it didn't recognize, with no preview and no confirmation.

## Merge-aware import
After basename dedup, frames now **attach to existing targets**:
- exact (case-insensitive) `OBJECT`-name match wins (nearest by coordinates when several targets share a name, e.g. mosaic panels);
- otherwise the nearest target within `--match-radius-deg` (default 0.5°).

Attached frames land under the target's own project **and profile**, reuse the profile's exposure template, and reuse a matching exposure plan (bumping `acquired`) or add one. Only genuinely unmatched frames fall through to the old equipment-signature grouping. `--no-attach` restores ground-zero behavior deliberately. A fully-attached import no longer resolves/creates an import profile, so multi-profile databases import cleanly.

## Preview-then-confirm UI
The Import button now runs a **dry-run preview** (rolled back server-side) and shows exactly what would happen — per-target attach lines with the match kind, `NEW` project lines, and skip counts. Nothing is written until the user clicks **Import N frame(s)**; Cancel discards the preview. The wording distinguishes `↳ existing` from `NEW` everywhere (CLI report too).

## Recovery
`psf-guard remove-imported <db> [--dry-run]` deletes the projects an import created (recognized by the `Imported by PSF Guard` description marker) together with their targets, plans, rule weights, and image rows. Frames attached to pre-existing projects are never touched, and imported rows only ever land in marker projects — so this cleanly undoes exactly the damage the old behavior caused.

## Testing
416 Rust tests: 8 new unit tests (attach by name / by coordinates / plan-reuse acquired-bump / no-attach / distant-frames-still-create / multi-profile fully-attached / dry-run clears ids / remove-imported preserves attached+pre-existing) plus an end-to-end integration test driving preview → confirm → verify single-target result. Frontend tsc clean, 91 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)