### PR TITLE
Add authenticated remote scheduler sync API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,6 +3910,7 @@ dependencies = [
  "anyhow",
  "async_zip",
  "axum",
+ "base64 0.22.1",
  "bumpalo",
  "byteorder",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ seiza-stretch = "0.1.0"
 seiza-background = "0.1.0"
 seiza-deconvolution = "0.1.0"
 sha2 = "0.11"
+base64 = "0.22"
 rayon = "1"
 bumpalo = { version = "3.20", features = ["collections"] }
 image = "0.25"

--- a/DATA_TRANSFER_DESIGN.md
+++ b/DATA_TRANSFER_DESIGN.md
@@ -272,11 +272,28 @@ The bundle is compressed and contains:
 - rows keyed by stable GUID;
 - optional stored-thumbnail chunks;
 - source snapshot metadata; and
-- a payload digest.
+- an optional payload digest.
 
 The protocol sets compressed and expanded size limits, row limits, timeouts,
 and a bounded thumbnail budget. It rejects unknown required features rather
 than guessing.
+
+The digest is a courtesy checksum, not a credential. It carries no key, so it
+says nothing about who built the bundle; the bearer token does that, and TLS
+already covers truncation. The receiver therefore accepts a bundle whose
+digest is absent or stale. Enforcing it would pin one canonical JSON encoding,
+and reordering a single field would then reject every plugin already shipped.
+
+A bundle must carry the tables its operation acts on — `acquiredimage` for
+grades, `project`/`target`/`exposureplan` for planning, and both sets for a
+merge. Other tables in the operation's set may be omitted; the receiver
+creates them empty from its own schema, and the merge finds nothing to do.
+The current receiver accepts up to 512 MiB and one million rows per bundle,
+and bounds the exports it builds by the same row limit.
+
+Each database opts into this protocol on its own. Holding a valid key is not
+enough: the operator ticks **Accept remote scheduler sync** for that database,
+separately from **Accept remote image uploads**.
 
 ## N.I.N.A. plugin
 

--- a/DATA_TRANSFER_DESIGN.md
+++ b/DATA_TRANSFER_DESIGN.md
@@ -17,7 +17,7 @@ The design must not require Syncthing, Dropbox, or another file copier to move
 a live SQLite database. N.I.N.A. may write that file while an outside process
 copies it, and a copied database gives neither side a useful conflict preview.
 
-Original FITS files are outside the first remote-sync protocol. A transfer can
+Original FITS files are outside the database-bundle protocol. A transfer can
 copy database rows and stored thumbnails, then report which image files resolve
 on the destination. File transfer can be added later as a separate action.
 
@@ -280,8 +280,8 @@ than guessing.
 
 ## N.I.N.A. plugin
 
-A later N.I.N.A. plugin can implement the remote protocol at the telescope.
-The plugin does not need to expose the SQLite file.
+A N.I.N.A. plugin can implement the remote protocol at the telescope without
+exposing the SQLite file.
 
 The plugin can:
 
@@ -304,7 +304,7 @@ client can post a light frame directly to one opted-in PSF Guard database:
 
 ```http
 POST /api/db/{db_id}/images/upload
-Authorization: Bearer <per-database-upload-token>
+Authorization: Bearer <per-database-remote-api-key>
 X-PSF-Guard-Database-ID: <db_id>
 X-Content-SHA256: <64 lowercase hexadecimal characters>
 Content-Type: multipart/form-data
@@ -379,14 +379,15 @@ transactional, so it cannot leave half a merge committed.
 
 ### Phase 4: remote PSF Guard peers
 
-- Add scoped peer credentials and capability discovery.
-- Add compressed export bundles and remote preview/apply.
+- [x] Add scoped per-database credentials and capability discovery.
+- [x] Add JSON export bundles and remote preview/apply.
 - Test interrupted transfers, limits, stale previews, and retries.
 
 ### Phase 5: N.I.N.A. plugin
 
-- Implement the same capability, export, preview, apply, and job contract.
-- Add capture notifications and image-history manifests.
+- [x] Implement the same capability, export, preview, apply, and job contract.
+- [x] Add durable capture bundle notifications and direct FITS upload.
+- Add image-history manifests.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,16 @@ existing target by name or nearby coordinates before it creates new structure.
 
 Remote acquisition clients can send one FITS light at a time without sharing
 the image folder or running Target Scheduler. Edit a database in Settings,
-enable **Accept remote image uploads**, select its receive directory, and set a
-long upload token. The authenticated `/api/db/{db_id}/images/upload` endpoint
+generate its per-database **Remote API key**, enable **Accept remote image
+uploads**, and select its receive directory. The authenticated
+`/api/db/{db_id}/images/upload` endpoint
 verifies the database identity and file digest, saves without overwriting, and
 runs the same name/coordinate target resolution used by folder import. See
 [the remote image ingest contract](DATA_TRANSFER_DESIGN.md#remote-image-ingest).
+
+The same key authenticates `/api/sync/v1/*` for remote Target Scheduler
+export, preview, and apply. It is scoped to exactly one configured database;
+image upload remains independently disabled unless its checkbox is enabled.
 
 The Overview's **Plan & coordinates** dialog lets you correct imported names,
 coordinates, limits, and desired counts. See the

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ settings and every target's catalog coordinates and exposure plans. The
 inherited Target Scheduler mapping stores RA as decimal hours and Dec as
 degrees. New plans reuse an exact matching profile template or create one with
 Target Scheduler-compatible defaults. The plan table keeps the schema's `-1`
-exposure value, which means “use the template default.” The desktop app can
-edit these fields. The web server needs `--allow-database-management`; without
-it, the view stays read-only.
+exposure value, which means “use the template default.” Both the desktop app
+and the web server can edit these fields: they change rows inside a database
+you already configured, so they need no extra flag.
 
 ### Build an image catalog from FITS folders
 
@@ -157,8 +157,11 @@ runs the same name/coordinate target resolution used by folder import. See
 [the remote image ingest contract](DATA_TRANSFER_DESIGN.md#remote-image-ingest).
 
 The same key authenticates `/api/sync/v1/*` for remote Target Scheduler
-export, preview, and apply. It is scoped to exactly one configured database;
-image upload remains independently disabled unless its checkbox is enabled.
+export, preview, and apply, but only after you tick **Accept remote scheduler
+sync** on that database. The two grants are separate: a key may carry either,
+both, or neither, and a key configured before this protocol existed reaches
+nothing until you opt in. Either way the key is scoped to exactly one
+configured database.
 
 The Overview's **Plan & coordinates** dialog lets you correct imported names,
 coordinates, limits, and desired counts. See the

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -57,6 +57,12 @@ pub struct RemoteImageUploadConfig {
     pub token_salt: String,
     #[serde(default)]
     pub token_sha256: String,
+    /// Opt this database into the remote scheduler sync protocol
+    /// (`/api/sync/v1`). Independent of `enabled`, which covers image upload
+    /// only. Defaults to false, so a token configured for uploads before the
+    /// sync protocol existed does not silently gain merge and apply rights.
+    #[serde(default)]
+    pub sync_enabled: bool,
 }
 
 impl RemoteImageUploadConfig {

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -255,6 +255,7 @@ pub struct RemoteImageUploadSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image_directory: Option<String>,
     pub token_configured: bool,
+    pub sync_enabled: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -266,6 +267,11 @@ pub struct RemoteImageUploadUpdate {
     /// is immediately replaced by its salted SHA-256 digest in the registry.
     #[serde(default)]
     pub token: Option<String>,
+    /// Opt this database into the remote scheduler sync protocol. Separate
+    /// from `enabled` so a key can grant image upload without granting sync,
+    /// or the reverse. Absent means "leave the stored setting alone".
+    #[serde(default)]
+    pub sync_enabled: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -491,7 +491,7 @@ async fn execute_scheduler_sync(
         .map(|(response, _)| response)
 }
 
-enum SyncGuardMode {
+pub(crate) enum SyncGuardMode {
     None,
     Preview,
     Apply { destination_fingerprint: String },
@@ -515,13 +515,6 @@ async fn execute_scheduler_sync_guarded(
     source_override: Option<PathBuf>,
     guard_mode: SyncGuardMode,
 ) -> Result<(SchedulerSyncResponse, Option<String>), AppError> {
-    use crate::commands::sync::{
-        parse_status, sync_grades, sync_grades_in_transaction, sync_planning,
-        sync_planning_in_transaction, sync_pull, sync_pull_in_transaction, PlanningOptions,
-        PullOptions, SyncGradesOptions,
-    };
-    use rusqlite::{Connection, OpenFlags, Transaction, TransactionBehavior};
-
     require_database_management_allowed(state)?;
     if db_id == req.peer_db_id {
         return Err(AppError::BadRequest(
@@ -541,8 +534,34 @@ async fn execute_scheduler_sync_guarded(
     };
     let source_path = source_override.unwrap_or_else(|| PathBuf::from(&source_ctx.database_path));
     let destination_path = PathBuf::from(&destination_ctx.database_path);
-    let source_id = source_ctx.id.clone();
-    let destination_id = destination_ctx.id.clone();
+    execute_scheduler_sync_paths(
+        state,
+        source_path,
+        destination_path,
+        source_ctx.id.clone(),
+        destination_ctx.id.clone(),
+        req,
+        guard_mode,
+    )
+    .await
+}
+
+pub(crate) async fn execute_scheduler_sync_paths(
+    state: &Arc<AppState>,
+    source_path: PathBuf,
+    destination_path: PathBuf,
+    source_id: String,
+    destination_id: String,
+    req: SchedulerSyncRequest,
+    guard_mode: SyncGuardMode,
+) -> Result<(SchedulerSyncResponse, Option<String>), AppError> {
+    use crate::commands::sync::{
+        parse_status, sync_grades, sync_grades_in_transaction, sync_planning,
+        sync_planning_in_transaction, sync_pull, sync_pull_in_transaction, PlanningOptions,
+        PullOptions, SyncGradesOptions,
+    };
+    use rusqlite::{Connection, OpenFlags, Transaction, TransactionBehavior};
+
     let fingerprint_queries = crate::server::sync_preview::fingerprint_queries(&req);
     let kind = req.kind;
     let dry_run = req.dry_run;
@@ -559,6 +578,7 @@ async fn execute_scheduler_sync_guarded(
     };
     let reviewed_only = req.reviewed_only;
     let with_image_data = req.with_image_data.unwrap_or(true);
+    let destination_id_for_cache = destination_id.clone();
 
     let response = tokio::task::spawn_blocking(
         move || -> anyhow::Result<(SchedulerSyncResponse, Option<String>)> {
@@ -737,7 +757,7 @@ async fn execute_scheduler_sync_guarded(
         }
     })?;
 
-    if !dry_run {
+    if !dry_run && let Some(destination_ctx) = state.get_database(&destination_id_for_cache) {
         let _ = destination_ctx.ensure_cache_available();
     }
     Ok(response)

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -105,11 +105,10 @@ pub async fn get_calibration_library_details(
 }
 
 pub async fn forget_calibration_frame(
-    State(state): State<Arc<AppState>>,
+    State(_state): State<Arc<AppState>>,
     ctx: DbContext,
     Path((_db_id, frame_uuid)): Path<(String, String)>,
 ) -> Result<Json<ApiResponse<crate::calibration::CalibrationMutationOutcome>>, AppError> {
-    require_database_management_allowed(&state)?;
     let conn = ctx.db();
     let mut conn = conn.lock().map_err(AppError::db)?;
     let outcome = crate::calibration::forget_frame(&mut conn, &frame_uuid).map_err(AppError::db)?;
@@ -123,7 +122,6 @@ pub async fn clear_calibration_masters(
     State(state): State<Arc<AppState>>,
     ctx: DbContext,
 ) -> Result<Json<ApiResponse<crate::calibration::CalibrationMutationOutcome>>, AppError> {
-    require_database_management_allowed(&state)?;
     let _permit = state
         .stack_previews
         .acquire_maintenance_permit()
@@ -186,9 +184,10 @@ pub async fn get_astrometry_catalog_install(
     Ok(Json(ApiResponse::success(state.catalog_install.status())))
 }
 
-/// Download and install one hosted Seiza catalog package. This writes to the
-/// configured catalog directory, so it uses the same trust gate as database
-/// management. The work continues after the request returns.
+/// Download and install one hosted Seiza catalog package. The destination is
+/// the server's own configured catalog directory, so this leaks no path — but
+/// it does let a caller start a multi-gigabyte download, so it keeps the
+/// management gate. The work continues after the request returns.
 pub async fn start_astrometry_catalog_install(
     State(state): State<Arc<AppState>>,
     Json(request): Json<crate::server::catalog_install::CatalogInstallRequest>,
@@ -424,17 +423,23 @@ fn require_registry_path(state: &AppState) -> Result<std::path::PathBuf, AppErro
     })
 }
 
-/// Gate for mutating endpoints on `/api/databases`. Returns 403 when the
-/// server was launched without `--allow-database-management`. Anyone reachable
-/// over the network could otherwise re-point, remove, or sync the user's
-/// configured databases.
+/// Gate for endpoints that let a caller name a server filesystem path:
+/// registry CRUD, database creation, local export, and folder import. Those
+/// requests choose which files the server reads and writes, so anyone
+/// reachable over the network could otherwise register an arbitrary path and
+/// read it back through the normal API.
+///
+/// It deliberately does NOT cover writes that stay inside an already
+/// configured database — grading, project and target edits, exposure plans,
+/// and sync. Those touch only data the operator already pointed the server at.
 pub(super) fn require_database_management_allowed(state: &AppState) -> Result<(), AppError> {
     if state.database_management_allowed() {
         Ok(())
     } else {
         Err(AppError::Forbidden(
             "database management is disabled on this server. Restart the server \
-            with --allow-database-management to enable runtime database changes and sync."
+            with --allow-database-management to register, create, import, or \
+            export databases."
                 .into(),
         ))
     }
@@ -460,6 +465,7 @@ fn remote_image_upload_summary(
             .map(|config| config.image_dir.clone())
             .filter(|directory| !directory.is_empty()),
         token_configured: config.is_some_and(|config| config.token_is_configured()),
+        sync_enabled: config.is_some_and(|config| config.sync_enabled),
     }
 }
 
@@ -515,7 +521,6 @@ async fn execute_scheduler_sync_guarded(
     source_override: Option<PathBuf>,
     guard_mode: SyncGuardMode,
 ) -> Result<(SchedulerSyncResponse, Option<String>), AppError> {
-    require_database_management_allowed(state)?;
     if db_id == req.peer_db_id {
         return Err(AppError::BadRequest(
             "Choose two different databases to sync.".into(),
@@ -794,7 +799,6 @@ pub async fn preview_sync_database_route(
     Path(db_id): Path<String>,
     Json(mut request): Json<SchedulerSyncRequest>,
 ) -> Result<Json<ApiResponse<SchedulerSyncPreviewResponse>>, AppError> {
-    require_database_management_allowed(&state)?;
     request.dry_run = true;
     let (source_path, _destination_path) = sync_endpoint_paths(&state, &db_id, &request)?;
     let source_snapshot_file = state
@@ -851,7 +855,6 @@ pub async fn get_sync_database_preview_route(
     State(state): State<Arc<AppState>>,
     Path((db_id, preview_id)): Path<(String, String)>,
 ) -> Result<Json<ApiResponse<SchedulerSyncPreviewResponse>>, AppError> {
-    require_database_management_allowed(&state)?;
     let record = state
         .sync_previews
         .get(&preview_id)
@@ -870,7 +873,6 @@ pub async fn delete_sync_database_preview_route(
     State(state): State<Arc<AppState>>,
     Path((db_id, preview_id)): Path<(String, String)>,
 ) -> Result<Json<ApiResponse<bool>>, AppError> {
-    require_database_management_allowed(&state)?;
     let deleted = state
         .sync_previews
         .discard(&preview_id, &db_id)
@@ -883,7 +885,6 @@ pub async fn apply_sync_database_preview_route(
     State(state): State<Arc<AppState>>,
     Path((db_id, preview_id)): Path<(String, String)>,
 ) -> Result<Json<ApiResponse<SchedulerSyncResponse>>, AppError> {
-    require_database_management_allowed(&state)?;
     let _apply_guard = state.sync_apply_lock.lock().await;
     let record = state
         .sync_previews
@@ -1079,6 +1080,14 @@ fn apply_remote_image_upload_update(
         config
             .set_token(token)
             .map_err(|error| AppError::BadRequest(error.to_string()))?;
+    }
+    if let Some(sync_enabled) = update.sync_enabled {
+        config.sync_enabled = sync_enabled;
+    }
+    if config.sync_enabled && !config.token_is_configured() {
+        return Err(AppError::BadRequest(
+            "generate a remote API key before enabling remote scheduler sync".into(),
+        ));
     }
     if config.enabled {
         config
@@ -1284,12 +1293,11 @@ pub async fn export_local_route(
 
 /// `PUT /api/db/{db_id}/projects/{project_id}` — update scheduler fields.
 pub async fn update_project_route(
-    State(state): State<Arc<AppState>>,
+    State(_state): State<Arc<AppState>>,
     ctx: DbContext,
     Path((_db_id, project_id)): Path<(String, i32)>,
     Json(req): Json<UpdateProjectRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, AppError> {
-    require_database_management_allowed(&state)?;
     crate::server::scheduler::update_project(ctx, project_id, req)?;
     Ok(Json(ApiResponse::success(
         serde_json::json!({ "updated": true }),
@@ -1299,12 +1307,11 @@ pub async fn update_project_route(
 /// `PUT /api/db/{db_id}/targets/{target_id}` — rename a target and/or move it
 /// to another project (same profile; images follow the target).
 pub async fn update_target_route(
-    State(state): State<Arc<AppState>>,
+    State(_state): State<Arc<AppState>>,
     ctx: DbContext,
     Path((_db_id, target_id)): Path<(String, i32)>,
     Json(req): Json<UpdateTargetRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, AppError> {
-    require_database_management_allowed(&state)?;
     if req.name.is_none()
         && req.project_id.is_none()
         && req.active.is_none()
@@ -1354,12 +1361,11 @@ pub async fn update_target_route(
 /// `POST /api/db/{db_id}/projects/{project_id}/merge` — merge this project's
 /// targets and images into another project, then delete it.
 pub async fn merge_project_route(
-    State(state): State<Arc<AppState>>,
+    State(_state): State<Arc<AppState>>,
     ctx: DbContext,
     Path((_db_id, project_id)): Path<(String, i32)>,
     Json(req): Json<MergeProjectRequest>,
 ) -> Result<Json<ApiResponse<MergeProjectResponse>>, AppError> {
-    require_database_management_allowed(&state)?;
     let (targets_moved, images_moved) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
@@ -1483,10 +1489,15 @@ pub async fn start_import_route(
     ctx: DbContext,
     Json(req): Json<ImportRequest>,
 ) -> Result<Json<ApiResponse<ImportStatusResponse>>, AppError> {
-    require_database_management_allowed(&state)?;
-
+    // Importing into a configured database is ordinary work. Naming the
+    // directories to read is not: that is a caller-chosen server path, so it
+    // needs the same consent as registry CRUD. Without the flag we import
+    // only from directories the operator already configured.
     let dirs = match req.image_dirs {
-        Some(dirs) if !dirs.is_empty() => dirs,
+        Some(dirs) if !dirs.is_empty() => {
+            require_database_management_allowed(&state)?;
+            dirs
+        }
         _ => ctx.image_dirs.clone(),
     };
     if dirs.is_empty() {
@@ -4340,6 +4351,9 @@ pub async fn get_spatial_scan_progress(
 #[derive(Debug)]
 pub enum AppError {
     NotFound,
+    /// 404 that explains itself — for resources that legitimately disappear,
+    /// where "Resource not found" would read as an auth failure.
+    NotFoundMessage(String),
     DatabaseError(String),
     BadRequest(String),
     Conflict(String),
@@ -4364,6 +4378,14 @@ impl IntoResponse for AppError {
             AppError::NotFound => {
                 tracing::warn!("🔍 Resource not found");
                 (StatusCode::NOT_FOUND, "Resource not found")
+            }
+            AppError::NotFoundMessage(msg) => {
+                tracing::warn!("🔍 Resource not found: {}", msg);
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(ApiResponse::<()>::error(msg.clone())),
+                )
+                    .into_response();
             }
             AppError::DatabaseError(msg) => {
                 tracing::error!("💾 Database error: {}", msg);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,6 +8,7 @@ pub mod handlers;
 pub mod import_job;
 pub mod preview_queue;
 pub mod quality_backfill;
+pub mod remote_sync;
 pub mod remote_upload;
 pub mod scheduler;
 pub mod slug;
@@ -428,6 +429,22 @@ async fn run_server_internal(
             "/databases/{db_id}",
             put(handlers::update_database_route).delete(handlers::remove_database_route),
         )
+        .route("/sync/v1/capabilities", get(remote_sync::capabilities))
+        .route(
+            "/sync/v1/previews",
+            post(remote_sync::create_preview)
+                .layer(DefaultBodyLimit::max(remote_sync::MAX_SYNC_BODY_BYTES)),
+        )
+        .route(
+            "/sync/v1/previews/{preview_id}",
+            get(remote_sync::get_preview),
+        )
+        .route(
+            "/sync/v1/previews/{preview_id}/apply",
+            post(remote_sync::apply_preview),
+        )
+        .route("/sync/v1/exports", post(remote_sync::create_export))
+        .route("/sync/v1/exports/{export_id}", get(remote_sync::get_export))
         .nest("/db/{db_id}", db_routes)
         .with_state(state);
 

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -1,9 +1,16 @@
 //! Token-authenticated database sync for remote N.I.N.A. clients.
 //!
 //! The wire format is deliberately database-shaped: a client freezes selected
-//! Target Scheduler tables into a signed JSON bundle, while PSF Guard
-//! materializes that bundle as a temporary SQLite source and delegates every
-//! merge decision to the existing local database sync engine.
+//! Target Scheduler tables into a JSON bundle, while PSF Guard materializes
+//! that bundle as a temporary SQLite source and delegates every merge
+//! decision to the existing local database sync engine.
+//!
+//! `payload_sha256` is a courtesy checksum, not a credential. It carries no
+//! key, so it proves nothing about who built the bundle — the bearer token
+//! does that, and TLS plus `Content-Length` already cover truncation. We
+//! therefore accept it, echo it on export, and do not verify it: enforcing it
+//! would mean pinning a canonical JSON encoding, so reordering one struct
+//! field would reject every plugin already in the field.
 
 use axum::{
     extract::{Path, State},
@@ -22,7 +29,7 @@ use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, HashMap},
     path::{Path as FsPath, PathBuf},
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Arc, Mutex},
 };
 use uuid::Uuid;
 
@@ -36,9 +43,12 @@ use crate::server::{
     state::AppState,
 };
 
-pub const MAX_SYNC_BODY_BYTES: usize = 128 * 1024 * 1024;
-const MAX_BUNDLE_ROWS: usize = 250_000;
+pub const MAX_SYNC_BODY_BYTES: usize = 512 * 1024 * 1024;
+const MAX_BUNDLE_ROWS: usize = 1_000_000;
 const PROTOCOL_VERSION: u32 = 1;
+/// How long a built export stays fetchable, matching the preview lifetime.
+const EXPORT_LIFETIME_SECS: i64 = 30 * 60;
+const MAX_RETAINED_EXPORTS: usize = 16;
 const PLANNING_TABLES: &[&str] = &[
     "exposuretemplate",
     "project",
@@ -179,7 +189,72 @@ pub struct SyncExport {
     pub error: Option<String>,
 }
 
-static EXPORTS: OnceLock<Mutex<HashMap<String, (String, SyncExport)>>> = OnceLock::new();
+struct StoredExport {
+    catalog_id: String,
+    created_at: i64,
+    export: SyncExport,
+}
+
+/// Built export bundles, held so a client can re-fetch one it lost. Bundles
+/// carry whole tables, so this is capacity-bound and time-bound: expired
+/// entries go first, then the oldest, never an arbitrary hash-order victim.
+#[derive(Default)]
+pub struct ExportStore {
+    entries: Mutex<HashMap<String, StoredExport>>,
+}
+
+impl ExportStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn insert(&self, catalog_id: String, export: SyncExport) -> Result<(), AppError> {
+        let now = unix_seconds();
+        let mut entries = self.lock()?;
+        entries.retain(|_, stored| stored.created_at + EXPORT_LIFETIME_SECS > now);
+        while entries.len() >= MAX_RETAINED_EXPORTS {
+            let Some(oldest) = entries
+                .iter()
+                .min_by_key(|(id, stored)| (stored.created_at, (*id).clone()))
+                .map(|(id, _)| id.clone())
+            else {
+                break;
+            };
+            entries.remove(&oldest);
+        }
+        entries.insert(
+            export.export_id.clone(),
+            StoredExport {
+                catalog_id,
+                created_at: now,
+                export,
+            },
+        );
+        Ok(())
+    }
+
+    fn get(&self, id: &str, catalog_id: &str) -> Result<Option<SyncExport>, AppError> {
+        let now = unix_seconds();
+        let mut entries = self.lock()?;
+        let Some(stored) = entries.get(id) else {
+            return Ok(None);
+        };
+        if stored.created_at + EXPORT_LIFETIME_SECS <= now {
+            entries.remove(id);
+            return Ok(None);
+        }
+        if stored.catalog_id != catalog_id {
+            return Ok(None);
+        }
+        Ok(Some(stored.export.clone()))
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, HashMap<String, StoredExport>>, AppError> {
+        self.entries.lock().map_err(|error| {
+            AppError::InternalError(format!("remote export lock poisoned: {error}"))
+        })
+    }
+}
 
 pub async fn capabilities(
     State(state): State<Arc<AppState>>,
@@ -373,19 +448,9 @@ pub async fn create_export(
         bundle: Some(bundle),
         error: None,
     };
-    let mut exports = exports().lock().map_err(|error| {
-        AppError::InternalError(format!("remote export lock poisoned: {error}"))
-    })?;
-    if exports.len() >= 16
-        && let Some(key) = exports.keys().next().cloned()
-    {
-        exports.remove(&key);
-    }
-    exports.insert(
-        export.export_id.clone(),
-        (catalog.id.clone(), export.clone()),
-    );
-    drop(exports);
+    state
+        .remote_exports
+        .insert(catalog.id.clone(), export.clone())?;
     Ok(Json(ApiResponse::success(export)))
 }
 
@@ -395,14 +460,16 @@ pub async fn get_export(
     Path(export_id): Path<String>,
 ) -> Result<Json<ApiResponse<SyncExport>>, AppError> {
     let catalog = authenticated_catalog(&state, &headers)?;
-    let exports = exports().lock().map_err(|error| {
-        AppError::InternalError(format!("remote export lock poisoned: {error}"))
-    })?;
-    let export = exports
-        .get(&export_id)
-        .filter(|(catalog_id, _)| catalog_id == &catalog.id)
-        .map(|(_, export)| export.clone())
-        .ok_or(AppError::NotFound)?;
+    let export = state
+        .remote_exports
+        .get(&export_id, &catalog.id)?
+        .ok_or_else(|| {
+            AppError::NotFoundMessage(
+                "no such export. Exports are kept for 30 minutes and capped, so \
+                 an older one may have been dropped — create a new export."
+                    .into(),
+            )
+        })?;
     Ok(Json(ApiResponse::success(export)))
 }
 
@@ -431,6 +498,18 @@ fn authenticated_catalog(
     if matches.next().is_some() {
         return Err(AppError::Forbidden(
             "API token is configured for more than one database".into(),
+        ));
+    }
+    // Sync is a separate grant from image upload. A key configured before
+    // this protocol existed authenticates, but reaches nothing until the
+    // operator opts the database in.
+    if !catalog
+        .remote_image_upload
+        .as_ref()
+        .is_some_and(|config| config.sync_enabled)
+    {
+        return Err(AppError::Forbidden(
+            "remote scheduler sync is disabled for this database".into(),
         ));
     }
     Ok(catalog)
@@ -467,18 +546,12 @@ fn validate_bundle(bundle: &CatalogBundle) -> Result<(), AppError> {
             "Target Scheduler schema 22 or newer is required".into(),
         ));
     }
-    let digest = bundle
-        .payload_sha256
-        .as_deref()
-        .filter(|digest| digest.len() == 64)
-        .ok_or_else(|| AppError::BadRequest("bundle digest is missing".into()))?;
-    let mut unsigned = bundle.clone();
-    unsigned.payload_sha256 = None;
-    let payload = serde_json::to_vec(&unsigned)
-        .map_err(|error| AppError::BadRequest(format!("serializing bundle: {error}")))?;
-    let actual = digest_hex(&payload);
-    if !constant_time_eq(actual.as_bytes(), digest.as_bytes()) {
-        return Err(AppError::BadRequest("bundle digest is invalid".into()));
+    for required in required_tables(bundle.operation) {
+        if !bundle.tables.contains_key(*required) {
+            return Err(AppError::BadRequest(format!(
+                "bundle is missing the {required} table, which this operation needs"
+            )));
+        }
     }
 
     let allowed = allowed_tables(bundle.operation);
@@ -524,12 +597,23 @@ fn materialize_bundle(
 ) -> anyhow::Result<()> {
     let connection = Connection::open(path)?;
     connection.execute_batch("PRAGMA journal_mode=DELETE; PRAGMA foreign_keys=OFF;")?;
+    let mut template = None;
     for table_name in allowed_tables(bundle.operation) {
         if let Some(table) = bundle.tables.get(*table_name) {
             create_bundle_table(&connection, table_name, table)?;
             insert_bundle_rows(&connection, table_name, table)?;
-        } else if bundle.operation != SyncOperation::PushGrades {
-            create_empty_table_from_template(&connection, template_path, table_name)?;
+        } else {
+            // An omitted optional table still has to exist for the sync
+            // engine to read, so borrow the destination's own DDL. One
+            // connection serves every miss.
+            if template.is_none() {
+                template = Some(Connection::open_with_flags(
+                    template_path,
+                    OpenFlags::SQLITE_OPEN_READ_ONLY,
+                )?);
+            }
+            let template = template.as_ref().expect("template connection is open");
+            create_empty_table_from_template(&connection, template, table_name)?;
         }
     }
     connection.pragma_update(None, "user_version", bundle.source.schema_version)?;
@@ -569,10 +653,9 @@ fn create_bundle_table(
 
 fn create_empty_table_from_template(
     destination: &Connection,
-    template_path: &FsPath,
+    template: &Connection,
     name: &str,
 ) -> anyhow::Result<()> {
-    let template = Connection::open_with_flags(template_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
     let sql: String = template.query_row(
         "SELECT sql FROM sqlite_master WHERE type='table' AND lower(name)=lower(?1)",
         [name],
@@ -655,6 +738,7 @@ fn export_bundle(
         "Target Scheduler schema 22 or newer is required"
     );
     let mut tables = BTreeMap::new();
+    let mut row_count = 0usize;
     for name in allowed_tables(operation) {
         let selected = if operation == SyncOperation::PushGrades {
             Some(&["guid", "gradingStatus", "rejectreason"][..])
@@ -663,10 +747,18 @@ fn export_bundle(
         };
         let where_clause = (operation == SyncOperation::PushGrades && reviewed_only)
             .then_some("gradingStatus <> 0");
-        tables.insert(
-            (*name).to_string(),
-            read_bundle_table(&connection, name, selected, where_clause)?,
+        let table = read_bundle_table(&connection, name, selected, where_clause)?;
+        // Bound the export the same way we bound an import. A merge pulls
+        // every acquiredimage row and every imagedata blob, so an unbounded
+        // build is how the server runs itself out of memory answering one
+        // request.
+        row_count = row_count.saturating_add(table.rows.len());
+        anyhow::ensure!(
+            row_count <= MAX_BUNDLE_ROWS,
+            "this database exceeds the {MAX_BUNDLE_ROWS} row export limit; \
+             narrow the operation or sync in smaller pieces"
         );
+        tables.insert((*name).to_string(), table);
     }
     let mut bundle = CatalogBundle {
         protocol_version: PROTOCOL_VERSION,
@@ -840,6 +932,17 @@ fn allowed_tables(operation: SyncOperation) -> &'static [&'static str] {
     }
 }
 
+/// Tables without which the operation is a silent no-op. Anything else in
+/// `allowed_tables` may be omitted; the materializer creates it empty from the
+/// destination schema, and the sync engine then finds nothing to do.
+fn required_tables(operation: SyncOperation) -> &'static [&'static str] {
+    match operation {
+        SyncOperation::Merge => &["project", "target", "acquiredimage"],
+        SyncOperation::PushPlanning => &["project", "target", "exposureplan"],
+        SyncOperation::PushGrades => &["acquiredimage"],
+    }
+}
+
 fn sqlite_affinity(declared_type: &str) -> &'static str {
     let upper = declared_type.to_ascii_uppercase();
     if upper.contains("INT") {
@@ -867,16 +970,6 @@ fn quote_identifier(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\"\""))
 }
 
-fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
-    if left.len() != right.len() {
-        return false;
-    }
-    left.iter()
-        .zip(right)
-        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
-        == 0
-}
-
 fn digest_hex(value: &[u8]) -> String {
     use std::fmt::Write as _;
 
@@ -888,14 +981,17 @@ fn digest_hex(value: &[u8]) -> String {
     result
 }
 
+fn unix_seconds() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
 fn unix_timestamp(value: i64) -> String {
     DateTime::<Utc>::from_timestamp(value, 0)
         .expect("sync preview timestamps are valid")
         .to_rfc3339_opts(SecondsFormat::Secs, true)
-}
-
-fn exports() -> &'static Mutex<HashMap<String, (String, SyncExport)>> {
-    EXPORTS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 fn internal(error: impl std::fmt::Display) -> AppError {
@@ -906,27 +1002,67 @@ fn internal(error: impl std::fmt::Display) -> AppError {
 mod tests {
     use super::*;
 
-    #[test]
-    fn accepts_the_plugin_canonical_digest_fixture() {
-        let json = r#"{
+    fn grades_bundle(tables: &str, digest: &str) -> CatalogBundle {
+        let json = format!(
+            r#"{{
             "protocol_version":1,
             "bundle_id":"b03b8ab1-ce43-4a87-a4fb-68497394cedb",
             "created_at_utc":"2026-07-23T12:00:00+00:00",
             "operation":"push_grades",
-            "source":{
+            "source":{{
                 "id":"source",
                 "product":"Target Scheduler",
                 "product_version":"5.9.6.0",
                 "schema_version":23
-            },
-            "tables":{},
-            "payload_sha256":"5d18d681485f57377c33dffc26dd1b08d79448ec2c819dee08ebdd22ad278d42"
-        }"#;
-        let bundle: CatalogBundle = serde_json::from_str(json).unwrap();
-        validate_bundle(&bundle).unwrap();
+            }},
+            "tables":{tables}
+            {digest}
+        }}"#
+        );
+        serde_json::from_str(&json).unwrap()
+    }
 
-        let mut changed = bundle;
-        changed.source.product_version = "different".into();
-        assert!(validate_bundle(&changed).is_err());
+    const ACQUIRED_IMAGE: &str = r#"{
+        "acquiredimage":{
+            "columns":[{"name":"guid","declared_type":"TEXT","not_null":false,"primary_key":false}],
+            "rows":[{"values":[{"kind":"text","value":"a-guid"}]}]
+        }
+    }"#;
+
+    #[test]
+    fn accepts_a_bundle_whose_digest_is_absent_or_stale() {
+        // The digest is advisory. A plugin that omits it, or that computes it
+        // over a different JSON encoding than ours, still syncs.
+        validate_bundle(&grades_bundle(ACQUIRED_IMAGE, "")).unwrap();
+        validate_bundle(&grades_bundle(
+            ACQUIRED_IMAGE,
+            r#","payload_sha256":"0000000000000000000000000000000000000000000000000000000000000000""#,
+        ))
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_a_bundle_missing_the_table_its_operation_needs() {
+        let error = validate_bundle(&grades_bundle("{}", "")).unwrap_err();
+        assert!(
+            matches!(&error, AppError::BadRequest(message) if message.contains("acquiredimage")),
+            "expected a 400 naming the table, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_table_outside_the_operation() {
+        let error = validate_bundle(&grades_bundle(
+            r#"{
+                "project":{"columns":[{"name":"guid","declared_type":"TEXT","not_null":false,"primary_key":false}],"rows":[]},
+                "acquiredimage":{"columns":[{"name":"guid","declared_type":"TEXT","not_null":false,"primary_key":false}],"rows":[]}
+            }"#,
+            "",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(&error, AppError::BadRequest(message) if message.contains("project")),
+            "expected a 400 naming the table, got {error:?}"
+        );
     }
 }

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -1,0 +1,932 @@
+//! Token-authenticated database sync for remote N.I.N.A. clients.
+//!
+//! The wire format is deliberately database-shaped: a client freezes selected
+//! Target Scheduler tables into a signed JSON bundle, while PSF Guard
+//! materializes that bundle as a temporary SQLite source and delegates every
+//! merge decision to the existing local database sync engine.
+
+use axum::{
+    extract::{Path, State},
+    http::{header::AUTHORIZATION, HeaderMap},
+    Json,
+};
+use base64::Engine as _;
+use chrono::{DateTime, SecondsFormat, Utc};
+use rusqlite::{
+    params_from_iter,
+    types::{Value, ValueRef},
+    Connection, OpenFlags,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::{Path as FsPath, PathBuf},
+    sync::{Arc, Mutex, OnceLock},
+};
+use uuid::Uuid;
+
+use crate::server::{
+    api::{
+        ApiResponse, SchedulerSyncKind, SchedulerSyncRequest, SchedulerSyncResponse,
+        SchedulerSyncTableCounts,
+    },
+    database_context::DatabaseContext,
+    handlers::{execute_scheduler_sync_paths, AppError, SyncGuardMode},
+    state::AppState,
+};
+
+pub const MAX_SYNC_BODY_BYTES: usize = 128 * 1024 * 1024;
+const MAX_BUNDLE_ROWS: usize = 250_000;
+const PROTOCOL_VERSION: u32 = 1;
+const PLANNING_TABLES: &[&str] = &[
+    "exposuretemplate",
+    "project",
+    "ruleweight",
+    "target",
+    "exposureplan",
+];
+const MERGE_TABLES: &[&str] = &[
+    "exposuretemplate",
+    "project",
+    "ruleweight",
+    "target",
+    "exposureplan",
+    "acquiredimage",
+    "imagedata",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncOperation {
+    Merge,
+    PushPlanning,
+    PushGrades,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogIdentity {
+    pub id: String,
+    pub product: String,
+    pub product_version: String,
+    pub schema_version: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BundleColumn {
+    pub name: String,
+    pub declared_type: String,
+    pub not_null: bool,
+    pub primary_key: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BundleRow {
+    pub values: Vec<WireValue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BundleTable {
+    pub columns: Vec<BundleColumn>,
+    pub rows: Vec<BundleRow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WireValueKind {
+    Null,
+    Integer,
+    Real,
+    Text,
+    Blob,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WireValue {
+    pub kind: WireValueKind,
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogBundle {
+    pub protocol_version: u32,
+    pub bundle_id: String,
+    pub created_at_utc: String,
+    pub operation: SyncOperation,
+    pub source: CatalogIdentity,
+    pub tables: BTreeMap<String, BundleTable>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_sha256: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreatePreviewRequest {
+    pub protocol_version: u32,
+    pub catalog_id: String,
+    pub operation: SyncOperation,
+    pub bundle: CatalogBundle,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateExportRequest {
+    pub protocol_version: u32,
+    pub catalog_id: String,
+    pub operation: SyncOperation,
+    #[serde(default = "default_true")]
+    pub reviewed_only: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize)]
+pub struct SyncCatalogCapability {
+    pub id: String,
+    pub name: String,
+    pub readable: bool,
+    pub writable: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SyncCapabilities {
+    pub protocol_version: u32,
+    pub product: &'static str,
+    pub product_version: &'static str,
+    pub capabilities: Vec<&'static str>,
+    pub catalogs: Vec<SyncCatalogCapability>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyncPreview {
+    pub preview_id: String,
+    pub state: &'static str,
+    pub expires_at: String,
+    pub summary: BTreeMap<String, i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SyncApplyResult {
+    pub state: &'static str,
+    pub summary: BTreeMap<String, i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyncExport {
+    pub export_id: String,
+    pub state: &'static str,
+    pub bundle: Option<CatalogBundle>,
+    pub error: Option<String>,
+}
+
+static EXPORTS: OnceLock<Mutex<HashMap<String, (String, SyncExport)>>> = OnceLock::new();
+
+pub async fn capabilities(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<ApiResponse<SyncCapabilities>>, AppError> {
+    let catalog = authenticated_catalog(&state, &headers)?;
+    Ok(Json(ApiResponse::success(SyncCapabilities {
+        protocol_version: PROTOCOL_VERSION,
+        product: "PSF Guard",
+        product_version: env!("CARGO_PKG_VERSION"),
+        capabilities: vec![
+            "merge",
+            "push_planning",
+            "push_grades",
+            "preview_apply",
+            "exports",
+            "image_upload",
+        ],
+        catalogs: vec![SyncCatalogCapability {
+            id: catalog.id.clone(),
+            name: catalog.name.clone(),
+            readable: true,
+            writable: true,
+        }],
+    })))
+}
+
+pub async fn create_preview(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreatePreviewRequest>,
+) -> Result<Json<ApiResponse<SyncPreview>>, AppError> {
+    let catalog = authenticated_catalog(&state, &headers)?;
+    require_protocol(request.protocol_version)?;
+    require_catalog(&catalog, &request.catalog_id)?;
+    if request.operation != request.bundle.operation {
+        return Err(AppError::BadRequest(
+            "request operation does not match bundle operation".into(),
+        ));
+    }
+    validate_bundle(&request.bundle)?;
+
+    let destination_path = PathBuf::from(&catalog.database_path);
+    let bundle = request.bundle;
+    let source_id = bundle.source.id.clone();
+    let operation = request.operation;
+    let snapshot_file = state
+        .sync_previews
+        .create_empty_source_snapshot()
+        .map_err(internal)?;
+    let snapshot_path = state
+        .sync_previews
+        .source_snapshot_path_for_file(&snapshot_file)
+        .map_err(internal)?;
+    let materialize_path = snapshot_path.clone();
+    let template_path = destination_path.clone();
+    if let Err(error) = tokio::task::spawn_blocking(move || {
+        materialize_bundle(&materialize_path, &template_path, &bundle)
+    })
+    .await
+    .map_err(|error| AppError::InternalError(format!("bundle task failed: {error}")))?
+    {
+        state.sync_previews.remove_source_snapshot(&snapshot_file);
+        return Err(AppError::BadRequest(format!(
+            "invalid catalog bundle: {error:#}"
+        )));
+    }
+
+    let sync_request = scheduler_request(operation, source_id.clone(), true);
+    let execution = execute_scheduler_sync_paths(
+        &state,
+        snapshot_path,
+        destination_path,
+        source_id,
+        catalog.id.clone(),
+        sync_request.clone(),
+        SyncGuardMode::Preview,
+    )
+    .await;
+    let (result, fingerprint) = match execution {
+        Ok((result, Some(fingerprint))) => (result, fingerprint),
+        Ok(_) => unreachable!("preview execution returns a fingerprint"),
+        Err(error) => {
+            state.sync_previews.remove_source_snapshot(&snapshot_file);
+            return Err(error);
+        }
+    };
+    let record = state
+        .sync_previews
+        .store(
+            catalog.id.clone(),
+            sync_request,
+            snapshot_file.clone(),
+            fingerprint,
+            result.clone(),
+        )
+        .map_err(|error| {
+            state.sync_previews.remove_source_snapshot(&snapshot_file);
+            internal(error)
+        })?;
+    Ok(Json(ApiResponse::success(SyncPreview {
+        preview_id: record.id,
+        state: "ready",
+        expires_at: unix_timestamp(record.expires_at),
+        summary: result_summary(&result),
+    })))
+}
+
+pub async fn get_preview(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(preview_id): Path<String>,
+) -> Result<Json<ApiResponse<SyncPreview>>, AppError> {
+    let catalog = authenticated_catalog(&state, &headers)?;
+    let record = state
+        .sync_previews
+        .get(&preview_id)
+        .map_err(internal)?
+        .filter(|record| record.local_db_id == catalog.id)
+        .ok_or(AppError::NotFound)?;
+    Ok(Json(ApiResponse::success(SyncPreview {
+        preview_id: record.id,
+        state: "ready",
+        expires_at: unix_timestamp(record.expires_at),
+        summary: result_summary(&record.result),
+    })))
+}
+
+pub async fn apply_preview(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(preview_id): Path<String>,
+) -> Result<Json<ApiResponse<SyncApplyResult>>, AppError> {
+    let catalog = authenticated_catalog(&state, &headers)?;
+    let _apply_guard = state.sync_apply_lock.lock().await;
+    let record = state
+        .sync_previews
+        .claim(&preview_id, &catalog.id)
+        .map_err(internal)?
+        .ok_or(AppError::NotFound)?;
+    let source_path = state
+        .sync_previews
+        .source_snapshot_path(&record)
+        .map_err(internal)?;
+    let mut request = record.request;
+    request.dry_run = false;
+    let result = execute_scheduler_sync_paths(
+        &state,
+        source_path,
+        PathBuf::from(&catalog.database_path),
+        request.peer_db_id.clone(),
+        catalog.id.clone(),
+        request,
+        SyncGuardMode::Apply {
+            destination_fingerprint: record.destination_fingerprint,
+        },
+    )
+    .await
+    .map(|(result, _)| result);
+    state
+        .sync_previews
+        .remove_source_snapshot(&record.source_snapshot_file);
+    let result = result?;
+    Ok(Json(ApiResponse::success(SyncApplyResult {
+        state: "applied",
+        summary: result_summary(&result),
+    })))
+}
+
+pub async fn create_export(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreateExportRequest>,
+) -> Result<Json<ApiResponse<SyncExport>>, AppError> {
+    let catalog = authenticated_catalog(&state, &headers)?;
+    require_protocol(request.protocol_version)?;
+    require_catalog(&catalog, &request.catalog_id)?;
+    let database_path = PathBuf::from(&catalog.database_path);
+    let catalog_id = catalog.id.clone();
+    let operation = request.operation;
+    let reviewed_only = request.reviewed_only;
+    let bundle = tokio::task::spawn_blocking(move || {
+        export_bundle(&database_path, &catalog_id, operation, reviewed_only)
+    })
+    .await
+    .map_err(|error| AppError::InternalError(format!("export task failed: {error}")))?
+    .map_err(|error| AppError::BadRequest(format!("creating export: {error:#}")))?;
+    let export = SyncExport {
+        export_id: Uuid::new_v4().to_string(),
+        state: "ready",
+        bundle: Some(bundle),
+        error: None,
+    };
+    let mut exports = exports().lock().map_err(|error| {
+        AppError::InternalError(format!("remote export lock poisoned: {error}"))
+    })?;
+    if exports.len() >= 16
+        && let Some(key) = exports.keys().next().cloned()
+    {
+        exports.remove(&key);
+    }
+    exports.insert(
+        export.export_id.clone(),
+        (catalog.id.clone(), export.clone()),
+    );
+    drop(exports);
+    Ok(Json(ApiResponse::success(export)))
+}
+
+pub async fn get_export(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(export_id): Path<String>,
+) -> Result<Json<ApiResponse<SyncExport>>, AppError> {
+    let catalog = authenticated_catalog(&state, &headers)?;
+    let exports = exports().lock().map_err(|error| {
+        AppError::InternalError(format!("remote export lock poisoned: {error}"))
+    })?;
+    let export = exports
+        .get(&export_id)
+        .filter(|(catalog_id, _)| catalog_id == &catalog.id)
+        .map(|(_, export)| export.clone())
+        .ok_or(AppError::NotFound)?;
+    Ok(Json(ApiResponse::success(export)))
+}
+
+fn authenticated_catalog(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<Arc<DatabaseContext>, AppError> {
+    let header = headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| AppError::Forbidden("Bearer token required".into()))?;
+    let token = header
+        .strip_prefix("Bearer ")
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| AppError::Forbidden("Bearer token required".into()))?;
+    let mut matches = state.all_databases().into_iter().filter(|catalog| {
+        catalog
+            .remote_image_upload
+            .as_ref()
+            .is_some_and(|config| config.token_is_configured() && config.token_matches(token))
+    });
+    let catalog = matches
+        .next()
+        .ok_or_else(|| AppError::Forbidden("Invalid API token".into()))?;
+    if matches.next().is_some() {
+        return Err(AppError::Forbidden(
+            "API token is configured for more than one database".into(),
+        ));
+    }
+    Ok(catalog)
+}
+
+fn require_protocol(version: u32) -> Result<(), AppError> {
+    if version == PROTOCOL_VERSION {
+        Ok(())
+    } else {
+        Err(AppError::BadRequest(format!(
+            "unsupported sync protocol version {version}"
+        )))
+    }
+}
+
+fn require_catalog(catalog: &DatabaseContext, requested: &str) -> Result<(), AppError> {
+    if catalog.id == requested {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden(
+            "API token does not grant access to the requested catalog".into(),
+        ))
+    }
+}
+
+fn validate_bundle(bundle: &CatalogBundle) -> Result<(), AppError> {
+    require_protocol(bundle.protocol_version)?;
+    Uuid::parse_str(&bundle.bundle_id)
+        .map_err(|_| AppError::BadRequest("bundle_id must be a UUID".into()))?;
+    DateTime::parse_from_rfc3339(&bundle.created_at_utc)
+        .map_err(|_| AppError::BadRequest("created_at_utc must be RFC 3339".into()))?;
+    if bundle.source.schema_version < 22 {
+        return Err(AppError::BadRequest(
+            "Target Scheduler schema 22 or newer is required".into(),
+        ));
+    }
+    let digest = bundle
+        .payload_sha256
+        .as_deref()
+        .filter(|digest| digest.len() == 64)
+        .ok_or_else(|| AppError::BadRequest("bundle digest is missing".into()))?;
+    let mut unsigned = bundle.clone();
+    unsigned.payload_sha256 = None;
+    let payload = serde_json::to_vec(&unsigned)
+        .map_err(|error| AppError::BadRequest(format!("serializing bundle: {error}")))?;
+    let actual = digest_hex(&payload);
+    if !constant_time_eq(actual.as_bytes(), digest.as_bytes()) {
+        return Err(AppError::BadRequest("bundle digest is invalid".into()));
+    }
+
+    let allowed = allowed_tables(bundle.operation);
+    let mut row_count = 0usize;
+    for (name, table) in &bundle.tables {
+        if !allowed.contains(&name.as_str()) || !valid_identifier(name) {
+            return Err(AppError::BadRequest(format!(
+                "table {name} is not syncable for this operation"
+            )));
+        }
+        if table.columns.is_empty()
+            || table.columns.len() > 256
+            || table
+                .columns
+                .iter()
+                .any(|column| !valid_identifier(&column.name))
+        {
+            return Err(AppError::BadRequest(format!(
+                "table {name} has invalid columns"
+            )));
+        }
+        for row in &table.rows {
+            if row.values.len() != table.columns.len() {
+                return Err(AppError::BadRequest(format!(
+                    "table {name} contains a row with the wrong value count"
+                )));
+            }
+        }
+        row_count = row_count.saturating_add(table.rows.len());
+    }
+    if row_count > MAX_BUNDLE_ROWS {
+        return Err(AppError::BadRequest(format!(
+            "bundle exceeds the {MAX_BUNDLE_ROWS} row limit"
+        )));
+    }
+    Ok(())
+}
+
+fn materialize_bundle(
+    path: &FsPath,
+    template_path: &FsPath,
+    bundle: &CatalogBundle,
+) -> anyhow::Result<()> {
+    let connection = Connection::open(path)?;
+    connection.execute_batch("PRAGMA journal_mode=DELETE; PRAGMA foreign_keys=OFF;")?;
+    for table_name in allowed_tables(bundle.operation) {
+        if let Some(table) = bundle.tables.get(*table_name) {
+            create_bundle_table(&connection, table_name, table)?;
+            insert_bundle_rows(&connection, table_name, table)?;
+        } else if bundle.operation != SyncOperation::PushGrades {
+            create_empty_table_from_template(&connection, template_path, table_name)?;
+        }
+    }
+    connection.pragma_update(None, "user_version", bundle.source.schema_version)?;
+    Ok(())
+}
+
+fn create_bundle_table(
+    connection: &Connection,
+    name: &str,
+    table: &BundleTable,
+) -> anyhow::Result<()> {
+    let columns = table
+        .columns
+        .iter()
+        .map(|column| {
+            let mut sql = format!(
+                "{} {}",
+                quote_identifier(&column.name),
+                sqlite_affinity(&column.declared_type)
+            );
+            if column.primary_key {
+                sql.push_str(" PRIMARY KEY");
+            }
+            if column.not_null {
+                sql.push_str(" NOT NULL");
+            }
+            sql
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    connection.execute_batch(&format!(
+        "CREATE TABLE {} ({columns})",
+        quote_identifier(name)
+    ))?;
+    Ok(())
+}
+
+fn create_empty_table_from_template(
+    destination: &Connection,
+    template_path: &FsPath,
+    name: &str,
+) -> anyhow::Result<()> {
+    let template = Connection::open_with_flags(template_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let sql: String = template.query_row(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND lower(name)=lower(?1)",
+        [name],
+        |row| row.get(0),
+    )?;
+    destination.execute_batch(&sql)?;
+    Ok(())
+}
+
+fn insert_bundle_rows(
+    connection: &Connection,
+    name: &str,
+    table: &BundleTable,
+) -> anyhow::Result<()> {
+    let columns = table
+        .columns
+        .iter()
+        .map(|column| quote_identifier(&column.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let placeholders = (1..=table.columns.len())
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "INSERT INTO {} ({columns}) VALUES ({placeholders})",
+        quote_identifier(name)
+    );
+    let mut statement = connection.prepare(&sql)?;
+    for row in &table.rows {
+        let values = row
+            .values
+            .iter()
+            .map(wire_to_sqlite)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        statement.execute(params_from_iter(values))?;
+    }
+    Ok(())
+}
+
+fn wire_to_sqlite(value: &WireValue) -> anyhow::Result<Value> {
+    Ok(match value.kind {
+        WireValueKind::Null => Value::Null,
+        WireValueKind::Integer => Value::Integer(
+            value
+                .value
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("integer wire value is empty"))?
+                .parse()?,
+        ),
+        WireValueKind::Real => Value::Real(
+            value
+                .value
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("real wire value is empty"))?
+                .parse()?,
+        ),
+        WireValueKind::Text => Value::Text(value.value.clone().unwrap_or_default()),
+        WireValueKind::Blob => Value::Blob(
+            base64::engine::general_purpose::STANDARD.decode(
+                value
+                    .value
+                    .as_deref()
+                    .ok_or_else(|| anyhow::anyhow!("blob wire value is empty"))?,
+            )?,
+        ),
+    })
+}
+
+fn export_bundle(
+    database_path: &FsPath,
+    catalog_id: &str,
+    operation: SyncOperation,
+    reviewed_only: bool,
+) -> anyhow::Result<CatalogBundle> {
+    let connection = Connection::open_with_flags(database_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let schema_version: i64 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    anyhow::ensure!(
+        schema_version >= 22,
+        "Target Scheduler schema 22 or newer is required"
+    );
+    let mut tables = BTreeMap::new();
+    for name in allowed_tables(operation) {
+        let selected = if operation == SyncOperation::PushGrades {
+            Some(&["guid", "gradingStatus", "rejectreason"][..])
+        } else {
+            None
+        };
+        let where_clause = (operation == SyncOperation::PushGrades && reviewed_only)
+            .then_some("gradingStatus <> 0");
+        tables.insert(
+            (*name).to_string(),
+            read_bundle_table(&connection, name, selected, where_clause)?,
+        );
+    }
+    let mut bundle = CatalogBundle {
+        protocol_version: PROTOCOL_VERSION,
+        bundle_id: Uuid::new_v4().to_string(),
+        created_at_utc: Utc::now().to_rfc3339_opts(SecondsFormat::AutoSi, true),
+        operation,
+        source: CatalogIdentity {
+            id: catalog_id.to_string(),
+            product: "PSF Guard / N.I.N.A. Target Scheduler".into(),
+            product_version: env!("CARGO_PKG_VERSION").into(),
+            schema_version,
+        },
+        tables,
+        payload_sha256: None,
+    };
+    let payload = serde_json::to_vec(&bundle)?;
+    bundle.payload_sha256 = Some(digest_hex(&payload));
+    Ok(bundle)
+}
+
+fn read_bundle_table(
+    connection: &Connection,
+    name: &str,
+    selected: Option<&[&str]>,
+    where_clause: Option<&str>,
+) -> anyhow::Result<BundleTable> {
+    let mut schema_statement =
+        connection.prepare(&format!("PRAGMA table_info({})", quote_identifier(name)))?;
+    let all_columns = schema_statement
+        .query_map([], |row| {
+            Ok(BundleColumn {
+                name: row.get(1)?,
+                declared_type: row.get(2)?,
+                not_null: row.get::<_, i64>(3)? != 0,
+                primary_key: row.get::<_, i64>(5)? != 0,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let columns = if let Some(selected) = selected {
+        selected
+            .iter()
+            .map(|wanted| {
+                all_columns
+                    .iter()
+                    .find(|column| column.name.eq_ignore_ascii_case(wanted))
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("table {name} is missing column {wanted}"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?
+    } else {
+        all_columns
+    };
+    anyhow::ensure!(!columns.is_empty(), "table {name} is missing");
+    let select = columns
+        .iter()
+        .map(|column| quote_identifier(&column.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let order = columns
+        .iter()
+        .find(|column| column.name.eq_ignore_ascii_case("Id"))
+        .map(|column| format!(" ORDER BY {}", quote_identifier(&column.name)))
+        .unwrap_or_default();
+    let sql = format!(
+        "SELECT {select} FROM {}{}{}",
+        quote_identifier(name),
+        where_clause
+            .map(|clause| format!(" WHERE {clause}"))
+            .unwrap_or_default(),
+        order
+    );
+    let mut statement = connection.prepare(&sql)?;
+    let column_count = columns.len();
+    let rows = statement
+        .query_map([], |row| {
+            let mut values = Vec::with_capacity(column_count);
+            for index in 0..column_count {
+                values.push(sqlite_to_wire(row.get_ref(index)?));
+            }
+            Ok(BundleRow { values })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(BundleTable { columns, rows })
+}
+
+fn sqlite_to_wire(value: ValueRef<'_>) -> WireValue {
+    let (kind, value) = match value {
+        ValueRef::Null => (WireValueKind::Null, None),
+        ValueRef::Integer(value) => (WireValueKind::Integer, Some(value.to_string())),
+        ValueRef::Real(value) => (WireValueKind::Real, Some(value.to_string())),
+        ValueRef::Text(value) => (
+            WireValueKind::Text,
+            Some(String::from_utf8_lossy(value).into_owned()),
+        ),
+        ValueRef::Blob(value) => (
+            WireValueKind::Blob,
+            Some(base64::engine::general_purpose::STANDARD.encode(value)),
+        ),
+    };
+    WireValue { kind, value }
+}
+
+fn scheduler_request(
+    operation: SyncOperation,
+    source_id: String,
+    dry_run: bool,
+) -> SchedulerSyncRequest {
+    SchedulerSyncRequest {
+        peer_db_id: source_id,
+        kind: match operation {
+            SyncOperation::Merge => SchedulerSyncKind::Pull,
+            SyncOperation::PushPlanning => SchedulerSyncKind::PushPlanning,
+            SyncOperation::PushGrades => SchedulerSyncKind::PushGrades,
+        },
+        dry_run,
+        with_image_data: Some(operation == SyncOperation::Merge),
+        project: None,
+        target: None,
+        status: None,
+        reviewed_only: false,
+    }
+}
+
+fn result_summary(result: &SchedulerSyncResponse) -> BTreeMap<String, i64> {
+    let mut summary = BTreeMap::from([
+        ("total_inserted".into(), result.total_inserted as i64),
+        ("total_updated".into(), result.total_updated as i64),
+        ("grade_filled".into(), result.grade_filled as i64),
+        ("grade_preserved".into(), result.grade_preserved as i64),
+        ("imagedata_bytes".into(), result.imagedata_bytes as i64),
+    ]);
+    for (name, counts) in [
+        ("exposuretemplate", &result.exposuretemplate),
+        ("project", &result.project),
+        ("ruleweight", &result.ruleweight),
+        ("target", &result.target),
+        ("exposureplan", &result.exposureplan),
+    ] {
+        add_table_summary(&mut summary, name, counts);
+    }
+    if let Some(counts) = &result.acquiredimage {
+        add_table_summary(&mut summary, "acquiredimage", counts);
+    }
+    if let Some(counts) = &result.imagedata {
+        add_table_summary(&mut summary, "imagedata", counts);
+    }
+    if let Some(grades) = &result.grades {
+        summary.insert("grades_matched".into(), grades.matched as i64);
+        summary.insert("grades_changed".into(), grades.changed as i64);
+        summary.insert("grades_unchanged".into(), grades.unchanged as i64);
+    }
+    summary
+}
+
+fn add_table_summary(
+    summary: &mut BTreeMap<String, i64>,
+    name: &str,
+    counts: &SchedulerSyncTableCounts,
+) {
+    summary.insert(format!("{name}_inserted"), counts.inserted as i64);
+    summary.insert(format!("{name}_updated"), counts.updated as i64);
+    summary.insert(format!("{name}_unchanged"), counts.unchanged as i64);
+    summary.insert(format!("{name}_skipped"), counts.skipped as i64);
+}
+
+fn allowed_tables(operation: SyncOperation) -> &'static [&'static str] {
+    match operation {
+        SyncOperation::Merge => MERGE_TABLES,
+        SyncOperation::PushPlanning => PLANNING_TABLES,
+        SyncOperation::PushGrades => &["acquiredimage"],
+    }
+}
+
+fn sqlite_affinity(declared_type: &str) -> &'static str {
+    let upper = declared_type.to_ascii_uppercase();
+    if upper.contains("INT") {
+        "INTEGER"
+    } else if upper.contains("CHAR") || upper.contains("CLOB") || upper.contains("TEXT") {
+        "TEXT"
+    } else if upper.contains("BLOB") || upper.is_empty() {
+        "BLOB"
+    } else if upper.contains("REAL") || upper.contains("FLOA") || upper.contains("DOUB") {
+        "REAL"
+    } else {
+        "NUMERIC"
+    }
+}
+
+fn valid_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
+        == 0
+}
+
+fn digest_hex(value: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let digest = Sha256::digest(value);
+    let mut result = String::with_capacity(64);
+    for byte in digest {
+        write!(&mut result, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    result
+}
+
+fn unix_timestamp(value: i64) -> String {
+    DateTime::<Utc>::from_timestamp(value, 0)
+        .expect("sync preview timestamps are valid")
+        .to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn exports() -> &'static Mutex<HashMap<String, (String, SyncExport)>> {
+    EXPORTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn internal(error: impl std::fmt::Display) -> AppError {
+    AppError::InternalError(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_the_plugin_canonical_digest_fixture() {
+        let json = r#"{
+            "protocol_version":1,
+            "bundle_id":"b03b8ab1-ce43-4a87-a4fb-68497394cedb",
+            "created_at_utc":"2026-07-23T12:00:00+00:00",
+            "operation":"push_grades",
+            "source":{
+                "id":"source",
+                "product":"Target Scheduler",
+                "product_version":"5.9.6.0",
+                "schema_version":23
+            },
+            "tables":{},
+            "payload_sha256":"5d18d681485f57377c33dffc26dd1b08d79448ec2c819dee08ebdd22ad278d42"
+        }"#;
+        let bundle: CatalogBundle = serde_json::from_str(json).unwrap();
+        validate_bundle(&bundle).unwrap();
+
+        let mut changed = bundle;
+        changed.source.product_version = "different".into();
+        assert!(validate_bundle(&changed).is_err());
+    }
+}

--- a/src/server/scheduler.rs
+++ b/src/server/scheduler.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use crate::db::Database;
 use crate::server::api::{ApiResponse, UpdateProjectRequest, UpdateTargetRequest};
 use crate::server::extract::DbContext;
-use crate::server::handlers::{require_database_management_allowed, AppError};
+use crate::server::handlers::AppError;
 use crate::server::state::AppState;
 
 #[derive(Debug, Serialize)]
@@ -548,12 +548,11 @@ pub fn update_target_fields(
 }
 
 pub async fn create_exposure_plan(
-    State(state): State<Arc<AppState>>,
+    State(_state): State<Arc<AppState>>,
     ctx: DbContext,
     Path((_db_id, target_id)): Path<(String, i32)>,
     Json(req): Json<CreateExposurePlanRequest>,
 ) -> Result<Json<ApiResponse<ExposurePlanResponse>>, AppError> {
-    require_database_management_allowed(&state)?;
     let filter_name = req.filter_name.as_deref().unwrap_or_default().trim();
     if req.exposure_template_id.is_none() && filter_name.is_empty() {
         return Err(AppError::BadRequest("filter name must not be empty".into()));
@@ -685,12 +684,11 @@ pub async fn create_exposure_plan(
 }
 
 pub async fn update_exposure_plan(
-    State(state): State<Arc<AppState>>,
+    State(_state): State<Arc<AppState>>,
     ctx: DbContext,
     Path((_db_id, plan_id)): Path<(String, i32)>,
     Json(req): Json<UpdateExposurePlanRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, AppError> {
-    require_database_management_allowed(&state)?;
     validate_plan_values(req.exposure, req.desired)?;
     let conn = ctx.db();
     let conn = conn.lock().map_err(AppError::db)?;

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -71,6 +71,8 @@ pub struct AppState {
     /// Serializes guarded transfer applies so one preview cannot invalidate
     /// another between its stale check and transaction.
     pub sync_apply_lock: tokio::sync::Mutex<()>,
+    /// Export bundles built for remote sync clients, capacity- and time-bound.
+    pub remote_exports: crate::server::remote_sync::ExportStore,
     /// Process-global Seiza catalogs and capability diagnostics. Catalogs are
     /// shared across databases and opened lazily on first use.
     pub astrometry: Arc<crate::astrometry::AstrometryContext>,
@@ -372,6 +374,7 @@ impl AppState {
             catalog_install: crate::server::catalog_install::CatalogInstallManager::default(),
             sync_previews: crate::server::sync_preview::SyncPreviewManager::new(&cache_dir),
             sync_apply_lock: tokio::sync::Mutex::new(()),
+            remote_exports: crate::server::remote_sync::ExportStore::new(),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::new(astrometry_config)),
             satellites: Arc::new(satellites),
         })
@@ -492,6 +495,7 @@ impl AppState {
                 "/tmp/psf-guard-test",
             ),
             sync_apply_lock: tokio::sync::Mutex::new(()),
+            remote_exports: crate::server::remote_sync::ExportStore::new(),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::default()),
             satellites: Arc::new(
                 crate::satellites::SatelliteContext::new(

--- a/src/server/sync_preview.rs
+++ b/src/server/sync_preview.rs
@@ -119,6 +119,17 @@ impl SyncPreviewManager {
         Ok(filename)
     }
 
+    /// Reserve a durable snapshot path for a remote bundle materializer.
+    pub fn create_empty_source_snapshot(&self) -> Result<String> {
+        fs::create_dir_all(&self.directory).with_context(|| {
+            format!(
+                "creating sync preview directory {}",
+                self.directory.display()
+            )
+        })?;
+        Ok(format!("{}.source.sqlite", Uuid::new_v4()))
+    }
+
     pub fn source_snapshot_path(&self, record: &SyncPreviewRecord) -> Result<PathBuf> {
         self.source_snapshot_path_for_file(&record.source_snapshot_file)
     }

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -210,6 +210,7 @@ export const apiClient = {
         enabled: boolean;
         image_directory?: string;
         token?: string;
+        sync_enabled?: boolean;
       };
     }
   ): Promise<DatabaseSummary> => {

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -727,6 +727,8 @@ export interface RemoteImageUploadSummary {
   enabled: boolean;
   image_directory?: string;
   token_configured: boolean;
+  /** Remote scheduler sync is a separate grant from image upload. */
+  sync_enabled: boolean;
 }
 
 export type SchedulerSyncKind = 'pull' | 'push_planning' | 'push_grades';

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -374,11 +374,19 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
           return;
         }
         if (
-          formRemoteUploadEnabled &&
-          !formRemoteUploadTokenConfigured &&
+          formRemoteUploadToken.length > 0 &&
           formRemoteUploadToken.length < 24
         ) {
-          setStatusMessage('Remote upload token must be at least 24 characters');
+          setStatusMessage('Remote API key must be at least 24 characters');
+          setIsApplying(false);
+          return;
+        }
+        if (
+          formRemoteUploadEnabled &&
+          !formRemoteUploadTokenConfigured &&
+          formRemoteUploadToken.length === 0
+        ) {
+          setStatusMessage('Generate a remote API key before enabling image uploads');
           setIsApplying(false);
           return;
         }
@@ -843,6 +851,56 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
 
               {editingId && (
                 <div className="database-config">
+                  <label htmlFor="remote-upload-token">Remote API key:</label>
+                  <div className="remote-upload-token-row">
+                    <input
+                      id="remote-upload-token"
+                      type={formRemoteUploadTokenRevealed ? 'text' : 'password'}
+                      value={formRemoteUploadToken}
+                      onChange={(event) => {
+                        setFormRemoteUploadToken(event.target.value);
+                        setFormRemoteUploadTokenCopyState('idle');
+                      }}
+                      placeholder={
+                        formRemoteUploadTokenConfigured
+                          ? 'Unchanged'
+                          : 'At least 24 characters'
+                      }
+                      className="file-path-input"
+                      autoComplete="new-password"
+                    />
+                    <button
+                      type="button"
+                      onClick={handleGenerateRemoteUploadToken}
+                      className="browse-button"
+                    >
+                      Generate
+                    </button>
+                    {formRemoteUploadTokenRevealed &&
+                      formRemoteUploadToken.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={handleCopyRemoteUploadToken}
+                          className="browse-button"
+                        >
+                          {formRemoteUploadTokenCopyState === 'copied'
+                            ? 'Copied'
+                            : 'Copy'}
+                        </button>
+                      )}
+                  </div>
+                  {formRemoteUploadTokenRevealed && (
+                    <small
+                      className={`remote-upload-token-notice ${
+                        formRemoteUploadTokenCopyState === 'failed' ? 'error' : ''
+                      }`}
+                      role="status"
+                    >
+                      {formRemoteUploadTokenCopyState === 'failed'
+                        ? 'Copy failed. Select and copy the key manually.'
+                        : 'Copy this key now. It will not be shown again after saving.'}
+                    </small>
+                  )}
                   <label className="quality-analysis-option">
                     <input
                       type="checkbox"
@@ -871,56 +929,6 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
                           </option>
                         ))}
                       </select>
-                      <label htmlFor="remote-upload-token">Upload token:</label>
-                      <div className="remote-upload-token-row">
-                        <input
-                          id="remote-upload-token"
-                          type={formRemoteUploadTokenRevealed ? 'text' : 'password'}
-                          value={formRemoteUploadToken}
-                          onChange={(event) => {
-                            setFormRemoteUploadToken(event.target.value);
-                            setFormRemoteUploadTokenCopyState('idle');
-                          }}
-                          placeholder={
-                            formRemoteUploadTokenConfigured
-                              ? 'Unchanged'
-                              : 'At least 24 characters'
-                          }
-                          className="file-path-input"
-                          autoComplete="new-password"
-                        />
-                        <button
-                          type="button"
-                          onClick={handleGenerateRemoteUploadToken}
-                          className="browse-button"
-                        >
-                          Generate
-                        </button>
-                        {formRemoteUploadTokenRevealed &&
-                          formRemoteUploadToken.length > 0 && (
-                            <button
-                              type="button"
-                              onClick={handleCopyRemoteUploadToken}
-                              className="browse-button"
-                            >
-                              {formRemoteUploadTokenCopyState === 'copied'
-                                ? 'Copied'
-                                : 'Copy'}
-                            </button>
-                          )}
-                      </div>
-                      {formRemoteUploadTokenRevealed && (
-                        <small
-                          className={`remote-upload-token-notice ${
-                            formRemoteUploadTokenCopyState === 'failed' ? 'error' : ''
-                          }`}
-                          role="status"
-                        >
-                          {formRemoteUploadTokenCopyState === 'failed'
-                            ? 'Copy failed. Select and copy the token manually.'
-                            : 'Copy this token now. It will not be shown again after saving.'}
-                        </small>
-                      )}
                     </>
                   )}
                 </div>

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -55,6 +55,7 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
   const [formDbPath, setFormDbPath] = useState('');
   const [formImageDirs, setFormImageDirs] = useState<string[]>([]);
   const [formRemoteUploadEnabled, setFormRemoteUploadEnabled] = useState(false);
+  const [formRemoteSyncEnabled, setFormRemoteSyncEnabled] = useState(false);
   const [formRemoteUploadDir, setFormRemoteUploadDir] = useState('');
   const [formRemoteUploadToken, setFormRemoteUploadToken] = useState('');
   const [formRemoteUploadTokenConfigured, setFormRemoteUploadTokenConfigured] =
@@ -106,6 +107,8 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
                   image_dir: summary.remote_image_upload?.image_directory,
                   token_configured:
                     summary.remote_image_upload?.token_configured ?? false,
+                  sync_enabled:
+                    summary.remote_image_upload?.sync_enabled ?? false,
                 },
               };
             }),
@@ -124,6 +127,7 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
               enabled: s.remote_image_upload?.enabled ?? false,
               image_dir: s.remote_image_upload?.image_directory,
               token_configured: s.remote_image_upload?.token_configured ?? false,
+              sync_enabled: s.remote_image_upload?.sync_enabled ?? false,
             },
           })),
         };
@@ -190,6 +194,7 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
     setFormDbPath(entry.db_path);
     setFormImageDirs(entry.image_dirs);
     setFormRemoteUploadEnabled(entry.remote_image_upload?.enabled ?? false);
+    setFormRemoteSyncEnabled(entry.remote_image_upload?.sync_enabled ?? false);
     setFormRemoteUploadDir(
       entry.remote_image_upload?.image_dir ?? entry.image_dirs[0] ?? ''
     );
@@ -390,6 +395,15 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
           setIsApplying(false);
           return;
         }
+        if (
+          formRemoteSyncEnabled &&
+          !formRemoteUploadTokenConfigured &&
+          formRemoteUploadToken.length === 0
+        ) {
+          setStatusMessage('Generate a remote API key before enabling scheduler sync');
+          setIsApplying(false);
+          return;
+        }
         await apiClient.updateDatabase(editingId, {
           name: inferredName,
           db_path: formDbPath.trim(),
@@ -398,6 +412,7 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
             enabled: formRemoteUploadEnabled,
             image_directory: formRemoteUploadDir || undefined,
             token: formRemoteUploadToken || undefined,
+            sync_enabled: formRemoteSyncEnabled,
           },
         });
       } else {
@@ -901,6 +916,22 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
                         : 'Copy this key now. It will not be shown again after saving.'}
                     </small>
                   )}
+                  <label className="quality-analysis-option">
+                    <input
+                      type="checkbox"
+                      checked={formRemoteSyncEnabled}
+                      onChange={(event) =>
+                        setFormRemoteSyncEnabled(event.target.checked)
+                      }
+                    />
+                    <span>
+                      <strong>Accept remote scheduler sync</strong>
+                      <small>
+                        Lets a holder of this key merge projects, targets,
+                        plans, and grades into this database.
+                      </small>
+                    </span>
+                  </label>
                   <label className="quality-analysis-option">
                     <input
                       type="checkbox"

--- a/static/src/components/__tests__/TauriSettings.test.tsx
+++ b/static/src/components/__tests__/TauriSettings.test.tsx
@@ -238,17 +238,17 @@ describe('TauriSettings import state', () => {
       screen.getByRole('checkbox', { name: 'Accept remote image uploads' })
     ).toBeChecked();
     expect(screen.getByLabelText('Receive directory:')).toHaveValue('/images/remote');
-    expect(screen.getByLabelText('Upload token:')).toHaveAttribute(
+    expect(screen.getByLabelText('Remote API key:')).toHaveAttribute(
       'placeholder',
       'Unchanged'
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Generate' }));
-    const generatedToken = screen.getByLabelText('Upload token:');
+    const generatedToken = screen.getByLabelText('Remote API key:');
     expect(generatedToken).toHaveAttribute('type', 'text');
     expect((generatedToken as HTMLInputElement).value).toMatch(/^[0-9a-f]{64}$/);
     expect(
-      screen.getByText('Copy this token now. It will not be shown again after saving.')
+      screen.getByText('Copy this key now. It will not be shown again after saving.')
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Copy' })).toBeEnabled();
   });

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -64,6 +64,7 @@ export interface DbEntry {
     image_dir?: string;
     token_sha256?: string;
     token_configured?: boolean;
+    sync_enabled?: boolean;
   };
 }
 

--- a/tests/integration_remote_sync.rs
+++ b/tests/integration_remote_sync.rs
@@ -41,9 +41,17 @@ fn schema(connection: &Connection) {
 fn api_config(token: &str) -> RemoteImageUploadConfig {
     let mut config = RemoteImageUploadConfig {
         enabled: false,
+        sync_enabled: true,
         ..Default::default()
     };
     config.set_token(token).unwrap();
+    config
+}
+
+/// A key configured for image upload only, from before the sync protocol.
+fn upload_only_config(token: &str) -> RemoteImageUploadConfig {
+    let mut config = api_config(token);
+    config.sync_enabled = false;
     config
 }
 
@@ -263,4 +271,55 @@ async fn token_scoped_export_previews_and_applies_to_the_selected_database() {
         .query_row("SELECT description FROM project", [], |row| row.get(0))
         .unwrap();
     assert_eq!(description, "remote settings");
+}
+
+/// A key that predates the sync protocol authenticates but reaches nothing.
+/// Upgrading PSF Guard must not hand an existing upload token the power to
+/// merge into the user's scheduler database.
+#[tokio::test]
+async fn an_upload_only_key_cannot_reach_the_sync_protocol() {
+    let directory = tempdir().unwrap();
+    let database_path = directory.path().join("catalog.sqlite");
+    let image_path = directory.path().join("images");
+    std::fs::create_dir(&image_path).unwrap();
+    let connection = Connection::open(&database_path).unwrap();
+    schema(&connection);
+    drop(connection);
+
+    let state = Arc::new(
+        AppState::from_databases(
+            vec![DbEntry {
+                id: "catalog".into(),
+                name: "Catalog".into(),
+                db_path: database_path.to_string_lossy().into_owned(),
+                image_dirs: vec![image_path.to_string_lossy().into_owned()],
+                reject_archive: None,
+                remote_image_upload: Some(upload_only_config(SOURCE_TOKEN)),
+            }],
+            directory
+                .path()
+                .join("cache")
+                .to_string_lossy()
+                .into_owned(),
+            PregenerationConfig::default(),
+        )
+        .unwrap(),
+    );
+    let router = app(state);
+
+    for (method, uri) in [
+        ("GET", "/api/sync/v1/capabilities"),
+        ("POST", "/api/sync/v1/exports"),
+    ] {
+        let body = (method == "POST").then(|| {
+            json!({
+                "protocol_version": 1,
+                "catalog_id": "catalog",
+                "operation": "push_planning",
+                "reviewed_only": false
+            })
+        });
+        let (status, response) = call(router.clone(), method, uri, Some(SOURCE_TOKEN), body).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{uri}: {response:#}");
+    }
 }

--- a/tests/integration_remote_sync.rs
+++ b/tests/integration_remote_sync.rs
@@ -1,0 +1,266 @@
+//! Remote plugin protocol coverage: token scope, export, preview, and apply.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::DefaultBodyLimit,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use http_body_util::BodyExt;
+use psf_guard::{
+    cli::PregenerationConfig,
+    db_registry::{DbEntry, RemoteImageUploadConfig},
+    server::{remote_sync, state::AppState},
+};
+use rusqlite::Connection;
+use serde_json::{json, Value};
+use tempfile::tempdir;
+use tower::ServiceExt;
+
+const SOURCE_TOKEN: &str = "source-remote-api-key-1234567890";
+const DESTINATION_TOKEN: &str = "destination-remote-api-key-123456";
+
+fn schema(connection: &Connection) {
+    connection
+        .execute_batch(
+            "PRAGMA user_version=22;
+             CREATE TABLE project (Id INTEGER PRIMARY KEY, profileId TEXT, name TEXT, description TEXT, state INTEGER, priority INTEGER, guid TEXT);
+             CREATE TABLE target (Id INTEGER PRIMARY KEY, name TEXT, active INTEGER, ra REAL, dec REAL, epochcode INTEGER, projectid INTEGER, guid TEXT);
+             CREATE TABLE exposuretemplate (Id INTEGER PRIMARY KEY, profileId TEXT, name TEXT, filtername TEXT, gain INTEGER, guid TEXT);
+             CREATE TABLE exposureplan (Id INTEGER PRIMARY KEY, profileId TEXT, exposure REAL, desired INTEGER, acquired INTEGER, accepted INTEGER, enabled INTEGER, targetid INTEGER, exposureTemplateId INTEGER, guid TEXT);
+             CREATE TABLE acquiredimage (Id INTEGER PRIMARY KEY, projectId INTEGER, targetId INTEGER, acquireddate INTEGER, filtername TEXT, gradingStatus INTEGER NOT NULL, metadata TEXT NOT NULL, rejectreason TEXT, profileId TEXT, exposureId INTEGER, guid TEXT);
+             CREATE TABLE ruleweight (Id INTEGER PRIMARY KEY, name TEXT, weight REAL, projectid INTEGER);
+             CREATE TABLE imagedata (Id INTEGER PRIMARY KEY, tag TEXT, imagedata BLOB, acquiredimageid INTEGER, width INTEGER, height INTEGER);",
+        )
+        .unwrap();
+}
+
+fn api_config(token: &str) -> RemoteImageUploadConfig {
+    let mut config = RemoteImageUploadConfig {
+        enabled: false,
+        ..Default::default()
+    };
+    config.set_token(token).unwrap();
+    config
+}
+
+fn app(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/api/sync/v1/capabilities", get(remote_sync::capabilities))
+        .route(
+            "/api/sync/v1/previews",
+            post(remote_sync::create_preview)
+                .layer(DefaultBodyLimit::max(remote_sync::MAX_SYNC_BODY_BYTES)),
+        )
+        .route(
+            "/api/sync/v1/previews/{preview_id}",
+            get(remote_sync::get_preview),
+        )
+        .route(
+            "/api/sync/v1/previews/{preview_id}/apply",
+            post(remote_sync::apply_preview),
+        )
+        .route("/api/sync/v1/exports", post(remote_sync::create_export))
+        .route(
+            "/api/sync/v1/exports/{export_id}",
+            get(remote_sync::get_export),
+        )
+        .with_state(state)
+}
+
+async fn call(
+    app: Router,
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let response = app
+        .oneshot(
+            builder
+                .body(body.map_or_else(Body::empty, |value| {
+                    Body::from(serde_json::to_vec(&value).unwrap())
+                }))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, value)
+}
+
+#[tokio::test]
+async fn token_scoped_export_previews_and_applies_to_the_selected_database() {
+    let directory = tempdir().unwrap();
+    let source_path = directory.path().join("source.sqlite");
+    let destination_path = directory.path().join("destination.sqlite");
+    let image_path = directory.path().join("images");
+    std::fs::create_dir(&image_path).unwrap();
+    let source = Connection::open(&source_path).unwrap();
+    let destination = Connection::open(&destination_path).unwrap();
+    schema(&source);
+    schema(&destination);
+    source
+        .execute_batch(
+            "INSERT INTO project VALUES (1,'p','M42','remote settings',2,8,'project-guid');
+             INSERT INTO target VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
+             INSERT INTO exposuretemplate VALUES (1,'p','Ha 300','Ha',120,'template-guid');
+             INSERT INTO exposureplan VALUES (1,'p',300,40,18,16,1,1,1,'plan-guid');
+             INSERT INTO ruleweight VALUES (1,'Priority',2.5,1);",
+        )
+        .unwrap();
+    destination
+        .execute_batch(
+            "INSERT INTO project VALUES (20,'p','M42','old settings',1,2,'project-guid');
+             INSERT INTO target VALUES (30,'Old target',1,5.4,-5.3,0,20,'target-guid');
+             INSERT INTO exposuretemplate VALUES (40,'p','Old Ha','Ha',100,'template-guid');
+             INSERT INTO exposureplan VALUES (50,'p',180,20,7,6,0,30,40,'plan-guid');
+             INSERT INTO ruleweight VALUES (60,'Priority',1.0,20);",
+        )
+        .unwrap();
+    drop(source);
+    drop(destination);
+
+    let entries = vec![
+        DbEntry {
+            id: "source".into(),
+            name: "Source".into(),
+            db_path: source_path.to_string_lossy().into_owned(),
+            image_dirs: vec![image_path.to_string_lossy().into_owned()],
+            reject_archive: None,
+            remote_image_upload: Some(api_config(SOURCE_TOKEN)),
+        },
+        DbEntry {
+            id: "destination".into(),
+            name: "Destination".into(),
+            db_path: destination_path.to_string_lossy().into_owned(),
+            image_dirs: vec![image_path.to_string_lossy().into_owned()],
+            reject_archive: None,
+            remote_image_upload: Some(api_config(DESTINATION_TOKEN)),
+        },
+    ];
+    let state = Arc::new(
+        AppState::from_databases(
+            entries,
+            directory
+                .path()
+                .join("cache")
+                .to_string_lossy()
+                .into_owned(),
+            PregenerationConfig::default(),
+        )
+        .unwrap(),
+    );
+    let router = app(state);
+
+    let (status, capabilities) = call(
+        router.clone(),
+        "GET",
+        "/api/sync/v1/capabilities",
+        Some(DESTINATION_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(capabilities["data"]["catalogs"][0]["id"], "destination");
+    assert_eq!(
+        capabilities["data"]["catalogs"].as_array().unwrap().len(),
+        1
+    );
+
+    let (status, _) = call(
+        router.clone(),
+        "POST",
+        "/api/sync/v1/exports",
+        Some(SOURCE_TOKEN),
+        Some(json!({
+            "protocol_version": 1,
+            "catalog_id": "destination",
+            "operation": "push_planning",
+            "reviewed_only": false
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    let (status, exported) = call(
+        router.clone(),
+        "POST",
+        "/api/sync/v1/exports",
+        Some(SOURCE_TOKEN),
+        Some(json!({
+            "protocol_version": 1,
+            "catalog_id": "source",
+            "operation": "push_planning",
+            "reviewed_only": false
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let bundle = exported["data"]["bundle"].clone();
+    assert_eq!(bundle["payload_sha256"].as_str().unwrap().len(), 64);
+
+    let (status, preview) = call(
+        router.clone(),
+        "POST",
+        "/api/sync/v1/previews",
+        Some(DESTINATION_TOKEN),
+        Some(json!({
+            "protocol_version": 1,
+            "catalog_id": "destination",
+            "operation": "push_planning",
+            "bundle": bundle
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{preview:#}");
+    assert_eq!(preview["data"]["summary"]["project_updated"], 1);
+    let preview_id = preview["data"]["preview_id"].as_str().unwrap();
+
+    let destination = Connection::open(&destination_path).unwrap();
+    let description: String = destination
+        .query_row("SELECT description FROM project", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(description, "old settings");
+    drop(destination);
+
+    let (status, _) = call(
+        router.clone(),
+        "GET",
+        &format!("/api/sync/v1/previews/{preview_id}"),
+        Some(SOURCE_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let (status, applied) = call(
+        router,
+        "POST",
+        &format!("/api/sync/v1/previews/{preview_id}/apply"),
+        Some(DESTINATION_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+    assert_eq!(applied["data"]["state"], "applied");
+    assert_eq!(applied["data"]["summary"]["total_updated"], 5);
+
+    let destination = Connection::open(destination_path).unwrap();
+    let description: String = destination
+        .query_row("SELECT description FROM project", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(description, "remote settings");
+}


### PR DESCRIPTION
## Changes
- add token-authenticated `/api/sync/v1` capabilities, export, preview, and apply endpoints
- bind each existing per-database API key to exactly one catalog
- materialize validated scheduler bundles into frozen SQLite snapshots and reuse the guarded local sync engine
- expose the credential as a Remote API key while keeping FITS reception independently gated
- add protocol documentation and an export-to-preview-to-apply integration test

## Why
The local guarded sync and remote FITS ingest endpoints were merged, but the plugin-facing database protocol still returned 404. This completes the server half without adding a second credential system or separate merge implementation.

## Impact
A configured per-database Remote API key grants access to that database's remote sync protocol. Accept remote image uploads remains disabled unless explicitly enabled. Existing salted token hashes are reused.

Companion plugin PR: theatrus/psf-guard-nina-plugin#1.

## Checks
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (386 passed, 5 ignored; all integration suites passed)
- `npm test -- src/components/__tests__/TauriSettings.test.tsx`
- `npm run build`