### PR TITLE
Add pinch zoom to image inspectors

### DIFF
--- a/static/e2e/image-detail.spec.ts
+++ b/static/e2e/image-detail.spec.ts
@@ -197,6 +197,85 @@ test('detail view loads the large preview and renders pixels', async ({
   expect(dims.natH).toBeGreaterThan(500);
 });
 
+test('detail view supports pinch zoom around a moving midpoint', async ({
+  page,
+}) => {
+  await page.goto(`/#/detail/1?db=${encodeURIComponent(dbId)}&project=1`);
+
+  const container = page.locator('.zoom-container').first();
+  const img = container.locator('img.detail-main-image').first();
+  await expect(img).toBeVisible({ timeout: 15_000 });
+  await page.waitForFunction(
+    (el) =>
+      el instanceof HTMLImageElement && el.complete && el.naturalWidth > 0,
+    await img.elementHandle(),
+    { timeout: 30_000 }
+  );
+
+  const before = await readDetailViewportAnchor(page);
+  const box = await container.boundingBox();
+  expect(box).not.toBeNull();
+  expect(await container.evaluate((el) => getComputedStyle(el).touchAction))
+    .toBe('none');
+
+  const startCenter = {
+    x: box!.x + box!.width / 2,
+    y: box!.y + box!.height / 2,
+  };
+  const movedCenter = {
+    x: startCenter.x + 30,
+    y: startCenter.y + 20,
+  };
+
+  await container.evaluate((el, center) => {
+    const event = new Event('touchstart', {
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'touches', {
+      value: [
+        { clientX: center.x - 80, clientY: center.y },
+        { clientX: center.x + 80, clientY: center.y },
+      ],
+    });
+    el.dispatchEvent(event);
+  }, startCenter);
+  await container.evaluate((el, center) => {
+    const event = new Event('touchmove', {
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'touches', {
+      value: [
+        { clientX: center.x - 120, clientY: center.y },
+        { clientX: center.x + 120, clientY: center.y },
+      ],
+    });
+    el.dispatchEvent(event);
+  }, movedCenter);
+  await container.evaluate((el) => {
+    const event = new Event('touchend', {
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, 'touches', { value: [] });
+    el.dispatchEvent(event);
+  });
+
+  await expect.poll(async () => (await readDetailViewportAnchor(page)).scale)
+    .toBeGreaterThan(before.scale * 1.45);
+
+  const after = await readDetailViewportAnchor(page);
+  const imageX =
+    (box!.width / 2 - before.offsetX) / before.scale;
+  const imageY =
+    (box!.height / 2 - before.offsetY) / before.scale;
+  expect(after.offsetX + imageX * after.scale)
+    .toBeCloseTo(box!.width / 2 + 30, 1);
+  expect(after.offsetY + imageY * after.scale)
+    .toBeCloseTo(box!.height / 2 + 20, 1);
+});
+
 test('detail view hides the pending image while arrow-key navigation generates it', async ({
   page,
 }) => {

--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -193,10 +193,14 @@ test('builds a real three-frame Seiza stack and exposes its frame decisions', as
   await stretchControls.getByRole('spinbutton', { name: 'Deconvolution Iterations' }).fill('1');
   await stretchControls.getByRole('spinbutton', { name: 'Alpha M44 B Target median' }).fill('0.25');
   await stretchControls.getByRole('button', { name: 'Apply processing' }).click();
-  await expect.poll(() => preview.getAttribute('src')).toMatch(
+  await expect(stretchControls).toContainText(
+    '3.1px deconv · Auto MTF applied',
+    { timeout: 30_000 }
+  );
+  await expect(preview).toHaveAttribute(
+    'src',
     /\/stack-previews\/stretch\/[a-f0-9]{64}\/preview$/
   );
-  await expect(stretchControls).toContainText('3.1px deconv · Auto MTF applied');
   if (process.env.PSF_GUARD_CAPTURE_DOCS === '1') {
     const docs = path.resolve(process.cwd(), '..', 'docs');
     fs.mkdirSync(docs, { recursive: true });

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -1065,6 +1065,7 @@
   position: relative;
   overflow: hidden;
   cursor: grab;
+  touch-action: none;
   outline: none;
   border: 2px solid transparent;
   transition: border-color 0.3s ease;

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -425,6 +425,38 @@ export default function ImageComparisonView({
     }
   }, [leftZoom, rightZoom, syncZoom]);
 
+  const routeRightTouch = useCallback((
+    e: React.TouchEvent,
+    phase: 'start' | 'move' | 'end'
+  ) => {
+    if (!syncZoom) {
+      if (phase === 'start') rightZoom.handleTouchStart(e);
+      if (phase === 'move') rightZoom.handleTouchMove(e);
+      if (phase === 'end') rightZoom.handleTouchEnd(e);
+      return;
+    }
+
+    const leftContainer = leftZoom.containerRef.current;
+    const rightContainer = rightZoom.containerRef.current;
+    if (!leftContainer || !rightContainer) return;
+
+    const leftRect = leftContainer.getBoundingClientRect();
+    const rightRect = rightContainer.getBoundingClientRect();
+    const touches = Array.from(e.touches, touch => ({
+      clientX: touch.clientX - rightRect.left + leftRect.left,
+      clientY: touch.clientY - rightRect.top + leftRect.top,
+    }));
+    const adjustedEvent = {
+      touches,
+      preventDefault: () => e.preventDefault(),
+      stopPropagation: () => e.stopPropagation(),
+    } as unknown as React.TouchEvent;
+
+    if (phase === 'start') leftZoom.handleTouchStart(adjustedEvent);
+    if (phase === 'move') leftZoom.handleTouchMove(adjustedEvent);
+    if (phase === 'end') leftZoom.handleTouchEnd(adjustedEvent);
+  }, [leftZoom, rightZoom, syncZoom]);
+
   const getStatusClass = (image: Image | null | undefined) => {
     if (!image) return '';
     switch (image.grading_status) {
@@ -505,6 +537,10 @@ export default function ImageComparisonView({
                 onMouseMove={handleLeftMouseMove}
                 onMouseUp={leftZoom.handleMouseUp}
                 onMouseLeave={leftZoom.handleMouseUp}
+                onTouchStart={leftZoom.handleTouchStart}
+                onTouchMove={leftZoom.handleTouchMove}
+                onTouchEnd={leftZoom.handleTouchEnd}
+                onTouchCancel={leftZoom.handleTouchEnd}
               >
                 {asyncLeft.state === 'error' ? (
                   <div className="comparison-image-error" style={{
@@ -674,6 +710,10 @@ export default function ImageComparisonView({
                     onMouseMove={handleRightMouseMove}
                     onMouseUp={syncZoom ? leftZoom.handleMouseUp : rightZoom.handleMouseUp}
                     onMouseLeave={syncZoom ? leftZoom.handleMouseUp : rightZoom.handleMouseUp}
+                    onTouchStart={(e) => routeRightTouch(e, 'start')}
+                    onTouchMove={(e) => routeRightTouch(e, 'move')}
+                    onTouchEnd={(e) => routeRightTouch(e, 'end')}
+                    onTouchCancel={(e) => routeRightTouch(e, 'end')}
                   >
                     {asyncRight.state === 'error' ? (
                       <div className="comparison-image-error" style={{

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -437,6 +437,10 @@ export default function ImageDetailView({
               onMouseMove={zoom.handleMouseMove}
               onMouseUp={zoom.handleMouseUp}
               onMouseLeave={zoom.handleMouseUp}
+              onTouchStart={zoom.handleTouchStart}
+              onTouchMove={zoom.handleTouchMove}
+              onTouchEnd={zoom.handleTouchEnd}
+              onTouchCancel={zoom.handleTouchEnd}
               tabIndex={0}
               onKeyDown={zoom.handleKeyDown}
             >

--- a/static/src/components/StackPreviewInspector.tsx
+++ b/static/src/components/StackPreviewInspector.tsx
@@ -72,6 +72,10 @@ export default function StackPreviewInspector({
           onMouseMove={zoom.handleMouseMove}
           onMouseUp={zoom.handleMouseUp}
           onMouseLeave={zoom.handleMouseUp}
+          onTouchStart={zoom.handleTouchStart}
+          onTouchMove={zoom.handleTouchMove}
+          onTouchEnd={zoom.handleTouchEnd}
+          onTouchCancel={zoom.handleTouchEnd}
           onKeyDown={zoom.handleKeyDown}
           tabIndex={0}
         >

--- a/static/src/hooks/__tests__/useImageZoom.test.tsx
+++ b/static/src/hooks/__tests__/useImageZoom.test.tsx
@@ -59,6 +59,17 @@ function panBy(
   });
 }
 
+function touchEvent(points: Array<{ x: number; y: number }>) {
+  const preventDefault = vi.fn();
+  return {
+    event: {
+      touches: points.map(({ x, y }) => ({ clientX: x, clientY: y })),
+      preventDefault,
+    } as unknown as React.TouchEvent,
+    preventDefault,
+  };
+}
+
 describe('useImageZoom applyBitmapDimensions', () => {
   it("fit mode centers the bitmap at the container's fit scale", () => {
     const { result } = setup();
@@ -242,6 +253,62 @@ describe('useImageZoom view-mode notifications', () => {
 
     act(() => result.current.zoomTo100());
     expect(onViewModeChange).toHaveBeenLastCalledWith('user');
+  });
+});
+
+describe('useImageZoom touch gestures', () => {
+  it('pinches around the moving midpoint and reports user intent', () => {
+    const onViewModeChange = vi.fn();
+    const { result } = setup(onViewModeChange);
+
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit');
+    });
+
+    const start = touchEvent([
+      { x: 310, y: 310 },
+      { x: 510, y: 310 },
+    ]);
+    const move = touchEvent([
+      { x: 260, y: 330 },
+      { x: 660, y: 330 },
+    ]);
+
+    act(() => result.current.handleTouchStart(start.event));
+    act(() => result.current.handleTouchMove(move.event));
+
+    const state = result.current.zoomState;
+    expect(state.scale).toBeCloseTo(0.8, 5);
+    expect(state.offsetX).toBeCloseTo(-340, 5);
+    expect(state.offsetY).toBeCloseTo(-203.2, 1);
+    expect(start.preventDefault).toHaveBeenCalled();
+    expect(move.preventDefault).toHaveBeenCalled();
+    expect(onViewModeChange).toHaveBeenLastCalledWith('user');
+  });
+
+  it('pans a zoomed image with one finger', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.applyBitmapDimensions(2000, 1333, 'fit');
+      result.current.zoomIn();
+    });
+    const before = result.current.zoomState;
+    const start = touchEvent([{ x: 400, y: 300 }]);
+    const move = touchEvent([{ x: 300, y: 220 }]);
+
+    act(() => result.current.handleTouchStart(start.event));
+    act(() => result.current.handleTouchMove(move.event));
+
+    expect(result.current.zoomState.offsetX).toBeCloseTo(
+      before.offsetX - 100,
+      5
+    );
+    expect(result.current.zoomState.offsetY).toBeCloseTo(
+      before.offsetY - 80,
+      5
+    );
+    expect(move.preventDefault).toHaveBeenCalled();
   });
 });
 

--- a/static/src/hooks/useImageZoom.ts
+++ b/static/src/hooks/useImageZoom.ts
@@ -32,6 +32,9 @@ export interface UseImageZoomReturn {
   handleMouseDown: (e: React.MouseEvent) => void;
   handleMouseMove: (e: React.MouseEvent) => void;
   handleMouseUp: (e: React.MouseEvent) => void;
+  handleTouchStart: (e: React.TouchEvent) => void;
+  handleTouchMove: (e: React.TouchEvent) => void;
+  handleTouchEnd: (e: React.TouchEvent) => void;
   handleKeyDown: (e: React.KeyboardEvent) => void;
   zoomIn: () => void;
   zoomOut: () => void;
@@ -75,6 +78,13 @@ export function useImageZoom(options: UseImageZoomOptions = DEFAULT_BOUNDS): Use
   const imageRef = useRef<HTMLImageElement>(null);
   const isPanningRef = useRef(false);
   const lastMousePosRef = useRef({ x: 0, y: 0 });
+  const lastTouchPosRef = useRef<{ x: number; y: number } | null>(null);
+  const pinchRef = useRef<{
+    distance: number;
+    centerX: number;
+    centerY: number;
+    state: ZoomState;
+  } | null>(null);
   const initialFitScaleRef = useRef(1);
 
   // Latest onViewModeChange without forcing callers to memoize it.
@@ -381,6 +391,128 @@ export function useImageZoom(options: UseImageZoomOptions = DEFAULT_BOUNDS): Use
     isPanningRef.current = false;
   }, []);
 
+  const beginPinch = useCallback((touches: React.TouchList, state: ZoomState) => {
+    const container = containerRef.current;
+    if (!container || touches.length < 2) return;
+
+    const rect = container.getBoundingClientRect();
+    const first = touches[0];
+    const second = touches[1];
+    const deltaX = second.clientX - first.clientX;
+    const deltaY = second.clientY - first.clientY;
+
+    pinchRef.current = {
+      distance: Math.hypot(deltaX, deltaY),
+      centerX: (first.clientX + second.clientX) / 2 - rect.left,
+      centerY: (first.clientY + second.clientY) / 2 - rect.top,
+      state,
+    };
+    lastTouchPosRef.current = null;
+  }, []);
+
+  // Touch uses one finger to pan and two fingers to zoom around their
+  // midpoint. The paired touch-action rule on .zoom-container keeps the
+  // browser from taking over the gesture.
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (e.touches.length >= 2) {
+      e.preventDefault();
+      beginPinch(e.touches, zoomState);
+      return;
+    }
+
+    if (e.touches.length === 1) {
+      const touch = e.touches[0];
+      lastTouchPosRef.current = { x: touch.clientX, y: touch.clientY };
+      pinchRef.current = null;
+    }
+  }, [beginPinch, zoomState]);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    if (e.touches.length >= 2) {
+      e.preventDefault();
+
+      if (!pinchRef.current) {
+        beginPinch(e.touches, zoomState);
+        return;
+      }
+
+      const first = e.touches[0];
+      const second = e.touches[1];
+      const rect = container.getBoundingClientRect();
+      const deltaX = second.clientX - first.clientX;
+      const deltaY = second.clientY - first.clientY;
+      const distance = Math.hypot(deltaX, deltaY);
+      const centerX = (first.clientX + second.clientX) / 2 - rect.left;
+      const centerY = (first.clientY + second.clientY) / 2 - rect.top;
+      const pinch = pinchRef.current;
+
+      if (pinch.distance <= 0) return;
+
+      const newScale = clampScale(
+        pinch.state.scale * (distance / pinch.distance)
+      );
+      const imageX =
+        (pinch.centerX - pinch.state.offsetX) / pinch.state.scale;
+      const imageY =
+        (pinch.centerY - pinch.state.offsetY) / pinch.state.scale;
+      const constrained = constrainPan(
+        centerX - imageX * newScale,
+        centerY - imageY * newScale,
+        newScale
+      );
+
+      intentionalZoomRef.current = true;
+      onViewModeChangeRef.current?.('user');
+      setZoomState({
+        scale: newScale,
+        offsetX: constrained.offsetX,
+        offsetY: constrained.offsetY,
+      });
+      return;
+    }
+
+    if (e.touches.length === 1 && lastTouchPosRef.current) {
+      e.preventDefault();
+      const touch = e.touches[0];
+      const deltaX = touch.clientX - lastTouchPosRef.current.x;
+      const deltaY = touch.clientY - lastTouchPosRef.current.y;
+
+      if (deltaX !== 0 || deltaY !== 0) {
+        onViewModeChangeRef.current?.('user');
+        setZoomState(prevState => {
+          const constrained = constrainPan(
+            prevState.offsetX + deltaX,
+            prevState.offsetY + deltaY,
+            prevState.scale
+          );
+          return {
+            ...prevState,
+            offsetX: constrained.offsetX,
+            offsetY: constrained.offsetY,
+          };
+        });
+      }
+
+      lastTouchPosRef.current = { x: touch.clientX, y: touch.clientY };
+    }
+  }, [beginPinch, clampScale, constrainPan, zoomState]);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (e.touches.length >= 2) {
+      beginPinch(e.touches, zoomState);
+    } else if (e.touches.length === 1) {
+      const touch = e.touches[0];
+      pinchRef.current = null;
+      lastTouchPosRef.current = { x: touch.clientX, y: touch.clientY };
+    } else {
+      pinchRef.current = null;
+      lastTouchPosRef.current = null;
+    }
+  }, [beginPinch, zoomState]);
+
   // Zoom in function
   const zoomIn = useCallback(() => {
     // Mark this as an intentional zoom operation
@@ -640,6 +772,9 @@ export function useImageZoom(options: UseImageZoomOptions = DEFAULT_BOUNDS): Use
     handleMouseDown,
     handleMouseMove,
     handleMouseUp,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
     handleKeyDown,
     zoomIn,
     zoomOut,


### PR DESCRIPTION
## Summary

- add two-finger pinch zoom and one-finger pan to the shared image zoom hook
- keep the image point under the moving pinch midpoint anchored while scaling
- enable touch gestures in image detail, comparison, and full-size stack inspection
- preserve comparison Sync Zoom when the right pane receives the gesture
- stop the browser from taking over touch gestures inside zoomable image panes

## Checks

- `npm run build`
- `npm run lint`
- `npm test` — 115 passed
- `npm run test:e2e -- image-detail.spec.ts` — 9 passed
