### PR TITLE
Show recent frame ages on overview

### DIFF
--- a/static/e2e/overview.spec.ts
+++ b/static/e2e/overview.spec.ts
@@ -35,6 +35,13 @@ test('overview puts projects ahead of a compact catalog summary', async ({
   await expect(alphaCard).toHaveCount(1);
   await expect(alphaCard.getByText('Open image grid')).toBeVisible();
   await expect(alphaCard.locator('.project-frame')).toHaveCount(3);
+  await expect(page.locator('.project-frame-age')).toHaveCount(4);
+  await expect(page.locator('.project-frame-age').first()).toContainText('Captured');
+  await expect(page.locator('.project-frame-age').first()).toContainText(/ago$/);
+  const newestFrame = page.locator('.project-frame.is-newest');
+  await expect(newestFrame).toHaveCount(1);
+  await expect(newestFrame.getByText('Newest', { exact: true })).toBeVisible();
+  await expect(newestFrame).toHaveAttribute('aria-label', /Beta Field/);
   await expect(
     alphaCard.getByRole('button', { name: 'Plan & coordinates' })
   ).toBeVisible();

--- a/static/src/components/Overview.css
+++ b/static/src/components/Overview.css
@@ -503,6 +503,11 @@
   box-shadow: 0 0 0 1px var(--color-primary-alpha-20);
 }
 
+.project-frame.is-newest {
+  border-color: var(--color-warning);
+  box-shadow: 0 0 0 2px var(--color-warning-alpha-40);
+}
+
 .project-frame-media {
   position: relative;
   display: block;
@@ -553,16 +558,36 @@
   text-transform: uppercase;
 }
 
+.project-frame-newest {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--color-warning);
+  color: var(--color-text-dark);
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .project-frame-caption {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+  display: grid;
+  gap: 2px;
   min-width: 0;
   padding: 5px 7px;
   font-size: 0.7rem;
 }
 
-.project-frame-caption strong {
+.project-frame-caption-main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.project-frame-caption-main strong {
   min-width: 0;
   overflow: hidden;
   color: var(--color-text-primary);
@@ -570,12 +595,19 @@
   white-space: nowrap;
 }
 
-.project-frame-caption > span {
+.project-frame-caption-main > span {
   flex: none;
   margin-left: auto;
   color: var(--color-text-muted);
 }
 
+.project-frame-age {
+  overflow: hidden;
+  color: var(--color-text-hint);
+  font-size: 0.64rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .project-targets-compact {
   margin-top: 13px;
   padding-top: 11px;

--- a/static/src/components/Overview.tsx
+++ b/static/src/components/Overview.tsx
@@ -25,6 +25,7 @@ import {
   projectSeenKey,
   saveProjectSeenState,
 } from '../utils/projectRecency';
+import { formatRelativeTime } from '../utils/relativeTime';
 import ProjectSchedulerDialog from './ProjectSchedulerDialog';
 import PreviewImage from './PreviewImage';
 import './Overview.css';
@@ -34,6 +35,10 @@ type Organizing =
   | { kind: 'project'; dbId: string; id: number; name: string; mergeInto: string }
   | { kind: 'target'; dbId: string; id: number; name: string; moveTo: string };
 
+function recentImageKey(dbId: string, projectId: number, imageId: number): string {
+  return `${dbId}:${projectId}:${imageId}`;
+}
+
 export default function Overview() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -42,6 +47,7 @@ export default function Overview() {
   const [organizeBusy, setOrganizeBusy] = useState(false);
   const [organizeError, setOrganizeError] = useState('');
   const [seenProjects, setSeenProjects] = useState(loadProjectSeenState);
+  const [relativeNow, setRelativeNow] = useState(Date.now);
   const [schedulerProject, setSchedulerProject] = useState<{
     dbId: string;
     id: number;
@@ -58,6 +64,11 @@ export default function Overview() {
   const { data: projects, isLoading: projectsLoading } = useMergedProjectsOverview();
   const { data: targets, isLoading: targetsLoading } = useMergedTargetsOverview();
   const organizeAllowed = serverInfo?.allow_database_management ?? false;
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setRelativeNow(Date.now()), 60_000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   // Desktop mode: export straight to a local folder (hardlink-or-copy) via
   // the native picker — the server IS this machine, so downloading a zip of
@@ -148,6 +159,24 @@ export default function Overview() {
       (map[p.db_id] ||= []).push(p);
     }
     return map;
+  }, [projects]);
+
+  const newestImageKey = useMemo(() => {
+    let newest: { key: string; acquiredDate: number } | null = null;
+    for (const project of projects) {
+      for (const image of project.recent_images) {
+        if (image.acquired_date === null) continue;
+        const key = recentImageKey(project.db_id, project.id, image.id);
+        if (
+          newest === null ||
+          image.acquired_date > newest.acquiredDate ||
+          (image.acquired_date === newest.acquiredDate && key > newest.key)
+        ) {
+          newest = { key, acquiredDate: image.acquired_date };
+        }
+      }
+    }
+    return newest?.key ?? null;
   }, [projects]);
 
   // Seed both project and target baselines the first time this browser sees
@@ -605,12 +634,23 @@ export default function Overview() {
                       <div className="project-recent-frames">
                         {project.recent_images.map((image, index) => {
                           const isNew = index < displayedNewImages;
+                          const isNewest =
+                            recentImageKey(project.db_id, project.id, image.id) ===
+                            newestImageKey;
                           const filter = image.filter_name || 'No filter';
+                          const relativeTime = formatRelativeTime(
+                            image.acquired_date,
+                            relativeNow
+                          );
                           return (
                             <button
                               key={image.id}
                               type="button"
-                              className={`project-frame ${isNew ? 'is-new' : ''}`}
+                              className={[
+                                'project-frame',
+                                isNew ? 'is-new' : '',
+                                isNewest ? 'is-newest' : '',
+                              ].filter(Boolean).join(' ')}
                               onClick={() => handleSelectImage(project, image)}
                               aria-label={`Open ${image.target_name}, ${filter} frame`}
                             >
@@ -634,10 +674,33 @@ export default function Overview() {
                                   }
                                 />
                                 {isNew && <span className="project-frame-new">New</span>}
+                                {isNewest && (
+                                  <span
+                                    className="project-frame-newest"
+                                    title="Newest frame across all databases"
+                                  >
+                                    Newest
+                                  </span>
+                                )}
                               </span>
                               <span className="project-frame-caption">
-                                <strong>{image.target_name}</strong>
-                                <span>{filter}</span>
+                                <span className="project-frame-caption-main">
+                                  <strong>{image.target_name}</strong>
+                                  <span>{filter}</span>
+                                </span>
+                                {image.acquired_date === null ? (
+                                  <span className="project-frame-age">{relativeTime}</span>
+                                ) : (
+                                  <time
+                                    className="project-frame-age"
+                                    dateTime={new Date(image.acquired_date * 1000).toISOString()}
+                                    title={`Captured ${new Date(
+                                      image.acquired_date * 1000
+                                    ).toLocaleString()}`}
+                                  >
+                                    Captured {relativeTime}
+                                  </time>
+                                )}
                               </span>
                             </button>
                           );

--- a/static/src/utils/__tests__/relativeTime.test.ts
+++ b/static/src/utils/__tests__/relativeTime.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { formatRelativeTime } from '../relativeTime';
+
+const NOW = Date.UTC(2026, 6, 24, 12, 0, 0);
+const NOW_SECONDS = NOW / 1000;
+
+describe('formatRelativeTime', () => {
+  it('uses compact units from minutes through years', () => {
+    expect(formatRelativeTime(NOW_SECONDS - 30, NOW)).toBe('just now');
+    expect(formatRelativeTime(NOW_SECONDS - 5 * 60, NOW)).toBe('5 mins ago');
+    expect(formatRelativeTime(NOW_SECONDS - 2 * 60 * 60, NOW)).toBe('2 hrs ago');
+    expect(formatRelativeTime(NOW_SECONDS - 24 * 60 * 60, NOW)).toBe('1 day ago');
+    expect(formatRelativeTime(NOW_SECONDS - 3 * 7 * 24 * 60 * 60, NOW)).toBe('3 wks ago');
+    expect(formatRelativeTime(NOW_SECONDS - 2 * 365 * 24 * 60 * 60, NOW)).toBe('2 yrs ago');
+  });
+
+  it('handles future and missing timestamps', () => {
+    expect(formatRelativeTime(NOW_SECONDS + 2 * 60 * 60, NOW)).toBe('in 2 hrs');
+    expect(formatRelativeTime(null, NOW)).toBe('Time unknown');
+  });
+});

--- a/static/src/utils/relativeTime.ts
+++ b/static/src/utils/relativeTime.ts
@@ -1,0 +1,47 @@
+const MINUTE_SECONDS = 60;
+const HOUR_SECONDS = 60 * MINUTE_SECONDS;
+const DAY_SECONDS = 24 * HOUR_SECONDS;
+const WEEK_SECONDS = 7 * DAY_SECONDS;
+const MONTH_SECONDS = 30 * DAY_SECONDS;
+const YEAR_SECONDS = 365 * DAY_SECONDS;
+
+interface RelativeUnit {
+  seconds: number;
+  singular: string;
+  plural: string;
+}
+
+const RELATIVE_UNITS: RelativeUnit[] = [
+  { seconds: YEAR_SECONDS, singular: 'yr', plural: 'yrs' },
+  { seconds: MONTH_SECONDS, singular: 'mo', plural: 'mos' },
+  { seconds: WEEK_SECONDS, singular: 'wk', plural: 'wks' },
+  { seconds: DAY_SECONDS, singular: 'day', plural: 'days' },
+  { seconds: HOUR_SECONDS, singular: 'hr', plural: 'hrs' },
+  { seconds: MINUTE_SECONDS, singular: 'min', plural: 'mins' },
+];
+
+/**
+ * Compact relative age for overview cards. The optional clock keeps tests
+ * deterministic and lets callers update every visible age in one render.
+ */
+export function formatRelativeTime(
+  timestampSeconds: number | null | undefined,
+  nowMilliseconds = Date.now()
+): string {
+  if (timestampSeconds === null || timestampSeconds === undefined) {
+    return 'Time unknown';
+  }
+
+  const differenceSeconds = Math.trunc(nowMilliseconds / 1000 - timestampSeconds);
+  const absoluteSeconds = Math.abs(differenceSeconds);
+  if (absoluteSeconds < MINUTE_SECONDS) return 'just now';
+
+  const unit =
+    RELATIVE_UNITS.find((candidate) => absoluteSeconds >= candidate.seconds) ??
+    RELATIVE_UNITS[RELATIVE_UNITS.length - 1];
+  const value = Math.floor(absoluteSeconds / unit.seconds);
+  const label = value === 1 ? unit.singular : unit.plural;
+  return differenceSeconds < 0
+    ? `in ${value} ${label}`
+    : `${value} ${label} ago`;
+}


### PR DESCRIPTION
## What changed

- show a compact relative capture age on every recent overview frame
- refresh visible ages once per minute
- mark the newest frame across all databases and projects
- keep the existing `New` state separate from the persistent global `Newest` marker
- expose the full local capture date on hover

## Why

The overview showed which frames were recent but not how old they were. It was also hard to find the newest frame when several databases and projects were visible.

The relative age uses the image's recorded acquisition date. No database or API change is needed.

## Validation

- `npm run lint`
- `npm test -- --run` — 133 passed
- `npm run build`
- `npx playwright test e2e/overview.spec.ts` — 4 passed
