### PR TITLE
Add authenticated remote FITS image ingest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 include_dir = "0.7"
 mime_guess = "2.0"
 humantime = "2.3"
+tempfile = "3.27"
 tauri = { version = "2.11.1", features = ["custom-protocol"], optional = true }
 tauri-plugin-dialog = { version = "2.7.1", optional = true }
 dirs = "6.0"
@@ -73,7 +74,6 @@ libc = "0.2"
 windows-sys = { version = "0.61", features = ["Win32_System_SystemInformation"] }
 
 [dev-dependencies]
-tempfile = "3.27"
 http-body-util = "0.1"
 
 [features]

--- a/DATA_TRANSFER_DESIGN.md
+++ b/DATA_TRANSFER_DESIGN.md
@@ -26,6 +26,8 @@ on the destination. File transfer can be added later as a separate action.
 The repository already has most of the local merge rules:
 
 - FITS import scans headers and runs a dry preview before the UI offers Apply.
+- Per-database remote FITS ingest is opt-in, authenticated, and imports one
+  verified light frame through the same target-resolution path.
 - `sync pull` merges scheduler structure and captures by stable GUID.
 - Pull keeps a reviewed destination grade and only fills a Pending grade.
 - `sync planning` sends projects, targets, templates, plans, and rule weights
@@ -294,6 +296,37 @@ The plugin can:
 The first plugin release should remain manual and preview-first. Automatic
 background sync can follow after the audit trail and conflict behavior have
 real use.
+
+### Remote image ingest
+
+Image transfer is independent of Target Scheduler catalog sync. A capture
+client can post a light frame directly to one opted-in PSF Guard database:
+
+```http
+POST /api/db/{db_id}/images/upload
+Authorization: Bearer <per-database-upload-token>
+X-PSF-Guard-Database-ID: <db_id>
+X-Content-SHA256: <64 lowercase hexadecimal characters>
+Content-Type: multipart/form-data
+
+image=@capture.fits
+```
+
+The database settings select one of that database's registered image roots as
+the receive directory. The server requires the URL slug and echoed database ID
+to agree, authenticates with the selected database's salted token hash, streams
+at most 512 MiB to a sibling temporary file, verifies SHA-256 and FITS headers,
+and publishes without overwriting an existing basename.
+
+The normal one-frame importer then resolves an existing target by object name
+or coordinates and reuses its exposure plan. If no target matches, it builds
+the project, target, template, and plan from FITS headers. This path therefore
+works with an existing Target Scheduler catalog and with a fresh PSF Guard
+catalog whose user never installed Target Scheduler.
+
+Identical retries are idempotent. The response returns the resolved database,
+project, target, and image IDs. A basename already registered elsewhere or an
+existing receive file with different content returns `409 Conflict`.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ photometric, spatial, and pointing evidence in a low-priority job;
 a dry preview, skips basenames already present, and attaches new frames to an
 existing target by name or nearby coordinates before it creates new structure.
 
+Remote acquisition clients can send one FITS light at a time without sharing
+the image folder or running Target Scheduler. Edit a database in Settings,
+enable **Accept remote image uploads**, select its receive directory, and set a
+long upload token. The authenticated `/api/db/{db_id}/images/upload` endpoint
+verifies the database identity and file digest, saves without overwriting, and
+runs the same name/coordinate target resolution used by folder import. See
+[the remote image ingest contract](DATA_TRANSFER_DESIGN.md#remote-image-ingest).
+
 The Overview's **Plan & coordinates** dialog lets you correct imported names,
 coordinates, limits, and desired counts. See the
 **[import and planning guide](docs/IMPORTING.md)** for database paths, grouping

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -177,7 +177,13 @@ pub fn import_frames(
 
     let tx = conn.transaction().context("starting import transaction")?;
 
-    let existing = existing_basenames(&tx)?;
+    let candidate_basenames: HashSet<String> = frames
+        .iter()
+        .map(FrameMeta::basename)
+        .map(|basename| basename.to_lowercase())
+        .filter(|basename| !basename.is_empty())
+        .collect();
+    let existing = existing_basenames(&tx, &candidate_basenames)?;
     let mut lights: Vec<FrameMeta> = Vec::new();
     for frame in frames {
         if !frame.readable {
@@ -544,27 +550,52 @@ fn attach_frames_to_target(
 }
 
 /// Basenames (lowercased) of every FileName already present in the DB.
-fn existing_basenames(conn: &Connection) -> Result<HashSet<String>> {
+fn existing_basenames(
+    conn: &Connection,
+    candidate_basenames: &HashSet<String>,
+) -> Result<HashSet<String>> {
     let mut set = HashSet::new();
-    let mut stmt = conn.prepare("SELECT metadata FROM acquiredimage")?;
-    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
-    for metadata in rows.flatten() {
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&metadata)
-            && let Some(file_name) = value.get("FileName").and_then(|v| v.as_str())
-        {
-            // TS stores Windows paths; take the basename across either
-            // separator convention.
-            let base = file_name
-                .rsplit(['/', '\\'])
-                .next()
-                .unwrap_or(file_name)
-                .to_lowercase();
-            if !base.is_empty() {
-                set.insert(base);
+    if candidate_basenames.len() <= 16 {
+        let mut stmt =
+            conn.prepare("SELECT metadata FROM acquiredimage WHERE metadata LIKE ?1 ESCAPE '!'")?;
+        for candidate in candidate_basenames {
+            let pattern = format!("%{}%", escape_like(candidate));
+            let rows = stmt.query_map([pattern], |row| row.get::<_, String>(0))?;
+            for metadata in rows.flatten() {
+                add_metadata_basename(&mut set, &metadata);
             }
+        }
+    } else {
+        let mut stmt = conn.prepare("SELECT metadata FROM acquiredimage")?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        for metadata in rows.flatten() {
+            add_metadata_basename(&mut set, &metadata);
         }
     }
     Ok(set)
+}
+
+fn add_metadata_basename(set: &mut HashSet<String>, metadata: &str) {
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(metadata)
+        && let Some(file_name) = value.get("FileName").and_then(|value| value.as_str())
+    {
+        // TS stores Windows paths; take the basename across either separator.
+        let basename = file_name
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or(file_name)
+            .to_lowercase();
+        if !basename.is_empty() {
+            set.insert(basename);
+        }
+    }
+}
+
+fn escape_like(value: &str) -> String {
+    value
+        .replace('!', "!!")
+        .replace('%', "!%")
+        .replace('_', "!_")
 }
 
 /// Pick (or create) the profile the imported rows belong to.

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -12,6 +12,8 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 
 use crate::server::slug::{compute_default_slug, validate_slug};
@@ -38,6 +40,121 @@ pub struct DbEntry {
     /// "no per-DB overrides — use CLI flags or defaults entirely."
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reject_archive: Option<RejectArchiveOverrides>,
+    /// Opt-in receiver for images posted by a remote N.I.N.A. instance or
+    /// another acquisition client. The token is stored only as a salted
+    /// SHA-256 digest; plaintext exists only in the management request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_image_upload: Option<RemoteImageUploadConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct RemoteImageUploadConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub image_dir: String,
+    #[serde(default)]
+    pub token_salt: String,
+    #[serde(default)]
+    pub token_sha256: String,
+}
+
+impl RemoteImageUploadConfig {
+    pub const MIN_TOKEN_LENGTH: usize = 24;
+    pub const MAX_TOKEN_LENGTH: usize = 256;
+
+    pub fn set_token(&mut self, token: &str) -> Result<()> {
+        if token.len() < Self::MIN_TOKEN_LENGTH || token.len() > Self::MAX_TOKEN_LENGTH {
+            anyhow::bail!(
+                "remote image upload token must be {}-{} characters",
+                Self::MIN_TOKEN_LENGTH,
+                Self::MAX_TOKEN_LENGTH
+            );
+        }
+        if token.chars().any(char::is_control) {
+            anyhow::bail!("remote image upload token cannot contain control characters");
+        }
+        self.token_salt = uuid::Uuid::new_v4().simple().to_string();
+        self.token_sha256 = salted_token_sha256(&self.token_salt, token);
+        Ok(())
+    }
+
+    pub fn token_is_configured(&self) -> bool {
+        self.token_salt.len() == 32
+            && self.token_salt.bytes().all(|byte| byte.is_ascii_hexdigit())
+            && self.token_sha256.len() == 64
+            && self
+                .token_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+    }
+
+    pub fn token_matches(&self, token: &str) -> bool {
+        let candidate = salted_token_sha256(&self.token_salt, token);
+        constant_time_eq(self.token_sha256.as_bytes(), candidate.as_bytes())
+    }
+
+    /// Resolve the selected receive directory and prove that it is exactly
+    /// one of this database's configured image roots.
+    pub fn validated_image_dir(&self, image_dirs: &[String]) -> Result<PathBuf> {
+        if !self.enabled {
+            anyhow::bail!("remote image upload is disabled");
+        }
+        if !self.token_is_configured() {
+            anyhow::bail!("remote image upload token is not configured");
+        }
+        if self.image_dir.trim().is_empty() {
+            anyhow::bail!("remote image upload directory is not configured");
+        }
+
+        let selected = dunce::canonicalize(&self.image_dir).with_context(|| {
+            format!("resolving remote image upload directory {}", self.image_dir)
+        })?;
+        if !selected.is_dir() {
+            anyhow::bail!(
+                "remote image upload directory is not a directory: {}",
+                selected.display()
+            );
+        }
+
+        let is_registered_root = image_dirs.iter().any(|root| {
+            dunce::canonicalize(root)
+                .map(|root| root == selected)
+                .unwrap_or(false)
+        });
+        if !is_registered_root {
+            anyhow::bail!("remote image upload directory must be one of the database's image_dirs");
+        }
+        Ok(selected)
+    }
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0u8;
+    for (&left, &right) in left.iter().zip(right) {
+        difference |= left ^ right;
+    }
+    difference == 0
+}
+
+fn salted_token_sha256(salt: &str, token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(salt.as_bytes());
+    hasher.update([0]);
+    hasher.update(token.as_bytes());
+    sha256_digest_hex(hasher.finalize())
+}
+
+fn sha256_digest_hex(digest: impl AsRef<[u8]>) -> String {
+    let digest = digest.as_ref();
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
 }
 
 /// Persisted per-DB override block for the reject archive. All fields are
@@ -161,6 +278,7 @@ impl DbRegistry {
                 db_path,
                 image_dirs: v1.image_directories,
                 reject_archive: None,
+                remote_image_upload: None,
             });
         }
         reg.save(path)?;
@@ -227,6 +345,7 @@ impl DbRegistry {
             db_path,
             image_dirs,
             reject_archive: None,
+            remote_image_upload: None,
         });
         Ok(self.databases.last().unwrap())
     }
@@ -478,6 +597,51 @@ mod tests {
             !json.contains("reject_archive"),
             "default config should not write the key: {json}"
         );
+    }
+
+    #[test]
+    fn remote_upload_round_trip_stores_only_a_token_digest() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let images = dir.path().join("images");
+        std::fs::create_dir(&images).unwrap();
+        let token = "a-long-random-upload-token-123456";
+        let mut config = RemoteImageUploadConfig {
+            enabled: true,
+            image_dir: images.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        config.set_token(token).unwrap();
+        assert!(config.token_matches(token));
+        assert!(!config.token_matches("a-different-long-upload-token"));
+        assert_eq!(
+            config
+                .validated_image_dir(&[images.to_string_lossy().into_owned()])
+                .unwrap(),
+            dunce::canonicalize(&images).unwrap()
+        );
+
+        let mut registry = DbRegistry::default();
+        registry
+            .add(
+                "Remote".into(),
+                "/tmp/remote.sqlite".into(),
+                vec![images.to_string_lossy().into_owned()],
+                Some("remote".into()),
+            )
+            .unwrap();
+        registry.databases[0].remote_image_upload = Some(config);
+        registry.save(&path).unwrap();
+
+        let serialized = std::fs::read_to_string(&path).unwrap();
+        assert!(!serialized.contains(token));
+        assert!(serialized.contains("token_sha256"));
+        let loaded = DbRegistry::load_or_init(&path).unwrap();
+        assert!(loaded.databases[0]
+            .remote_image_upload
+            .as_ref()
+            .unwrap()
+            .token_matches(token));
     }
 
     #[test]

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -246,6 +246,46 @@ pub struct DatabaseSummary {
     pub name: String,
     pub database_path: String,
     pub image_directories: Vec<String>,
+    pub remote_image_upload: RemoteImageUploadSummary,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RemoteImageUploadSummary {
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_directory: Option<String>,
+    pub token_configured: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemoteImageUploadUpdate {
+    pub enabled: bool,
+    #[serde(default)]
+    pub image_directory: Option<String>,
+    /// Plaintext is accepted only by this management-gated settings route and
+    /// is immediately replaced by its salted SHA-256 digest in the registry.
+    #[serde(default)]
+    pub token: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RemoteImageResolution {
+    pub image_id: i64,
+    pub project_id: i64,
+    pub project_name: String,
+    pub target_id: i64,
+    pub target_name: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RemoteImageUploadResponse {
+    pub database_id: String,
+    pub filename: String,
+    pub bytes: u64,
+    pub sha256: String,
+    pub already_present: bool,
+    pub resolution: RemoteImageResolution,
+    pub import: crate::commands::import::ImportOutcome,
 }
 
 /// Database-to-database operations exposed by the management UI.
@@ -560,6 +600,8 @@ pub struct UpdateDatabaseRequest {
     pub db_path: Option<String>,
     #[serde(default)]
     pub image_dirs: Option<Vec<String>>,
+    #[serde(default)]
+    pub remote_image_upload: Option<RemoteImageUploadUpdate>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -151,6 +151,8 @@ pub struct DatabaseContext {
     pub database_path: String,
     pub image_dirs: Vec<String>,
     pub image_dir_paths: Vec<PathBuf>,
+    pub remote_image_upload: Option<crate::db_registry::RemoteImageUploadConfig>,
+    pub remote_image_upload_dir: Option<PathBuf>,
     /// Per-DB cache directory: `<cache_root>/<slug>/`. Created on construction.
     /// All preview/annotated/PSF artifacts for this database live below here,
     /// so two DBs with overlapping image IDs do not collide.
@@ -186,6 +188,9 @@ pub struct DatabaseContext {
     pub import_job: crate::server::import_job::SharedImportJob,
     /// Database-wide, low-priority quality analysis state.
     pub quality_backfill: crate::server::quality_backfill::SharedQualityBackfill,
+    /// Serializes publish/import for remotely posted images within one
+    /// database, keeping basename checks and database inserts coherent.
+    pub image_import_mutex: Arc<TokioMutex<()>>,
 }
 
 impl DatabaseContext {
@@ -196,6 +201,7 @@ impl DatabaseContext {
         name: String,
         db_path: String,
         image_dirs: Vec<String>,
+        remote_image_upload: Option<crate::db_registry::RemoteImageUploadConfig>,
         cache_root: String,
     ) -> Result<Self> {
         use std::path::Path;
@@ -219,6 +225,12 @@ impl DatabaseContext {
             ));
         }
 
+        let remote_image_upload_dir = remote_image_upload
+            .as_ref()
+            .filter(|config| config.enabled)
+            .map(|config| config.validated_image_dir(&image_dirs))
+            .transpose()?;
+
         let cache_dir_path = PathBuf::from(&cache_root).join(&id);
         std::fs::create_dir_all(&cache_dir_path).map_err(|e| {
             anyhow::anyhow!(
@@ -238,6 +250,8 @@ impl DatabaseContext {
             database_path: db_path,
             image_dirs,
             image_dir_paths,
+            remote_image_upload,
+            remote_image_upload_dir,
             cache_dir,
             cache_dir_path,
             db_connection: Arc::new(Mutex::new(conn)),
@@ -253,6 +267,7 @@ impl DatabaseContext {
             spatial_metrics: Arc::new(RwLock::new(Default::default())),
             import_job: Arc::new(RwLock::new(Default::default())),
             quality_backfill: Arc::new(RwLock::new(Default::default())),
+            image_import_mutex: Arc::new(TokioMutex::new(())),
         })
     }
 
@@ -941,6 +956,8 @@ impl DatabaseContext {
             database_path: ":memory:".to_string(),
             image_dirs: vec![],
             image_dir_paths: vec![],
+            remote_image_upload: None,
+            remote_image_upload_dir: None,
             cache_dir: "/tmp/psf-guard-test".to_string(),
             cache_dir_path: PathBuf::from("/tmp/psf-guard-test"),
             db_connection: Arc::new(Mutex::new(conn)),
@@ -956,6 +973,7 @@ impl DatabaseContext {
             spatial_metrics: Arc::new(RwLock::new(Default::default())),
             import_job: Arc::new(RwLock::new(Default::default())),
             quality_backfill: Arc::new(RwLock::new(Default::default())),
+            image_import_mutex: Arc::new(TokioMutex::new(())),
         }
     }
 }
@@ -968,6 +986,8 @@ impl Clone for DatabaseContext {
             database_path: self.database_path.clone(),
             image_dirs: self.image_dirs.clone(),
             image_dir_paths: self.image_dir_paths.clone(),
+            remote_image_upload: self.remote_image_upload.clone(),
+            remote_image_upload_dir: self.remote_image_upload_dir.clone(),
             cache_dir: self.cache_dir.clone(),
             cache_dir_path: self.cache_dir_path.clone(),
             db_connection: self.db_connection.clone(),
@@ -983,6 +1003,7 @@ impl Clone for DatabaseContext {
             spatial_metrics: self.spatial_metrics.clone(),
             import_job: self.import_job.clone(),
             quality_backfill: self.quality_backfill.clone(),
+            image_import_mutex: self.image_import_mutex.clone(),
         }
     }
 }
@@ -1093,6 +1114,7 @@ mod tests {
             "Test".into(),
             db_path.to_string_lossy().into_owned(),
             vec![img_dir.to_string_lossy().into_owned()],
+            None,
             dir.join("cache").to_string_lossy().into_owned(),
         )
         .unwrap()

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -334,6 +334,7 @@ pub async fn list_databases(
             name: ctx.name.clone(),
             database_path: ctx.database_path.clone(),
             image_directories: ctx.image_dirs.clone(),
+            remote_image_upload: remote_image_upload_summary(ctx),
         })
         .collect();
     summaries.sort_by(|a, b| a.id.cmp(&b.id));
@@ -370,6 +371,20 @@ fn summary_of(ctx: &crate::server::database_context::DatabaseContext) -> Databas
         name: ctx.name.clone(),
         database_path: ctx.database_path.clone(),
         image_directories: ctx.image_dirs.clone(),
+        remote_image_upload: remote_image_upload_summary(ctx),
+    }
+}
+
+fn remote_image_upload_summary(
+    ctx: &crate::server::database_context::DatabaseContext,
+) -> RemoteImageUploadSummary {
+    let config = ctx.remote_image_upload.as_ref();
+    RemoteImageUploadSummary {
+        enabled: ctx.remote_image_upload_dir.is_some(),
+        image_directory: config
+            .map(|config| config.image_dir.clone())
+            .filter(|directory| !directory.is_empty()),
+        token_configured: config.is_some_and(|config| config.token_is_configured()),
     }
 }
 
@@ -833,6 +848,7 @@ pub async fn add_database_route(
             entry.name.clone(),
             entry.db_path.clone(),
             entry.image_dirs.clone(),
+            entry.remote_image_upload.clone(),
             state.cache_dir_root.clone(),
         )
         .map_err(|e| AppError::BadRequest(format!("opening database: {}", e)))?,
@@ -885,6 +901,16 @@ pub async fn update_database_route(
 
     // Pull the entry back out (post-rename) so we can rebuild the context.
     let new_id = req.slug.clone().unwrap_or_else(|| db_id.clone());
+    if let Some(update) = req.remote_image_upload.as_ref() {
+        let entry = reg
+            .databases
+            .iter_mut()
+            .find(|entry| entry.id == new_id)
+            .ok_or(AppError::InternalError(
+                "registry update lost the entry".into(),
+            ))?;
+        apply_remote_image_upload_update(entry, update)?;
+    }
     let entry = reg
         .find(&new_id)
         .ok_or(AppError::InternalError(
@@ -922,6 +948,7 @@ pub async fn update_database_route(
             entry.name.clone(),
             entry.db_path.clone(),
             entry.image_dirs.clone(),
+            entry.remote_image_upload.clone(),
             state.cache_dir_root.clone(),
         )
         .map_err(|e| AppError::BadRequest(format!("opening database: {}", e)))?,
@@ -942,6 +969,29 @@ pub async fn update_database_route(
     let _ = new_ctx.ensure_cache_available();
 
     Ok(Json(ApiResponse::success(summary_of(&new_ctx))))
+}
+
+fn apply_remote_image_upload_update(
+    entry: &mut crate::db_registry::DbEntry,
+    update: &RemoteImageUploadUpdate,
+) -> Result<(), AppError> {
+    let mut config = entry.remote_image_upload.clone().unwrap_or_default();
+    config.enabled = update.enabled;
+    if let Some(directory) = update.image_directory.as_ref() {
+        config.image_dir = directory.trim().to_string();
+    }
+    if let Some(token) = update.token.as_ref() {
+        config
+            .set_token(token)
+            .map_err(|error| AppError::BadRequest(error.to_string()))?;
+    }
+    if config.enabled {
+        config
+            .validated_image_dir(&entry.image_dirs)
+            .map_err(|error| AppError::BadRequest(error.to_string()))?;
+    }
+    entry.remote_image_upload = Some(config);
+    Ok(())
 }
 
 /// `DELETE /api/databases/{db_id}` — drop the registered database. Returns
@@ -1294,6 +1344,7 @@ pub async fn create_database_route(
             entry.name.clone(),
             entry.db_path.clone(),
             entry.image_dirs.clone(),
+            entry.remote_image_upload.clone(),
             state.cache_dir_root.clone(),
         )
         .map_err(|e| AppError::InternalError(format!("opening new database: {}", e)))?,
@@ -1452,6 +1503,7 @@ fn spawn_import_job(
     let state = state.clone();
     tokio::spawn(async move {
         let job_store = ctx.import_job.clone();
+        let _import_guard = ctx.image_import_mutex.lock().await;
 
         let blocking_ctx = ctx.clone();
         let blocking_options = options.clone();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,6 +8,7 @@ pub mod handlers;
 pub mod import_job;
 pub mod preview_queue;
 pub mod quality_backfill;
+pub mod remote_upload;
 pub mod scheduler;
 pub mod slug;
 pub mod spatial_scan;
@@ -18,6 +19,7 @@ pub mod sync_preview;
 
 use anyhow::{Context, Result};
 use axum::{
+    extract::DefaultBodyLimit,
     routing::{get, post, put},
     Router,
 };
@@ -307,6 +309,11 @@ async fn run_server_internal(
             get(stack_preview::color::download_stack_color_fits),
         )
         .route("/images", get(handlers::get_images))
+        .route(
+            "/images/upload",
+            post(remote_upload::upload_image)
+                .layer(DefaultBodyLimit::max(remote_upload::MAX_MULTIPART_BYTES)),
+        )
         .route("/images/{image_id}", get(handlers::get_image))
         .route(
             "/images/{image_id}/astrometry",

--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -1,0 +1,456 @@
+//! Authenticated, per-database image ingest for remote acquisition clients.
+//!
+//! The URL database, echoed database header, selected receive root, and
+//! bearer-token hash all come from the same `DatabaseContext`. Uploads are
+//! streamed to a temporary sibling, verified, published without clobbering,
+//! and passed through the normal one-frame FITS importer.
+
+use axum::{
+    extract::Multipart,
+    http::{header::AUTHORIZATION, HeaderMap},
+    Json,
+};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
+
+use crate::commands::import::{self, ImportOptions, ImportOutcome};
+use crate::server::api::{ApiResponse, RemoteImageResolution, RemoteImageUploadResponse};
+use crate::server::extract::DbContext;
+use crate::server::handlers::AppError;
+
+pub const MAX_IMAGE_BYTES: u64 = 512 * 1024 * 1024;
+pub const MAX_MULTIPART_BYTES: usize = MAX_IMAGE_BYTES as usize + 1024 * 1024;
+
+const DATABASE_ID_HEADER: &str = "x-psf-guard-database-id";
+const CONTENT_SHA256_HEADER: &str = "x-content-sha256";
+
+pub async fn upload_image(
+    ctx: DbContext,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Result<Json<ApiResponse<RemoteImageUploadResponse>>, AppError> {
+    let config = ctx
+        .remote_image_upload
+        .as_ref()
+        .filter(|config| config.enabled)
+        .cloned()
+        .ok_or_else(|| {
+            AppError::Forbidden("remote image upload is disabled for this database".into())
+        })?;
+    let upload_dir = ctx.remote_image_upload_dir.clone().ok_or_else(|| {
+        AppError::Forbidden("remote image upload is disabled for this database".into())
+    })?;
+
+    require_database_identity(&headers, &ctx.id)?;
+    require_bearer_token(&headers, &config)?;
+    let expected_sha256 = required_sha256_header(&headers)?;
+
+    let mut received = None;
+    while let Some(mut field) = multipart
+        .next_field()
+        .await
+        .map_err(|error| AppError::BadRequest(format!("reading multipart upload: {error}")))?
+    {
+        if field.name() != Some("image") {
+            continue;
+        }
+        if received.is_some() {
+            return Err(AppError::BadRequest(
+                "multipart request must contain exactly one image field".into(),
+            ));
+        }
+
+        let filename = field
+            .file_name()
+            .map(str::to_string)
+            .ok_or_else(|| AppError::BadRequest("image field has no filename".into()))?;
+        validate_filename(&filename)?;
+
+        let temporary = tempfile::NamedTempFile::new_in(&upload_dir).map_err(|error| {
+            AppError::InternalError(format!(
+                "creating upload temporary file in {}: {error}",
+                upload_dir.display()
+            ))
+        })?;
+        let reopened = temporary.reopen().map_err(|error| {
+            AppError::InternalError(format!("opening upload temporary file: {error}"))
+        })?;
+        let mut output = tokio::fs::File::from_std(reopened);
+        let mut hasher = Sha256::new();
+        let mut bytes = 0u64;
+
+        while let Some(chunk) = field
+            .chunk()
+            .await
+            .map_err(|error| AppError::BadRequest(format!("reading uploaded image: {error}")))?
+        {
+            bytes = bytes
+                .checked_add(chunk.len() as u64)
+                .ok_or_else(|| AppError::BadRequest("uploaded image is too large".into()))?;
+            if bytes > MAX_IMAGE_BYTES {
+                return Err(AppError::BadRequest(format!(
+                    "uploaded image exceeds the {} MiB limit",
+                    MAX_IMAGE_BYTES / 1024 / 1024
+                )));
+            }
+            hasher.update(&chunk);
+            output.write_all(&chunk).await.map_err(|error| {
+                AppError::InternalError(format!("writing uploaded image: {error}"))
+            })?;
+        }
+        output
+            .sync_all()
+            .await
+            .map_err(|error| AppError::InternalError(format!("syncing uploaded image: {error}")))?;
+        drop(output);
+
+        if bytes == 0 {
+            return Err(AppError::BadRequest("uploaded image is empty".into()));
+        }
+        let actual_sha256 = encode_digest(hasher.finalize());
+        if !constant_time_eq(expected_sha256.as_bytes(), actual_sha256.as_bytes()) {
+            return Err(AppError::BadRequest(
+                "uploaded image SHA-256 does not match X-Content-SHA256".into(),
+            ));
+        }
+        received = Some((temporary, filename, bytes, actual_sha256));
+    }
+
+    let (temporary, filename, bytes, sha256) = received.ok_or_else(|| {
+        AppError::BadRequest("multipart request must contain one image field".into())
+    })?;
+    let temporary_path = temporary.path().to_path_buf();
+    let frame =
+        tokio::task::spawn_blocking(move || import::headers::read_frame_meta(&temporary_path))
+            .await
+            .map_err(|error| {
+                AppError::InternalError(format!("FITS header validation task failed: {error}"))
+            })?;
+    if !frame.readable {
+        return Err(AppError::BadRequest(
+            "uploaded image is not a readable FITS file".into(),
+        ));
+    }
+    if !frame.is_light() {
+        return Err(AppError::BadRequest(
+            "only light frames can be imported into an image database".into(),
+        ));
+    }
+
+    let _upload_guard = ctx.image_import_mutex.try_lock().map_err(|_| {
+        AppError::Conflict("another image import is already running for this database".into())
+    })?;
+    let database_path = ctx.database_path.clone();
+    let database_id = ctx.id.clone();
+    let destination = upload_dir.join(&filename);
+    let response_sha256 = sha256.clone();
+    let response_filename = filename.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        publish_and_import(
+            &database_id,
+            &database_path,
+            destination,
+            temporary,
+            frame,
+            filename,
+            bytes,
+            sha256,
+        )
+    })
+    .await
+    .map_err(|error| AppError::InternalError(format!("image import task failed: {error}")))??;
+
+    ctx.clear_directory_tree_cache();
+    ctx.file_check_cache.write().unwrap().clear();
+    let _ = ctx.ensure_cache_available();
+    tracing::info!(
+        "Remote image received for db={}: {} ({} bytes, sha256={})",
+        ctx.id,
+        response_filename,
+        bytes,
+        response_sha256
+    );
+    Ok(Json(ApiResponse::success(result)))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn publish_and_import(
+    database_id: &str,
+    database_path: &str,
+    destination: PathBuf,
+    temporary: tempfile::NamedTempFile,
+    mut frame: import::headers::FrameMeta,
+    filename: String,
+    bytes: u64,
+    sha256: String,
+) -> Result<RemoteImageUploadResponse, AppError> {
+    let mut connection = rusqlite::Connection::open_with_flags(
+        database_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(AppError::db)?;
+
+    let existing_resolution = find_resolution(&connection, &filename)?;
+    if existing_resolution.is_some() && !destination.is_file() {
+        return Err(AppError::Conflict(format!(
+            "{filename} is already registered in this database at another location"
+        )));
+    }
+
+    let already_present = if destination.is_file() {
+        let existing_sha256 = sha256_file(&destination)?;
+        if !constant_time_eq(existing_sha256.as_bytes(), sha256.as_bytes()) {
+            return Err(AppError::Conflict(format!(
+                "{filename} already exists in the receive directory with different content"
+            )));
+        }
+        true
+    } else {
+        match temporary.persist_noclobber(&destination) {
+            Ok(_) => false,
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let existing_sha256 = sha256_file(&destination)?;
+                if !constant_time_eq(existing_sha256.as_bytes(), sha256.as_bytes()) {
+                    return Err(AppError::Conflict(format!(
+                        "{filename} appeared concurrently with different content"
+                    )));
+                }
+                true
+            }
+            Err(error) => {
+                return Err(AppError::InternalError(format!(
+                    "publishing uploaded image {}: {}",
+                    destination.display(),
+                    error.error
+                )));
+            }
+        }
+    };
+
+    let outcome = if existing_resolution.is_some() {
+        ImportOutcome {
+            scanned: 1,
+            skipped_existing: 1,
+            ..Default::default()
+        }
+    } else {
+        frame.path = destination.clone();
+        match import::import_frames(&mut connection, vec![frame], &ImportOptions::default()) {
+            Ok(outcome) if outcome.imported == 1 => outcome,
+            Ok(outcome) => {
+                if !already_present {
+                    let _ = std::fs::remove_file(&destination);
+                }
+                return Err(AppError::BadRequest(format!(
+                    "uploaded image was not imported (unreadable={}, non_light={}, duplicate={})",
+                    outcome.unreadable, outcome.non_light, outcome.skipped_existing
+                )));
+            }
+            Err(error) => {
+                if !already_present {
+                    let _ = std::fs::remove_file(&destination);
+                }
+                return Err(AppError::DatabaseError(format!(
+                    "importing uploaded image: {error:#}"
+                )));
+            }
+        }
+    };
+
+    let resolution = find_resolution(&connection, &filename)?.ok_or_else(|| {
+        AppError::InternalError("uploaded image was imported but cannot be resolved".into())
+    })?;
+    Ok(RemoteImageUploadResponse {
+        database_id: database_id.to_string(),
+        filename,
+        bytes,
+        sha256,
+        already_present,
+        resolution,
+        import: outcome,
+    })
+}
+
+fn find_resolution(
+    connection: &rusqlite::Connection,
+    filename: &str,
+) -> Result<Option<RemoteImageResolution>, AppError> {
+    let mut statement = connection
+        .prepare(
+            "SELECT ai.Id, ai.metadata, p.Id, p.name, t.Id, t.name
+             FROM acquiredimage ai
+             JOIN project p ON p.Id = ai.projectId
+             JOIN target t ON t.Id = ai.targetId
+             WHERE ai.metadata LIKE ?1 ESCAPE '!'
+             ORDER BY ai.Id",
+        )
+        .map_err(AppError::db)?;
+    let pattern = format!("%{}%", escape_like(filename));
+    let rows = statement
+        .query_map([pattern], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, String>(5)?,
+            ))
+        })
+        .map_err(AppError::db)?;
+
+    let mut matches = Vec::new();
+    for row in rows {
+        let (image_id, metadata, project_id, project_name, target_id, target_name) =
+            row.map_err(AppError::db)?;
+        let registered_filename = serde_json::from_str::<serde_json::Value>(&metadata)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("FileName")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+            })
+            .and_then(|path| path.rsplit(['/', '\\']).next().map(str::to_string));
+        if registered_filename
+            .as_deref()
+            .is_some_and(|registered| registered.eq_ignore_ascii_case(filename))
+        {
+            matches.push(RemoteImageResolution {
+                image_id,
+                project_id,
+                project_name,
+                target_id,
+                target_name,
+            });
+        }
+    }
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        count => Err(AppError::Conflict(format!(
+            "{filename} matches {count} database rows; remote ingest requires an unambiguous basename"
+        ))),
+    }
+}
+
+fn escape_like(value: &str) -> String {
+    value
+        .replace('!', "!!")
+        .replace('%', "!%")
+        .replace('_', "!_")
+}
+
+fn sha256_file(path: &Path) -> Result<String, AppError> {
+    let mut file = std::fs::File::open(path).map_err(|error| {
+        AppError::InternalError(format!("opening {} for hashing: {error}", path.display()))
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|error| {
+            AppError::InternalError(format!("reading {} for hashing: {error}", path.display()))
+        })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(encode_digest(hasher.finalize()))
+}
+
+fn require_database_identity(headers: &HeaderMap, database_id: &str) -> Result<(), AppError> {
+    let echoed = headers
+        .get(DATABASE_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| AppError::BadRequest(format!("{DATABASE_ID_HEADER} header is required")))?;
+    if echoed != database_id {
+        return Err(AppError::BadRequest(format!(
+            "database identity mismatch: URL selects {database_id}, header selects {echoed}"
+        )));
+    }
+    Ok(())
+}
+
+fn require_bearer_token(
+    headers: &HeaderMap,
+    config: &crate::db_registry::RemoteImageUploadConfig,
+) -> Result<(), AppError> {
+    let token = headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .filter(|token| !token.is_empty());
+    if token.is_none_or(|token| !config.token_matches(token)) {
+        return Err(AppError::Forbidden(
+            "remote image upload credentials are invalid".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn required_sha256_header(headers: &HeaderMap) -> Result<String, AppError> {
+    let value = headers
+        .get(CONTENT_SHA256_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_ascii_lowercase)
+        .ok_or_else(|| {
+            AppError::BadRequest(format!("{CONTENT_SHA256_HEADER} header is required"))
+        })?;
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(AppError::BadRequest(format!(
+            "{CONTENT_SHA256_HEADER} must be a 64-character hexadecimal SHA-256"
+        )));
+    }
+    Ok(value)
+}
+
+fn validate_filename(filename: &str) -> Result<(), AppError> {
+    if filename.is_empty()
+        || filename.len() > 240
+        || filename == "."
+        || filename == ".."
+        || filename.ends_with(['.', ' '])
+        || filename
+            .chars()
+            .any(|character| character.is_control() || r#"<>:"/\|?*"#.contains(character))
+    {
+        return Err(AppError::BadRequest(
+            "image filename is not filesystem-safe".into(),
+        ));
+    }
+    let extension = Path::new(filename)
+        .extension()
+        .and_then(|extension| extension.to_str());
+    if !extension.is_some_and(|extension| {
+        extension.eq_ignore_ascii_case("fit") || extension.eq_ignore_ascii_case("fits")
+    }) {
+        return Err(AppError::BadRequest(
+            "remote image upload currently accepts only .fit and .fits files".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0u8;
+    for (&left, &right) in left.iter().zip(right) {
+        difference |= left ^ right;
+    }
+    difference == 0
+}
+
+fn encode_digest(digest: impl AsRef<[u8]>) -> String {
+    let digest = digest.as_ref();
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -352,6 +352,7 @@ impl AppState {
                 entry.name,
                 entry.db_path,
                 entry.image_dirs,
+                entry.remote_image_upload,
                 cache_dir.clone(),
             )?);
             map.insert(entry.id, ctx);
@@ -446,6 +447,7 @@ impl AppState {
                 db_path,
                 image_dirs,
                 reject_archive: None,
+                remote_image_upload: None,
             }],
             cache_dir,
             pregeneration_config,

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -523,6 +523,7 @@ mod tests {
                 db_path: root.join("catalog.sqlite").display().to_string(),
                 image_dirs: vec![root.display().to_string()],
                 reject_archive: None,
+                remote_image_upload: None,
             }],
             active_db_id: None,
             astrometry: None,

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -203,6 +203,11 @@ export const apiClient = {
       slug?: string;
       db_path?: string;
       image_dirs?: string[];
+      remote_image_upload?: {
+        enabled: boolean;
+        image_directory?: string;
+        token?: string;
+      };
     }
   ): Promise<DatabaseSummary> => {
     const apiInstance = await getApi();

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -704,6 +704,13 @@ export interface DatabaseSummary {
   name: string;
   database_path: string;
   image_directories: string[];
+  remote_image_upload: RemoteImageUploadSummary;
+}
+
+export interface RemoteImageUploadSummary {
+  enabled: boolean;
+  image_directory?: string;
+  token_configured: boolean;
 }
 
 export type SchedulerSyncKind = 'pull' | 'push_planning' | 'push_grades';

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -178,6 +178,28 @@
   background-color: var(--color-bg-hover);
 }
 
+.tauri-settings .remote-upload-token-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.tauri-settings .remote-upload-token-row .browse-button {
+  min-width: 78px;
+}
+
+.tauri-settings .remote-upload-token-notice {
+  display: block;
+  margin-top: 8px;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+.tauri-settings .remote-upload-token-notice.error {
+  color: var(--color-error);
+}
+
 .tauri-settings .path-info {
   font-size: 12px;
   color: var(--color-text-muted);
@@ -882,6 +904,14 @@
 }
 
 @media (max-width: 820px) {
+  .tauri-settings .remote-upload-token-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .tauri-settings .remote-upload-token-row .file-path-input {
+    grid-column: 1 / -1;
+  }
+
   .tauri-settings .catalog-heading {
     display: block;
   }

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -53,6 +53,11 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
   const [formName, setFormName] = useState('');
   const [formDbPath, setFormDbPath] = useState('');
   const [formImageDirs, setFormImageDirs] = useState<string[]>([]);
+  const [formRemoteUploadEnabled, setFormRemoteUploadEnabled] = useState(false);
+  const [formRemoteUploadDir, setFormRemoteUploadDir] = useState('');
+  const [formRemoteUploadToken, setFormRemoteUploadToken] = useState('');
+  const [formRemoteUploadTokenConfigured, setFormRemoteUploadTokenConfigured] =
+    useState(false);
   const [showAddForm, setShowAddForm] = useState(false);
   // true = "create a brand-new TS database from image folders" flow (no
   // existing .sqlite required; the server bootstraps the full TS schema).
@@ -75,11 +80,34 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
       // schema_version and active_db_id); fall back to the HTTP listing
       // which gives us enough to render the UI.
       let reg: DbRegistry | null = null;
+      const summaries: DatabaseSummary[] = await apiClient.getDatabases();
       if (isTauri) {
         reg = await tauriConfig.getCurrentConfiguration();
+        if (reg) {
+          reg = {
+            ...reg,
+            databases: summaries.map((summary) => {
+              const persisted = reg?.databases.find(
+                (entry) => entry.id === summary.id
+              );
+              return {
+                ...persisted,
+                id: summary.id,
+                name: summary.name,
+                db_path: summary.database_path,
+                image_dirs: summary.image_directories,
+                remote_image_upload: {
+                  enabled: summary.remote_image_upload?.enabled ?? false,
+                  image_dir: summary.remote_image_upload?.image_directory,
+                  token_configured:
+                    summary.remote_image_upload?.token_configured ?? false,
+                },
+              };
+            }),
+          };
+        }
       }
       if (!reg) {
-        const summaries: DatabaseSummary[] = await apiClient.getDatabases();
         reg = {
           schema_version: 2,
           databases: summaries.map((s) => ({
@@ -87,6 +115,11 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
             name: s.name,
             db_path: s.database_path,
             image_dirs: s.image_directories,
+            remote_image_upload: {
+              enabled: s.remote_image_upload?.enabled ?? false,
+              image_dir: s.remote_image_upload?.image_directory,
+              token_configured: s.remote_image_upload?.token_configured ?? false,
+            },
           })),
         };
       }
@@ -135,6 +168,10 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setFormName('');
     setFormDbPath('');
     setFormImageDirs([]);
+    setFormRemoteUploadEnabled(false);
+    setFormRemoteUploadDir('');
+    setFormRemoteUploadToken('');
+    setFormRemoteUploadTokenConfigured(false);
     setShowAddForm(false);
     setCreateMode(false);
     setCreateAnalyzeQuality(false);
@@ -145,6 +182,15 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setFormName(entry.name);
     setFormDbPath(entry.db_path);
     setFormImageDirs(entry.image_dirs);
+    setFormRemoteUploadEnabled(entry.remote_image_upload?.enabled ?? false);
+    setFormRemoteUploadDir(
+      entry.remote_image_upload?.image_dir ?? entry.image_dirs[0] ?? ''
+    );
+    setFormRemoteUploadToken('');
+    setFormRemoteUploadTokenConfigured(
+      entry.remote_image_upload?.token_configured ??
+        Boolean(entry.remote_image_upload?.token_sha256)
+    );
     setShowAddForm(true);
     setCreateMode(false);
   };
@@ -154,6 +200,10 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setFormName('');
     setFormDbPath('');
     setFormImageDirs([]);
+    setFormRemoteUploadEnabled(false);
+    setFormRemoteUploadDir('');
+    setFormRemoteUploadToken('');
+    setFormRemoteUploadTokenConfigured(false);
     setShowAddForm(true);
     setCreateMode(true);
     setCreateAnalyzeQuality(false);
@@ -163,6 +213,10 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setEditingId(null);
     setFormName('');
     setFormImageDirs([]);
+    setFormRemoteUploadEnabled(false);
+    setFormRemoteUploadDir('');
+    setFormRemoteUploadToken('');
+    setFormRemoteUploadTokenConfigured(false);
     setShowAddForm(true);
     setCreateMode(false);
     setFormDbPath('');
@@ -221,7 +275,12 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
   };
 
   const handleRemoveImageDir = (index: number) => {
-    setFormImageDirs(formImageDirs.filter((_, i) => i !== index));
+    const removed = formImageDirs[index];
+    const remaining = formImageDirs.filter((_, i) => i !== index);
+    setFormImageDirs(remaining);
+    if (formRemoteUploadDir === removed) {
+      setFormRemoteUploadDir(remaining[0] ?? '');
+    }
   };
 
   const handleSaveForm = async () => {
@@ -275,10 +334,29 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
       // mode, and updating live `AppState.databases` rather than waiting for
       // a server restart.
       if (editingId) {
+        if (formRemoteUploadEnabled && !formRemoteUploadDir) {
+          setStatusMessage('Select an image directory for remote uploads');
+          setIsApplying(false);
+          return;
+        }
+        if (
+          formRemoteUploadEnabled &&
+          !formRemoteUploadTokenConfigured &&
+          formRemoteUploadToken.length < 24
+        ) {
+          setStatusMessage('Remote upload token must be at least 24 characters');
+          setIsApplying(false);
+          return;
+        }
         await apiClient.updateDatabase(editingId, {
           name: inferredName,
           db_path: formDbPath.trim(),
           image_dirs: formImageDirs,
+          remote_image_upload: {
+            enabled: formRemoteUploadEnabled,
+            image_directory: formRemoteUploadDir || undefined,
+            token: formRemoteUploadToken || undefined,
+          },
         });
       } else {
         await apiClient.addDatabase({
@@ -471,6 +549,11 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
                   {entry.image_dirs.length > 0 && (
                     <div className="path-info muted">
                       {entry.image_dirs.join(', ')}
+                    </div>
+                  )}
+                  {entry.remote_image_upload?.enabled && (
+                    <div className="path-info muted">
+                      Remote receive: {entry.remote_image_upload.image_dir}
                     </div>
                   )}
                   <QualityBackfillControls dbId={entry.id} />
@@ -710,6 +793,55 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
                   </div>
                 )}
               </div>
+
+              {editingId && (
+                <div className="database-config">
+                  <label className="quality-analysis-option">
+                    <input
+                      type="checkbox"
+                      checked={formRemoteUploadEnabled}
+                      onChange={(event) =>
+                        setFormRemoteUploadEnabled(event.target.checked)
+                      }
+                    />
+                    <span>
+                      <strong>Accept remote image uploads</strong>
+                    </span>
+                  </label>
+                  {formRemoteUploadEnabled && (
+                    <>
+                      <label htmlFor="remote-upload-directory">Receive directory:</label>
+                      <select
+                        id="remote-upload-directory"
+                        value={formRemoteUploadDir}
+                        onChange={(event) => setFormRemoteUploadDir(event.target.value)}
+                        className="file-path-input"
+                      >
+                        <option value="">Select an image directory</option>
+                        {formImageDirs.map((directory) => (
+                          <option key={directory} value={directory}>
+                            {directory}
+                          </option>
+                        ))}
+                      </select>
+                      <label htmlFor="remote-upload-token">Upload token:</label>
+                      <input
+                        id="remote-upload-token"
+                        type="password"
+                        value={formRemoteUploadToken}
+                        onChange={(event) => setFormRemoteUploadToken(event.target.value)}
+                        placeholder={
+                          formRemoteUploadTokenConfigured
+                            ? 'Unchanged'
+                            : 'At least 24 characters'
+                        }
+                        className="file-path-input"
+                        autoComplete="new-password"
+                      />
+                    </>
+                  )}
+                </div>
+              )}
 
               {createMode && (
                 <label className="quality-analysis-option">

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -58,6 +58,10 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
   const [formRemoteUploadToken, setFormRemoteUploadToken] = useState('');
   const [formRemoteUploadTokenConfigured, setFormRemoteUploadTokenConfigured] =
     useState(false);
+  const [formRemoteUploadTokenRevealed, setFormRemoteUploadTokenRevealed] =
+    useState(false);
+  const [formRemoteUploadTokenCopyState, setFormRemoteUploadTokenCopyState] =
+    useState<'idle' | 'copied' | 'failed'>('idle');
   const [showAddForm, setShowAddForm] = useState(false);
   // true = "create a brand-new TS database from image folders" flow (no
   // existing .sqlite required; the server bootstraps the full TS schema).
@@ -172,6 +176,8 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setFormRemoteUploadDir('');
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(false);
+    setFormRemoteUploadTokenRevealed(false);
+    setFormRemoteUploadTokenCopyState('idle');
     setShowAddForm(false);
     setCreateMode(false);
     setCreateAnalyzeQuality(false);
@@ -191,6 +197,8 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
       entry.remote_image_upload?.token_configured ??
         Boolean(entry.remote_image_upload?.token_sha256)
     );
+    setFormRemoteUploadTokenRevealed(false);
+    setFormRemoteUploadTokenCopyState('idle');
     setShowAddForm(true);
     setCreateMode(false);
   };
@@ -204,6 +212,8 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setFormRemoteUploadDir('');
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(false);
+    setFormRemoteUploadTokenRevealed(false);
+    setFormRemoteUploadTokenCopyState('idle');
     setShowAddForm(true);
     setCreateMode(true);
     setCreateAnalyzeQuality(false);
@@ -217,6 +227,8 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setFormRemoteUploadDir('');
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(false);
+    setFormRemoteUploadTokenRevealed(false);
+    setFormRemoteUploadTokenCopyState('idle');
     setShowAddForm(true);
     setCreateMode(false);
     setFormDbPath('');
@@ -280,6 +292,27 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setFormImageDirs(remaining);
     if (formRemoteUploadDir === removed) {
       setFormRemoteUploadDir(remaining[0] ?? '');
+    }
+  };
+
+  const handleGenerateRemoteUploadToken = () => {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    const token = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+      ''
+    );
+    setFormRemoteUploadToken(token);
+    setFormRemoteUploadTokenRevealed(true);
+    setFormRemoteUploadTokenCopyState('idle');
+  };
+
+  const handleCopyRemoteUploadToken = async () => {
+    try {
+      await navigator.clipboard.writeText(formRemoteUploadToken);
+      setFormRemoteUploadTokenCopyState('copied');
+    } catch (error) {
+      console.error('Failed to copy remote upload token:', error);
+      setFormRemoteUploadTokenCopyState('failed');
     }
   };
 
@@ -825,19 +858,55 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
                         ))}
                       </select>
                       <label htmlFor="remote-upload-token">Upload token:</label>
-                      <input
-                        id="remote-upload-token"
-                        type="password"
-                        value={formRemoteUploadToken}
-                        onChange={(event) => setFormRemoteUploadToken(event.target.value)}
-                        placeholder={
-                          formRemoteUploadTokenConfigured
-                            ? 'Unchanged'
-                            : 'At least 24 characters'
-                        }
-                        className="file-path-input"
-                        autoComplete="new-password"
-                      />
+                      <div className="remote-upload-token-row">
+                        <input
+                          id="remote-upload-token"
+                          type={formRemoteUploadTokenRevealed ? 'text' : 'password'}
+                          value={formRemoteUploadToken}
+                          onChange={(event) => {
+                            setFormRemoteUploadToken(event.target.value);
+                            setFormRemoteUploadTokenCopyState('idle');
+                          }}
+                          placeholder={
+                            formRemoteUploadTokenConfigured
+                              ? 'Unchanged'
+                              : 'At least 24 characters'
+                          }
+                          className="file-path-input"
+                          autoComplete="new-password"
+                        />
+                        <button
+                          type="button"
+                          onClick={handleGenerateRemoteUploadToken}
+                          className="browse-button"
+                        >
+                          Generate
+                        </button>
+                        {formRemoteUploadTokenRevealed &&
+                          formRemoteUploadToken.length > 0 && (
+                            <button
+                              type="button"
+                              onClick={handleCopyRemoteUploadToken}
+                              className="browse-button"
+                            >
+                              {formRemoteUploadTokenCopyState === 'copied'
+                                ? 'Copied'
+                                : 'Copy'}
+                            </button>
+                          )}
+                      </div>
+                      {formRemoteUploadTokenRevealed && (
+                        <small
+                          className={`remote-upload-token-notice ${
+                            formRemoteUploadTokenCopyState === 'failed' ? 'error' : ''
+                          }`}
+                          role="status"
+                        >
+                          {formRemoteUploadTokenCopyState === 'failed'
+                            ? 'Copy failed. Select and copy the token manually.'
+                            : 'Copy this token now. It will not be shown again after saving.'}
+                        </small>
+                      )}
                     </>
                   )}
                 </div>

--- a/static/src/components/__tests__/TauriSettings.test.tsx
+++ b/static/src/components/__tests__/TauriSettings.test.tsx
@@ -242,5 +242,14 @@ describe('TauriSettings import state', () => {
       'placeholder',
       'Unchanged'
     );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
+    const generatedToken = screen.getByLabelText('Upload token:');
+    expect(generatedToken).toHaveAttribute('type', 'text');
+    expect((generatedToken as HTMLInputElement).value).toMatch(/^[0-9a-f]{64}$/);
+    expect(
+      screen.getByText('Copy this token now. It will not be shown again after saving.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeEnabled();
   });
 });

--- a/static/src/components/__tests__/TauriSettings.test.tsx
+++ b/static/src/components/__tests__/TauriSettings.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
 import { describe, expect, it } from 'vitest';
 import { server } from '../../test/msw-server';
@@ -169,5 +169,78 @@ describe('TauriSettings import state', () => {
       await screen.findByText(/Analyzing quality in the background… 1\/4 targets/)
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Import' })).toBeEnabled();
+  });
+
+  it('edits the per-database remote image receiver without exposing its token', async () => {
+    server.use(
+      http.get('/api/info', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            version: 'test',
+            cache_directory: '/tmp/cache',
+            allow_database_management: true,
+          },
+          error: null,
+          status: 'ready',
+        })
+      ),
+      http.get('/api/databases', () =>
+        HttpResponse.json({
+          success: true,
+          data: [
+            {
+              id: 'remote',
+              name: 'Remote catalog',
+              database_path: '/tmp/remote.sqlite',
+              image_directories: ['/images/remote'],
+              remote_image_upload: {
+                enabled: true,
+                image_directory: '/images/remote',
+                token_configured: true,
+              },
+            },
+          ],
+          error: null,
+          status: 'ready',
+        })
+      ),
+      http.get('/api/db/remote/import', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            started: false,
+            progress: {
+              running: false,
+              stage: '',
+              image_dirs: [],
+              total_files: 0,
+              scanned_files: 0,
+              outcome: null,
+              started_at: null,
+              finished_at: null,
+              error: null,
+            },
+          },
+          error: null,
+          status: 'ready',
+        })
+      )
+    );
+
+    render(<TauriSettings isOpen onClose={() => undefined} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(await screen.findByText('Remote receive: /images/remote')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(
+      screen.getByRole('checkbox', { name: 'Accept remote image uploads' })
+    ).toBeChecked();
+    expect(screen.getByLabelText('Receive directory:')).toHaveValue('/images/remote');
+    expect(screen.getByLabelText('Upload token:')).toHaveAttribute(
+      'placeholder',
+      'Unchanged'
+    );
   });
 });

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -59,6 +59,12 @@ export interface DbEntry {
   db_path: string;
   image_dirs: string[];
   reject_archive?: RejectArchiveOverrides;
+  remote_image_upload?: {
+    enabled: boolean;
+    image_dir?: string;
+    token_sha256?: string;
+    token_configured?: boolean;
+  };
 }
 
 // Process-global Seiza catalog paths. data_dir configures a complete bundle;

--- a/tests/integration_db_crud.rs
+++ b/tests/integration_db_crud.rs
@@ -163,6 +163,35 @@ async fn crud_lifecycle_adds_uses_and_removes_a_database() {
     assert_eq!(body["data"].as_array().unwrap().len(), 1);
     assert_eq!(body["data"][0]["id"], slug);
 
+    let upload_token = "test-remote-upload-token-123456";
+    let (status, body) = json_request(
+        build_app(state.clone()),
+        "PUT",
+        &format!("/api/databases/{}", slug),
+        Some(serde_json::json!({
+            "remote_image_upload": {
+                "enabled": true,
+                "image_directory": image_dir.to_string_lossy(),
+                "token": upload_token,
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["remote_image_upload"]["enabled"], true);
+    assert_eq!(
+        body["data"]["remote_image_upload"]["image_directory"],
+        image_dir.to_string_lossy().as_ref()
+    );
+    assert_eq!(
+        body["data"]["remote_image_upload"]["token_configured"],
+        true
+    );
+    assert!(!body.to_string().contains(upload_token));
+    assert!(!std::fs::read_to_string(&registry_path)
+        .unwrap()
+        .contains(upload_token));
+
     // 4) Hit a per-DB endpoint for the new DB — should be reachable.
     let (status, _) = json_request(
         build_app(state.clone()),
@@ -214,6 +243,7 @@ async fn crud_lifecycle_adds_uses_and_removes_a_database() {
     let dbs = parsed["databases"].as_array().unwrap();
     assert_eq!(dbs.len(), 1);
     assert_eq!(dbs[0]["id"], "renamed-rig");
+    assert_eq!(dbs[0]["remote_image_upload"]["enabled"], true);
 
     // 8) Remove it.
     let (status, body) = json_request(

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -1,0 +1,348 @@
+use std::fmt::Write as _;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::DefaultBodyLimit;
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use axum::Router;
+use http_body_util::BodyExt;
+use psf_guard::cli::PregenerationConfig;
+use psf_guard::db_registry::{DbEntry, RemoteImageUploadConfig};
+use psf_guard::server::{remote_upload, state::AppState};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tempfile::{tempdir, TempDir};
+use tower::ServiceExt;
+
+const TOKEN_A: &str = "test-upload-token-a-1234567890";
+const TOKEN_B: &str = "test-upload-token-b-1234567890";
+
+struct Fixture {
+    _directory: TempDir,
+    state: Arc<AppState>,
+    database_a: std::path::PathBuf,
+    database_b: std::path::PathBuf,
+    images_a: std::path::PathBuf,
+    images_b: std::path::PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = tempdir().unwrap();
+        let database_a = directory.path().join("a.sqlite");
+        let database_b = directory.path().join("b.sqlite");
+        let images_a = directory.path().join("images-a");
+        let images_b = directory.path().join("images-b");
+        std::fs::create_dir_all(&images_a).unwrap();
+        std::fs::create_dir_all(&images_b).unwrap();
+        psf_guard::ts_schema::create_fresh_db(&database_a).unwrap();
+        psf_guard::ts_schema::create_fresh_db(&database_b).unwrap();
+
+        let mut config_a = RemoteImageUploadConfig {
+            enabled: true,
+            image_dir: images_a.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        config_a.set_token(TOKEN_A).unwrap();
+        let mut config_b = RemoteImageUploadConfig {
+            enabled: false,
+            image_dir: images_b.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        config_b.set_token(TOKEN_B).unwrap();
+
+        let entries = vec![
+            DbEntry {
+                id: "catalog-a".into(),
+                name: "Catalog A".into(),
+                db_path: database_a.to_string_lossy().into_owned(),
+                image_dirs: vec![images_a.to_string_lossy().into_owned()],
+                reject_archive: None,
+                remote_image_upload: Some(config_a),
+            },
+            DbEntry {
+                id: "catalog-b".into(),
+                name: "Catalog B".into(),
+                db_path: database_b.to_string_lossy().into_owned(),
+                image_dirs: vec![images_b.to_string_lossy().into_owned()],
+                reject_archive: None,
+                remote_image_upload: Some(config_b),
+            },
+        ];
+        let state = Arc::new(
+            AppState::from_databases(
+                entries,
+                directory
+                    .path()
+                    .join("cache")
+                    .to_string_lossy()
+                    .into_owned(),
+                PregenerationConfig::default(),
+            )
+            .unwrap(),
+        );
+
+        Self {
+            _directory: directory,
+            state,
+            database_a,
+            database_b,
+            images_a,
+            images_b,
+        }
+    }
+}
+
+fn build_app(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route(
+            "/api/db/{db_id}/images/upload",
+            post(remote_upload::upload_image)
+                .layer(DefaultBodyLimit::max(remote_upload::MAX_MULTIPART_BYTES)),
+        )
+        .with_state(state)
+}
+
+fn fits_bytes(object: &str, date_obs: &str) -> Vec<u8> {
+    fn card(output: &mut Vec<u8>, text: &str) {
+        let mut bytes = text.as_bytes().to_vec();
+        assert!(bytes.len() <= 80);
+        bytes.resize(80, b' ');
+        output.extend_from_slice(&bytes);
+    }
+
+    let mut bytes = Vec::new();
+    card(&mut bytes, "SIMPLE  =                    T");
+    card(&mut bytes, "BITPIX  =                   16");
+    card(&mut bytes, "NAXIS   =                    2");
+    card(&mut bytes, "NAXIS1  =                   10");
+    card(&mut bytes, "NAXIS2  =                   10");
+    card(&mut bytes, "IMAGETYP= 'LIGHT   '");
+    card(&mut bytes, &format!("OBJECT  = '{object}'"));
+    card(&mut bytes, "FILTER  = 'Ha      '");
+    card(&mut bytes, &format!("DATE-OBS= '{date_obs}'"));
+    card(&mut bytes, "EXPTIME =                300.0");
+    card(&mut bytes, "GAIN    =                  100");
+    card(&mut bytes, "OFFSET  =                   30");
+    card(&mut bytes, "XBINNING=                    1");
+    card(&mut bytes, "YBINNING=                    1");
+    card(&mut bytes, "RA      =            10.680000");
+    card(&mut bytes, "DEC     =            41.268700");
+    card(&mut bytes, "END");
+    bytes.resize(bytes.len().div_ceil(2880) * 2880, b' ');
+    bytes.extend_from_slice(&[0u8; 2880]);
+    bytes
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(64);
+    for byte in digest {
+        write!(encoded, "{byte:02x}").unwrap();
+    }
+    encoded
+}
+
+fn multipart(filename: &str, image: &[u8]) -> (String, Vec<u8>) {
+    let boundary = "psf-guard-test-boundary";
+    let mut body = format!(
+        "--{boundary}\r\n\
+         Content-Disposition: form-data; name=\"image\"; filename=\"{filename}\"\r\n\
+         Content-Type: application/fits\r\n\r\n"
+    )
+    .into_bytes();
+    body.extend_from_slice(image);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    (boundary.into(), body)
+}
+
+async fn upload(
+    state: Arc<AppState>,
+    url_database: &str,
+    echoed_database: &str,
+    token: &str,
+    filename: &str,
+    image: &[u8],
+    checksum: &str,
+) -> (StatusCode, Value) {
+    let (boundary, body) = multipart(filename, image);
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/api/db/{url_database}/images/upload"))
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .header("authorization", format!("Bearer {token}"))
+        .header("x-psf-guard-database-id", echoed_database)
+        .header("x-content-sha256", checksum)
+        .body(Body::from(body))
+        .unwrap();
+    let response = build_app(state).oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, body)
+}
+
+fn image_count(path: &std::path::Path) -> i64 {
+    rusqlite::Connection::open(path)
+        .unwrap()
+        .query_row("SELECT COUNT(*) FROM acquiredimage", [], |row| row.get(0))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn upload_is_scoped_to_the_selected_database_and_attaches_followup_frames() {
+    let fixture = Fixture::new();
+    let first = fits_bytes("M 31", "2026-07-24T05:00:00");
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "m31-001.fits",
+        &first,
+        &sha256(&first),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["database_id"], "catalog-a");
+    assert_eq!(body["data"]["resolution"]["target_name"], "M 31");
+    assert_eq!(body["data"]["import"]["targets_created"], 1);
+    let target_id = body["data"]["resolution"]["target_id"].as_i64().unwrap();
+    assert!(fixture.images_a.join("m31-001.fits").is_file());
+    assert!(!fixture.images_b.join("m31-001.fits").exists());
+    assert_eq!(image_count(&fixture.database_a), 1);
+    assert_eq!(image_count(&fixture.database_b), 0);
+
+    let second = fits_bytes("M 31", "2026-07-24T05:05:00");
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "m31-002.fits",
+        &second,
+        &sha256(&second),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["resolution"]["target_id"], target_id);
+    assert_eq!(body["data"]["import"]["attached"], 1);
+    assert_eq!(body["data"]["import"]["targets_created"], 0);
+    assert_eq!(image_count(&fixture.database_a), 2);
+}
+
+#[tokio::test]
+async fn identical_retry_is_idempotent() {
+    let fixture = Fixture::new();
+    let image = fits_bytes("M 42", "2026-07-24T06:00:00");
+    let checksum = sha256(&image);
+    for expected_present in [false, true] {
+        let (status, body) = upload(
+            fixture.state.clone(),
+            "catalog-a",
+            "catalog-a",
+            TOKEN_A,
+            "m42-001.fits",
+            &image,
+            &checksum,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["data"]["already_present"], expected_present);
+    }
+    assert_eq!(image_count(&fixture.database_a), 1);
+
+    let changed = fits_bytes("M 42", "2026-07-24T06:01:00");
+    let (status, _) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "m42-001.fits",
+        &changed,
+        &sha256(&changed),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        sha256(&std::fs::read(fixture.images_a.join("m42-001.fits")).unwrap()),
+        checksum
+    );
+    assert_eq!(image_count(&fixture.database_a), 1);
+}
+
+#[tokio::test]
+async fn database_echo_token_and_checksum_are_required_before_publish() {
+    let fixture = Fixture::new();
+    let image = fits_bytes("M 33", "2026-07-24T07:00:00");
+    let checksum = sha256(&image);
+
+    let (status, _) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-b",
+        TOKEN_A,
+        "m33-001.fits",
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let (status, _) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_B,
+        "m33-001.fits",
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    let (status, _) = upload(
+        fixture.state.clone(),
+        "catalog-b",
+        "catalog-b",
+        TOKEN_B,
+        "m33-001.fits",
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    let (status, _) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "m33-001.fits",
+        &image,
+        &"0".repeat(64),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let catalog = fixture.state.get_database("catalog-a").unwrap();
+    let _import_guard = catalog.image_import_mutex.lock().await;
+    let (status, _) = upload(
+        fixture.state,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "m33-001.fits",
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(!fixture.images_a.join("m33-001.fits").exists());
+    assert_eq!(image_count(&fixture.database_a), 0);
+    assert_eq!(image_count(&fixture.database_b), 0);
+}

--- a/tests/integration_sync_api.rs
+++ b/tests/integration_sync_api.rs
@@ -95,6 +95,7 @@ async fn planning_and_grade_pushes_preview_before_writing() {
             db_path: local_path.to_string_lossy().into_owned(),
             image_dirs: vec![image_dir.to_string_lossy().into_owned()],
             reject_archive: None,
+            remote_image_upload: None,
         },
         DbEntry {
             id: "scope".into(),
@@ -102,6 +103,7 @@ async fn planning_and_grade_pushes_preview_before_writing() {
             db_path: telescope_path.to_string_lossy().into_owned(),
             image_dirs: vec![image_dir.to_string_lossy().into_owned()],
             reject_archive: None,
+            remote_image_upload: None,
         },
     ];
     let state = Arc::new(


### PR DESCRIPTION
## Summary
- add a settings-gated remote FITS upload endpoint scoped to a specific PSF Guard database
- authenticate with a per-database bearer token, echoed database ID, and SHA-256; stream into the selected registered image root without overwriting
- pass each LIGHT frame through the existing importer so it attaches by target name or coordinates, or creates project and target structure when Target Scheduler is not used
- expose safe receiver controls in desktop Settings and store only salted token hashes
- serialize imports, make identical retries idempotent, and reject basename/content conflicts

## Verification
- cargo fmt --all -- --check
- cargo clippy --quiet --all-targets -- -D warnings
- cargo test --quiet (385 unit tests plus every integration suite)
- cargo check --quiet --features tauri --all-targets
- npm run lint
- npm test -- --run (131 tests)
- npm run build

This PR is intentionally limited to PSF Guard; no N.I.N.A. plugin registry changes are included.