### PR TITLE
Collapse the detail-view file path

### DIFF
--- a/static/e2e/image-detail.spec.ts
+++ b/static/e2e/image-detail.spec.ts
@@ -198,11 +198,17 @@ test('detail view loads the large preview and renders pixels', async ({
   expect(dims.natH).toBeGreaterThan(500);
 });
 
-test('detail view shows the resolved file path', async ({ page }) => {
+test('detail view reveals the resolved file path on demand', async ({ page }) => {
   await page.goto(`/#/detail/1?db=${encodeURIComponent(dbId)}&project=1`);
 
+  const disclosure = page.getByTestId('image-file-location');
+  await expect(disclosure).toBeVisible({ timeout: 15_000 });
+
   const filePath = page.getByTestId('image-file-path');
-  await expect(filePath).toBeVisible({ timeout: 15_000 });
+  await expect(filePath).toBeHidden();
+
+  await disclosure.getByText('File path').click();
+  await expect(filePath).toBeVisible();
   await expect(filePath).toContainText(fixtureImageDir());
   await expect(filePath).toContainText('.fits');
   await expect(page.getByRole('button', { name: 'Copy path' })).toBeVisible();

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -1616,12 +1616,40 @@
 .image-file-heading {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin-bottom: 0.45rem;
+  gap: 0.4rem;
   color: var(--color-text-muted);
   font-size: 0.78rem;
   font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.image-file-heading::-webkit-details-marker {
+  display: none;
+}
+
+.image-file-heading::before {
+  content: '▸';
+  font-size: 0.7rem;
+  line-height: 1;
+  transition: transform 0.12s ease;
+}
+
+.image-file-location[open] > .image-file-heading::before {
+  transform: rotate(90deg);
+}
+
+.image-file-heading:hover {
+  color: var(--color-text-primary);
+}
+
+.image-file-heading > span:first-of-type {
+  margin-right: auto;
+}
+
+.image-file-body {
+  margin-top: 0.45rem;
 }
 
 .file-path-resolved,

--- a/static/src/components/ImageFileLocation.tsx
+++ b/static/src/components/ImageFileLocation.tsx
@@ -55,46 +55,48 @@ export default function ImageFileLocation({
   };
 
   return (
-    <div className="image-file-location">
-      <div className="image-file-heading">
+    <details className="image-file-location" data-testid="image-file-location">
+      <summary className="image-file-heading">
         <span>File path</span>
         <span className={pathState.className}>{pathState.label}</span>
-      </div>
+      </summary>
 
-      {path ? (
-        <code className="image-file-path" data-testid="image-file-path" title={path}>
-          {path}
-        </code>
-      ) : (
-        <span className="image-file-unavailable">No file path is recorded.</span>
-      )}
+      <div className="image-file-body">
+        {path ? (
+          <code className="image-file-path" data-testid="image-file-path" title={path}>
+            {path}
+          </code>
+        ) : (
+          <span className="image-file-unavailable">No file path is recorded.</span>
+        )}
 
-      {!filesystemPath && catalogPath && (
-        <p className="image-file-note">
-          This catalog path does not resolve in the configured image folders.
-        </p>
-      )}
+        {!filesystemPath && catalogPath && (
+          <p className="image-file-note">
+            This catalog path does not resolve in the configured image folders.
+          </p>
+        )}
 
-      {path && (
-        <div className="image-file-actions">
-          <button type="button" onClick={copyPath}>
-            {actionState === 'copied' ? 'Copied' : 'Copy path'}
-          </button>
-          {canReveal && (
-            <button
-              type="button"
-              onClick={showInFolder}
-              disabled={actionState === 'opening'}
-            >
-              {actionState === 'opening' ? 'Opening…' : 'Show in folder'}
+        {path && (
+          <div className="image-file-actions">
+            <button type="button" onClick={copyPath}>
+              {actionState === 'copied' ? 'Copied' : 'Copy path'}
             </button>
-          )}
-        </div>
-      )}
+            {canReveal && (
+              <button
+                type="button"
+                onClick={showInFolder}
+                disabled={actionState === 'opening'}
+              >
+                {actionState === 'opening' ? 'Opening…' : 'Show in folder'}
+              </button>
+            )}
+          </div>
+        )}
 
-      <div className="image-file-feedback" aria-live="polite">
-        {error}
+        <div className="image-file-feedback" aria-live="polite">
+          {error}
+        </div>
       </div>
-    </div>
+    </details>
   );
 }

--- a/static/src/components/__tests__/ImageFileLocation.test.tsx
+++ b/static/src/components/__tests__/ImageFileLocation.test.tsx
@@ -15,13 +15,37 @@ vi.mock('../../utils/tauri', () => ({
   },
 }));
 
+const expand = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByText('File path'));
+};
+
 describe('ImageFileLocation', () => {
   beforeEach(() => {
     tauriMocks.isTauriApp.mockReturnValue(false);
     tauriMocks.showImageInFolder.mockReset();
   });
 
-  it('shows a resolved path without a native action in browser mode', () => {
+  it('keeps the path collapsed until the summary is opened', async () => {
+    const user = userEvent.setup();
+    render(
+      <ImageFileLocation
+        dbId="archive"
+        filesystemPath="/images/target/frame.fits"
+        catalogPath={null}
+      />
+    );
+
+    expect(screen.getByTestId('image-file-location')).not.toHaveAttribute('open');
+    expect(screen.getByTestId('image-file-path')).not.toBeVisible();
+    expect(screen.getByText('Resolved')).toBeVisible();
+
+    await expand(user);
+
+    expect(screen.getByTestId('image-file-path')).toBeVisible();
+  });
+
+  it('shows a resolved path without a native action in browser mode', async () => {
+    const user = userEvent.setup();
     render(
       <ImageFileLocation
         dbId="archive"
@@ -29,6 +53,7 @@ describe('ImageFileLocation', () => {
         catalogPath="D:\\Capture\\frame.fits"
       />
     );
+    await expand(user);
 
     expect(screen.getByTestId('image-file-path')).toHaveTextContent(
       '/images/target/frame.fits'
@@ -46,6 +71,7 @@ describe('ImageFileLocation', () => {
         catalogPath={null}
       />
     );
+    await expand(user);
 
     await user.click(screen.getByRole('button', { name: 'Copy path' }));
 
@@ -53,8 +79,9 @@ describe('ImageFileLocation', () => {
     expect(await navigator.clipboard.readText()).toBe('/images/target/frame.fits');
   });
 
-  it('falls back to the recorded catalog path when the file is missing', () => {
+  it('falls back to the recorded catalog path when the file is missing', async () => {
     tauriMocks.isTauriApp.mockReturnValue(true);
+    const user = userEvent.setup();
 
     render(
       <ImageFileLocation
@@ -63,6 +90,7 @@ describe('ImageFileLocation', () => {
         catalogPath={'D:\\Capture\\missing.fits'}
       />
     );
+    await expand(user);
 
     expect(screen.getByTestId('image-file-path')).toHaveTextContent(
       'D:\\Capture\\missing.fits'
@@ -74,7 +102,8 @@ describe('ImageFileLocation', () => {
     expect(screen.queryByRole('button', { name: 'Show in folder' })).not.toBeInTheDocument();
   });
 
-  it('marks an image with no recorded path as unavailable', () => {
+  it('marks an image with no recorded path as unavailable', async () => {
+    const user = userEvent.setup();
     render(
       <ImageFileLocation
         dbId="archive"
@@ -82,6 +111,7 @@ describe('ImageFileLocation', () => {
         catalogPath={null}
       />
     );
+    await expand(user);
 
     expect(screen.getByText('Unavailable')).toBeInTheDocument();
     expect(screen.getByText('No file path is recorded.')).toBeInTheDocument();
@@ -100,6 +130,7 @@ describe('ImageFileLocation', () => {
         catalogPath={null}
       />
     );
+    await expand(user);
 
     await user.click(screen.getByRole('button', { name: 'Show in folder' }));
 


### PR DESCRIPTION
## Summary

The file path panel sat open in the image details sidebar, taking a block of space most reviews never need. It is now a small `<details>` disclosure that starts closed.

- `ImageFileLocation` renders a `<details>`; the heading became the `<summary>` and the path, note, buttons, and feedback moved into an `.image-file-body` wrapper.
- The summary stays one line: a chevron, "File path", and the status chip (Resolved / Catalog only / Unavailable). The chip still shows while collapsed, so you can tell whether the file resolved without opening it.
- CSS hides the native marker, rotates a `▸` on open, adds a hover colour, and pushes the chip to the right edge.

## Testing

- Updated the five unit tests to open the disclosure first, plus a new one checking it starts closed. Full frontend suite passes (132 tests).
- `npx tsc --noEmit` clean.
- Reworked the Playwright case to assert hidden → click → visible. Not run locally — it needs a built release binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)