### PR TITLE
Add guarded catalog data transfer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["backup", "bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml_edit = { version = "0.25", features = ["serde"] }

--- a/DATA_TRANSFER_DESIGN.md
+++ b/DATA_TRANSFER_DESIGN.md
@@ -1,0 +1,381 @@
+# Data transfer, database merge, and remote sync
+
+Status: design approved in principle. The first implementation slice adds
+local grade push and server-owned preview IDs with expiry and stale checks.
+
+## Purpose
+
+PSF Guard needs one safe way to:
+
+- import FITS folders into a catalog;
+- merge one Target Scheduler database into another;
+- send planning changes or reviewed grades to another database;
+- do the same work through a remote PSF Guard server; and
+- later let a N.I.N.A. plugin provide the telescope-side endpoint.
+
+The design must not require Syncthing, Dropbox, or another file copier to move
+a live SQLite database. N.I.N.A. may write that file while an outside process
+copies it, and a copied database gives neither side a useful conflict preview.
+
+Original FITS files are outside the first remote-sync protocol. A transfer can
+copy database rows and stored thumbnails, then report which image files resolve
+on the destination. File transfer can be added later as a separate action.
+
+## Current state
+
+The repository already has most of the local merge rules:
+
+- FITS import scans headers and runs a dry preview before the UI offers Apply.
+- `sync pull` merges scheduler structure and captures by stable GUID.
+- Pull keeps a reviewed destination grade and only fills a Pending grade.
+- `sync planning` sends projects, targets, templates, plans, and rule weights
+  without changing capture history, plan progress, or grades.
+- `sync grades` sends grading state and reject reasons by image GUID.
+- The management API and Settings UI expose local pull and planning push.
+
+The missing pieces are:
+
+- one clear transfer workspace instead of controls repeated under each catalog;
+- a frozen source bundle so source edits after Preview can wait for the next
+  transfer instead of making the preview stale;
+- durable job and preview state;
+- local-file selection without first keeping a catalog in the registry;
+- remote peers, authentication, and a versioned wire format; and
+- an endpoint that a future N.I.N.A. plugin can implement.
+
+## Terms
+
+**Catalog endpoint**
+: A readable or writable source of catalog records. It can be a registered
+  local SQLite database, a file selected in the desktop app, a remote PSF Guard
+  server, or a future N.I.N.A. plugin.
+
+**Merge**
+: A one-way, additive copy into a destination. It can insert and update rows
+  under the rules below. Version 1 never deletes destination rows.
+
+**Preview**
+: A frozen source snapshot, selected options, destination preconditions, and
+  the exact changes an Apply would make.
+
+**Apply**
+: One transactional write of an approved preview. Apply is not a fresh sync
+  request.
+
+This is not a three-way merge. Target Scheduler rows do not carry enough edit
+history to prove that both sides changed the same field since a common base.
+Direction and data class therefore define which side wins.
+
+## User operations
+
+### Import FITS folders
+
+Source: one or more local folders.
+
+Destination: one local writable catalog.
+
+The importer reads FITS headers, attaches frames to a confirmed existing
+target when possible, and creates structure for the rest. Pixel quality work
+is a separate background action and defaults off.
+
+### Merge catalog
+
+Source: any catalog endpoint.
+
+Destination: any writable catalog endpoint.
+
+Copies projects, targets, exposure templates, exposure plans, rule weights,
+captures, and optional stored thumbnails. Matching uses stable GUIDs.
+Destination reviewed grades win. New captures retain the source grade.
+
+### Send planning
+
+Source planning fields win. The destination keeps capture history, plan
+`acquired` and `accepted` counts, images, grades, and reject reasons.
+
+### Send grades
+
+Only `gradingStatus` and `rejectreason` change. Images match by stable GUID.
+The source wins. The UI defaults to reviewed grades only, so a Pending source
+row cannot erase a telescope decision by accident. Project, target, and grade
+filters remain available.
+
+## Merge rules
+
+| Data | Match | Default rule |
+| --- | --- | --- |
+| Project, target, template, plan | Stable GUID | Directional source wins |
+| Rule weight | Project GUID plus name | Directional source wins |
+| Captured image | Stable GUID | Insert or update capture fields |
+| Existing reviewed grade during merge | Image GUID | Destination wins |
+| Existing Pending grade during merge | Image GUID | Fill from source |
+| Explicit grade push | Image GUID | Source grade and reason win |
+| Destination-only row | None | Keep |
+| Duplicate or empty GUID | None | Skip and report |
+| Non-null parent that cannot map | Parent GUID | Skip and report |
+| Same-looking object with another GUID | Name and coordinates | Warn; never auto-merge |
+
+The preview can offer an explicit target mapping for likely duplicates in a
+later phase. Name or coordinate similarity must never silently replace GUID
+identity.
+
+## Interface
+
+Add a full Data Transfer page reached from Settings. Do not add another item to
+the already busy image toolbar.
+
+```
+Data Transfer
+
+[ Import FITS folders ] [ Merge catalogs ] [ Send changes ]
+
+Source                               Destination
+[ Local / Remote ]  Review copy  -> [ Local / Remote ]  Telescope
+
+Data
+[x] Projects and targets       [x] Captures
+[x] Plans and templates        [ ] Stored thumbnails
+[ ] Reviewed grades
+
+Scope
+[ All projects ] [ Optional target ] [ Optional grade ]
+
+                                      [ Preview changes ]
+```
+
+Before a preview, the page has no Apply action. The preview page contains:
+
+- source, destination, direction, snapshot time, and expiry;
+- inserted, updated, unchanged, and skipped counts per data class;
+- grade transitions;
+- detailed row changes;
+- duplicate GUID, schema, and missing-parent warnings;
+- likely duplicate targets that need a mapping choice;
+- stored-thumbnail bytes;
+- resolved and missing image-file counts; and
+- a clear note that original FITS files are not transferred.
+
+Only a valid preview shows **Apply this preview**.
+
+The page also shows recent and running jobs. Reloading the page must recover
+their state.
+
+### Local files
+
+The desktop app can choose a source or destination SQLite file with a native
+picker. The backend opens a source read-only and an existing destination
+read-write. A selected file does not need to remain in the normal catalog
+registry.
+
+Browser mode can use registered local catalogs. It must not accept arbitrary
+server filesystem paths from an HTTP request.
+
+### Remote peers
+
+Settings stores a peer name, HTTPS base URL, server-held credential, allowed
+remote catalog, optional path mappings, and granted capabilities. The browser
+never receives the credential.
+
+The connection test shows:
+
+- peer and protocol version;
+- remote product and Target Scheduler schema versions;
+- readable and writable catalogs allowed by the credential;
+- read, merge, planning-write, and grade-write capabilities; and
+- the last successful connection and sync.
+
+## Preview and apply
+
+The local API now records each dry run under an opaque preview ID and Apply
+accepts only that ID. It fingerprints the relevant source and destination
+tables and returns `409 Conflict` if either changed. That prevents the browser
+from changing options between Preview and Apply and rejects catalog drift, but
+source rows are not frozen yet.
+Preview IDs are one-use, and guarded applies run one at a time so two requests
+cannot both pass the same precondition check.
+
+Complete the model in phases:
+
+1. Read the source into an immutable, versioned transfer bundle.
+2. Plan that bundle against the destination without writing destination rows.
+3. Save the bundle, options, summary, detailed changes, and destination
+   preconditions under an opaque preview ID.
+4. Return the preview ID and expiry to the UI.
+5. Apply only by preview ID.
+6. Recheck destination preconditions under the destination write lock.
+7. Return `409 preview_stale` if relevant destination rows changed.
+8. Back up the destination, apply in one transaction, and save an audit result.
+
+If the source changes after preview, Apply still uses the frozen source bundle.
+Those later source changes arrive in the next transfer. If the destination
+changes, the preview becomes stale because its conflict results may no longer
+hold.
+
+Previews and jobs live below the server cache, not only in React state. The
+default preview lifetime is 30 minutes. Completed job records can persist
+longer with a bounded count and size.
+
+## Local API
+
+The UI talks only to its local PSF Guard server.
+
+```
+GET    /api/data-transfer/capabilities
+GET    /api/data-transfer/endpoints
+POST   /api/data-transfer/previews
+GET    /api/data-transfer/previews/{preview_id}
+DELETE /api/data-transfer/previews/{preview_id}
+POST   /api/data-transfer/previews/{preview_id}/apply
+GET    /api/data-transfer/jobs
+GET    /api/data-transfer/jobs/{job_id}
+```
+
+`POST /previews` accepts endpoint references, an operation, data selection,
+and filters. It never accepts `apply=true`. Apply has its own endpoint and
+requires the opaque preview ID.
+
+The current guarded local routes are:
+
+```
+POST /api/databases/{id}/sync/preview
+POST /api/databases/{id}/sync/previews/{preview_id}/apply
+```
+
+The existing `/api/databases/{id}/sync` endpoint remains during migration.
+Omitting `dry_run` means preview, never Apply. New UI code uses only the
+guarded routes.
+
+## Remote protocol
+
+The coordinator uses a versioned protocol rather than copying SQLite:
+
+```
+GET  /api/sync/v1/capabilities
+POST /api/sync/v1/exports
+GET  /api/sync/v1/exports/{export_id}
+POST /api/sync/v1/previews
+GET  /api/sync/v1/previews/{preview_id}
+POST /api/sync/v1/previews/{preview_id}/apply
+GET  /api/sync/v1/jobs/{job_id}
+```
+
+For a pull, the coordinator requests a bundle from the remote source and plans
+and applies it locally. For a push, it creates a local bundle and sends it to
+the remote destination, which owns preview and Apply.
+
+The bundle is compressed and contains:
+
+- protocol and producer versions;
+- source catalog identity and Target Scheduler schema facts;
+- operation and filters;
+- table schemas needed to preserve shared columns;
+- rows keyed by stable GUID;
+- optional stored-thumbnail chunks;
+- source snapshot metadata; and
+- a payload digest.
+
+The protocol sets compressed and expanded size limits, row limits, timeouts,
+and a bounded thumbnail budget. It rejects unknown required features rather
+than guessing.
+
+## N.I.N.A. plugin
+
+A later N.I.N.A. plugin can implement the remote protocol at the telescope.
+The plugin does not need to expose the SQLite file.
+
+The plugin can:
+
+- read a consistent Target Scheduler snapshot;
+- expose schema and capability facts;
+- export planning and capture history;
+- preview and transactionally apply planning or grade changes;
+- report new captures;
+- expose configured image-history roots or manifests; and
+- notify PSF Guard after a capture changes the catalog.
+
+The first plugin release should remain manual and preview-first. Automatic
+background sync can follow after the audit trail and conflict behavior have
+real use.
+
+## Security
+
+Remote sync is disabled by default.
+
+- Require HTTPS except for loopback development.
+- Store peer credentials in the backend or desktop secret store.
+- Store only salted token hashes on the receiving server.
+- Scope tokens to catalog IDs and actions.
+- Never expose arbitrary file paths or SQL through the protocol.
+- Rate-limit preview and export creation.
+- Log peer, catalog, operation, preview digest, actor, counts, and result.
+- Redact credentials and local paths from logs returned to a remote caller.
+- Keep database-management and sync permissions separate.
+
+## Concurrency and recovery
+
+Use one mutation coordinator per destination catalog. Import, merge, planning
+push, grade push, and other database writes must not overlap on that catalog.
+Reads and previews can run concurrently where SQLite permits.
+
+Each job records queued, snapshotting, planning, waiting-for-approval,
+applying, complete, cancelled, stale, or failed. A restart recovers durable
+non-terminal jobs or marks an interrupted Apply for inspection. Apply remains
+transactional, so it cannot leave half a merge committed.
+
+## Delivery
+
+### Phase 1: complete the existing local path
+
+- [x] Add grade push to the management API and Settings UI.
+- [x] Default grade push to reviewed rows only.
+- [x] Make omitted `dry_run` mean preview.
+- [x] Improve summaries and tests.
+
+### Phase 2: immutable local previews
+
+- [ ] Refactor sync cores into bundle, plan, and apply stages.
+- [x] Add preview IDs, expiry, and source and destination stale checks.
+- [ ] Add destination backups and audit jobs.
+- [x] Add the Data Transfer workspace for registered local catalogs.
+- [ ] Move FITS import onto the same preview and job model.
+
+### Phase 3: desktop local files
+
+- Add Tauri source and destination file pickers.
+- Pass selected files through native commands, not arbitrary browser paths.
+- Add optional path mappings and file-resolution reporting.
+
+### Phase 4: remote PSF Guard peers
+
+- Add scoped peer credentials and capability discovery.
+- Add compressed export bundles and remote preview/apply.
+- Test interrupted transfers, limits, stale previews, and retries.
+
+### Phase 5: N.I.N.A. plugin
+
+- Implement the same capability, export, preview, apply, and job contract.
+- Add capture notifications and image-history manifests.
+
+## Verification
+
+Rust tests must cover:
+
+- every merge policy and grade transition;
+- dry preview making no row changes;
+- source snapshot immutability;
+- stale destination rejection;
+- duplicate GUID and missing-parent handling;
+- transaction rollback and backup failure;
+- protocol version, authentication, and size limits; and
+- restart recovery.
+
+Frontend tests must cover:
+
+- Apply absent before preview;
+- changed options invalidating a preview;
+- detailed counts and warnings;
+- reload recovery;
+- stale-preview handling;
+- local file selection in Tauri;
+- remote capability errors; and
+- successful local and remote preview/apply flows in Playwright.

--- a/DATA_TRANSFER_DESIGN.md
+++ b/DATA_TRANSFER_DESIGN.md
@@ -36,8 +36,6 @@ The repository already has most of the local merge rules:
 The missing pieces are:
 
 - one clear transfer workspace instead of controls repeated under each catalog;
-- a frozen source bundle so source edits after Preview can wait for the next
-  transfer instead of making the preview stale;
 - durable job and preview state;
 - local-file selection without first keeping a catalog in the registry;
 - remote peers, authentication, and a versioned wire format; and
@@ -187,10 +185,10 @@ The connection test shows:
 ## Preview and apply
 
 The local API now records each dry run under an opaque preview ID and Apply
-accepts only that ID. It fingerprints the relevant source and destination
-tables and returns `409 Conflict` if either changed. That prevents the browser
-from changing options between Preview and Apply and rejects catalog drift, but
-source rows are not frozen yet.
+accepts only that ID. Preview takes an online SQLite snapshot of the source.
+Apply reads that snapshot, takes the destination write lock, and checks the
+destination fingerprint in the same transaction as the write. Source edits
+wait for the next transfer; destination edits return `409 Conflict`.
 Preview IDs are one-use, and guarded applies run one at a time so two requests
 cannot both pass the same precondition check.
 
@@ -334,7 +332,8 @@ transactional, so it cannot leave half a merge committed.
 ### Phase 2: immutable local previews
 
 - [ ] Refactor sync cores into bundle, plan, and apply stages.
-- [x] Add preview IDs, expiry, and source and destination stale checks.
+- [x] Add preview IDs, expiry, frozen source snapshots, and atomic destination
+  stale checks.
 - [ ] Add destination backups and audit jobs.
 - [x] Add the Data Transfer workspace for registered local catalogs.
 - [ ] Move FITS import onto the same preview and job model.

--- a/README.md
+++ b/README.md
@@ -613,11 +613,12 @@ push planning settings and grades back. All three commands support
 `--status`), open the source read-only, and run in one transaction. The
 Settings has one Data Transfer workspace with explicit source and destination
 catalogs. It offers merge, planning, and reviewed-grade actions with a
-server-owned preview before Apply. Pending grades are excluded from the UI
-grade push by default.
+server-owned preview before Apply. The preview keeps a frozen source snapshot
+and returns after a page reload. Apply rejects destination changes before it
+writes. Pending grades are excluded from the UI grade push by default.
 
-Native one-off file handles, frozen source bundles, the remote protocol, and
-the future N.I.N.A. plugin boundary are tracked in
+Native one-off file handles, versioned remote bundles, the remote protocol,
+and the future N.I.N.A. plugin boundary are tracked in
 [DATA_TRANSFER_DESIGN.md](./DATA_TRANSFER_DESIGN.md).
 
 ## ⌨️ CLI reference

--- a/README.md
+++ b/README.md
@@ -611,8 +611,14 @@ Pull complete new projects and captures, edit plans or grade locally, then
 push planning settings and grades back. All three commands support
 `--project` filters and `--dry-run` (`grades` also supports `--target` and
 `--status`), open the source read-only, and run in one transaction. The
-Settings panel offers the same full-pull and planning-push actions with a
-dry-run preview before Apply.
+Settings has one Data Transfer workspace with explicit source and destination
+catalogs. It offers merge, planning, and reviewed-grade actions with a
+server-owned preview before Apply. Pending grades are excluded from the UI
+grade push by default.
+
+Native one-off file handles, frozen source bundles, the remote protocol, and
+the future N.I.N.A. plugin boundary are tracked in
+[DATA_TRANSFER_DESIGN.md](./DATA_TRANSFER_DESIGN.md).
 
 ## ⌨️ CLI reference
 
@@ -806,6 +812,15 @@ curl -X POST "localhost:3000/api/databases/my-db/sync" \
 curl -X POST "localhost:3000/api/databases/my-db/sync" \
   -H "Content-Type: application/json" \
   -d '{"peer_db_id":"telescope","kind":"push_planning","dry_run":true}'
+
+# Create a server-owned preview of reviewed grade changes.
+curl -X POST "localhost:3000/api/databases/my-db/sync/preview" \
+  -H "Content-Type: application/json" \
+  -d '{"peer_db_id":"telescope","kind":"push_grades"}'
+
+# Apply only the preview you reviewed (use preview_id from the prior response).
+curl -X POST \
+  "localhost:3000/api/databases/my-db/sync/previews/<preview_id>/apply"
 ```
 
 ## ⚠️ Known limitations

--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -135,17 +135,20 @@ header name grouped them poorly.
 
 ## Sync with the telescope database
 
-Add both the local and telescope databases in Settings, then expand
-**Scheduler database sync**:
+Add both the local and telescope databases in Settings, then use
+**Data Transfer**:
 
-- **Preview full pull** copies new or changed projects, targets, templates,
-  plans, captures, and grades from the telescope database into the local one.
-  Local reviewed grades win.
-- **Preview planning push** sends project, target, template, plan, and rule
-  settings back to the telescope database. It does not change telescope image
-  rows, capture counts, or grades.
+- **Merge catalogs** copies new or changed projects, targets, templates, plans,
+  captures, and grades from the selected source into the destination. Reviewed
+  grades already at the destination win.
+- **Send planning** sends project, target, template, plan, and rule settings.
+  It does not change destination image rows, capture counts, or grades.
+- **Send reviewed grades** sends Accepted and Rejected grades and reject
+  reasons for matching image GUIDs. Pending source rows are skipped.
 
-Both actions show a dry preview before **Apply**. The CLI equivalents are:
+All three actions create a server-owned preview before **Apply**. The preview
+expires after 30 minutes and becomes stale if either database changes. The CLI
+equivalents are:
 
 ```bash
 psf-guard sync pull --from telescope.sqlite --to archive.sqlite --dry-run
@@ -154,3 +157,7 @@ psf-guard sync grades --from archive.sqlite --to telescope.sqlite --dry-run
 ```
 
 Back up both databases before the first write.
+
+See [the data-transfer design](../DATA_TRANSFER_DESIGN.md) for planned native
+one-off file handles, frozen source bundles, remote peers, and the N.I.N.A.
+plugin endpoint.

--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -147,8 +147,8 @@ Add both the local and telescope databases in Settings, then use
   reasons for matching image GUIDs. Pending source rows are skipped.
 
 All three actions create a server-owned preview before **Apply**. The preview
-expires after 30 minutes and becomes stale if either database changes. The CLI
-equivalents are:
+expires after 30 minutes. It keeps the source state you reviewed and becomes
+stale if the destination changes. The CLI equivalents are:
 
 ```bash
 psf-guard sync pull --from telescope.sqlite --to archive.sqlite --dry-run
@@ -159,5 +159,5 @@ psf-guard sync grades --from archive.sqlite --to telescope.sqlite --dry-run
 Back up both databases before the first write.
 
 See [the data-transfer design](../DATA_TRANSFER_DESIGN.md) for planned native
-one-off file handles, frozen source bundles, remote peers, and the N.I.N.A.
+one-off file handles, versioned remote bundles, remote peers, and the N.I.N.A.
 plugin endpoint.

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -702,6 +702,7 @@ pub fn main() -> Result<()> {
 
                 let options = SyncGradesOptions {
                     status_filter,
+                    reviewed_only: false,
                     project_filter: project,
                     target_filter: target,
                     dry_run,

--- a/src/commands/sync/grades.rs
+++ b/src/commands/sync/grades.rs
@@ -13,7 +13,7 @@ use crate::commands::reject_archive::require_target_scheduler_guid;
 use crate::db::Database;
 use crate::models::GradingStatus;
 use anyhow::{anyhow, Context, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Knobs for a one-way grade push.
@@ -93,8 +93,27 @@ pub fn sync_grades(
     require_target_scheduler_guid(src).context("source database")?;
     require_target_scheduler_guid(dest).context("destination database")?;
 
+    let tx = dest.unchecked_transaction()?;
+    let summary = sync_grades_in_transaction(src, &tx, opts)?;
+    if opts.dry_run {
+        tx.rollback()?;
+    } else {
+        tx.commit()?;
+    }
+    Ok(summary)
+}
+
+/// Stage one grade push inside a transaction owned by the caller.
+pub(crate) fn sync_grades_in_transaction(
+    src: &Connection,
+    tx: &Transaction<'_>,
+    opts: &SyncGradesOptions,
+) -> Result<SyncSummary> {
+    require_target_scheduler_guid(src).context("source database")?;
+    require_target_scheduler_guid(tx).context("destination database")?;
+
     let src_db = Database::new(src);
-    let dest_db = Database::new(dest);
+    let dest_db = Database::new(tx);
 
     let src_rows = src_db.query_images(
         opts.status_filter,
@@ -215,10 +234,14 @@ pub fn sync_grades(
         .filter(|g| !matched_dest.contains(g.as_str()))
         .count();
 
-    if !opts.dry_run && !updates.is_empty() {
-        dest_db
-            .batch_update_grading_status(&updates)
-            .context("applying grade updates to destination")?;
+    if !opts.dry_run {
+        for (id, status, reason) in updates {
+            tx.execute(
+                "UPDATE acquiredimage SET gradingStatus = ?1, rejectreason = ?2 WHERE Id = ?3",
+                rusqlite::params![status as i32, reason.as_deref(), id],
+            )
+            .context("applying grade update to destination")?;
+        }
     }
 
     Ok(summary)

--- a/src/commands/sync/grades.rs
+++ b/src/commands/sync/grades.rs
@@ -20,6 +20,10 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 pub struct SyncGradesOptions {
     /// Only consider source rows with this grade (None = all).
     pub status_filter: Option<GradingStatus>,
+    /// When no exact status filter is set, skip Pending rows. This is the safe
+    /// default for UI-driven grade pushes: an unreviewed source row must not
+    /// erase a decision already made at the destination.
+    pub reviewed_only: bool,
     /// Restrict to source rows whose project name matches (substring).
     pub project_filter: Option<String>,
     /// Restrict to source rows whose target name matches (substring).
@@ -152,6 +156,12 @@ pub fn sync_grades(
     let mut updates: Vec<(i32, GradingStatus, Option<String>)> = Vec::new();
 
     for (img, _, _) in &src_rows {
+        if opts.status_filter.is_none()
+            && opts.reviewed_only
+            && img.grading_status == GradingStatus::Pending as i32
+        {
+            continue;
+        }
         let guid = match img.guid.as_deref() {
             Some(g) if !g.is_empty() => g,
             _ => {
@@ -263,6 +273,7 @@ mod tests {
     fn opts() -> SyncGradesOptions {
         SyncGradesOptions {
             status_filter: None,
+            reviewed_only: false,
             project_filter: None,
             target_filter: None,
             dry_run: false,
@@ -359,6 +370,39 @@ mod tests {
         assert_eq!(summary.changed, 1);
         assert_eq!(grade_of(&dest, "g1"), (2, Some("x".to_string())));
         assert_eq!(grade_of(&dest, "g2"), (0, None)); // not pushed (filtered out)
+    }
+
+    #[test]
+    fn reviewed_only_does_not_clear_a_destination_grade() {
+        let src = setup_db(
+            &[
+                (1, 0, Some("pending"), None),
+                (2, 1, Some("accepted"), None),
+                (3, 2, Some("rejected"), Some("clouds")),
+            ],
+            true,
+        );
+        let dest = setup_db(
+            &[
+                (10, 2, Some("pending"), Some("tracking")),
+                (20, 0, Some("accepted"), None),
+                (30, 0, Some("rejected"), None),
+            ],
+            true,
+        );
+
+        let mut o = opts();
+        o.reviewed_only = true;
+        let summary = sync_grades(&src, &dest, &o).unwrap();
+
+        assert_eq!(summary.source_considered, 2);
+        assert_eq!(summary.changed, 2);
+        assert_eq!(
+            grade_of(&dest, "pending"),
+            (2, Some("tracking".to_string()))
+        );
+        assert_eq!(grade_of(&dest, "accepted"), (1, None));
+        assert_eq!(grade_of(&dest, "rejected"), (2, Some("clouds".to_string())));
     }
 
     #[test]

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -16,8 +16,11 @@ mod grades;
 mod planning;
 mod pull;
 
+pub(crate) use grades::sync_grades_in_transaction;
 pub use grades::{sync_grades, GradeChange, SyncGradesOptions, SyncSummary};
+pub(crate) use planning::sync_planning_in_transaction;
 pub use planning::{sync_planning, PlanningOptions, PlanningSummary};
+pub(crate) use pull::sync_pull_in_transaction;
 pub use pull::{sync_pull, PullOptions, PullSummary, TableCounts};
 
 use crate::db_registry::DbRegistry;

--- a/src/commands/sync/planning.rs
+++ b/src/commands/sync/planning.rs
@@ -8,7 +8,7 @@
 use super::pull::sync_structure;
 use super::{require_planning_capable, TableCounts};
 use anyhow::{Context, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, Transaction};
 
 /// Options for a planning-only settings push.
 pub struct PlanningOptions {
@@ -59,10 +59,32 @@ pub fn sync_planning(
     require_planning_capable(dest).context("destination database")?;
 
     let tx = dest.unchecked_transaction()?;
+    let summary = sync_planning_in_transaction(src, &tx, opts)?;
+    if opts.dry_run {
+        tx.rollback()?;
+    } else {
+        tx.commit()?;
+    }
+    Ok(summary)
+}
+
+/// Stage one planning sync inside a transaction owned by the caller.
+///
+/// The guarded server path uses this form so it can verify destination
+/// preconditions after taking SQLite's write lock, then apply in that same
+/// transaction.
+pub(crate) fn sync_planning_in_transaction(
+    src: &Connection,
+    tx: &Transaction<'_>,
+    opts: &PlanningOptions,
+) -> Result<PlanningSummary> {
+    require_planning_capable(src).context("source database")?;
+    require_planning_capable(tx).context("destination database")?;
+
     let mut summary = PlanningSummary::default();
     let structure = sync_structure(
         src,
-        &tx,
+        tx,
         opts.project_filter.as_deref(),
         true,
         &mut summary.changes,
@@ -74,11 +96,6 @@ pub fn sync_planning(
     summary.target = structure.target;
     summary.exposureplan = structure.exposureplan;
 
-    if opts.dry_run {
-        tx.rollback()?;
-    } else {
-        tx.commit()?;
-    }
     Ok(summary)
 }
 

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -785,11 +785,29 @@ pub fn sync_pull(src: &Connection, dest: &Connection, opts: &PullOptions) -> Res
     require_pull_capable(dest).context("destination database")?;
 
     let tx = dest.unchecked_transaction()?;
+    let summary = sync_pull_in_transaction(src, &tx, opts)?;
+    if opts.dry_run {
+        tx.rollback()?;
+    } else {
+        tx.commit()?;
+    }
+    Ok(summary)
+}
+
+/// Stage one full pull inside a transaction owned by the caller.
+pub(crate) fn sync_pull_in_transaction(
+    src: &Connection,
+    tx: &Transaction<'_>,
+    opts: &PullOptions,
+) -> Result<PullSummary> {
+    require_pull_capable(src).context("source database")?;
+    require_pull_capable(tx).context("destination database")?;
+
     let mut summary = PullSummary::default();
 
     let structure = sync_structure(
         src,
-        &tx,
+        tx,
         opts.project_filter.as_deref(),
         false,
         &mut summary.changes,
@@ -803,7 +821,7 @@ pub fn sync_pull(src: &Connection, dest: &Connection, opts: &PullOptions) -> Res
     // 6. acquiredimage (grade fill-if-pending; remap proj/tgt/exposureId)
     let img_map = upsert_acquired_images(
         src,
-        &tx,
+        tx,
         &structure.project_map,
         &structure.target_map,
         &structure.plan_map,
@@ -815,7 +833,7 @@ pub fn sync_pull(src: &Connection, dest: &Connection, opts: &PullOptions) -> Res
     if opts.with_image_data {
         copy_imagedata(
             src,
-            &tx,
+            tx,
             &img_map,
             &mut summary.imagedata,
             &mut summary.imagedata_bytes,
@@ -824,11 +842,6 @@ pub fn sync_pull(src: &Connection, dest: &Connection, opts: &PullOptions) -> Res
         summary.imagedata_synced = true;
     }
 
-    if opts.dry_run {
-        tx.rollback()?;
-    } else {
-        tx.commit()?;
-    }
     Ok(summary)
 }
 

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -248,23 +248,30 @@ pub struct DatabaseSummary {
 }
 
 /// Database-to-database operations exposed by the management UI.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SchedulerSyncKind {
     /// Telescope → local: structure, captures, and optional image data.
     Pull,
     /// Local → telescope: planning settings only.
     PushPlanning,
+    /// Local → telescope: grading state and reject reasons only.
+    PushGrades,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Body of `POST /api/databases/{db_id}/sync`. `db_id` is the local working
 /// database; `peer_db_id` is the telescope scheduler database.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SchedulerSyncRequest {
     pub peer_db_id: String,
     pub kind: SchedulerSyncKind,
-    /// Plan and count without changing either database.
-    #[serde(default)]
+    /// Plan and count without changing either database. Omitted means true:
+    /// callers must opt in to a live write.
+    #[serde(default = "default_true")]
     pub dry_run: bool,
     /// Pull image-data BLOBs. Defaults to true and has no effect on a planning
     /// push.
@@ -273,10 +280,20 @@ pub struct SchedulerSyncRequest {
     /// Optional project-name substring filter.
     #[serde(default)]
     pub project: Option<String>,
+    /// Optional target-name substring filter for grade pushes.
+    #[serde(default)]
+    pub target: Option<String>,
+    /// Optional exact source grade for grade pushes.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// When no exact status is selected, send Accepted and Rejected rows but
+    /// leave Pending rows alone. Defaults to true.
+    #[serde(default = "default_true")]
+    pub reviewed_only: bool,
 }
 
 /// Insert/update counts for one scheduler table.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct SchedulerSyncTableCounts {
     pub inserted: usize,
     pub updated: usize,
@@ -295,8 +312,22 @@ impl From<&crate::commands::sync::TableCounts> for SchedulerSyncTableCounts {
     }
 }
 
+/// Grade-push counts. Present only for `push_grades`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct SchedulerSyncGradeCounts {
+    pub source_considered: usize,
+    pub source_no_guid: usize,
+    pub matched: usize,
+    pub changed: usize,
+    pub unchanged: usize,
+    pub unmatched_source: usize,
+    pub destination_only: usize,
+    pub duplicate_guids: usize,
+    pub transitions: std::collections::BTreeMap<String, usize>,
+}
+
 /// Result of a database-to-database scheduler sync or dry-run preview.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SchedulerSyncResponse {
     pub kind: SchedulerSyncKind,
     pub dry_run: bool,
@@ -311,11 +342,21 @@ pub struct SchedulerSyncResponse {
     pub acquiredimage: Option<SchedulerSyncTableCounts>,
     /// Present only for a full pull with image-data syncing enabled.
     pub imagedata: Option<SchedulerSyncTableCounts>,
+    /// Present only for a grade push.
+    pub grades: Option<SchedulerSyncGradeCounts>,
     pub grade_filled: usize,
     pub grade_preserved: usize,
     pub imagedata_bytes: u64,
     pub total_inserted: usize,
     pub total_updated: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SchedulerSyncPreviewResponse {
+    pub preview_id: String,
+    pub created_at: i64,
+    pub expires_at: i64,
+    pub result: SchedulerSyncResponse,
 }
 
 /// Body of `POST /api/databases`.

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -396,11 +396,41 @@ async fn execute_scheduler_sync(
     db_id: &str,
     req: SchedulerSyncRequest,
 ) -> Result<SchedulerSyncResponse, AppError> {
+    execute_scheduler_sync_guarded(state, db_id, req, None, SyncGuardMode::None)
+        .await
+        .map(|(response, _)| response)
+}
+
+enum SyncGuardMode {
+    None,
+    Preview,
+    Apply { destination_fingerprint: String },
+}
+
+#[derive(Debug)]
+struct StaleSyncPreview;
+
+impl std::fmt::Display for StaleSyncPreview {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("sync preview destination changed")
+    }
+}
+
+impl std::error::Error for StaleSyncPreview {}
+
+async fn execute_scheduler_sync_guarded(
+    state: &Arc<AppState>,
+    db_id: &str,
+    req: SchedulerSyncRequest,
+    source_override: Option<PathBuf>,
+    guard_mode: SyncGuardMode,
+) -> Result<(SchedulerSyncResponse, Option<String>), AppError> {
     use crate::commands::sync::{
-        parse_status, sync_grades, sync_planning, sync_pull, PlanningOptions, PullOptions,
-        SyncGradesOptions,
+        parse_status, sync_grades, sync_grades_in_transaction, sync_planning,
+        sync_planning_in_transaction, sync_pull, sync_pull_in_transaction, PlanningOptions,
+        PullOptions, SyncGradesOptions,
     };
-    use rusqlite::{Connection, OpenFlags};
+    use rusqlite::{Connection, OpenFlags, Transaction, TransactionBehavior};
 
     require_database_management_allowed(state)?;
     if db_id == req.peer_db_id {
@@ -419,10 +449,11 @@ async fn execute_scheduler_sync(
             (Arc::clone(&local), Arc::clone(&peer))
         }
     };
-    let source_path = PathBuf::from(&source_ctx.database_path);
+    let source_path = source_override.unwrap_or_else(|| PathBuf::from(&source_ctx.database_path));
     let destination_path = PathBuf::from(&destination_ctx.database_path);
     let source_id = source_ctx.id.clone();
     let destination_id = destination_ctx.id.clone();
+    let fingerprint_queries = crate::server::sync_preview::fingerprint_queries(&req);
     let kind = req.kind;
     let dry_run = req.dry_run;
     let project = req.project;
@@ -439,130 +470,182 @@ async fn execute_scheduler_sync(
     let reviewed_only = req.reviewed_only;
     let with_image_data = req.with_image_data.unwrap_or(true);
 
-    let response = tokio::task::spawn_blocking(move || -> anyhow::Result<SchedulerSyncResponse> {
-        let source_canon =
-            std::fs::canonicalize(&source_path).unwrap_or_else(|_| source_path.clone());
-        let destination_canon =
-            std::fs::canonicalize(&destination_path).unwrap_or_else(|_| destination_path.clone());
-        anyhow::ensure!(
-            source_canon != destination_canon,
-            "The two configured entries point to the same database file."
-        );
+    let response = tokio::task::spawn_blocking(
+        move || -> anyhow::Result<(SchedulerSyncResponse, Option<String>)> {
+            let source_canon =
+                std::fs::canonicalize(&source_path).unwrap_or_else(|_| source_path.clone());
+            let destination_canon = std::fs::canonicalize(&destination_path)
+                .unwrap_or_else(|_| destination_path.clone());
+            anyhow::ensure!(
+                source_canon != destination_canon,
+                "The two configured entries point to the same database file."
+            );
 
-        let source = Connection::open_with_flags(&source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-        let destination =
-            Connection::open_with_flags(&destination_path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
+            let source =
+                Connection::open_with_flags(&source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+            let destination =
+                Connection::open_with_flags(&destination_path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
 
-        let response = match kind {
-            SchedulerSyncKind::Pull => {
-                let summary = sync_pull(
-                    &source,
-                    &destination,
-                    &PullOptions {
-                        dry_run,
-                        with_image_data,
-                        project_filter: project,
-                    },
-                )?;
-                SchedulerSyncResponse {
-                    kind,
-                    dry_run,
-                    source_db_id: source_id,
-                    destination_db_id: destination_id,
-                    exposuretemplate: (&summary.exposuretemplate).into(),
-                    project: (&summary.project).into(),
-                    ruleweight: (&summary.ruleweight).into(),
-                    target: (&summary.target).into(),
-                    exposureplan: (&summary.exposureplan).into(),
-                    acquiredimage: Some((&summary.acquiredimage).into()),
-                    imagedata: summary
-                        .imagedata_synced
-                        .then(|| (&summary.imagedata).into()),
-                    grades: None,
-                    grade_filled: summary.grade_filled,
-                    grade_preserved: summary.grade_preserved,
-                    imagedata_bytes: summary.imagedata_bytes,
-                    total_inserted: summary.total_inserted(),
-                    total_updated: summary.total_updated(),
+            let run =
+                |transaction: Option<&Transaction<'_>>| -> anyhow::Result<SchedulerSyncResponse> {
+                    let response = match kind {
+                        SchedulerSyncKind::Pull => {
+                            let options = PullOptions {
+                                dry_run,
+                                with_image_data,
+                                project_filter: project.clone(),
+                            };
+                            let summary = match transaction {
+                                Some(transaction) => {
+                                    sync_pull_in_transaction(&source, transaction, &options)?
+                                }
+                                None => sync_pull(&source, &destination, &options)?,
+                            };
+                            SchedulerSyncResponse {
+                                kind,
+                                dry_run,
+                                source_db_id: source_id,
+                                destination_db_id: destination_id,
+                                exposuretemplate: (&summary.exposuretemplate).into(),
+                                project: (&summary.project).into(),
+                                ruleweight: (&summary.ruleweight).into(),
+                                target: (&summary.target).into(),
+                                exposureplan: (&summary.exposureplan).into(),
+                                acquiredimage: Some((&summary.acquiredimage).into()),
+                                imagedata: summary
+                                    .imagedata_synced
+                                    .then(|| (&summary.imagedata).into()),
+                                grades: None,
+                                grade_filled: summary.grade_filled,
+                                grade_preserved: summary.grade_preserved,
+                                imagedata_bytes: summary.imagedata_bytes,
+                                total_inserted: summary.total_inserted(),
+                                total_updated: summary.total_updated(),
+                            }
+                        }
+                        SchedulerSyncKind::PushPlanning => {
+                            let options = PlanningOptions {
+                                dry_run,
+                                project_filter: project.clone(),
+                            };
+                            let summary = match transaction {
+                                Some(transaction) => {
+                                    sync_planning_in_transaction(&source, transaction, &options)?
+                                }
+                                None => sync_planning(&source, &destination, &options)?,
+                            };
+                            SchedulerSyncResponse {
+                                kind,
+                                dry_run,
+                                source_db_id: source_id,
+                                destination_db_id: destination_id,
+                                exposuretemplate: (&summary.exposuretemplate).into(),
+                                project: (&summary.project).into(),
+                                ruleweight: (&summary.ruleweight).into(),
+                                target: (&summary.target).into(),
+                                exposureplan: (&summary.exposureplan).into(),
+                                acquiredimage: None,
+                                imagedata: None,
+                                grades: None,
+                                grade_filled: 0,
+                                grade_preserved: 0,
+                                imagedata_bytes: 0,
+                                total_inserted: summary.total_inserted(),
+                                total_updated: summary.total_updated(),
+                            }
+                        }
+                        SchedulerSyncKind::PushGrades => {
+                            let options = SyncGradesOptions {
+                                status_filter,
+                                reviewed_only,
+                                project_filter: project.clone(),
+                                target_filter: target.clone(),
+                                dry_run,
+                            };
+                            let summary = match transaction {
+                                Some(transaction) => {
+                                    sync_grades_in_transaction(&source, transaction, &options)?
+                                }
+                                None => sync_grades(&source, &destination, &options)?,
+                            };
+                            SchedulerSyncResponse {
+                                kind,
+                                dry_run,
+                                source_db_id: source_id,
+                                destination_db_id: destination_id,
+                                exposuretemplate: SchedulerSyncTableCounts::default(),
+                                project: SchedulerSyncTableCounts::default(),
+                                ruleweight: SchedulerSyncTableCounts::default(),
+                                target: SchedulerSyncTableCounts::default(),
+                                exposureplan: SchedulerSyncTableCounts::default(),
+                                acquiredimage: None,
+                                imagedata: None,
+                                grades: Some(SchedulerSyncGradeCounts {
+                                    source_considered: summary.source_considered,
+                                    source_no_guid: summary.source_no_guid,
+                                    matched: summary.matched,
+                                    changed: summary.changed,
+                                    unchanged: summary.unchanged,
+                                    unmatched_source: summary.unmatched_source,
+                                    destination_only: summary.dest_only,
+                                    duplicate_guids: summary.duplicate_guids,
+                                    transitions: summary.transitions,
+                                }),
+                                grade_filled: 0,
+                                grade_preserved: 0,
+                                imagedata_bytes: 0,
+                                total_inserted: 0,
+                                total_updated: summary.changed,
+                            }
+                        }
+                    };
+                    Ok(response)
+                };
+
+            match guard_mode {
+                SyncGuardMode::None => Ok((run(None)?, None)),
+                SyncGuardMode::Preview => {
+                    let transaction =
+                        Transaction::new_unchecked(&destination, TransactionBehavior::Deferred)?;
+                    let fingerprint = crate::server::sync_preview::connection_fingerprint(
+                        &transaction,
+                        &fingerprint_queries,
+                    )?;
+                    let response = run(Some(&transaction))?;
+                    transaction.rollback()?;
+                    Ok((response, Some(fingerprint)))
+                }
+                SyncGuardMode::Apply {
+                    destination_fingerprint,
+                } => {
+                    let transaction =
+                        Transaction::new_unchecked(&destination, TransactionBehavior::Immediate)?;
+                    let fingerprint = crate::server::sync_preview::connection_fingerprint(
+                        &transaction,
+                        &fingerprint_queries,
+                    )?;
+                    if fingerprint != destination_fingerprint {
+                        return Err(StaleSyncPreview.into());
+                    }
+                    let response = run(Some(&transaction))?;
+                    transaction.commit()?;
+                    Ok((response, None))
                 }
             }
-            SchedulerSyncKind::PushPlanning => {
-                let summary = sync_planning(
-                    &source,
-                    &destination,
-                    &PlanningOptions {
-                        dry_run,
-                        project_filter: project,
-                    },
-                )?;
-                SchedulerSyncResponse {
-                    kind,
-                    dry_run,
-                    source_db_id: source_id,
-                    destination_db_id: destination_id,
-                    exposuretemplate: (&summary.exposuretemplate).into(),
-                    project: (&summary.project).into(),
-                    ruleweight: (&summary.ruleweight).into(),
-                    target: (&summary.target).into(),
-                    exposureplan: (&summary.exposureplan).into(),
-                    acquiredimage: None,
-                    imagedata: None,
-                    grades: None,
-                    grade_filled: 0,
-                    grade_preserved: 0,
-                    imagedata_bytes: 0,
-                    total_inserted: summary.total_inserted(),
-                    total_updated: summary.total_updated(),
-                }
-            }
-            SchedulerSyncKind::PushGrades => {
-                let summary = sync_grades(
-                    &source,
-                    &destination,
-                    &SyncGradesOptions {
-                        status_filter,
-                        reviewed_only,
-                        project_filter: project,
-                        target_filter: target,
-                        dry_run,
-                    },
-                )?;
-                SchedulerSyncResponse {
-                    kind,
-                    dry_run,
-                    source_db_id: source_id,
-                    destination_db_id: destination_id,
-                    exposuretemplate: SchedulerSyncTableCounts::default(),
-                    project: SchedulerSyncTableCounts::default(),
-                    ruleweight: SchedulerSyncTableCounts::default(),
-                    target: SchedulerSyncTableCounts::default(),
-                    exposureplan: SchedulerSyncTableCounts::default(),
-                    acquiredimage: None,
-                    imagedata: None,
-                    grades: Some(SchedulerSyncGradeCounts {
-                        source_considered: summary.source_considered,
-                        source_no_guid: summary.source_no_guid,
-                        matched: summary.matched,
-                        changed: summary.changed,
-                        unchanged: summary.unchanged,
-                        unmatched_source: summary.unmatched_source,
-                        destination_only: summary.dest_only,
-                        duplicate_guids: summary.duplicate_guids,
-                        transitions: summary.transitions,
-                    }),
-                    grade_filled: 0,
-                    grade_preserved: 0,
-                    imagedata_bytes: 0,
-                    total_inserted: 0,
-                    total_updated: summary.changed,
-                }
-            }
-        };
-        Ok(response)
-    })
+        },
+    )
     .await
     .map_err(|error| AppError::InternalError(format!("scheduler sync task failed: {error}")))?
-    .map_err(|error| AppError::BadRequest(format!("{error:#}")))?;
+    .map_err(|error| {
+        if error.downcast_ref::<StaleSyncPreview>().is_some() {
+            AppError::Conflict(
+                "This preview is stale because the destination database changed. Preview again."
+                    .into(),
+            )
+        } else {
+            AppError::BadRequest(format!("{error:#}"))
+        }
+    })?;
 
     if !dry_run {
         let _ = destination_ctx.ensure_cache_available();
@@ -594,49 +677,6 @@ fn sync_endpoint_paths(
     ))
 }
 
-fn sync_fingerprint_tables(request: &SchedulerSyncRequest) -> Vec<&'static str> {
-    match request.kind {
-        SchedulerSyncKind::Pull => {
-            let mut tables = vec![
-                "exposuretemplate",
-                "project",
-                "ruleweight",
-                "target",
-                "exposureplan",
-                "acquiredimage",
-            ];
-            if request.with_image_data.unwrap_or(true) {
-                tables.push("imagedata");
-            }
-            tables
-        }
-        SchedulerSyncKind::PushPlanning => vec![
-            "exposuretemplate",
-            "project",
-            "ruleweight",
-            "target",
-            "exposureplan",
-        ],
-        SchedulerSyncKind::PushGrades => vec!["acquiredimage"],
-    }
-}
-
-async fn sync_fingerprint_pair(
-    source_path: PathBuf,
-    destination_path: PathBuf,
-    tables: Vec<&'static str>,
-) -> Result<(String, String), AppError> {
-    tokio::task::spawn_blocking(move || {
-        let source = crate::server::sync_preview::database_fingerprint(&source_path, &tables)?;
-        let destination =
-            crate::server::sync_preview::database_fingerprint(&destination_path, &tables)?;
-        Ok::<_, anyhow::Error>((source, destination))
-    })
-    .await
-    .map_err(|error| AppError::InternalError(format!("sync fingerprint task failed: {error}")))?
-    .map_err(|error| AppError::BadRequest(format!("{error:#}")))
-}
-
 /// Create a server-owned dry preview. Apply is a separate endpoint keyed by
 /// the returned opaque preview ID.
 pub async fn preview_sync_database_route(
@@ -646,27 +686,47 @@ pub async fn preview_sync_database_route(
 ) -> Result<Json<ApiResponse<SchedulerSyncPreviewResponse>>, AppError> {
     require_database_management_allowed(&state)?;
     request.dry_run = true;
-    let (source_path, destination_path) = sync_endpoint_paths(&state, &db_id, &request)?;
-    let tables = sync_fingerprint_tables(&request);
-    let before = sync_fingerprint_pair(
-        source_path.clone(),
-        destination_path.clone(),
-        tables.clone(),
+    let (source_path, _destination_path) = sync_endpoint_paths(&state, &db_id, &request)?;
+    let source_snapshot_file = state
+        .sync_previews
+        .create_source_snapshot(&source_path)
+        .map_err(|error| AppError::BadRequest(format!("{error:#}")))?;
+    let source_snapshot_path = state
+        .sync_previews
+        .source_snapshot_path_for_file(&source_snapshot_file)
+        .map_err(|error| AppError::InternalError(format!("{error:#}")))?;
+    let preview = execute_scheduler_sync_guarded(
+        &state,
+        &db_id,
+        request.clone(),
+        Some(source_snapshot_path),
+        SyncGuardMode::Preview,
     )
-    .await?;
-    let result = execute_scheduler_sync(&state, &db_id, request.clone()).await?;
-    let after = sync_fingerprint_pair(source_path, destination_path, tables).await?;
-    if before != after {
-        return Err(AppError::Conflict(
-            "A source or destination database changed while the preview was running. Preview again."
-                .into(),
-        ));
-    }
+    .await;
+    let (result, destination_fingerprint) = match preview {
+        Ok((result, Some(fingerprint))) => (result, fingerprint),
+        Ok(_) => unreachable!("preview execution always returns a fingerprint"),
+        Err(error) => {
+            state
+                .sync_previews
+                .remove_source_snapshot(&source_snapshot_file);
+            return Err(error);
+        }
+    };
 
     let record = state
         .sync_previews
-        .store(db_id, request, before.0, before.1, result.clone())
+        .store(
+            db_id,
+            request,
+            source_snapshot_file.clone(),
+            destination_fingerprint,
+            result.clone(),
+        )
         .map_err(|error| {
+            state
+                .sync_previews
+                .remove_source_snapshot(&source_snapshot_file);
             AppError::InternalError(format!("saving scheduler sync preview: {error}"))
         })?;
     Ok(Json(ApiResponse::success(SchedulerSyncPreviewResponse {
@@ -675,6 +735,37 @@ pub async fn preview_sync_database_route(
         expires_at: record.expires_at,
         result,
     })))
+}
+
+pub async fn get_sync_database_preview_route(
+    State(state): State<Arc<AppState>>,
+    Path((db_id, preview_id)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<SchedulerSyncPreviewResponse>>, AppError> {
+    require_database_management_allowed(&state)?;
+    let record = state
+        .sync_previews
+        .get(&preview_id)
+        .map_err(|error| AppError::InternalError(format!("loading sync preview: {error}")))?
+        .filter(|record| record.local_db_id == db_id)
+        .ok_or(AppError::NotFound)?;
+    Ok(Json(ApiResponse::success(SchedulerSyncPreviewResponse {
+        preview_id: record.id,
+        created_at: record.created_at,
+        expires_at: record.expires_at,
+        result: record.result,
+    })))
+}
+
+pub async fn delete_sync_database_preview_route(
+    State(state): State<Arc<AppState>>,
+    Path((db_id, preview_id)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<bool>>, AppError> {
+    require_database_management_allowed(&state)?;
+    let deleted = state
+        .sync_previews
+        .discard(&preview_id, &db_id)
+        .map_err(|error| AppError::InternalError(format!("deleting sync preview: {error}")))?;
+    Ok(Json(ApiResponse::success(deleted)))
 }
 
 /// Apply one unexpired preview after proving that neither catalog changed.
@@ -690,25 +781,28 @@ pub async fn apply_sync_database_preview_route(
         .map_err(|error| AppError::InternalError(format!("loading sync preview: {error}")))?
         .ok_or(AppError::NotFound)?;
 
-    let (source_path, destination_path) = sync_endpoint_paths(&state, &db_id, &record.request)?;
-    let fingerprints = sync_fingerprint_pair(
-        source_path,
-        destination_path,
-        sync_fingerprint_tables(&record.request),
-    )
-    .await?;
-    if fingerprints.0 != record.source_fingerprint
-        || fingerprints.1 != record.destination_fingerprint
-    {
-        return Err(AppError::Conflict(
-            "This preview is stale because a source or destination database changed. Preview again."
-                .into(),
-        ));
-    }
+    let source_snapshot = state
+        .sync_previews
+        .source_snapshot_path(&record)
+        .map_err(|error| AppError::InternalError(format!("{error:#}")))?;
 
     let mut request = record.request;
     request.dry_run = false;
-    let result = execute_scheduler_sync(&state, &db_id, request).await?;
+    let result = execute_scheduler_sync_guarded(
+        &state,
+        &db_id,
+        request,
+        Some(source_snapshot),
+        SyncGuardMode::Apply {
+            destination_fingerprint: record.destination_fingerprint,
+        },
+    )
+    .await
+    .map(|(result, _)| result);
+    state
+        .sync_previews
+        .remove_source_snapshot(&record.source_snapshot_file);
+    let result = result?;
     Ok(Json(ApiResponse::success(result)))
 }
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -382,23 +382,42 @@ pub async fn sync_database_route(
     Path(db_id): Path<String>,
     Json(req): Json<SchedulerSyncRequest>,
 ) -> Result<Json<ApiResponse<SchedulerSyncResponse>>, AppError> {
-    use crate::commands::sync::{sync_planning, sync_pull, PlanningOptions, PullOptions};
+    let _apply_guard = if req.dry_run {
+        None
+    } else {
+        Some(state.sync_apply_lock.lock().await)
+    };
+    let response = execute_scheduler_sync(&state, &db_id, req).await?;
+    Ok(Json(ApiResponse::success(response)))
+}
+
+async fn execute_scheduler_sync(
+    state: &Arc<AppState>,
+    db_id: &str,
+    req: SchedulerSyncRequest,
+) -> Result<SchedulerSyncResponse, AppError> {
+    use crate::commands::sync::{
+        parse_status, sync_grades, sync_planning, sync_pull, PlanningOptions, PullOptions,
+        SyncGradesOptions,
+    };
     use rusqlite::{Connection, OpenFlags};
 
-    require_database_management_allowed(&state)?;
+    require_database_management_allowed(state)?;
     if db_id == req.peer_db_id {
         return Err(AppError::BadRequest(
             "Choose two different databases to sync.".into(),
         ));
     }
 
-    let local = state.get_database(&db_id).ok_or(AppError::NotFound)?;
+    let local = state.get_database(db_id).ok_or(AppError::NotFound)?;
     let peer = state
         .get_database(&req.peer_db_id)
         .ok_or(AppError::NotFound)?;
     let (source_ctx, destination_ctx) = match req.kind {
         SchedulerSyncKind::Pull => (Arc::clone(&peer), Arc::clone(&local)),
-        SchedulerSyncKind::PushPlanning => (Arc::clone(&local), Arc::clone(&peer)),
+        SchedulerSyncKind::PushPlanning | SchedulerSyncKind::PushGrades => {
+            (Arc::clone(&local), Arc::clone(&peer))
+        }
     };
     let source_path = PathBuf::from(&source_ctx.database_path);
     let destination_path = PathBuf::from(&destination_ctx.database_path);
@@ -407,6 +426,17 @@ pub async fn sync_database_route(
     let kind = req.kind;
     let dry_run = req.dry_run;
     let project = req.project;
+    let target = req.target;
+    let status_filter = if matches!(kind, SchedulerSyncKind::PushGrades) {
+        req.status
+            .as_deref()
+            .map(parse_status)
+            .transpose()
+            .map_err(|error| AppError::BadRequest(error.to_string()))?
+    } else {
+        None
+    };
+    let reviewed_only = req.reviewed_only;
     let with_image_data = req.with_image_data.unwrap_or(true);
 
     let response = tokio::task::spawn_blocking(move || -> anyhow::Result<SchedulerSyncResponse> {
@@ -448,6 +478,7 @@ pub async fn sync_database_route(
                     imagedata: summary
                         .imagedata_synced
                         .then(|| (&summary.imagedata).into()),
+                    grades: None,
                     grade_filled: summary.grade_filled,
                     grade_preserved: summary.grade_preserved,
                     imagedata_bytes: summary.imagedata_bytes,
@@ -476,6 +507,7 @@ pub async fn sync_database_route(
                     exposureplan: (&summary.exposureplan).into(),
                     acquiredimage: None,
                     imagedata: None,
+                    grades: None,
                     grade_filled: 0,
                     grade_preserved: 0,
                     imagedata_bytes: 0,
@@ -483,17 +515,201 @@ pub async fn sync_database_route(
                     total_updated: summary.total_updated(),
                 }
             }
+            SchedulerSyncKind::PushGrades => {
+                let summary = sync_grades(
+                    &source,
+                    &destination,
+                    &SyncGradesOptions {
+                        status_filter,
+                        reviewed_only,
+                        project_filter: project,
+                        target_filter: target,
+                        dry_run,
+                    },
+                )?;
+                SchedulerSyncResponse {
+                    kind,
+                    dry_run,
+                    source_db_id: source_id,
+                    destination_db_id: destination_id,
+                    exposuretemplate: SchedulerSyncTableCounts::default(),
+                    project: SchedulerSyncTableCounts::default(),
+                    ruleweight: SchedulerSyncTableCounts::default(),
+                    target: SchedulerSyncTableCounts::default(),
+                    exposureplan: SchedulerSyncTableCounts::default(),
+                    acquiredimage: None,
+                    imagedata: None,
+                    grades: Some(SchedulerSyncGradeCounts {
+                        source_considered: summary.source_considered,
+                        source_no_guid: summary.source_no_guid,
+                        matched: summary.matched,
+                        changed: summary.changed,
+                        unchanged: summary.unchanged,
+                        unmatched_source: summary.unmatched_source,
+                        destination_only: summary.dest_only,
+                        duplicate_guids: summary.duplicate_guids,
+                        transitions: summary.transitions,
+                    }),
+                    grade_filled: 0,
+                    grade_preserved: 0,
+                    imagedata_bytes: 0,
+                    total_inserted: 0,
+                    total_updated: summary.changed,
+                }
+            }
         };
         Ok(response)
     })
     .await
     .map_err(|error| AppError::InternalError(format!("scheduler sync task failed: {error}")))?
-    .map_err(|error| AppError::BadRequest(error.to_string()))?;
+    .map_err(|error| AppError::BadRequest(format!("{error:#}")))?;
 
     if !dry_run {
         let _ = destination_ctx.ensure_cache_available();
     }
-    Ok(Json(ApiResponse::success(response)))
+    Ok(response)
+}
+
+fn sync_endpoint_paths(
+    state: &AppState,
+    local_db_id: &str,
+    request: &SchedulerSyncRequest,
+) -> Result<(PathBuf, PathBuf), AppError> {
+    if local_db_id == request.peer_db_id {
+        return Err(AppError::BadRequest(
+            "Choose two different databases to sync.".into(),
+        ));
+    }
+    let local = state.get_database(local_db_id).ok_or(AppError::NotFound)?;
+    let peer = state
+        .get_database(&request.peer_db_id)
+        .ok_or(AppError::NotFound)?;
+    let (source, destination) = match request.kind {
+        SchedulerSyncKind::Pull => (peer, local),
+        SchedulerSyncKind::PushPlanning | SchedulerSyncKind::PushGrades => (local, peer),
+    };
+    Ok((
+        PathBuf::from(&source.database_path),
+        PathBuf::from(&destination.database_path),
+    ))
+}
+
+fn sync_fingerprint_tables(request: &SchedulerSyncRequest) -> Vec<&'static str> {
+    match request.kind {
+        SchedulerSyncKind::Pull => {
+            let mut tables = vec![
+                "exposuretemplate",
+                "project",
+                "ruleweight",
+                "target",
+                "exposureplan",
+                "acquiredimage",
+            ];
+            if request.with_image_data.unwrap_or(true) {
+                tables.push("imagedata");
+            }
+            tables
+        }
+        SchedulerSyncKind::PushPlanning => vec![
+            "exposuretemplate",
+            "project",
+            "ruleweight",
+            "target",
+            "exposureplan",
+        ],
+        SchedulerSyncKind::PushGrades => vec!["acquiredimage"],
+    }
+}
+
+async fn sync_fingerprint_pair(
+    source_path: PathBuf,
+    destination_path: PathBuf,
+    tables: Vec<&'static str>,
+) -> Result<(String, String), AppError> {
+    tokio::task::spawn_blocking(move || {
+        let source = crate::server::sync_preview::database_fingerprint(&source_path, &tables)?;
+        let destination =
+            crate::server::sync_preview::database_fingerprint(&destination_path, &tables)?;
+        Ok::<_, anyhow::Error>((source, destination))
+    })
+    .await
+    .map_err(|error| AppError::InternalError(format!("sync fingerprint task failed: {error}")))?
+    .map_err(|error| AppError::BadRequest(format!("{error:#}")))
+}
+
+/// Create a server-owned dry preview. Apply is a separate endpoint keyed by
+/// the returned opaque preview ID.
+pub async fn preview_sync_database_route(
+    State(state): State<Arc<AppState>>,
+    Path(db_id): Path<String>,
+    Json(mut request): Json<SchedulerSyncRequest>,
+) -> Result<Json<ApiResponse<SchedulerSyncPreviewResponse>>, AppError> {
+    require_database_management_allowed(&state)?;
+    request.dry_run = true;
+    let (source_path, destination_path) = sync_endpoint_paths(&state, &db_id, &request)?;
+    let tables = sync_fingerprint_tables(&request);
+    let before = sync_fingerprint_pair(
+        source_path.clone(),
+        destination_path.clone(),
+        tables.clone(),
+    )
+    .await?;
+    let result = execute_scheduler_sync(&state, &db_id, request.clone()).await?;
+    let after = sync_fingerprint_pair(source_path, destination_path, tables).await?;
+    if before != after {
+        return Err(AppError::Conflict(
+            "A source or destination database changed while the preview was running. Preview again."
+                .into(),
+        ));
+    }
+
+    let record = state
+        .sync_previews
+        .store(db_id, request, before.0, before.1, result.clone())
+        .map_err(|error| {
+            AppError::InternalError(format!("saving scheduler sync preview: {error}"))
+        })?;
+    Ok(Json(ApiResponse::success(SchedulerSyncPreviewResponse {
+        preview_id: record.id,
+        created_at: record.created_at,
+        expires_at: record.expires_at,
+        result,
+    })))
+}
+
+/// Apply one unexpired preview after proving that neither catalog changed.
+pub async fn apply_sync_database_preview_route(
+    State(state): State<Arc<AppState>>,
+    Path((db_id, preview_id)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<SchedulerSyncResponse>>, AppError> {
+    require_database_management_allowed(&state)?;
+    let _apply_guard = state.sync_apply_lock.lock().await;
+    let record = state
+        .sync_previews
+        .claim(&preview_id, &db_id)
+        .map_err(|error| AppError::InternalError(format!("loading sync preview: {error}")))?
+        .ok_or(AppError::NotFound)?;
+
+    let (source_path, destination_path) = sync_endpoint_paths(&state, &db_id, &record.request)?;
+    let fingerprints = sync_fingerprint_pair(
+        source_path,
+        destination_path,
+        sync_fingerprint_tables(&record.request),
+    )
+    .await?;
+    if fingerprints.0 != record.source_fingerprint
+        || fingerprints.1 != record.destination_fingerprint
+    {
+        return Err(AppError::Conflict(
+            "This preview is stale because a source or destination database changed. Preview again."
+                .into(),
+        ));
+    }
+
+    let mut request = record.request;
+    request.dry_run = false;
+    let result = execute_scheduler_sync(&state, &db_id, request).await?;
+    Ok(Json(ApiResponse::success(result)))
 }
 
 /// `POST /api/databases` — register a new database. Validates that the file
@@ -3869,6 +4085,7 @@ pub enum AppError {
     NotFound,
     DatabaseError(String),
     BadRequest(String),
+    Conflict(String),
     Forbidden(String),
     InternalError(String),
     NotImplemented,
@@ -3903,6 +4120,14 @@ impl IntoResponse for AppError {
                 tracing::warn!("❌ Bad request: {}", msg);
                 return (
                     StatusCode::BAD_REQUEST,
+                    Json(ApiResponse::<()>::error(msg.clone())),
+                )
+                    .into_response();
+            }
+            AppError::Conflict(msg) => {
+                tracing::warn!("⚠️ Conflict: {}", msg);
+                return (
+                    StatusCode::CONFLICT,
                     Json(ApiResponse::<()>::error(msg.clone())),
                 )
                     .into_response();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -14,6 +14,7 @@ pub mod spatial_scan;
 pub mod stack_preview;
 pub mod state;
 pub mod static_file_service;
+pub mod sync_preview;
 
 use anyhow::{Context, Result};
 use axum::{
@@ -389,6 +390,14 @@ async fn run_server_internal(
         .route(
             "/databases/{db_id}/sync",
             post(handlers::sync_database_route),
+        )
+        .route(
+            "/databases/{db_id}/sync/preview",
+            post(handlers::preview_sync_database_route),
+        )
+        .route(
+            "/databases/{db_id}/sync/previews/{preview_id}/apply",
+            post(handlers::apply_sync_database_preview_route),
         )
         .route(
             "/databases/{db_id}",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -400,6 +400,11 @@ async fn run_server_internal(
             post(handlers::apply_sync_database_preview_route),
         )
         .route(
+            "/databases/{db_id}/sync/previews/{preview_id}",
+            get(handlers::get_sync_database_preview_route)
+                .delete(handlers::delete_sync_database_preview_route),
+        )
+        .route(
             "/databases/{db_id}",
             put(handlers::update_database_route).delete(handlers::remove_database_route),
         )

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -66,6 +66,11 @@ pub struct AppState {
     /// Process-global, single-flight Seiza catalog installation with progress
     /// that survives closing and reopening the Settings page.
     pub catalog_install: crate::server::catalog_install::CatalogInstallManager,
+    /// Durable, preview-first database transfer state.
+    pub sync_previews: crate::server::sync_preview::SyncPreviewManager,
+    /// Serializes guarded transfer applies so one preview cannot invalidate
+    /// another between its stale check and transaction.
+    pub sync_apply_lock: tokio::sync::Mutex<()>,
     /// Process-global Seiza catalogs and capability diagnostics. Catalogs are
     /// shared across databases and opened lazily on first use.
     pub astrometry: Arc<crate::astrometry::AstrometryContext>,
@@ -355,7 +360,7 @@ impl AppState {
         Ok(Self {
             databases: RwLock::new(map),
             pregeneration_config,
-            cache_dir_root: cache_dir,
+            cache_dir_root: cache_dir.clone(),
             registry_path: RwLock::new(None),
             allow_database_management: RwLock::new(false),
             site_banner: RwLock::new(None),
@@ -364,6 +369,8 @@ impl AppState {
             preview_queue: crate::server::preview_queue::PreviewQueue::default(),
             stack_previews: crate::server::stack_preview::StackPreviewManager::default(),
             catalog_install: crate::server::catalog_install::CatalogInstallManager::default(),
+            sync_previews: crate::server::sync_preview::SyncPreviewManager::new(&cache_dir),
+            sync_apply_lock: tokio::sync::Mutex::new(()),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::new(astrometry_config)),
             satellites: Arc::new(satellites),
         })
@@ -479,6 +486,10 @@ impl AppState {
             preview_queue: crate::server::preview_queue::PreviewQueue::default(),
             stack_previews: crate::server::stack_preview::StackPreviewManager::default(),
             catalog_install: crate::server::catalog_install::CatalogInstallManager::default(),
+            sync_previews: crate::server::sync_preview::SyncPreviewManager::new(
+                "/tmp/psf-guard-test",
+            ),
+            sync_apply_lock: tokio::sync::Mutex::new(()),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::default()),
             satellites: Arc::new(
                 crate::satellites::SatelliteContext::new(

--- a/src/server/sync_preview.rs
+++ b/src/server/sync_preview.rs
@@ -1,0 +1,325 @@
+//! Durable, server-owned previews for database sync.
+//!
+//! The first version records the exact request plus logical source and
+//! destination fingerprints. Apply refuses a preview when either catalog has
+//! changed. A later transfer-bundle phase will freeze the source rows too, so
+//! source changes can wait for the next transfer instead of making a preview
+//! stale.
+
+use crate::server::api::{SchedulerSyncRequest, SchedulerSyncResponse};
+use anyhow::{Context, Result};
+use rusqlite::types::ValueRef;
+use rusqlite::{Connection, OpenFlags};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
+
+const PREVIEW_LIFETIME: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncPreviewRecord {
+    pub id: String,
+    pub local_db_id: String,
+    pub request: SchedulerSyncRequest,
+    pub source_fingerprint: String,
+    pub destination_fingerprint: String,
+    pub created_at: i64,
+    pub expires_at: i64,
+    pub result: SchedulerSyncResponse,
+}
+
+pub struct SyncPreviewManager {
+    directory: PathBuf,
+    records: Mutex<HashMap<String, SyncPreviewRecord>>,
+}
+
+impl SyncPreviewManager {
+    pub fn new(cache_root: impl AsRef<Path>) -> Self {
+        let directory = cache_root.as_ref().join("sync-previews");
+        let records = load_records(&directory);
+        Self {
+            directory,
+            records: Mutex::new(records),
+        }
+    }
+
+    pub fn store(
+        &self,
+        local_db_id: String,
+        request: SchedulerSyncRequest,
+        source_fingerprint: String,
+        destination_fingerprint: String,
+        result: SchedulerSyncResponse,
+    ) -> Result<SyncPreviewRecord> {
+        let created_at = unix_seconds();
+        let record = SyncPreviewRecord {
+            id: Uuid::new_v4().to_string(),
+            local_db_id,
+            request,
+            source_fingerprint,
+            destination_fingerprint,
+            created_at,
+            expires_at: created_at + PREVIEW_LIFETIME.as_secs() as i64,
+            result,
+        };
+        fs::create_dir_all(&self.directory).with_context(|| {
+            format!(
+                "creating sync preview directory {}",
+                self.directory.display()
+            )
+        })?;
+        write_record(&self.directory, &record)?;
+        self.records
+            .lock()
+            .map_err(|error| anyhow::anyhow!("sync preview lock poisoned: {error}"))?
+            .insert(record.id.clone(), record.clone());
+        Ok(record)
+    }
+
+    pub fn get(&self, id: &str) -> Result<Option<SyncPreviewRecord>> {
+        let mut records = self
+            .records
+            .lock()
+            .map_err(|error| anyhow::anyhow!("sync preview lock poisoned: {error}"))?;
+        let Some(record) = records.get(id).cloned() else {
+            return Ok(None);
+        };
+        if record.expires_at <= unix_seconds() {
+            records.remove(id);
+            let _ = fs::remove_file(record_path(&self.directory, id));
+            return Ok(None);
+        }
+        Ok(Some(record))
+    }
+
+    /// Atomically take a preview for one Apply attempt. A stale or failed
+    /// Apply must be previewed again; two callers can never apply the same ID.
+    pub fn claim(&self, id: &str, local_db_id: &str) -> Result<Option<SyncPreviewRecord>> {
+        let mut records = self
+            .records
+            .lock()
+            .map_err(|error| anyhow::anyhow!("sync preview lock poisoned: {error}"))?;
+        let Some(record) = records.get(id).cloned() else {
+            return Ok(None);
+        };
+        if record.local_db_id != local_db_id {
+            return Ok(None);
+        }
+        if record.expires_at <= unix_seconds() {
+            records.remove(id);
+            let _ = fs::remove_file(record_path(&self.directory, id));
+            return Ok(None);
+        }
+        match fs::remove_file(record_path(&self.directory, id)) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error).context("claiming sync preview"),
+        }
+        records.remove(id);
+        Ok(Some(record))
+    }
+}
+
+pub fn database_fingerprint(path: &Path, tables: &[&str]) -> Result<String> {
+    let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("opening {} for sync fingerprint", path.display()))?;
+    let transaction = connection
+        .unchecked_transaction()
+        .context("starting sync fingerprint snapshot")?;
+    let mut hasher = Sha256::new();
+
+    for table in tables {
+        hash_part(&mut hasher, table.as_bytes());
+        let mut statement = transaction
+            .prepare(&format!("SELECT * FROM \"{table}\" ORDER BY rowid"))
+            .with_context(|| format!("reading {table} for sync fingerprint"))?;
+        for column in statement.column_names() {
+            hash_part(&mut hasher, column.as_bytes());
+        }
+        let column_count = statement.column_count();
+        let mut rows = statement.query([])?;
+        while let Some(row) = rows.next()? {
+            hasher.update([0xff]);
+            for index in 0..column_count {
+                match row.get_ref(index)? {
+                    ValueRef::Null => hasher.update([0]),
+                    ValueRef::Integer(value) => {
+                        hasher.update([1]);
+                        hasher.update(value.to_le_bytes());
+                    }
+                    ValueRef::Real(value) => {
+                        hasher.update([2]);
+                        hasher.update(value.to_bits().to_le_bytes());
+                    }
+                    ValueRef::Text(value) => {
+                        hasher.update([3]);
+                        hash_part(&mut hasher, value);
+                    }
+                    ValueRef::Blob(value) => {
+                        hasher.update([4]);
+                        hash_part(&mut hasher, value);
+                    }
+                }
+            }
+        }
+    }
+
+    transaction.rollback()?;
+    let mut fingerprint = String::with_capacity(64);
+    for byte in hasher.finalize() {
+        write!(&mut fingerprint, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(fingerprint)
+}
+
+fn hash_part(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn unix_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+fn load_records(directory: &Path) -> HashMap<String, SyncPreviewRecord> {
+    let mut records = HashMap::new();
+    let Ok(entries) = fs::read_dir(directory) else {
+        return records;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(bytes) = fs::read(&path) else {
+            continue;
+        };
+        let Ok(record) = serde_json::from_slice::<SyncPreviewRecord>(&bytes) else {
+            continue;
+        };
+        if record.expires_at > unix_seconds() {
+            records.insert(record.id.clone(), record);
+        } else {
+            let _ = fs::remove_file(path);
+        }
+    }
+    records
+}
+
+fn write_record(directory: &Path, record: &SyncPreviewRecord) -> Result<()> {
+    let path = record_path(directory, &record.id);
+    let temporary = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(record)?;
+    fs::write(&temporary, bytes)
+        .with_context(|| format!("writing sync preview {}", temporary.display()))?;
+    fs::rename(&temporary, &path)
+        .with_context(|| format!("publishing sync preview {}", path.display()))?;
+    Ok(())
+}
+
+fn record_path(directory: &Path, id: &str) -> PathBuf {
+    directory.join(format!("{id}.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::api::{
+        SchedulerSyncGradeCounts, SchedulerSyncKind, SchedulerSyncTableCounts,
+    };
+    use tempfile::tempdir;
+
+    fn response() -> SchedulerSyncResponse {
+        SchedulerSyncResponse {
+            kind: SchedulerSyncKind::PushGrades,
+            dry_run: true,
+            source_db_id: "source".into(),
+            destination_db_id: "destination".into(),
+            exposuretemplate: SchedulerSyncTableCounts::default(),
+            project: SchedulerSyncTableCounts::default(),
+            ruleweight: SchedulerSyncTableCounts::default(),
+            target: SchedulerSyncTableCounts::default(),
+            exposureplan: SchedulerSyncTableCounts::default(),
+            acquiredimage: None,
+            imagedata: None,
+            grades: Some(SchedulerSyncGradeCounts::default()),
+            grade_filled: 0,
+            grade_preserved: 0,
+            imagedata_bytes: 0,
+            total_inserted: 0,
+            total_updated: 0,
+        }
+    }
+
+    fn request() -> SchedulerSyncRequest {
+        SchedulerSyncRequest {
+            peer_db_id: "destination".into(),
+            kind: SchedulerSyncKind::PushGrades,
+            dry_run: true,
+            with_image_data: None,
+            project: None,
+            target: None,
+            status: None,
+            reviewed_only: true,
+        }
+    }
+
+    #[test]
+    fn records_survive_manager_recreation_and_can_be_claimed_once() {
+        let directory = tempdir().unwrap();
+        let manager = SyncPreviewManager::new(directory.path());
+        let record = manager
+            .store(
+                "source".into(),
+                request(),
+                "source-fingerprint".into(),
+                "destination-fingerprint".into(),
+                response(),
+            )
+            .unwrap();
+        drop(manager);
+
+        let manager = SyncPreviewManager::new(directory.path());
+        assert!(manager.get(&record.id).unwrap().is_some());
+        assert!(manager
+            .claim(&record.id, "wrong-database")
+            .unwrap()
+            .is_none());
+        assert!(manager.claim(&record.id, "source").unwrap().is_some());
+        assert!(manager.claim(&record.id, "source").unwrap().is_none());
+        assert!(manager.get(&record.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn logical_fingerprint_changes_with_a_row() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("catalog.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE acquiredimage (Id INTEGER PRIMARY KEY, gradingStatus INTEGER);
+                 INSERT INTO acquiredimage VALUES (1, 0);",
+            )
+            .unwrap();
+        drop(connection);
+
+        let before = database_fingerprint(&path, &["acquiredimage"]).unwrap();
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute("UPDATE acquiredimage SET gradingStatus = 2", [])
+            .unwrap();
+        drop(connection);
+        let after = database_fingerprint(&path, &["acquiredimage"]).unwrap();
+
+        assert_ne!(before, after);
+    }
+}

--- a/src/server/sync_preview.rs
+++ b/src/server/sync_preview.rs
@@ -1,13 +1,13 @@
 //! Durable, server-owned previews for database sync.
 //!
-//! The first version records the exact request plus logical source and
-//! destination fingerprints. Apply refuses a preview when either catalog has
-//! changed. A later transfer-bundle phase will freeze the source rows too, so
-//! source changes can wait for the next transfer instead of making a preview
-//! stale.
+//! Each preview owns an online SQLite snapshot of its source plus a logical
+//! destination fingerprint. Apply reads the snapshot and verifies the
+//! destination after taking SQLite's write lock, so it writes the same source
+//! data the user reviewed or refuses a stale destination.
 
-use crate::server::api::{SchedulerSyncRequest, SchedulerSyncResponse};
+use crate::server::api::{SchedulerSyncKind, SchedulerSyncRequest, SchedulerSyncResponse};
 use anyhow::{Context, Result};
+use rusqlite::backup::Backup;
 use rusqlite::types::ValueRef;
 use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ pub struct SyncPreviewRecord {
     pub id: String,
     pub local_db_id: String,
     pub request: SchedulerSyncRequest,
-    pub source_fingerprint: String,
+    pub source_snapshot_file: String,
     pub destination_fingerprint: String,
     pub created_at: i64,
     pub expires_at: i64,
@@ -53,7 +53,7 @@ impl SyncPreviewManager {
         &self,
         local_db_id: String,
         request: SchedulerSyncRequest,
-        source_fingerprint: String,
+        source_snapshot_file: String,
         destination_fingerprint: String,
         result: SchedulerSyncResponse,
     ) -> Result<SyncPreviewRecord> {
@@ -62,7 +62,7 @@ impl SyncPreviewManager {
             id: Uuid::new_v4().to_string(),
             local_db_id,
             request,
-            source_fingerprint,
+            source_snapshot_file,
             destination_fingerprint,
             created_at,
             expires_at: created_at + PREVIEW_LIFETIME.as_secs() as i64,
@@ -82,6 +82,57 @@ impl SyncPreviewManager {
         Ok(record)
     }
 
+    /// Take a transactionally consistent online copy of a live SQLite source.
+    pub fn create_source_snapshot(&self, source_path: &Path) -> Result<String> {
+        fs::create_dir_all(&self.directory).with_context(|| {
+            format!(
+                "creating sync preview directory {}",
+                self.directory.display()
+            )
+        })?;
+        let filename = format!("{}.source.sqlite", Uuid::new_v4());
+        let published = self.directory.join(&filename);
+        let temporary = self.directory.join(format!("{filename}.tmp"));
+        let copy = || -> Result<()> {
+            let source = Connection::open_with_flags(source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .with_context(|| {
+                    format!("opening {} for transfer snapshot", source_path.display())
+                })?;
+            let mut destination = Connection::open(&temporary)
+                .with_context(|| format!("creating transfer snapshot {}", temporary.display()))?;
+            {
+                let backup = Backup::new(&source, &mut destination)
+                    .context("starting transfer source snapshot")?;
+                backup
+                    .run_to_completion(256, Duration::from_millis(10), None)
+                    .context("copying transfer source snapshot")?;
+            }
+            drop(destination);
+            fs::rename(&temporary, &published)
+                .with_context(|| format!("publishing transfer snapshot {}", published.display()))?;
+            Ok(())
+        };
+        if let Err(error) = copy() {
+            let _ = fs::remove_file(&temporary);
+            return Err(error);
+        }
+        Ok(filename)
+    }
+
+    pub fn source_snapshot_path(&self, record: &SyncPreviewRecord) -> Result<PathBuf> {
+        self.source_snapshot_path_for_file(&record.source_snapshot_file)
+    }
+
+    pub fn source_snapshot_path_for_file(&self, filename: &str) -> Result<PathBuf> {
+        snapshot_path(&self.directory, filename)
+    }
+
+    pub fn remove_source_snapshot(&self, filename: &str) {
+        if let Ok(path) = snapshot_path(&self.directory, filename) {
+            let _ = fs::remove_file(path);
+        }
+    }
+
     pub fn get(&self, id: &str) -> Result<Option<SyncPreviewRecord>> {
         let mut records = self
             .records
@@ -91,6 +142,12 @@ impl SyncPreviewManager {
             return Ok(None);
         };
         if record.expires_at <= unix_seconds() {
+            records.remove(id);
+            let _ = fs::remove_file(record_path(&self.directory, id));
+            self.remove_source_snapshot(&record.source_snapshot_file);
+            return Ok(None);
+        }
+        if !self.source_snapshot_path(&record)?.is_file() {
             records.remove(id);
             let _ = fs::remove_file(record_path(&self.directory, id));
             return Ok(None);
@@ -114,6 +171,7 @@ impl SyncPreviewManager {
         if record.expires_at <= unix_seconds() {
             records.remove(id);
             let _ = fs::remove_file(record_path(&self.directory, id));
+            self.remove_source_snapshot(&record.source_snapshot_file);
             return Ok(None);
         }
         match fs::remove_file(record_path(&self.directory, id)) {
@@ -124,21 +182,109 @@ impl SyncPreviewManager {
         records.remove(id);
         Ok(Some(record))
     }
+
+    pub fn discard(&self, id: &str, local_db_id: &str) -> Result<bool> {
+        let mut records = self
+            .records
+            .lock()
+            .map_err(|error| anyhow::anyhow!("sync preview lock poisoned: {error}"))?;
+        let Some(record) = records.get(id).cloned() else {
+            return Ok(false);
+        };
+        if record.local_db_id != local_db_id {
+            return Ok(false);
+        }
+        records.remove(id);
+        let _ = fs::remove_file(record_path(&self.directory, id));
+        self.remove_source_snapshot(&record.source_snapshot_file);
+        Ok(true)
+    }
 }
 
-pub fn database_fingerprint(path: &Path, tables: &[&str]) -> Result<String> {
+#[derive(Clone, Copy)]
+pub struct FingerprintQuery {
+    label: &'static str,
+    sql: &'static str,
+}
+
+pub fn fingerprint_queries(request: &SchedulerSyncRequest) -> Vec<FingerprintQuery> {
+    const EXPOSURE_TEMPLATE: FingerprintQuery = FingerprintQuery {
+        label: "exposuretemplate",
+        sql: "SELECT * FROM exposuretemplate ORDER BY rowid",
+    };
+    const PROJECT: FingerprintQuery = FingerprintQuery {
+        label: "project",
+        sql: "SELECT * FROM project ORDER BY rowid",
+    };
+    const RULE_WEIGHT: FingerprintQuery = FingerprintQuery {
+        label: "ruleweight",
+        sql: "SELECT * FROM ruleweight ORDER BY rowid",
+    };
+    const TARGET: FingerprintQuery = FingerprintQuery {
+        label: "target",
+        sql: "SELECT * FROM target ORDER BY rowid",
+    };
+    const EXPOSURE_PLAN: FingerprintQuery = FingerprintQuery {
+        label: "exposureplan",
+        sql: "SELECT * FROM exposureplan ORDER BY rowid",
+    };
+    const ACQUIRED_IMAGE: FingerprintQuery = FingerprintQuery {
+        label: "acquiredimage",
+        sql: "SELECT * FROM acquiredimage ORDER BY rowid",
+    };
+    const IMAGE_DATA_KEYS: FingerprintQuery = FingerprintQuery {
+        label: "imagedata-keys",
+        sql: "SELECT acquiredimageid, tag FROM imagedata \
+              ORDER BY acquiredimageid, tag, Id",
+    };
+    const GRADES: FingerprintQuery = FingerprintQuery {
+        label: "grades",
+        sql: "SELECT guid, gradingStatus, rejectreason FROM acquiredimage ORDER BY guid, Id",
+    };
+
+    match request.kind {
+        SchedulerSyncKind::Pull => {
+            let mut queries = vec![
+                EXPOSURE_TEMPLATE,
+                PROJECT,
+                RULE_WEIGHT,
+                TARGET,
+                EXPOSURE_PLAN,
+                ACQUIRED_IMAGE,
+            ];
+            if request.with_image_data.unwrap_or(true) {
+                queries.push(IMAGE_DATA_KEYS);
+            }
+            queries
+        }
+        SchedulerSyncKind::PushPlanning => vec![
+            EXPOSURE_TEMPLATE,
+            PROJECT,
+            RULE_WEIGHT,
+            TARGET,
+            EXPOSURE_PLAN,
+        ],
+        SchedulerSyncKind::PushGrades => vec![GRADES],
+    }
+}
+
+pub fn database_fingerprint(path: &Path, queries: &[FingerprintQuery]) -> Result<String> {
     let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| format!("opening {} for sync fingerprint", path.display()))?;
-    let transaction = connection
-        .unchecked_transaction()
-        .context("starting sync fingerprint snapshot")?;
+    connection_fingerprint(&connection, queries)
+}
+
+pub fn connection_fingerprint(
+    connection: &Connection,
+    queries: &[FingerprintQuery],
+) -> Result<String> {
     let mut hasher = Sha256::new();
 
-    for table in tables {
-        hash_part(&mut hasher, table.as_bytes());
-        let mut statement = transaction
-            .prepare(&format!("SELECT * FROM \"{table}\" ORDER BY rowid"))
-            .with_context(|| format!("reading {table} for sync fingerprint"))?;
+    for query in queries {
+        hash_part(&mut hasher, query.label.as_bytes());
+        let mut statement = connection
+            .prepare(query.sql)
+            .with_context(|| format!("reading {} for sync fingerprint", query.label))?;
         for column in statement.column_names() {
             hash_part(&mut hasher, column.as_bytes());
         }
@@ -170,7 +316,6 @@ pub fn database_fingerprint(path: &Path, tables: &[&str]) -> Result<String> {
         }
     }
 
-    transaction.rollback()?;
     let mut fingerprint = String::with_capacity(64);
     for byte in hasher.finalize() {
         write!(&mut fingerprint, "{byte:02x}").expect("writing to a String cannot fail");
@@ -210,6 +355,9 @@ fn load_records(directory: &Path) -> HashMap<String, SyncPreviewRecord> {
             records.insert(record.id.clone(), record);
         } else {
             let _ = fs::remove_file(path);
+            if let Ok(snapshot) = snapshot_path(directory, &record.source_snapshot_file) {
+                let _ = fs::remove_file(snapshot);
+            }
         }
     }
     records
@@ -228,6 +376,16 @@ fn write_record(directory: &Path, record: &SyncPreviewRecord) -> Result<()> {
 
 fn record_path(directory: &Path, id: &str) -> PathBuf {
     directory.join(format!("{id}.json"))
+}
+
+fn snapshot_path(directory: &Path, filename: &str) -> Result<PathBuf> {
+    let name = Path::new(filename);
+    anyhow::ensure!(
+        name.file_name().and_then(|value| value.to_str()) == Some(filename)
+            && filename.ends_with(".source.sqlite"),
+        "invalid transfer snapshot name"
+    );
+    Ok(directory.join(name))
 }
 
 #[cfg(test)]
@@ -277,11 +435,18 @@ mod tests {
     fn records_survive_manager_recreation_and_can_be_claimed_once() {
         let directory = tempdir().unwrap();
         let manager = SyncPreviewManager::new(directory.path());
+        let source_path = directory.path().join("source.sqlite");
+        let source = Connection::open(&source_path).unwrap();
+        source
+            .execute_batch("CREATE TABLE sample (value TEXT);")
+            .unwrap();
+        drop(source);
+        let snapshot = manager.create_source_snapshot(&source_path).unwrap();
         let record = manager
             .store(
                 "source".into(),
                 request(),
-                "source-fingerprint".into(),
+                snapshot,
                 "destination-fingerprint".into(),
                 response(),
             )
@@ -300,6 +465,34 @@ mod tests {
     }
 
     #[test]
+    fn source_snapshot_keeps_the_previewed_rows() {
+        let directory = tempdir().unwrap();
+        let source_path = directory.path().join("source.sqlite");
+        let source = Connection::open(&source_path).unwrap();
+        source
+            .execute_batch(
+                "CREATE TABLE sample (value TEXT);
+                 INSERT INTO sample VALUES ('previewed');",
+            )
+            .unwrap();
+        drop(source);
+
+        let manager = SyncPreviewManager::new(directory.path().join("cache"));
+        let filename = manager.create_source_snapshot(&source_path).unwrap();
+        let source = Connection::open(&source_path).unwrap();
+        source
+            .execute("UPDATE sample SET value = 'later'", [])
+            .unwrap();
+
+        let snapshot =
+            Connection::open(manager.source_snapshot_path_for_file(&filename).unwrap()).unwrap();
+        let value: String = snapshot
+            .query_row("SELECT value FROM sample", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(value, "previewed");
+    }
+
+    #[test]
     fn logical_fingerprint_changes_with_a_row() {
         let directory = tempdir().unwrap();
         let path = directory.path().join("catalog.sqlite");
@@ -312,13 +505,17 @@ mod tests {
             .unwrap();
         drop(connection);
 
-        let before = database_fingerprint(&path, &["acquiredimage"]).unwrap();
+        let query = FingerprintQuery {
+            label: "acquiredimage",
+            sql: "SELECT * FROM acquiredimage ORDER BY rowid",
+        };
+        let before = database_fingerprint(&path, &[query]).unwrap();
         let connection = Connection::open(&path).unwrap();
         connection
             .execute("UPDATE acquiredimage SET gradingStatus = 2", [])
             .unwrap();
         drop(connection);
-        let after = database_fingerprint(&path, &["acquiredimage"]).unwrap();
+        let after = database_fingerprint(&path, &[query]).unwrap();
 
         assert_ne!(before, after);
     }

--- a/static/e2e/data-transfer.spec.ts
+++ b/static/e2e/data-transfer.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  fixtureDbPath,
+  fixtureImageDir,
+  resetDatabases,
+  tmpBase,
+} from './helpers';
+
+test.beforeEach(async ({ request }) => {
+  await resetDatabases(request);
+  const peerPath = path.join(tmpBase(), 'telescope.sqlite');
+  fs.copyFileSync(fixtureDbPath(), peerPath);
+
+  for (const database of [
+    { name: 'Review copy', db_path: fixtureDbPath(), slug: 'review' },
+    { name: 'Telescope scheduler', db_path: peerPath, slug: 'telescope' },
+  ]) {
+    const response = await request.post('/api/databases', {
+      data: {
+        ...database,
+        image_dirs: [fixtureImageDir()],
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+  }
+});
+
+test('grade transfer requires a dry preview before Apply appears', async ({
+  page,
+}) => {
+  const requests: Array<Record<string, unknown>> = [];
+  await page.route('**/api/databases/review/sync/preview', async (route) => {
+    requests.push(route.request().postDataJSON() as Record<string, unknown>);
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: {
+          preview_id: 'grade-preview',
+          created_at: 1,
+          expires_at: 4_102_444_800,
+          result: {
+            kind: 'push_grades',
+            dry_run: true,
+            source_db_id: 'review',
+            destination_db_id: 'telescope',
+            exposuretemplate: {
+              inserted: 0,
+              updated: 0,
+              unchanged: 0,
+              skipped: 0,
+            },
+            project: { inserted: 0, updated: 0, unchanged: 0, skipped: 0 },
+            ruleweight: { inserted: 0, updated: 0, unchanged: 0, skipped: 0 },
+            target: { inserted: 0, updated: 0, unchanged: 0, skipped: 0 },
+            exposureplan: {
+              inserted: 0,
+              updated: 0,
+              unchanged: 0,
+              skipped: 0,
+            },
+            acquiredimage: null,
+            imagedata: null,
+            grades: {
+              source_considered: 4,
+              source_no_guid: 0,
+              matched: 4,
+              changed: 2,
+              unchanged: 2,
+              unmatched_source: 0,
+              destination_only: 0,
+              duplicate_guids: 0,
+              transitions: { 'Pending→Accepted': 2 },
+            },
+            grade_filled: 0,
+            grade_preserved: 0,
+            imagedata_bytes: 0,
+            total_inserted: 0,
+            total_updated: 2,
+          },
+        },
+        error: null,
+        status: 'ready',
+      }),
+    });
+  });
+
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Settings' }).click();
+
+  const workspace = page.locator('.scheduler-sync-workspace');
+  await workspace.getByLabel('Transfer source').selectOption({ label: 'Review copy' });
+  await workspace
+    .getByLabel('Transfer destination')
+    .selectOption({ label: 'Telescope scheduler' });
+  await workspace.getByRole('button', { name: 'Send reviewed grades' }).click();
+  await expect(
+    workspace.getByRole('button', { name: 'Apply this preview' })
+  ).toHaveCount(0);
+
+  await workspace.getByRole('button', { name: 'Preview changes' }).click();
+
+  await expect(
+    workspace.getByText('2 reviewed grade(s) will change')
+  ).toBeVisible();
+  await expect(
+    workspace.getByRole('button', { name: 'Apply this preview' })
+  ).toBeVisible();
+  expect(requests).toHaveLength(1);
+  expect(requests[0]).toMatchObject({
+    peer_db_id: 'telescope',
+    kind: 'push_grades',
+    dry_run: true,
+    reviewed_only: true,
+  });
+});
+
+test('data transfer controls fit a compact settings view', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Settings' }).click();
+
+  const workspace = page.locator('.scheduler-sync-workspace');
+  await expect(workspace.getByRole('heading', { name: 'Data Transfer' })).toBeVisible();
+  await expect(workspace.getByLabel('Transfer source')).toBeVisible();
+  await expect(workspace.getByLabel('Transfer destination')).toBeVisible();
+  await expect(
+    workspace.getByRole('button', { name: 'Swap source and destination' })
+  ).toBeVisible();
+
+  const overflows = await workspace.evaluate(
+    (element) => element.scrollWidth > element.clientWidth + 1
+  );
+  expect(overflows).toBe(false);
+});

--- a/static/e2e/data-transfer.spec.ts
+++ b/static/e2e/data-transfer.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Route } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -135,4 +135,73 @@ test('data transfer controls fit a compact settings view', async ({ page }) => {
     (element) => element.scrollWidth > element.clientWidth + 1
   );
   expect(overflows).toBe(false);
+});
+
+test('a pending transfer preview returns after a page reload', async ({ page }) => {
+  const counts = { inserted: 0, updated: 0, unchanged: 0, skipped: 0 };
+  const preview = {
+    preview_id: 'reload-preview',
+    created_at: 1,
+    expires_at: 4_102_444_800,
+    result: {
+      kind: 'push_planning',
+      dry_run: true,
+      source_db_id: 'review',
+      destination_db_id: 'telescope',
+      exposuretemplate: counts,
+      project: counts,
+      ruleweight: counts,
+      target: counts,
+      exposureplan: counts,
+      acquiredimage: null,
+      imagedata: null,
+      grades: null,
+      grade_filled: 0,
+      grade_preserved: 0,
+      imagedata_bytes: 0,
+      total_inserted: 0,
+      total_updated: 0,
+    },
+  };
+  const fulfillPreview = (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        success: true,
+        data: preview,
+        error: null,
+        status: 'ready',
+      }),
+    });
+  await page.route('**/api/databases/review/sync/preview', fulfillPreview);
+  await page.route(
+    '**/api/databases/review/sync/previews/reload-preview',
+    fulfillPreview
+  );
+
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Settings' }).click();
+
+  let workspace = page.locator('.scheduler-sync-workspace');
+  await workspace.getByLabel('Transfer source').selectOption({ label: 'Review copy' });
+  await workspace
+    .getByLabel('Transfer destination')
+    .selectOption({ label: 'Telescope scheduler' });
+  await workspace.getByRole('button', { name: 'Send planning' }).click();
+  await workspace.getByRole('button', { name: 'Preview changes' }).click();
+  await expect(
+    workspace.getByRole('button', { name: 'Apply this preview' })
+  ).toBeVisible();
+
+  await page.reload();
+  await page.getByRole('button', { name: 'Settings' }).click();
+  workspace = page.locator('.scheduler-sync-workspace');
+  await expect(
+    workspace.getByText('Restored the pending transfer preview.')
+  ).toBeVisible();
+  await expect(
+    workspace.getByRole('button', { name: 'Apply this preview' })
+  ).toBeVisible();
+  await workspace.getByRole('button', { name: 'Cancel' }).click();
 });

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -12,6 +12,7 @@ import type {
   PreviewOptions,
   ServerInfo,
   SchedulerSyncRequest,
+  SchedulerSyncPreviewResponse,
   SchedulerSyncResponse,
   DatabaseSummary,
   CreateDatabaseRequest,
@@ -233,6 +234,33 @@ export const apiClient = {
       req
     );
     if (!data.data) throw new Error(data.error || 'Failed to sync databases');
+    return data.data;
+  },
+
+  /** Create a server-owned dry preview that must be applied by its ID. */
+  previewDatabaseSync: async (
+    dbId: string,
+    req: SchedulerSyncRequest
+  ): Promise<SchedulerSyncPreviewResponse> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<SchedulerSyncPreviewResponse>>(
+      `/databases/${encodeURIComponent(dbId)}/sync/preview`,
+      req
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to preview database sync');
+    return data.data;
+  },
+
+  /** Apply one unexpired server-owned preview. */
+  applyDatabaseSyncPreview: async (
+    dbId: string,
+    previewId: string
+  ): Promise<SchedulerSyncResponse> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<SchedulerSyncResponse>>(
+      `/databases/${encodeURIComponent(dbId)}/sync/previews/${encodeURIComponent(previewId)}/apply`
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to apply database sync preview');
     return data.data;
   },
 

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -251,6 +251,26 @@ export const apiClient = {
     return data.data;
   },
 
+  /** Reload one durable preview after the Settings UI closes or reloads. */
+  getDatabaseSyncPreview: async (
+    dbId: string,
+    previewId: string
+  ): Promise<SchedulerSyncPreviewResponse> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<SchedulerSyncPreviewResponse>>(
+      `/databases/${encodeURIComponent(dbId)}/sync/previews/${encodeURIComponent(previewId)}`
+    );
+    if (!data.data) throw new Error(data.error || 'Database sync preview not found');
+    return data.data;
+  },
+
+  deleteDatabaseSyncPreview: async (dbId: string, previewId: string): Promise<void> => {
+    const apiInstance = await getApi();
+    await apiInstance.delete(
+      `/databases/${encodeURIComponent(dbId)}/sync/previews/${encodeURIComponent(previewId)}`
+    );
+  },
+
   /** Apply one unexpired server-owned preview. */
   applyDatabaseSyncPreview: async (
     dbId: string,

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -706,7 +706,7 @@ export interface DatabaseSummary {
   image_directories: string[];
 }
 
-export type SchedulerSyncKind = 'pull' | 'push_planning';
+export type SchedulerSyncKind = 'pull' | 'push_planning' | 'push_grades';
 
 export interface SchedulerSyncRequest {
   peer_db_id: string;
@@ -714,6 +714,9 @@ export interface SchedulerSyncRequest {
   dry_run?: boolean;
   with_image_data?: boolean;
   project?: string;
+  target?: string;
+  status?: 'pending' | 'accepted' | 'rejected';
+  reviewed_only?: boolean;
 }
 
 export interface SchedulerSyncTableCounts {
@@ -721,6 +724,18 @@ export interface SchedulerSyncTableCounts {
   updated: number;
   unchanged: number;
   skipped: number;
+}
+
+export interface SchedulerSyncGradeCounts {
+  source_considered: number;
+  source_no_guid: number;
+  matched: number;
+  changed: number;
+  unchanged: number;
+  unmatched_source: number;
+  destination_only: number;
+  duplicate_guids: number;
+  transitions: Record<string, number>;
 }
 
 export interface SchedulerSyncResponse {
@@ -735,11 +750,19 @@ export interface SchedulerSyncResponse {
   exposureplan: SchedulerSyncTableCounts;
   acquiredimage: SchedulerSyncTableCounts | null;
   imagedata: SchedulerSyncTableCounts | null;
+  grades: SchedulerSyncGradeCounts | null;
   grade_filled: number;
   grade_preserved: number;
   imagedata_bytes: number;
   total_inserted: number;
   total_updated: number;
+}
+
+export interface SchedulerSyncPreviewResponse {
+  preview_id: string;
+  created_at: number;
+  expires_at: number;
+  result: SchedulerSyncResponse;
 }
 
 /** Per-project line of an import outcome report. */

--- a/static/src/components/SchedulerSyncControls.tsx
+++ b/static/src/components/SchedulerSyncControls.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import type { SchedulerSyncKind, SchedulerSyncResponse } from '../api/types';
@@ -10,11 +10,13 @@ interface SchedulerSyncControlsProps {
 }
 
 interface PendingSync {
-  kind: SchedulerSyncKind;
+  localDbId: string;
   previewId: string;
   expiresAt: number;
   result: SchedulerSyncResponse;
 }
+
+const STORED_PREVIEW_KEY = 'psf-guard.scheduler-sync-preview';
 
 const operationLabel = (kind: SchedulerSyncKind) => {
   switch (kind) {
@@ -39,6 +41,7 @@ export default function SchedulerSyncControls({
   const [pending, setPending] = useState<PendingSync | null>(null);
   const [running, setRunning] = useState(false);
   const [message, setMessage] = useState('');
+  const recoveryAttempted = useRef(false);
 
   const source = useMemo(
     () => databases.find((database) => database.id === sourceId) ?? databases[0],
@@ -51,10 +54,60 @@ export default function SchedulerSyncControls({
     [databases, destinationId, source?.id]
   );
 
-  const invalidatePreview = () => {
+  const forgetPending = (discardServerPreview: boolean) => {
+    if (pending && discardServerPreview) {
+      void apiClient
+        .deleteDatabaseSyncPreview(pending.localDbId, pending.previewId)
+        .catch(() => undefined);
+    }
+    sessionStorage.removeItem(STORED_PREVIEW_KEY);
     setPending(null);
     setMessage('');
   };
+
+  const invalidatePreview = () => forgetPending(true);
+
+  useEffect(() => {
+    if (recoveryAttempted.current || databases.length === 0) return;
+    recoveryAttempted.current = true;
+    const stored = sessionStorage.getItem(STORED_PREVIEW_KEY);
+    if (!stored) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const reference = JSON.parse(stored) as {
+          localDbId?: string;
+          previewId?: string;
+        };
+        if (!reference.localDbId || !reference.previewId) {
+          throw new Error('invalid stored preview');
+        }
+        const response = await apiClient.getDatabaseSyncPreview(
+          reference.localDbId,
+          reference.previewId
+        );
+        if (cancelled) return;
+        const restored = {
+          localDbId: reference.localDbId,
+          previewId: response.preview_id,
+          expiresAt: response.expires_at,
+          result: response.result,
+        };
+        setPending(restored);
+        setKind(response.result.kind);
+        setSourceId(response.result.source_db_id);
+        setDestinationId(response.result.destination_db_id);
+        setWithImageData(response.result.imagedata !== null);
+        setMessage('Restored the pending transfer preview.');
+      } catch {
+        sessionStorage.removeItem(STORED_PREVIEW_KEY);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [databases]);
 
   const changeSource = (nextSourceId: string) => {
     setSourceId(nextSourceId);
@@ -84,6 +137,13 @@ export default function SchedulerSyncControls({
     setRunning(true);
     setMessage('');
     try {
+      if (pending) {
+        await apiClient
+          .deleteDatabaseSyncPreview(pending.localDbId, pending.previewId)
+          .catch(() => undefined);
+        sessionStorage.removeItem(STORED_PREVIEW_KEY);
+        setPending(null);
+      }
       const localDbId = kind === 'pull' ? destination.id : source.id;
       const peerDbId = kind === 'pull' ? source.id : destination.id;
       const response = await apiClient.previewDatabaseSync(localDbId, {
@@ -94,11 +154,15 @@ export default function SchedulerSyncControls({
         reviewed_only: kind === 'push_grades',
       });
       setPending({
-        kind,
+        localDbId,
         previewId: response.preview_id,
         expiresAt: response.expires_at,
         result: response.result,
       });
+      sessionStorage.setItem(
+        STORED_PREVIEW_KEY,
+        JSON.stringify({ localDbId, previewId: response.preview_id })
+      );
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       setMessage(`Preview failed: ${detail}`);
@@ -113,11 +177,10 @@ export default function SchedulerSyncControls({
     setMessage('');
     try {
       const result = await apiClient.applyDatabaseSyncPreview(
-        pending.result.kind === 'pull'
-          ? pending.result.destination_db_id
-          : pending.result.source_db_id,
+        pending.localDbId,
         pending.previewId
       );
+      sessionStorage.removeItem(STORED_PREVIEW_KEY);
       setPending(null);
       setMessage(
         `${operationLabel(result.kind)} complete: ${result.total_inserted} added, ` +
@@ -128,6 +191,7 @@ export default function SchedulerSyncControls({
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       setMessage(`Apply failed: ${detail}`);
+      sessionStorage.removeItem(STORED_PREVIEW_KEY);
       setPending(null);
     } finally {
       setRunning(false);
@@ -320,13 +384,13 @@ export default function SchedulerSyncControls({
           )}
           <small>
             Preview expires at {new Date(pending.expiresAt * 1000).toLocaleTimeString()}.
-            Changing either database makes it stale.
+            Source edits wait for the next preview; destination edits make this one stale.
           </small>
           <div className="scheduler-sync-confirm">
             <button className="save-button" onClick={apply} disabled={disabled}>
               Apply this preview
             </button>
-            <button className="cancel-button" onClick={() => setPending(null)}>
+            <button className="cancel-button" onClick={() => forgetPending(true)}>
               Cancel
             </button>
           </div>

--- a/static/src/components/SchedulerSyncControls.tsx
+++ b/static/src/components/SchedulerSyncControls.tsx
@@ -5,178 +5,334 @@ import type { SchedulerSyncKind, SchedulerSyncResponse } from '../api/types';
 import type { DbEntry } from '../utils/tauri';
 
 interface SchedulerSyncControlsProps {
-  database: DbEntry;
   databases: DbEntry[];
   disabled?: boolean;
 }
 
 interface PendingSync {
   kind: SchedulerSyncKind;
+  previewId: string;
+  expiresAt: number;
   result: SchedulerSyncResponse;
 }
 
-const actionLabel = (kind: SchedulerSyncKind) =>
-  kind === 'pull' ? 'full pull' : 'planning push';
+const operationLabel = (kind: SchedulerSyncKind) => {
+  switch (kind) {
+    case 'pull':
+      return 'Merge catalogs';
+    case 'push_planning':
+      return 'Send planning';
+    case 'push_grades':
+      return 'Send reviewed grades';
+  }
+};
 
 export default function SchedulerSyncControls({
-  database,
   databases,
   disabled = false,
 }: SchedulerSyncControlsProps) {
   const queryClient = useQueryClient();
-  const peers = useMemo(
-    () => databases.filter((candidate) => candidate.id !== database.id),
-    [database.id, databases]
-  );
-  const [peerId, setPeerId] = useState(peers[0]?.id ?? '');
+  const [sourceId, setSourceId] = useState(databases[0]?.id ?? '');
+  const [destinationId, setDestinationId] = useState(databases[1]?.id ?? '');
+  const [kind, setKind] = useState<SchedulerSyncKind>('pull');
   const [withImageData, setWithImageData] = useState(true);
   const [pending, setPending] = useState<PendingSync | null>(null);
   const [running, setRunning] = useState(false);
   const [message, setMessage] = useState('');
 
-  const selectedPeerId = peers.some((peer) => peer.id === peerId)
-    ? peerId
-    : (peers[0]?.id ?? '');
-  const peerName =
-    peers.find((peer) => peer.id === selectedPeerId)?.name ?? selectedPeerId;
+  const source = useMemo(
+    () => databases.find((database) => database.id === sourceId) ?? databases[0],
+    [databases, sourceId]
+  );
+  const destination = useMemo(
+    () =>
+      databases.find((database) => database.id === destinationId) ??
+      databases.find((database) => database.id !== source?.id),
+    [databases, destinationId, source?.id]
+  );
 
-  const run = async (kind: SchedulerSyncKind, dryRun: boolean) => {
-    if (!selectedPeerId) return;
+  const invalidatePreview = () => {
+    setPending(null);
+    setMessage('');
+  };
+
+  const changeSource = (nextSourceId: string) => {
+    setSourceId(nextSourceId);
+    if (nextSourceId === destination?.id) {
+      setDestinationId(source?.id ?? '');
+    }
+    invalidatePreview();
+  };
+
+  const changeDestination = (nextDestinationId: string) => {
+    setDestinationId(nextDestinationId);
+    if (nextDestinationId === source?.id) {
+      setSourceId(destination?.id ?? '');
+    }
+    invalidatePreview();
+  };
+
+  const swapEndpoints = () => {
+    if (!source || !destination) return;
+    setSourceId(destination.id);
+    setDestinationId(source.id);
+    invalidatePreview();
+  };
+
+  const preview = async () => {
+    if (!source || !destination || source.id === destination.id) return;
     setRunning(true);
     setMessage('');
     try {
-      const result = await apiClient.syncDatabase(database.id, {
-        peer_db_id: selectedPeerId,
+      const localDbId = kind === 'pull' ? destination.id : source.id;
+      const peerDbId = kind === 'pull' ? source.id : destination.id;
+      const response = await apiClient.previewDatabaseSync(localDbId, {
+        peer_db_id: peerDbId,
         kind,
-        dry_run: dryRun,
+        dry_run: true,
         with_image_data: withImageData,
+        reviewed_only: kind === 'push_grades',
       });
-      if (dryRun) {
-        setPending({ kind, result });
-      } else {
-        setPending(null);
-        setMessage(
-          `${kind === 'pull' ? 'Pulled from' : 'Pushed planning settings to'} ${peerName}: ` +
-            `${result.total_inserted} added, ${result.total_updated} updated.`
-        );
-        queryClient.invalidateQueries({ queryKey: ['databases'] });
-        queryClient.invalidateQueries({ queryKey: ['db'] });
-      }
+      setPending({
+        kind,
+        previewId: response.preview_id,
+        expiresAt: response.expires_at,
+        result: response.result,
+      });
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      setMessage(`${dryRun ? 'Preview' : 'Sync'} failed: ${detail}`);
+      setMessage(`Preview failed: ${detail}`);
     } finally {
       setRunning(false);
     }
   };
 
-  if (peers.length === 0) {
+  const apply = async () => {
+    if (!pending) return;
+    setRunning(true);
+    setMessage('');
+    try {
+      const result = await apiClient.applyDatabaseSyncPreview(
+        pending.result.kind === 'pull'
+          ? pending.result.destination_db_id
+          : pending.result.source_db_id,
+        pending.previewId
+      );
+      setPending(null);
+      setMessage(
+        `${operationLabel(result.kind)} complete: ${result.total_inserted} added, ` +
+          `${result.total_updated} updated.`
+      );
+      queryClient.invalidateQueries({ queryKey: ['databases'] });
+      queryClient.invalidateQueries({ queryKey: ['db'] });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      setMessage(`Apply failed: ${detail}`);
+      setPending(null);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  if (databases.length < 2) {
     return (
       <div className="scheduler-sync-empty muted">
-        Add the telescope scheduler database here to sync projects and plans.
+        Add a second catalog to merge data or send planning and grades.
       </div>
     );
   }
 
   return (
-    <details className="scheduler-sync-controls">
-      <summary>Scheduler database sync</summary>
-      <div className="scheduler-sync-body">
+    <section className="settings-section scheduler-sync-workspace">
+      <div className="scheduler-sync-heading">
+        <div>
+          <h3>Data Transfer</h3>
+          <p>
+            Move catalog records in one direction. Preview is always required before
+            Apply.
+          </p>
+        </div>
+        <span className="scheduler-sync-safety">Preview first</span>
+      </div>
+
+      <div className="scheduler-sync-operation" role="group" aria-label="Transfer operation">
+        {(['pull', 'push_planning', 'push_grades'] as SchedulerSyncKind[]).map(
+          (operation) => (
+            <button
+              key={operation}
+              type="button"
+              className={kind === operation ? 'active' : ''}
+              aria-pressed={kind === operation}
+              onClick={() => {
+                setKind(operation);
+                invalidatePreview();
+              }}
+              disabled={disabled || running}
+            >
+              {operationLabel(operation)}
+            </button>
+          )
+        )}
+      </div>
+
+      <div className="scheduler-sync-endpoints">
         <label>
-          Other database
+          <span>Source</span>
           <select
-            value={selectedPeerId}
-            onChange={(event) => {
-              setPeerId(event.target.value);
-              setPending(null);
-              setMessage('');
-            }}
+            aria-label="Transfer source"
+            value={source?.id ?? ''}
+            onChange={(event) => changeSource(event.target.value)}
             disabled={disabled || running}
           >
-            {peers.map((peer) => (
-              <option value={peer.id} key={peer.id}>
-                {peer.name}
+            {databases.map((database) => (
+              <option key={database.id} value={database.id}>
+                {database.name}
               </option>
             ))}
           </select>
+          <small>{source?.db_path}</small>
         </label>
 
-        <div className="scheduler-sync-actions">
-          <div>
-            <strong>Pull full projects into {database.name}</strong>
-            <small>
-              Adds or updates projects, targets, plans, captures, and grades from {peerName}.
-              Local reviewed grades win.
-            </small>
+        <button
+          type="button"
+          className="scheduler-sync-swap"
+          onClick={swapEndpoints}
+          disabled={disabled || running}
+          aria-label="Swap source and destination"
+          title="Swap source and destination"
+        >
+          ⇄
+        </button>
+
+        <label>
+          <span>Destination</span>
+          <select
+            aria-label="Transfer destination"
+            value={destination?.id ?? ''}
+            onChange={(event) => changeDestination(event.target.value)}
+            disabled={disabled || running}
+          >
+            {databases.map((database) => (
+              <option key={database.id} value={database.id}>
+                {database.name}
+              </option>
+            ))}
+          </select>
+          <small>{destination?.db_path}</small>
+        </label>
+      </div>
+
+      <div className="scheduler-sync-description">
+        {kind === 'pull' && (
+          <>
+            <strong>Merge projects and captures</strong>
+            <span>
+              Adds or updates catalog structure and captures. Reviewed grades already at
+              the destination win.
+            </span>
             <label className="scheduler-sync-check">
               <input
                 type="checkbox"
                 checked={withImageData}
                 onChange={(event) => {
                   setWithImageData(event.target.checked);
-                  setPending(null);
-                  setMessage('');
+                  invalidatePreview();
                 }}
                 disabled={disabled || running}
               />
               Include stored image thumbnails
             </label>
-            <button
-              className="browse-button"
-              onClick={() => run('pull', true)}
-              disabled={disabled || running}
-            >
-              Preview full pull
-            </button>
-          </div>
+          </>
+        )}
+        {kind === 'push_planning' && (
+          <>
+            <strong>Send projects and exposure plans</strong>
+            <span>
+              Source planning settings win. Capture counts, images, and grades at the
+              destination stay unchanged.
+            </span>
+          </>
+        )}
+        {kind === 'push_grades' && (
+          <>
+            <strong>Send reviewed grades and reject reasons</strong>
+            <span>
+              Accepted and Rejected rows update matching image GUIDs. Pending rows cannot
+              erase a destination decision.
+            </span>
+          </>
+        )}
+      </div>
 
-          <div>
-            <strong>Push planning settings to {peerName}</strong>
-            <small>
-              Adds or updates projects, targets, templates, plans, and rule weights. Capture
-              counts, images, and grades on {peerName} stay unchanged.
-            </small>
-            <button
-              className="browse-button"
-              onClick={() => run('push_planning', true)}
-              disabled={disabled || running}
-            >
-              Preview planning push
+      <div className="scheduler-sync-primary-action">
+        <button
+          className="browse-button"
+          onClick={preview}
+          disabled={disabled || running || !source || !destination}
+        >
+          Preview changes
+        </button>
+      </div>
+
+      {running && <div className="scheduler-sync-status">Checking databases…</div>}
+      {pending && !running && (
+        <div className="scheduler-sync-preview">
+          {pending.result.grades ? (
+            <>
+              <strong>
+                {pending.result.grades.changed} reviewed grade(s) will change
+              </strong>
+              <small>
+                {pending.result.grades.matched} matched,{' '}
+                {pending.result.grades.unchanged} unchanged,{' '}
+                {pending.result.grades.unmatched_source} missing at the destination
+                {pending.result.grades.duplicate_guids > 0
+                  ? `, ${pending.result.grades.duplicate_guids} duplicate GUID(s) skipped`
+                  : ''}
+              </small>
+              {Object.keys(pending.result.grades.transitions).length > 0 && (
+                <ul className="scheduler-sync-transitions">
+                  {Object.entries(pending.result.grades.transitions).map(([label, count]) => (
+                    <li key={label}>
+                      {label}: {count}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          ) : (
+            <>
+              <strong>
+                {pending.result.total_inserted} rows will be added and{' '}
+                {pending.result.total_updated} updated
+              </strong>
+              <small>
+                Projects +{pending.result.project.inserted}/
+                {pending.result.project.updated}, targets +
+                {pending.result.target.inserted}/{pending.result.target.updated}, plans +
+                {pending.result.exposureplan.inserted}/
+                {pending.result.exposureplan.updated}
+                {pending.result.acquiredimage
+                  ? `, captures +${pending.result.acquiredimage.inserted}/${pending.result.acquiredimage.updated}`
+                  : ''}
+              </small>
+            </>
+          )}
+          <small>
+            Preview expires at {new Date(pending.expiresAt * 1000).toLocaleTimeString()}.
+            Changing either database makes it stale.
+          </small>
+          <div className="scheduler-sync-confirm">
+            <button className="save-button" onClick={apply} disabled={disabled}>
+              Apply this preview
+            </button>
+            <button className="cancel-button" onClick={() => setPending(null)}>
+              Cancel
             </button>
           </div>
         </div>
-
-        {running && <div className="scheduler-sync-status">Checking databases…</div>}
-        {pending && !running && (
-          <div className="scheduler-sync-preview">
-            <strong>
-              Preview: {pending.result.total_inserted} rows added and{' '}
-              {pending.result.total_updated} updated
-            </strong>
-            <small>
-              Projects +{pending.result.project.inserted}/{pending.result.project.updated}, targets
-              +{pending.result.target.inserted}/{pending.result.target.updated}, plans +
-              {pending.result.exposureplan.inserted}/{pending.result.exposureplan.updated}
-              {pending.result.acquiredimage
-                ? `, captures +${pending.result.acquiredimage.inserted}/${pending.result.acquiredimage.updated}`
-                : ''}
-            </small>
-            <div className="scheduler-sync-confirm">
-              <button
-                className="save-button"
-                onClick={() => run(pending.kind, false)}
-                disabled={disabled}
-              >
-                Apply {actionLabel(pending.kind)}
-              </button>
-              <button className="cancel-button" onClick={() => setPending(null)}>
-                Cancel
-              </button>
-            </div>
-          </div>
-        )}
-        {message && <div className="scheduler-sync-status">{message}</div>}
-      </div>
-    </details>
+      )}
+      {message && <div className="scheduler-sync-status">{message}</div>}
+    </section>
   );
 }

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -494,66 +494,150 @@
   display: block;
 }
 
-.tauri-settings .scheduler-sync-empty,
-.tauri-settings .scheduler-sync-controls {
+.tauri-settings .scheduler-sync-empty {
   margin-top: 10px;
   font-size: 13px;
 }
 
-.tauri-settings .scheduler-sync-controls {
-  border-top: 1px solid var(--color-border, #444);
-  padding-top: 8px;
-}
-
-.tauri-settings .scheduler-sync-controls summary {
-  cursor: pointer;
-  color: var(--color-primary);
-  font-weight: 600;
-}
-
-.tauri-settings .scheduler-sync-body {
+.tauri-settings .scheduler-sync-workspace {
   display: grid;
-  gap: 10px;
-  margin-top: 10px;
+  gap: 14px;
 }
 
-.tauri-settings .scheduler-sync-body > label {
-  display: grid;
-  grid-template-columns: auto minmax(140px, 1fr);
+.tauri-settings .scheduler-sync-heading {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: 16px;
 }
 
-.tauri-settings .scheduler-sync-body select {
+.tauri-settings .scheduler-sync-heading h3,
+.tauri-settings .scheduler-sync-heading p {
+  margin: 0;
+}
+
+.tauri-settings .scheduler-sync-heading p {
+  margin-top: 4px;
+  color: var(--color-text-secondary);
+}
+
+.tauri-settings .scheduler-sync-safety {
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  color: var(--color-primary);
+  border: 1px solid color-mix(in srgb, var(--color-primary) 55%, transparent);
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.tauri-settings .scheduler-sync-operation {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+  padding: 4px;
+  background: var(--color-bg-input);
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
+}
+
+.tauri-settings .scheduler-sync-operation button {
+  padding: 8px 10px;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 0;
+  border-radius: 5px;
+  font-weight: 650;
+}
+
+.tauri-settings .scheduler-sync-operation button.active {
+  color: var(--color-text);
+  background: color-mix(in srgb, var(--color-primary) 20%, var(--color-bg-input));
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--color-primary) 50%, transparent);
+}
+
+.tauri-settings .scheduler-sync-endpoints {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.tauri-settings .scheduler-sync-endpoints label {
+  display: grid;
+  gap: 5px;
   min-width: 0;
-  padding: 5px 7px;
+}
+
+.tauri-settings .scheduler-sync-endpoints label > span {
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.tauri-settings .scheduler-sync-endpoints select {
+  width: 100%;
+  min-width: 0;
+  padding: 8px 9px;
   color: var(--color-text);
   background: var(--color-bg-input);
   border: 1px solid var(--color-border);
   border-radius: 4px;
 }
 
-.tauri-settings .scheduler-sync-actions {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
+.tauri-settings .scheduler-sync-endpoints small {
+  overflow: hidden;
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.tauri-settings .scheduler-sync-actions > div {
+.tauri-settings .scheduler-sync-swap {
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  color: var(--color-primary);
+  background: var(--color-bg-input);
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  font-size: 20px;
+}
+
+.tauri-settings .scheduler-sync-description {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 6px;
-  padding: 9px;
+  gap: 5px;
+  padding: 12px;
+  background: color-mix(in srgb, var(--color-bg-input) 70%, transparent);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: 6px;
 }
 
-.tauri-settings .scheduler-sync-actions small,
+.tauri-settings .scheduler-sync-description span,
 .tauri-settings .scheduler-sync-preview small {
   display: block;
   color: var(--color-text-secondary);
   line-height: 1.35;
+}
+
+.tauri-settings .scheduler-sync-primary-action {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.tauri-settings .scheduler-sync-primary-action button {
+  width: auto;
+}
+
+.tauri-settings .scheduler-sync-transitions {
+  margin: 8px 0 0;
+  padding-left: 18px;
+  color: var(--color-text-secondary);
 }
 
 .tauri-settings .scheduler-sync-check {
@@ -583,8 +667,14 @@
 }
 
 @media (max-width: 760px) {
-  .tauri-settings .scheduler-sync-actions {
+  .tauri-settings .scheduler-sync-operation,
+  .tauri-settings .scheduler-sync-endpoints {
     grid-template-columns: 1fr;
+  }
+
+  .tauri-settings .scheduler-sync-swap {
+    justify-self: center;
+    transform: rotate(90deg);
   }
 }
 

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -445,6 +445,10 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
 
           {managementAllowed && <SeizaCatalogControls />}
 
+          {managementAllowed && (
+            <SchedulerSyncControls databases={databases} disabled={isApplying} />
+          )}
+
           <div className="settings-section">
             <h3>Configured Databases {hasDatabases && <span className="muted">({databases.length})</span>}</h3>
 
@@ -470,13 +474,6 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
                     </div>
                   )}
                   <QualityBackfillControls dbId={entry.id} />
-                  {managementAllowed && (
-                    <SchedulerSyncControls
-                      database={entry}
-                      databases={databases}
-                      disabled={isApplying}
-                    />
-                  )}
                 </div>
                 {managementAllowed && (
                   <div className="db-row-actions">

--- a/static/src/components/__tests__/SchedulerSyncControls.test.tsx
+++ b/static/src/components/__tests__/SchedulerSyncControls.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { server } from '../../test/msw-server';
 import SchedulerSyncControls from '../SchedulerSyncControls';
 
@@ -32,6 +32,63 @@ function wrapper() {
 const counts = { inserted: 0, updated: 0, unchanged: 0, skipped: 0 };
 
 describe('SchedulerSyncControls', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('restores a durable preview after the Settings UI reloads', async () => {
+    const result = {
+      kind: 'push_planning' as const,
+      dry_run: true,
+      source_db_id: 'local',
+      destination_db_id: 'scope',
+      exposuretemplate: counts,
+      project: { ...counts, updated: 1 },
+      ruleweight: counts,
+      target: counts,
+      exposureplan: counts,
+      acquiredimage: null,
+      imagedata: null,
+      grades: null,
+      grade_filled: 0,
+      grade_preserved: 0,
+      imagedata_bytes: 0,
+      total_inserted: 0,
+      total_updated: 1,
+    };
+    sessionStorage.setItem(
+      'psf-guard.scheduler-sync-preview',
+      JSON.stringify({ localDbId: 'local', previewId: 'restored-preview' })
+    );
+    server.use(
+      http.get(
+        '/api/databases/local/sync/previews/restored-preview',
+        () => HttpResponse.json({
+          success: true,
+          data: {
+            preview_id: 'restored-preview',
+            created_at: 1,
+            expires_at: 4_102_444_800,
+            result,
+          },
+          error: null,
+          status: 'ready',
+        })
+      )
+    );
+
+    render(<SchedulerSyncControls databases={[local, telescope]} />, {
+      wrapper: wrapper(),
+    });
+
+    expect(await screen.findByText('Restored the pending transfer preview.'))
+      .toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply this preview' }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send planning' }))
+      .toHaveAttribute('aria-pressed', 'true');
+  });
+
   it('previews before applying a planning-only push', async () => {
     const requests: Array<Record<string, unknown>> = [];
     const result = {

--- a/static/src/components/__tests__/SchedulerSyncControls.test.tsx
+++ b/static/src/components/__tests__/SchedulerSyncControls.test.tsx
@@ -34,45 +34,63 @@ const counts = { inserted: 0, updated: 0, unchanged: 0, skipped: 0 };
 describe('SchedulerSyncControls', () => {
   it('previews before applying a planning-only push', async () => {
     const requests: Array<Record<string, unknown>> = [];
+    const result = {
+      kind: 'push_planning',
+      dry_run: true,
+      source_db_id: 'local',
+      destination_db_id: 'scope',
+      exposuretemplate: counts,
+      project: { ...counts, updated: 1 },
+      ruleweight: counts,
+      target: { ...counts, updated: 2 },
+      exposureplan: { ...counts, inserted: 1 },
+      acquiredimage: null,
+      imagedata: null,
+      grades: null,
+      grade_filled: 0,
+      grade_preserved: 0,
+      imagedata_bytes: 0,
+      total_inserted: 1,
+      total_updated: 3,
+    };
     server.use(
-      http.post('/api/databases/local/sync', async ({ request }) => {
+      http.post('/api/databases/local/sync/preview', async ({ request }) => {
         const body = (await request.json()) as Record<string, unknown>;
         requests.push(body);
         return HttpResponse.json({
           success: true,
           data: {
-            kind: body.kind,
-            dry_run: body.dry_run,
-            source_db_id: 'local',
-            destination_db_id: 'scope',
-            exposuretemplate: counts,
-            project: { ...counts, updated: 1 },
-            ruleweight: counts,
-            target: { ...counts, updated: 2 },
-            exposureplan: { ...counts, inserted: 1 },
-            acquiredimage: null,
-            imagedata: null,
-            grade_filled: 0,
-            grade_preserved: 0,
-            imagedata_bytes: 0,
-            total_inserted: 1,
-            total_updated: 3,
+            preview_id: 'planning-preview',
+            created_at: 1,
+            expires_at: 4_102_444_800,
+            result,
           },
           error: null,
           status: 'ready',
         });
-      })
+      }),
+      http.post(
+        '/api/databases/local/sync/previews/planning-preview/apply',
+        () => {
+          requests.push({ preview_id: 'planning-preview' });
+          return HttpResponse.json({
+            success: true,
+            data: { ...result, dry_run: false },
+            error: null,
+            status: 'ready',
+          });
+        }
+      )
     );
 
     const user = userEvent.setup();
-    render(
-      <SchedulerSyncControls database={local} databases={[local, telescope]} />,
-      { wrapper: wrapper() }
-    );
+    render(<SchedulerSyncControls databases={[local, telescope]} />, {
+      wrapper: wrapper(),
+    });
 
-    await user.click(screen.getByText('Scheduler database sync'));
-    await user.click(screen.getByRole('button', { name: 'Preview planning push' }));
-    expect(await screen.findByText(/Preview: 1 rows added and 3 updated/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Send planning' }));
+    await user.click(screen.getByRole('button', { name: 'Preview changes' }));
+    expect(await screen.findByText(/1 rows will be added and 3 updated/)).toBeInTheDocument();
     expect(requests).toHaveLength(1);
     expect(requests[0]).toMatchObject({
       peer_db_id: 'scope',
@@ -80,36 +98,42 @@ describe('SchedulerSyncControls', () => {
       dry_run: true,
     });
 
-    await user.click(screen.getByRole('button', { name: 'Apply planning push' }));
-    expect(await screen.findByText(/Pushed planning settings to Telescope scheduler/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Apply this preview' }));
+    expect(await screen.findByText(/Send planning complete/)).toBeInTheDocument();
     expect(requests).toHaveLength(2);
-    expect(requests[1]).toMatchObject({ kind: 'push_planning', dry_run: false });
+    expect(requests[1]).toEqual({ preview_id: 'planning-preview' });
   });
 
   it('offers a full pull with image data by default', async () => {
     let body: Record<string, unknown> | null = null;
     server.use(
-      http.post('/api/databases/local/sync', async ({ request }) => {
+      http.post('/api/databases/scope/sync/preview', async ({ request }) => {
         body = (await request.json()) as Record<string, unknown>;
         return HttpResponse.json({
           success: true,
           data: {
-            kind: 'pull',
-            dry_run: true,
-            source_db_id: 'scope',
-            destination_db_id: 'local',
-            exposuretemplate: counts,
-            project: counts,
-            ruleweight: counts,
-            target: counts,
-            exposureplan: counts,
-            acquiredimage: { ...counts, inserted: 5 },
-            imagedata: { ...counts, inserted: 5 },
-            grade_filled: 0,
-            grade_preserved: 0,
-            imagedata_bytes: 500,
-            total_inserted: 10,
-            total_updated: 0,
+            preview_id: 'merge-preview',
+            created_at: 1,
+            expires_at: 4_102_444_800,
+            result: {
+              kind: 'pull',
+              dry_run: true,
+              source_db_id: 'local',
+              destination_db_id: 'scope',
+              exposuretemplate: counts,
+              project: counts,
+              ruleweight: counts,
+              target: counts,
+              exposureplan: counts,
+              acquiredimage: { ...counts, inserted: 5 },
+              imagedata: { ...counts, inserted: 5 },
+              grades: null,
+              grade_filled: 0,
+              grade_preserved: 0,
+              imagedata_bytes: 500,
+              total_inserted: 10,
+              total_updated: 0,
+            },
           },
           error: null,
           status: 'ready',
@@ -118,18 +142,174 @@ describe('SchedulerSyncControls', () => {
     );
 
     const user = userEvent.setup();
-    render(
-      <SchedulerSyncControls database={local} databases={[local, telescope]} />,
-      { wrapper: wrapper() }
-    );
-    await user.click(screen.getByText('Scheduler database sync'));
-    await user.click(screen.getByRole('button', { name: 'Preview full pull' }));
-    expect(await screen.findByText(/Preview: 10 rows added/)).toBeInTheDocument();
+    render(<SchedulerSyncControls databases={[local, telescope]} />, {
+      wrapper: wrapper(),
+    });
+    await user.click(screen.getByRole('button', { name: 'Preview changes' }));
+    expect(await screen.findByText(/10 rows will be added/)).toBeInTheDocument();
     expect(body).toMatchObject({
-      peer_db_id: 'scope',
+      peer_db_id: 'local',
       kind: 'pull',
       dry_run: true,
       with_image_data: true,
     });
+
+    await user.click(screen.getByRole('button', { name: 'Send planning' }));
+    expect(
+      screen.queryByRole('button', { name: 'Apply this preview' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('previews reviewed grades before offering a grade push', async () => {
+    const requests: Array<Record<string, unknown>> = [];
+    const result = {
+      kind: 'push_grades',
+      dry_run: true,
+      source_db_id: 'local',
+      destination_db_id: 'scope',
+      exposuretemplate: counts,
+      project: counts,
+      ruleweight: counts,
+      target: counts,
+      exposureplan: counts,
+      acquiredimage: null,
+      imagedata: null,
+      grades: {
+        source_considered: 8,
+        source_no_guid: 0,
+        matched: 7,
+        changed: 3,
+        unchanged: 4,
+        unmatched_source: 1,
+        destination_only: 2,
+        duplicate_guids: 0,
+        transitions: { 'Pending→Accepted': 2, 'Pending→Rejected': 1 },
+      },
+      grade_filled: 0,
+      grade_preserved: 0,
+      imagedata_bytes: 0,
+      total_inserted: 0,
+      total_updated: 3,
+    };
+    server.use(
+      http.post('/api/databases/local/sync/preview', async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        requests.push(body);
+        return HttpResponse.json({
+          success: true,
+          data: {
+            preview_id: 'grade-preview',
+            created_at: 1,
+            expires_at: 4_102_444_800,
+            result,
+          },
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.post('/api/databases/local/sync/previews/grade-preview/apply', () => {
+        requests.push({ preview_id: 'grade-preview' });
+        return HttpResponse.json({
+          success: true,
+          data: { ...result, dry_run: false },
+          error: null,
+          status: 'ready',
+        });
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<SchedulerSyncControls databases={[local, telescope]} />, {
+      wrapper: wrapper(),
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Send reviewed grades' }));
+    await user.click(screen.getByRole('button', { name: 'Preview changes' }));
+
+    expect(
+      await screen.findByText('3 reviewed grade(s) will change')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Pending→Accepted: 2')).toBeInTheDocument();
+    expect(requests[0]).toMatchObject({
+      peer_db_id: 'scope',
+      kind: 'push_grades',
+      dry_run: true,
+      reviewed_only: true,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Apply this preview' }));
+    expect(await screen.findByText(/Send reviewed grades complete/))
+      .toBeInTheDocument();
+    expect(requests[1]).toMatchObject({
+      preview_id: 'grade-preview',
+    });
+  });
+
+  it('drops a stale preview and requires a new preview', async () => {
+    const result = {
+      kind: 'push_planning',
+      dry_run: true,
+      source_db_id: 'local',
+      destination_db_id: 'scope',
+      exposuretemplate: counts,
+      project: { ...counts, updated: 1 },
+      ruleweight: counts,
+      target: counts,
+      exposureplan: counts,
+      acquiredimage: null,
+      imagedata: null,
+      grades: null,
+      grade_filled: 0,
+      grade_preserved: 0,
+      imagedata_bytes: 0,
+      total_inserted: 0,
+      total_updated: 1,
+    };
+    server.use(
+      http.post('/api/databases/local/sync/preview', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            preview_id: 'stale-preview',
+            created_at: 1,
+            expires_at: 4_102_444_800,
+            result,
+          },
+          error: null,
+          status: 'ready',
+        })
+      ),
+      http.post(
+        '/api/databases/local/sync/previews/stale-preview/apply',
+        () =>
+          HttpResponse.json(
+            {
+              success: false,
+              data: null,
+              error:
+                'This preview is stale because a source or destination database changed. Preview again.',
+              status: null,
+            },
+            { status: 409 }
+          )
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<SchedulerSyncControls databases={[local, telescope]} />, {
+      wrapper: wrapper(),
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Send planning' }));
+    await user.click(screen.getByRole('button', { name: 'Preview changes' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Apply this preview' })
+    );
+
+    expect(await screen.findByText(/Apply failed: This preview is stale/))
+      .toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Apply this preview' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/tests/integration_sync_api.rs
+++ b/tests/integration_sync_api.rs
@@ -29,10 +29,10 @@ fn schema(conn: &Connection) {
     .unwrap();
 }
 
-async fn request(app: Router, body: Value) -> (StatusCode, Value) {
+async fn request(app: Router, uri: &str, body: Value) -> (StatusCode, Value) {
     let response = app
         .oneshot(
-            Request::post("/api/databases/local/sync")
+            Request::post(uri)
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::to_vec(&body).unwrap()))
                 .unwrap(),
@@ -45,7 +45,7 @@ async fn request(app: Router, body: Value) -> (StatusCode, Value) {
 }
 
 #[tokio::test]
-async fn planning_push_previews_then_keeps_telescope_capture_state() {
+async fn planning_and_grade_pushes_preview_before_writing() {
     let dir = tempdir().unwrap();
     let local_path = dir.path().join("local.sqlite");
     let telescope_path = dir.path().join("telescope.sqlite");
@@ -59,7 +59,8 @@ async fn planning_push_previews_then_keeps_telescope_capture_state() {
          INSERT INTO target VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
          INSERT INTO exposuretemplate VALUES (1,'p','Ha 300','Ha',120,'template-guid');
          INSERT INTO exposureplan VALUES (1,'p',300,40,18,16,1,1,1,'plan-guid');
-         INSERT INTO ruleweight VALUES (1,'Priority',2.5,1);",
+         INSERT INTO ruleweight VALUES (1,'Priority',2.5,1);
+         INSERT INTO acquiredimage VALUES (1,1,1,1000,'Ha',1,'{}',NULL,'p',1,'image-guid');",
         )
         .unwrap();
     telescope
@@ -107,6 +108,14 @@ async fn planning_push_previews_then_keeps_telescope_capture_state() {
             "/api/databases/{db_id}/sync",
             post(handlers::sync_database_route),
         )
+        .route(
+            "/api/databases/{db_id}/sync/preview",
+            post(handlers::preview_sync_database_route),
+        )
+        .route(
+            "/api/databases/{db_id}/sync/previews/{preview_id}/apply",
+            post(handlers::apply_sync_database_preview_route),
+        )
         .with_state(state);
 
     let payload = json!({
@@ -114,7 +123,7 @@ async fn planning_push_previews_then_keeps_telescope_capture_state() {
         "kind": "push_planning",
         "dry_run": true
     });
-    let (status, preview) = request(app.clone(), payload).await;
+    let (status, preview) = request(app.clone(), "/api/databases/local/sync", payload).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(preview["data"]["project"]["updated"], 1);
     let telescope = Connection::open(&telescope_path).unwrap();
@@ -128,7 +137,8 @@ async fn planning_push_previews_then_keeps_telescope_capture_state() {
     drop(telescope);
 
     let (status, applied) = request(
-        app,
+        app.clone(),
+        "/api/databases/local/sync",
         json!({
             "peer_db_id": "scope",
             "kind": "push_planning",
@@ -161,6 +171,99 @@ async fn planning_push_previews_then_keeps_telescope_capture_state() {
             .unwrap(),
         6
     );
+    assert_eq!(
+        telescope
+            .query_row("SELECT gradingStatus FROM acquiredimage", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        2
+    );
+    drop(telescope);
+
+    // Omitting dry_run is safe: the route previews reviewed grade changes.
+    let (status, preview) = request(
+        app.clone(),
+        "/api/databases/local/sync/preview",
+        json!({
+            "peer_db_id": "scope",
+            "kind": "push_grades"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(preview["data"]["result"]["dry_run"], true);
+    assert_eq!(preview["data"]["result"]["grades"]["changed"], 1);
+    let preview_id = preview["data"]["preview_id"].as_str().unwrap();
+    let telescope = Connection::open(&telescope_path).unwrap();
+    assert_eq!(
+        telescope
+            .query_row("SELECT gradingStatus FROM acquiredimage", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        2
+    );
+    drop(telescope);
+
+    let (status, applied) = request(
+        app.clone(),
+        &format!("/api/databases/local/sync/previews/{preview_id}/apply"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(applied["data"]["grades"]["changed"], 1);
+    let telescope = Connection::open(&telescope_path).unwrap();
+    assert_eq!(
+        telescope
+            .query_row("SELECT gradingStatus FROM acquiredimage", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        1
+    );
+    drop(telescope);
+
+    let (status, _) = request(
+        app.clone(),
+        &format!("/api/databases/local/sync/previews/{preview_id}/apply"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let (status, stale_preview) = request(
+        app.clone(),
+        "/api/databases/local/sync/preview",
+        json!({
+            "peer_db_id": "scope",
+            "kind": "push_grades"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let stale_preview_id = stale_preview["data"]["preview_id"].as_str().unwrap();
+
+    let telescope = Connection::open(&telescope_path).unwrap();
+    telescope
+        .execute(
+            "UPDATE acquiredimage SET gradingStatus = 2, rejectreason = 'new cloud'",
+            [],
+        )
+        .unwrap();
+    drop(telescope);
+
+    let (status, stale_apply) = request(
+        app,
+        &format!("/api/databases/local/sync/previews/{stale_preview_id}/apply"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(stale_apply["error"]
+        .as_str()
+        .unwrap()
+        .contains("preview is stale"));
+
+    let telescope = Connection::open(&telescope_path).unwrap();
     assert_eq!(
         telescope
             .query_row("SELECT gradingStatus FROM acquiredimage", [], |row| row

--- a/tests/integration_sync_api.rs
+++ b/tests/integration_sync_api.rs
@@ -44,6 +44,16 @@ async fn request(app: Router, uri: &str, body: Value) -> (StatusCode, Value) {
     (status, serde_json::from_slice(&bytes).unwrap())
 }
 
+async fn get_request(app: Router, uri: &str) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(Request::get(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    (status, serde_json::from_slice(&bytes).unwrap())
+}
+
 #[tokio::test]
 async fn planning_and_grade_pushes_preview_before_writing() {
     let dir = tempdir().unwrap();
@@ -115,6 +125,11 @@ async fn planning_and_grade_pushes_preview_before_writing() {
         .route(
             "/api/databases/{db_id}/sync/previews/{preview_id}/apply",
             post(handlers::apply_sync_database_preview_route),
+        )
+        .route(
+            "/api/databases/{db_id}/sync/previews/{preview_id}",
+            axum::routing::get(handlers::get_sync_database_preview_route)
+                .delete(handlers::delete_sync_database_preview_route),
         )
         .with_state(state);
 
@@ -194,6 +209,14 @@ async fn planning_and_grade_pushes_preview_before_writing() {
     assert_eq!(preview["data"]["result"]["dry_run"], true);
     assert_eq!(preview["data"]["result"]["grades"]["changed"], 1);
     let preview_id = preview["data"]["preview_id"].as_str().unwrap();
+    let (status, restored) = get_request(
+        app.clone(),
+        &format!("/api/databases/local/sync/previews/{preview_id}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(restored["data"]["preview_id"], preview_id);
+    assert_eq!(restored["data"]["result"]["grades"]["changed"], 1);
     let telescope = Connection::open(&telescope_path).unwrap();
     assert_eq!(
         telescope
@@ -229,6 +252,52 @@ async fn planning_and_grade_pushes_preview_before_writing() {
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // Apply uses the frozen source snapshot, not source rows edited after
+    // Preview.
+    let telescope = Connection::open(&telescope_path).unwrap();
+    telescope
+        .execute(
+            "UPDATE acquiredimage SET gradingStatus = 0, rejectreason = NULL",
+            [],
+        )
+        .unwrap();
+    drop(telescope);
+    let (status, frozen_preview) = request(
+        app.clone(),
+        "/api/databases/local/sync/preview",
+        json!({
+            "peer_db_id": "scope",
+            "kind": "push_grades"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let frozen_preview_id = frozen_preview["data"]["preview_id"].as_str().unwrap();
+    let local = Connection::open(&local_path).unwrap();
+    local
+        .execute(
+            "UPDATE acquiredimage SET gradingStatus = 2, rejectreason = 'later source edit'",
+            [],
+        )
+        .unwrap();
+    drop(local);
+    let (status, _) = request(
+        app.clone(),
+        &format!("/api/databases/local/sync/previews/{frozen_preview_id}/apply"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let telescope = Connection::open(&telescope_path).unwrap();
+    assert_eq!(
+        telescope
+            .query_row("SELECT gradingStatus FROM acquiredimage", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        1
+    );
+    drop(telescope);
 
     let (status, stale_preview) = request(
         app.clone(),


### PR DESCRIPTION
## What changed

- add one Data Transfer workspace with explicit source, destination, and direction
- add catalog merge, planning send, and reviewed-grade send actions
- make grade sends skip Pending rows by default
- create durable, one-use preview IDs with a 30-minute expiry
- reject stale previews when either database changes
- serialize guarded applies so two requests cannot pass the same precondition
- document the full local-file and remote-sync design

## Why

Copying a live SQLite database is unsafe and gives the user no useful conflict
review. This starts a preview-first transfer path that can later support native
file selection, remote PSF Guard peers, and a N.I.N.A. plugin without Syncthing.

## Checks

- `cargo test --lib` — 383 passed, 5 ignored
- `cargo test --test integration_sync_api`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm test` — 117 passed
- `npm run lint`
- `npm run build`
- `npx playwright test e2e/data-transfer.spec.ts` — desktop flow and 390 px layout
