### PR TITLE
Reveal image files from details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3915,6 +3915,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "dunce",
  "http-body-util",
  "humantime",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ humantime = "2.3"
 tauri = { version = "2.11.1", features = ["custom-protocol"], optional = true }
 tauri-plugin-dialog = { version = "2.7.1", optional = true }
 dirs = "6.0"
+dunce = "1"
 async_zip = { version = "0.0.18", features = ["tokio"] }
 # Platform memory probes for the occlusion-scan worker budget in
 # `concurrency` (both already in the tree transitively). Linux uses

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ processing. Your image files stay where they are.
   while the source files stay in place.
 - **Review frames quickly** in the desktop app or browser with stretched
   previews, zoom and pan, comparison, batch grading, keyboard controls, and
-  undo.
+  undo. Image details show the resolved or recorded file path; the desktop app
+  can reveal a resolved file in Finder, Explorer, or the Linux file manager.
 - **Screen image quality** with spatial metrics, cross-frame photometry, and
   fresh pixel-derived plate solutions. The evidence can expose clouds,
   occlusion, stray light, off-target frames, and lost tracking.
@@ -315,6 +316,9 @@ the image grid and comparison tools:
 - **Smart loading**: fast previews first, full resolution on zoom; previews
   generate on demand in the background, so a fresh install is browsable
   immediately.
+- **File location**: image details show the resolved path when the source file
+  is present and fall back to the path recorded in the catalog. Copy any shown
+  path, or use **Show in folder** in the desktop app.
 - **Stack previews**: in a single project, build an uncalibrated registered
   preview from an explicit multi-selection or the current visible filters.
   PSF Guard excludes rejected and regrade-recommended frames before Seiza

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -372,14 +372,14 @@ fn validate_image_reveal_path(
     let database = registry
         .find(db_id)
         .ok_or_else(|| "Image catalog is not configured".to_string())?;
-    let path = std::fs::canonicalize(requested)
-        .map_err(|e| format!("Image file is not available: {e}"))?;
+    let path =
+        dunce::canonicalize(requested).map_err(|e| format!("Image file is not available: {e}"))?;
     if !path.is_file() {
         return Err("Image path does not point to a file".to_string());
     }
 
     let registered = database.image_dirs.iter().any(|root| {
-        std::fs::canonicalize(root)
+        dunce::canonicalize(root)
             .map(|root| path.starts_with(root))
             .unwrap_or(false)
     });
@@ -543,7 +543,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(validated, std::fs::canonicalize(file).unwrap());
+        assert_eq!(validated, dunce::canonicalize(file).unwrap());
     }
 
     #[test]
@@ -625,6 +625,30 @@ mod tests {
             command.get_args().collect::<Vec<_>>(),
             vec![OsStr::new(r"/select,C:\images\frame.fits")]
         );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn validated_reveal_path_uses_an_explorer_compatible_path() {
+        use std::ffi::OsStr;
+
+        let root = tempdir().unwrap();
+        let file = root.path().join("frame.fits");
+        std::fs::write(&file, b"fits").unwrap();
+        let validated = validate_image_reveal_path(
+            &registry_with_root(root.path()),
+            "test",
+            file.to_str().unwrap(),
+        )
+        .unwrap();
+        let command = file_manager_command(&validated).unwrap();
+        let argument = command.get_args().next().unwrap();
+
+        assert_eq!(
+            argument,
+            OsStr::new(&format!("/select,{}", validated.display()))
+        );
+        assert!(!argument.to_string_lossy().contains(r"\\?\"));
     }
 
     #[test]

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -1,6 +1,7 @@
 use crate::cli::PregenerationConfig;
 use crate::db_registry::{DbEntry, DbRegistry};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
 use tracing_subscriber;
@@ -98,6 +99,7 @@ pub fn main() {
             get_current_configuration,
             add_database,
             remove_database,
+            show_image_in_folder,
             restart_application,
             restart_server,
             is_configuration_valid
@@ -335,6 +337,101 @@ fn remove_database(state: tauri::State<ServerState>, db_id: String) -> Result<bo
 }
 
 #[tauri::command]
+async fn show_image_in_folder(
+    state: tauri::State<'_, ServerState>,
+    db_id: String,
+    path: String,
+) -> Result<(), String> {
+    // Database CRUD runs through the local HTTP server, so the Tauri-side
+    // in-memory mirror can lag behind. Reload the small registry file before
+    // validating the requested path.
+    let registry_path = state
+        .registry_path
+        .lock()
+        .map_err(|e| e.to_string())?
+        .clone();
+    tokio::task::spawn_blocking(move || {
+        let registry = DbRegistry::load_or_init(&registry_path)
+            .map_err(|e| format!("Could not read the database registry: {e:#}"))?;
+        let path = validate_image_reveal_path(&registry, &db_id, &path)?;
+        launch_file_manager(&path)
+    })
+    .await
+    .map_err(|e| format!("File manager task failed: {e}"))?
+}
+
+fn validate_image_reveal_path(
+    registry: &DbRegistry,
+    db_id: &str,
+    requested: &str,
+) -> Result<PathBuf, String> {
+    if requested.trim().is_empty() {
+        return Err("Image path is empty".to_string());
+    }
+
+    let database = registry
+        .find(db_id)
+        .ok_or_else(|| "Image catalog is not configured".to_string())?;
+    let path = std::fs::canonicalize(requested)
+        .map_err(|e| format!("Image file is not available: {e}"))?;
+    if !path.is_file() {
+        return Err("Image path does not point to a file".to_string());
+    }
+
+    let registered = database.image_dirs.iter().any(|root| {
+        std::fs::canonicalize(root)
+            .map(|root| path.starts_with(root))
+            .unwrap_or(false)
+    });
+    if !registered {
+        return Err("Image file is outside the configured image folders".to_string());
+    }
+
+    Ok(path)
+}
+
+fn launch_file_manager(path: &Path) -> Result<(), String> {
+    let mut command = file_manager_command(path)?;
+    let status = command
+        .status()
+        .map_err(|e| format!("Could not open the file manager: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("The file manager exited with status {status}"))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn file_manager_command(path: &Path) -> Result<Command, String> {
+    let mut command = Command::new("open");
+    command.arg("-R").arg(path);
+    Ok(command)
+}
+
+#[cfg(target_os = "windows")]
+fn file_manager_command(path: &Path) -> Result<Command, String> {
+    let mut command = Command::new("explorer.exe");
+    command.arg(format!("/select,{}", path.display()));
+    Ok(command)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn file_manager_command(path: &Path) -> Result<Command, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Image file has no parent folder".to_string())?;
+    let mut command = Command::new("xdg-open");
+    command.arg(parent);
+    Ok(command)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", unix)))]
+fn file_manager_command(_path: &Path) -> Result<Command, String> {
+    Err("Showing files is not supported on this platform".to_string())
+}
+
+#[tauri::command]
 async fn restart_application(app: tauri::AppHandle) -> Result<(), String> {
     app.restart();
 }
@@ -409,4 +506,138 @@ fn is_configuration_valid(state: tauri::State<ServerState>) -> Result<bool, Stri
         .databases
         .iter()
         .any(|d| !d.db_path.trim().is_empty() && std::path::Path::new(&d.db_path).exists()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db_registry::CURRENT_SCHEMA_VERSION;
+    use tempfile::tempdir;
+
+    fn registry_with_root(root: &Path) -> DbRegistry {
+        DbRegistry {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            databases: vec![DbEntry {
+                id: "test".to_string(),
+                name: "Test".to_string(),
+                db_path: root.join("catalog.sqlite").display().to_string(),
+                image_dirs: vec![root.display().to_string()],
+                reject_archive: None,
+            }],
+            active_db_id: None,
+            astrometry: None,
+        }
+    }
+
+    #[test]
+    fn reveal_path_accepts_an_existing_file_under_an_image_root() {
+        let root = tempdir().unwrap();
+        let file = root.path().join("lights").join("frame.fits");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, b"fits").unwrap();
+
+        let validated = validate_image_reveal_path(
+            &registry_with_root(root.path()),
+            "test",
+            file.to_str().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(validated, std::fs::canonicalize(file).unwrap());
+    }
+
+    #[test]
+    fn reveal_path_rejects_files_outside_registered_image_roots() {
+        let root = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let file = outside.path().join("frame.fits");
+        std::fs::write(&file, b"fits").unwrap();
+
+        let error = validate_image_reveal_path(
+            &registry_with_root(root.path()),
+            "test",
+            file.to_str().unwrap(),
+        )
+        .unwrap_err();
+
+        assert_eq!(error, "Image file is outside the configured image folders");
+    }
+
+    #[test]
+    fn reveal_path_rejects_missing_files_and_directories() {
+        let root = tempdir().unwrap();
+        let registry = registry_with_root(root.path());
+
+        assert!(validate_image_reveal_path(
+            &registry,
+            "test",
+            root.path().join("missing.fits").to_str().unwrap()
+        )
+        .unwrap_err()
+        .starts_with("Image file is not available:"));
+        assert_eq!(
+            validate_image_reveal_path(&registry, "test", root.path().to_str().unwrap())
+                .unwrap_err(),
+            "Image path does not point to a file"
+        );
+    }
+
+    #[test]
+    fn reveal_path_rejects_unknown_catalogs() {
+        let root = tempdir().unwrap();
+        let file = root.path().join("frame.fits");
+        std::fs::write(&file, b"fits").unwrap();
+
+        assert_eq!(
+            validate_image_reveal_path(
+                &registry_with_root(root.path()),
+                "other",
+                file.to_str().unwrap()
+            )
+            .unwrap_err(),
+            "Image catalog is not configured"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn file_manager_command_reveals_the_file_in_finder() {
+        use std::ffi::OsStr;
+
+        let command = file_manager_command(Path::new("/tmp/frame.fits")).unwrap();
+
+        assert_eq!(command.get_program(), OsStr::new("open"));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("-R"), OsStr::new("/tmp/frame.fits")]
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn file_manager_command_selects_the_file_in_explorer() {
+        use std::ffi::OsStr;
+
+        let command = file_manager_command(Path::new(r"C:\images\frame.fits")).unwrap();
+
+        assert_eq!(command.get_program(), OsStr::new("explorer.exe"));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new(r"/select,C:\images\frame.fits")]
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, not(target_os = "macos")))]
+    fn file_manager_command_opens_the_parent_directory() {
+        use std::ffi::OsStr;
+
+        let command = file_manager_command(Path::new("/tmp/images/frame.fits")).unwrap();
+
+        assert_eq!(command.get_program(), OsStr::new("xdg-open"));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("/tmp/images")]
+        );
+    }
 }

--- a/static/e2e/image-detail.spec.ts
+++ b/static/e2e/image-detail.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import {
+  fixtureImageDir,
   registerFixtureDb,
   resetDatabases,
   waitForCacheReady,
@@ -195,6 +196,17 @@ test('detail view loads the large preview and renders pixels', async ({
   }));
   expect(dims.natW).toBeGreaterThan(500);
   expect(dims.natH).toBeGreaterThan(500);
+});
+
+test('detail view shows the resolved file path', async ({ page }) => {
+  await page.goto(`/#/detail/1?db=${encodeURIComponent(dbId)}&project=1`);
+
+  const filePath = page.getByTestId('image-file-path');
+  await expect(filePath).toBeVisible({ timeout: 15_000 });
+  await expect(filePath).toContainText(fixtureImageDir());
+  await expect(filePath).toContainText('.fits');
+  await expect(page.getByRole('button', { name: 'Copy path' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Show in folder' })).toHaveCount(0);
 });
 
 test('detail view supports pinch zoom around a moving midpoint', async ({

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -1490,6 +1490,104 @@
   flex: 1;
 }
 
+.image-file-location {
+  margin-top: 1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--color-bg-tertiary);
+}
+
+.image-file-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.file-path-resolved,
+.file-path-catalog,
+.file-path-unavailable {
+  padding: 0.08rem 0.4rem;
+  border: 1px solid var(--color-bg-input);
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.file-path-resolved {
+  border-color: var(--color-success);
+  color: var(--color-success-light);
+}
+
+.file-path-catalog {
+  color: var(--color-warning-light);
+}
+
+.file-path-unavailable {
+  color: var(--color-text-muted);
+}
+
+.image-file-path {
+  display: block;
+  max-width: 100%;
+  padding: 0.55rem 0.65rem;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--color-bg-tertiary);
+  border-radius: 4px;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  user-select: text;
+}
+
+.image-file-note,
+.image-file-unavailable,
+.image-file-feedback {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+}
+
+.image-file-note {
+  margin: 0.45rem 0 0;
+}
+
+.image-file-actions {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 0.55rem;
+}
+
+.image-file-actions button {
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--color-bg-input);
+  border-radius: 4px;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-size: 0.72rem;
+}
+
+.image-file-actions button:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.image-file-actions button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.image-file-feedback {
+  min-height: 1rem;
+  margin-top: 0.3rem;
+  color: var(--color-error-light);
+}
+
 .detail-actions {
   display: flex;
   gap: 0.5rem;

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -13,6 +13,7 @@ import AstrometryPanel from './AstrometryPanel';
 import AstrometryOverlay from './AstrometryOverlay';
 import SatellitePanel from './SatellitePanel';
 import SatelliteTrackOverlay from './SatelliteTrackOverlay';
+import ImageFileLocation from './ImageFileLocation';
 
 interface ImageDetailViewProps {
   dbId: string;
@@ -698,6 +699,16 @@ export default function ImageDetailView({
                   </>
                 )}
               </dl>
+
+              <ImageFileLocation
+                dbId={dbId}
+                filesystemPath={image.filesystem_path}
+                catalogPath={
+                  typeof image.metadata?.FileName === 'string'
+                    ? image.metadata.FileName
+                    : null
+                }
+              />
               
               {image.reject_reason && (
                 <div className="reject-reason">

--- a/static/src/components/ImageFileLocation.tsx
+++ b/static/src/components/ImageFileLocation.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { isTauriApp, tauriFileSystem } from '../utils/tauri';
+
+interface ImageFileLocationProps {
+  dbId: string;
+  filesystemPath: string | null;
+  catalogPath?: string | null;
+}
+
+type ActionState = 'idle' | 'copied' | 'opening' | 'error';
+
+export default function ImageFileLocation({
+  dbId,
+  filesystemPath,
+  catalogPath,
+}: ImageFileLocationProps) {
+  const path = filesystemPath || catalogPath || null;
+  const [actionState, setActionState] = useState<ActionState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const canReveal = isTauriApp() && !!filesystemPath;
+  const pathState = filesystemPath
+    ? { label: 'Resolved', className: 'file-path-resolved' }
+    : catalogPath
+      ? { label: 'Catalog only', className: 'file-path-catalog' }
+      : { label: 'Unavailable', className: 'file-path-unavailable' };
+
+  useEffect(() => {
+    setActionState('idle');
+    setError(null);
+  }, [path]);
+
+  const copyPath = async () => {
+    if (!path) return;
+    try {
+      await navigator.clipboard.writeText(path);
+      setActionState('copied');
+      setError(null);
+    } catch {
+      setActionState('error');
+      setError('Could not copy the path.');
+    }
+  };
+
+  const showInFolder = async () => {
+    if (!filesystemPath) return;
+    setActionState('opening');
+    setError(null);
+    try {
+      await tauriFileSystem.showImageInFolder(dbId, filesystemPath);
+      setActionState('idle');
+    } catch (cause) {
+      setActionState('error');
+      setError(cause instanceof Error ? cause.message : 'Could not open the folder.');
+    }
+  };
+
+  return (
+    <div className="image-file-location">
+      <div className="image-file-heading">
+        <span>File path</span>
+        <span className={pathState.className}>{pathState.label}</span>
+      </div>
+
+      {path ? (
+        <code className="image-file-path" data-testid="image-file-path" title={path}>
+          {path}
+        </code>
+      ) : (
+        <span className="image-file-unavailable">No file path is recorded.</span>
+      )}
+
+      {!filesystemPath && catalogPath && (
+        <p className="image-file-note">
+          This catalog path does not resolve in the configured image folders.
+        </p>
+      )}
+
+      {path && (
+        <div className="image-file-actions">
+          <button type="button" onClick={copyPath}>
+            {actionState === 'copied' ? 'Copied' : 'Copy path'}
+          </button>
+          {canReveal && (
+            <button
+              type="button"
+              onClick={showInFolder}
+              disabled={actionState === 'opening'}
+            >
+              {actionState === 'opening' ? 'Opening…' : 'Show in folder'}
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className="image-file-feedback" aria-live="polite">
+        {error}
+      </div>
+    </div>
+  );
+}

--- a/static/src/components/__tests__/ImageFileLocation.test.tsx
+++ b/static/src/components/__tests__/ImageFileLocation.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ImageFileLocation from '../ImageFileLocation';
+
+const tauriMocks = vi.hoisted(() => ({
+  isTauriApp: vi.fn(),
+  showImageInFolder: vi.fn(),
+}));
+
+vi.mock('../../utils/tauri', () => ({
+  isTauriApp: tauriMocks.isTauriApp,
+  tauriFileSystem: {
+    showImageInFolder: tauriMocks.showImageInFolder,
+  },
+}));
+
+describe('ImageFileLocation', () => {
+  beforeEach(() => {
+    tauriMocks.isTauriApp.mockReturnValue(false);
+    tauriMocks.showImageInFolder.mockReset();
+  });
+
+  it('shows a resolved path without a native action in browser mode', () => {
+    render(
+      <ImageFileLocation
+        dbId="archive"
+        filesystemPath="/images/target/frame.fits"
+        catalogPath="D:\\Capture\\frame.fits"
+      />
+    );
+
+    expect(screen.getByTestId('image-file-path')).toHaveTextContent(
+      '/images/target/frame.fits'
+    );
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show in folder' })).not.toBeInTheDocument();
+  });
+
+  it('copies the displayed path', async () => {
+    const user = userEvent.setup();
+    render(
+      <ImageFileLocation
+        dbId="archive"
+        filesystemPath="/images/target/frame.fits"
+        catalogPath={null}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Copy path' }));
+
+    expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument();
+    expect(await navigator.clipboard.readText()).toBe('/images/target/frame.fits');
+  });
+
+  it('falls back to the recorded catalog path when the file is missing', () => {
+    tauriMocks.isTauriApp.mockReturnValue(true);
+
+    render(
+      <ImageFileLocation
+        dbId="archive"
+        filesystemPath={null}
+        catalogPath={'D:\\Capture\\missing.fits'}
+      />
+    );
+
+    expect(screen.getByTestId('image-file-path')).toHaveTextContent(
+      'D:\\Capture\\missing.fits'
+    );
+    expect(screen.getByText('Catalog only')).toBeInTheDocument();
+    expect(
+      screen.getByText('This catalog path does not resolve in the configured image folders.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show in folder' })).not.toBeInTheDocument();
+  });
+
+  it('marks an image with no recorded path as unavailable', () => {
+    render(
+      <ImageFileLocation
+        dbId="archive"
+        filesystemPath={null}
+        catalogPath={null}
+      />
+    );
+
+    expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    expect(screen.getByText('No file path is recorded.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Copy path' })).not.toBeInTheDocument();
+  });
+
+  it('asks Tauri to show a resolved image in its folder', async () => {
+    tauriMocks.isTauriApp.mockReturnValue(true);
+    tauriMocks.showImageInFolder.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(
+      <ImageFileLocation
+        dbId="archive"
+        filesystemPath="/images/target/frame.fits"
+        catalogPath={null}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Show in folder' }));
+
+    expect(tauriMocks.showImageInFolder).toHaveBeenCalledWith(
+      'archive',
+      '/images/target/frame.fits'
+    );
+  });
+});

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -115,6 +115,16 @@ export const tauriFileSystem = {
     }
   },
 
+  // Show a resolved image file in Finder, Explorer, or the Linux file manager.
+  showImageInFolder: async (dbId: string, path: string): Promise<void> => {
+    if (!isTauriApp()) {
+      throw new Error('Showing files is available only in the desktop app.');
+    }
+
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('show_image_in_folder', { dbId, path });
+  },
+
   // Get default N.I.N.A. database path (Windows only)
   getDefaultNinaPath: async (): Promise<string | null> => {
     if (!isTauriApp()) return null;


### PR DESCRIPTION
## What changed

- show the resolved image file path in Image Details
- fall back to the path recorded in the catalog when the file cannot resolve
- add Copy Path in browser and desktop modes
- add Show in Folder in the Tauri app
- reveal the file in Finder and Explorer, or open its parent folder on Linux
- validate native requests against the live catalog registry and configured image roots
- document the image-location controls in the README

## Why

The detail view showed image metadata but did not expose where the source FITS
file lived. Users had to search outside PSF Guard before inspecting, moving, or
processing the original file.

## Safety

The native command canonicalizes the requested file, requires it to exist, and
rejects paths outside that catalog's configured image folders. It reloads the
registry from disk so database changes made through Settings work without a
desktop restart.

## Checks

- `cargo test --features tauri --lib tauri_main::tests` — 5 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm test` — 120 passed
- `npm run lint`
- `npm run build`
- `npx playwright test e2e/image-detail.spec.ts` — 10 passed
