### PR TITLE
Parallelize HocusFocus preprocessing intra-frame, bit-exact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,23 @@ wavelets / structure removal.
   path runtime-dispatches FMA on x86-64 (`is_x86_feature_detected!`) and is
   native-FMA on aarch64, mirroring OpenCV's own dispatch. Single-core
   throughput is on par with single-threaded OpenCV (canny ~1.2x, otsu
-  faster); frame-level parallelism stays in psf-guard's worker pools.
+  faster).
+- **Intra-frame parallelism (2026-07)**: psf-guard enables seiza-imgproc's
+  opt-in `parallel` feature (rayon), and the HocusFocus preprocessing
+  passes in `hocus_focus_star_detection.rs` (hot-pixel filter, noise blur,
+  edge blend, structure-map build) split by row bands on rayon's global
+  pool. All splits are bit-exact: rows/columns are independent and
+  per-pixel operation order is unchanged. Kappa-sigma and the structure-map
+  median stay serial ON PURPOSE — they are order-sensitive f64 reductions
+  and parallelizing them changes bits. Frame-level parallelism still comes
+  from psf-guard's worker pools; rayon's shared global pool bounds the
+  intra-frame threads regardless of how many frames run at once. Measured:
+  HocusFocus on a 61 MP frame went 21.8 s (pre-optimization) -> 8.0 s
+  (bit-exact single-thread rewrites) -> ~3 s (parallel); detection output
+  identical throughout (1076 stars, sigma 50.771, threshold 1584.803).
+  Removing the structure-removal passes was measured and REJECTED: they
+  are behavior-load-bearing (without them sigma drops 50.8 -> 22.6 and
+  detections jump 1076 -> 1919).
 - The old `--features opencv` flag, build.rs probing, and all CI OpenCV
   installs (vcpkg/brew/apt) are gone; `default = []` now.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4766,9 +4766,12 @@ dependencies = [
 
 [[package]]
 name = "seiza-imgproc"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a58c6c76281e5439f696a80de1dcad51bc47123087e3f1208a7879c95b0d07"
+checksum = "3be616763b4354b830e1cb68222798bc168397c56a53654934f1698adc62e312"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "seiza-satellites"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 byteorder = "1.5"
 seiza = "0.12.0"
-seiza-imgproc = "0.2.0"
+seiza-imgproc = { version = "0.3.0", features = ["parallel"] }
 seiza-fits = "=0.2.0"
 seiza-satellites = { version = "0.4.2", features = ["serde"] }
 seiza-stacking = "0.1.0"

--- a/src/hocus_focus_star_detection.rs
+++ b/src/hocus_focus_star_detection.rs
@@ -252,7 +252,6 @@ fn apply_hotpixel_filter(
     // whole row's min/max ops vectorize. Same median values as sorting each
     // neighborhood, without a per-pixel allocation and sort.
     let ilen = width - 2;
-    let mut p: Vec<Vec<u16>> = vec![vec![0u16; ilen]; 9];
     const NET: [(usize, usize); 19] = [
         (1, 2),
         (4, 5),
@@ -274,39 +273,49 @@ fn apply_hotpixel_filter(
         (6, 4),
         (4, 2),
     ];
-    for y in 1..(height - 1) {
-        for (r, sy) in [y - 1, y, y + 1].into_iter().enumerate() {
-            let srow = &data[sy * width..(sy + 1) * width];
-            p[r * 3].copy_from_slice(&srow[..ilen]);
-            p[r * 3 + 1].copy_from_slice(&srow[1..1 + ilen]);
-            p[r * 3 + 2].copy_from_slice(&srow[2..2 + ilen]);
-        }
-        for &(a, b) in NET.iter() {
-            let (lo, hi) = (a.min(b), a.max(b));
-            let (head, tail) = p.split_at_mut(hi);
-            let (pa, pb) = (&mut head[lo], &mut tail[0]);
-            if a < b {
-                for (x, y) in pa.iter_mut().zip(pb.iter_mut()) {
-                    let (mn, mx) = ((*x).min(*y), (*x).max(*y));
-                    *x = mn;
-                    *y = mx;
+    // Interior rows are independent: split them across threads, with one
+    // 9-row network scratch per thread. Per-pixel arithmetic is unchanged.
+    use rayon::prelude::*;
+    result[width..(height - 1) * width]
+        .par_chunks_exact_mut(width)
+        .enumerate()
+        .for_each_init(
+            || vec![vec![0u16; ilen]; 9],
+            |p, (i, out_row)| {
+                let y = i + 1;
+                for (r, sy) in [y - 1, y, y + 1].into_iter().enumerate() {
+                    let srow = &data[sy * width..(sy + 1) * width];
+                    p[r * 3].copy_from_slice(&srow[..ilen]);
+                    p[r * 3 + 1].copy_from_slice(&srow[1..1 + ilen]);
+                    p[r * 3 + 2].copy_from_slice(&srow[2..2 + ilen]);
                 }
-            } else {
-                for (y, x) in pa.iter_mut().zip(pb.iter_mut()) {
-                    let (mn, mx) = ((*x).min(*y), (*x).max(*y));
-                    *x = mn;
-                    *y = mx;
+                for &(a, b) in NET.iter() {
+                    let (lo, hi) = (a.min(b), a.max(b));
+                    let (head, tail) = p.split_at_mut(hi);
+                    let (pa, pb) = (&mut head[lo], &mut tail[0]);
+                    if a < b {
+                        for (x, y) in pa.iter_mut().zip(pb.iter_mut()) {
+                            let (mn, mx) = ((*x).min(*y), (*x).max(*y));
+                            *x = mn;
+                            *y = mx;
+                        }
+                    } else {
+                        for (y, x) in pa.iter_mut().zip(pb.iter_mut()) {
+                            let (mn, mx) = ((*x).min(*y), (*x).max(*y));
+                            *x = mn;
+                            *y = mx;
+                        }
+                    }
                 }
-            }
-        }
-        let out = &mut result[y * width + 1..y * width + 1 + ilen];
-        let center = &data[y * width + 1..y * width + 1 + ilen];
-        for ((o, &c), &m) in out.iter_mut().zip(center.iter()).zip(p[4].iter()) {
-            if (c as f64 - m as f64).abs() > threshold {
-                *o = m;
-            }
-        }
-    }
+                let out = &mut out_row[1..1 + ilen];
+                let center = &data[y * width + 1..y * width + 1 + ilen];
+                for ((o, &c), &m) in out.iter_mut().zip(center.iter()).zip(p[4].iter()) {
+                    if (c as f64 - m as f64).abs() > threshold {
+                        *o = m;
+                    }
+                }
+            },
+        );
 
     result
 }
@@ -345,25 +354,34 @@ fn apply_gaussian_blur(data: &[u16], width: usize, height: usize, kernel_size: u
     if width < kernel_size || height < kernel_size {
         return result;
     }
+    // Output rows are independent: split them across threads with one row
+    // accumulator per thread. Tap order per output pixel is unchanged.
+    use rayon::prelude::*;
     let ilen = width - 2 * radius;
-    let mut acc = vec![0f64; ilen];
-    for y in radius..(height - radius) {
-        acc.fill(0.0);
-        for ky in 0..kernel_size {
-            let srow = &data[(y + ky - radius) * width..(y + ky - radius + 1) * width];
-            for kx in 0..kernel_size {
-                let kv = kernel[ky * kernel_size + kx];
-                let s = &srow[kx..kx + ilen];
-                for (a, &v) in acc.iter_mut().zip(s.iter()) {
-                    *a += v as f64 * kv;
+    result[radius * width..(height - radius) * width]
+        .par_chunks_exact_mut(width)
+        .enumerate()
+        .for_each_init(
+            || vec![0f64; ilen],
+            |acc, (i, out_row)| {
+                let y = i + radius;
+                acc.fill(0.0);
+                for ky in 0..kernel_size {
+                    let srow = &data[(y + ky - radius) * width..(y + ky - radius + 1) * width];
+                    for kx in 0..kernel_size {
+                        let kv = kernel[ky * kernel_size + kx];
+                        let s = &srow[kx..kx + ilen];
+                        for (a, &v) in acc.iter_mut().zip(s.iter()) {
+                            *a += v as f64 * kv;
+                        }
+                    }
                 }
-            }
-        }
-        let orow = &mut result[y * width + radius..y * width + radius + ilen];
-        for (o, &a) in orow.iter_mut().zip(acc.iter()) {
-            *o = a as u16;
-        }
-    }
+                let orow = &mut out_row[radius..radius + ilen];
+                for (o, &a) in orow.iter_mut().zip(acc.iter()) {
+                    *o = a as u16;
+                }
+            },
+        );
 
     result
 }
@@ -381,15 +399,21 @@ fn create_structure_map(
     // f32, so the f32 entry point skips two full-image f64 conversions
     // while producing bit-identical residuals; the subtraction below is
     // done in f64 exactly as before (each operand widens exactly).
-    let float_data: Vec<f32> = data.iter().map(|&v| v as f32).collect();
+    use rayon::prelude::*;
+    let float_data: Vec<f32> = data.par_iter().map(|&v| v as f32).collect();
     let wavelet_remover = StructureRemover::new(params.structure_layers);
     let residual = wavelet_remover.remove_structures_filtered_f32(&float_data, width, height);
 
     // Subtract residual from original to remove large structures
     let mut structure_map = vec![0f64; data.len()];
-    for i in 0..structure_map.len() {
-        structure_map[i] = (data[i] as f64 - residual[i] as f64).max(0.0);
-    }
+    structure_map
+        .par_chunks_mut(4096)
+        .zip(data.par_chunks(4096).zip(residual.par_chunks(4096)))
+        .for_each(|(out, (d, r))| {
+            for ((o, &dv), &rv) in out.iter_mut().zip(d.iter()).zip(r.iter()) {
+                *o = (dv as f64 - rv as f64).max(0.0);
+            }
+        });
 
     // Debug statistics cost six full passes over the map — only compute
     // them when debug output is actually enabled.
@@ -456,23 +480,32 @@ fn smooth_gaussian(data: &mut [f64], width: usize, height: usize, kernel_size: u
     if width < kernel_size || height < kernel_size {
         return;
     }
+    // Output rows are independent: split them across threads with one row
+    // accumulator per thread. Tap order per output pixel is unchanged.
+    use rayon::prelude::*;
     let original = data.to_vec();
     let ilen = width - 2 * radius;
-    let mut acc = vec![0f64; ilen];
-    for y in radius..(height - radius) {
-        acc.fill(0.0);
-        for ky in 0..kernel_size {
-            let srow = &original[(y + ky - radius) * width..(y + ky - radius + 1) * width];
-            for kx in 0..kernel_size {
-                let kv = kernel[ky * kernel_size + kx];
-                let sr = &srow[kx..kx + ilen];
-                for (a, &v) in acc.iter_mut().zip(sr.iter()) {
-                    *a += v * kv;
+    data[radius * width..(height - radius) * width]
+        .par_chunks_exact_mut(width)
+        .enumerate()
+        .for_each_init(
+            || vec![0f64; ilen],
+            |acc, (i, out_row)| {
+                let y = i + radius;
+                acc.fill(0.0);
+                for ky in 0..kernel_size {
+                    let srow = &original[(y + ky - radius) * width..(y + ky - radius + 1) * width];
+                    for kx in 0..kernel_size {
+                        let kv = kernel[ky * kernel_size + kx];
+                        let sr = &srow[kx..kx + ilen];
+                        for (a, &v) in acc.iter_mut().zip(sr.iter()) {
+                            *a += v * kv;
+                        }
+                    }
                 }
-            }
-        }
-        data[y * width + radius..y * width + radius + ilen].copy_from_slice(&acc);
-    }
+                out_row[radius..radius + ilen].copy_from_slice(acc);
+            },
+        );
 }
 
 /// Kappa-Sigma noise estimation matching HocusFocus implementation

--- a/src/nina_star_detection.rs
+++ b/src/nina_star_detection.rs
@@ -9,7 +9,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// Convert 16-bit data to 8-bit using NINA's exact method
 /// Matches Accord.NET's Convert16bppTo8bpp: *d = (byte)(*s >> 8);
 fn convert_16bpp_to_8bpp_nina(data: &[u16]) -> Vec<u8> {
-    data.iter().map(|&pixel| (pixel >> 8) as u8).collect()
+    use rayon::prelude::*;
+    data.par_iter().map(|&pixel| (pixel >> 8) as u8).collect()
 }
 
 /// Banker's rounding (round half to even) to match .NET's default Math.Round


### PR DESCRIPTION
## Summary
The "limited intra-frame parallelism" phase, on top of #211/#213's single-thread rewrites:
- Enables seiza-imgproc 0.3.0's opt-in `parallel` feature (theatrus/seiza#90): row-split Gaussian passes (with per-row `#[target_feature]` FMA dispatch, since rayon closures don't inherit it) and column-split dt-filter passes via a transposed buffer.
- Splits psf-guard's own preprocessing by row bands on rayon's global pool: hot-pixel median network, 9×9 noise blur, structure-map edge blend, structure-map build, and the N.I.N.A. 16→8-bit conversion.
- Every split is along independent rows/columns with unchanged per-pixel operation order, so results are **bit-identical**. Kappa-sigma and the structure-map median stay serial on purpose — order-sensitive f64 reductions.
- CLAUDE.md documents the policy (worker pools own frame-level parallelism; rayon's shared global pool bounds intra-frame threads) and records that removing the structure-removal passes was measured and rejected (σ 50.8 → 22.6, detections 1076 → 1919 — they are behavior-load-bearing).

## Test plan
- [x] Reference frame vs the published crate: 1076 stars, HFR 2.658, noise_sigma 50.771, threshold 1584.803, median 1381.717 — all identical
- [x] `analyze-fits --detector hocusfocus` wall time **8.0 s → 2.9 s** at ~680% CPU (21.8 s at the start of this series)
- [x] seiza-imgproc golden tests pass with the parallel feature on (its CI runs `--all-features` permanently)
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (10 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)