### PR TITLE
Audit remote sync and keep previews across a refused apply

### DIFF
--- a/DATA_TRANSFER_DESIGN.md
+++ b/DATA_TRANSFER_DESIGN.md
@@ -256,6 +256,7 @@ GET  /api/sync/v1/exports/{export_id}
 POST /api/sync/v1/previews
 GET  /api/sync/v1/previews/{preview_id}
 POST /api/sync/v1/previews/{preview_id}/apply
+POST /api/sync/v1/previews/{preview_id}/refresh
 GET  /api/sync/v1/jobs/{job_id}
 ```
 
@@ -284,16 +285,44 @@ already covers truncation. The receiver therefore accepts a bundle whose
 digest is absent or stale. Enforcing it would pin one canonical JSON encoding,
 and reordering a single field would then reject every plugin already shipped.
 
-A bundle must carry the tables its operation acts on — `acquiredimage` for
-grades, `project`/`target`/`exposureplan` for planning, and both sets for a
-merge. Other tables in the operation's set may be omitted; the receiver
-creates them empty from its own schema, and the merge finds nothing to do.
-The current receiver accepts up to 512 MiB and one million rows per bundle,
-and bounds the exports it builds by the same row limit.
+A bundle must carry the tables its operation acts on — `project`, `target`,
+and `acquiredimage` for grades, `project`/`target`/`exposureplan` for planning,
+and both sets for a merge. Other tables in the operation's set may be omitted;
+the receiver creates them empty from its own schema, and the merge finds
+nothing to do. The current receiver accepts up to 512 MiB and one million rows
+per bundle, and bounds the exports it builds by the same row limit.
+
+A grade push carries `project` and `target` even though it writes neither,
+because the receiver reads its source rows through the scheduler's own
+project/target join. A bundle of bare `acquiredimage` rows is not a Target
+Scheduler database and the read fails outright.
 
 Each database opts into this protocol on its own. Holding a valid key is not
 enough: the operator ticks **Accept remote scheduler sync** for that database,
 separately from **Accept remote image uploads**.
+
+### Keeping a preview across a refusal
+
+Apply claims a preview once, so no two callers can apply the same one. But an
+apply that refuses — the destination moved under the preview — or that breaks
+on a locked file has written nothing, and its uploaded source data is still
+good. The receiver therefore puts the preview back rather than dropping it.
+
+The client's way forward is `POST .../refresh`: it re-runs the same stored
+source against the destination as it now stands, keeps the preview ID, and
+returns a fresh summary to review. Only a successful apply consumes the
+preview. Without this, a stale destination would cost a remote client a
+re-upload of the whole bundle.
+
+### Audit log
+
+Every remote action lands in `remote-sync-audit.jsonl` under the cache root,
+one JSON object per line: when, which catalog, which action, which operation,
+the outcome, and the row counts. Refusals are recorded too, including ones
+that never named a catalog, because a run of rejected applies is what a stolen
+token looks like from the server side. Entries carry no token, no filesystem
+path, and no row contents. The file rolls at 8 MiB, keeping one previous
+generation.
 
 ## N.I.N.A. plugin
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ export, preview, and apply, but only after you tick **Accept remote scheduler
 sync** on that database. The two grants are separate: a key may carry either,
 both, or neither, and a key configured before this protocol existed reaches
 nothing until you opt in. Either way the key is scoped to exactly one
-configured database.
+configured database. Every remote action, refusals included, is appended to
+`remote-sync-audit.jsonl` in the cache directory, so you can tell afterwards
+what a key-holder did and when.
 
 The Overview's **Plan & coordinates** dialog lets you correct imported names,
 coordinates, limits, and desired counts. See the

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -897,7 +897,7 @@ pub async fn apply_sync_database_preview_route(
         .source_snapshot_path(&record)
         .map_err(|error| AppError::InternalError(format!("{error:#}")))?;
 
-    let mut request = record.request;
+    let mut request = record.request.clone();
     request.dry_run = false;
     let result = execute_scheduler_sync_guarded(
         &state,
@@ -905,15 +905,26 @@ pub async fn apply_sync_database_preview_route(
         request,
         Some(source_snapshot),
         SyncGuardMode::Apply {
-            destination_fingerprint: record.destination_fingerprint,
+            destination_fingerprint: record.destination_fingerprint.clone(),
         },
     )
     .await
     .map(|(result, _)| result);
+    let result = match result {
+        Ok(result) => result,
+        Err(error) => {
+            // Nothing was written, so the snapshot still holds exactly the
+            // source rows the user reviewed. Put the preview back rather than
+            // making them rebuild it to retry.
+            if let Err(restore_error) = state.sync_previews.restore(&record) {
+                tracing::warn!("could not restore sync preview {preview_id}: {restore_error:#}");
+            }
+            return Err(error);
+        }
+    };
     state
         .sync_previews
         .remove_source_snapshot(&record.source_snapshot_file);
-    let result = result?;
     Ok(Json(ApiResponse::success(result)))
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,6 +8,7 @@ pub mod handlers;
 pub mod import_job;
 pub mod preview_queue;
 pub mod quality_backfill;
+pub mod remote_audit;
 pub mod remote_sync;
 pub mod remote_upload;
 pub mod scheduler;
@@ -443,6 +444,10 @@ async fn run_server_internal(
         .route(
             "/sync/v1/previews/{preview_id}/apply",
             post(remote_sync::apply_preview),
+        )
+        .route(
+            "/sync/v1/previews/{preview_id}/refresh",
+            post(remote_sync::refresh_preview),
         )
         .route("/sync/v1/exports", post(remote_sync::create_export))
         .route("/sync/v1/exports/{export_id}", get(remote_sync::get_export))

--- a/src/server/remote_audit.rs
+++ b/src/server/remote_audit.rs
@@ -1,0 +1,228 @@
+//! Append-only record of every remote sync action.
+//!
+//! The remote protocol lets a holder of one bearer token write into the user's
+//! scheduler database from off the machine. When a grade or a plan later looks
+//! wrong, the operator needs to be able to answer "did a remote client do
+//! this, and when" without having kept a terminal open. Console logging alone
+//! cannot answer that, so each action also lands in a JSONL file under the
+//! cache root.
+//!
+//! Every action is recorded, including the ones that were turned away: a run
+//! of rejected applies is exactly the shape a stolen token leaves behind.
+//! Entries carry no token, no path, and no row contents — only which catalog,
+//! which operation, and what it did.
+
+use serde::Serialize;
+use std::{
+    collections::BTreeMap,
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+
+/// Roll the log once it passes this size, keeping one previous generation.
+/// Bounds the audit trail at twice this without a cron job or a config knob.
+const MAX_LOG_BYTES: u64 = 8 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditAction {
+    Capabilities,
+    Export,
+    Preview,
+    PreviewRefresh,
+    Apply,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditOutcome {
+    /// The action ran and changed or reported what the client asked for.
+    Ok,
+    /// The server refused on purpose: a stale preview, an unknown ID, a bundle
+    /// that failed validation.
+    Refused,
+    /// The action broke for an operational reason.
+    Failed,
+}
+
+#[derive(Debug, Serialize)]
+struct AuditEntry<'a> {
+    at: String,
+    catalog_id: &'a str,
+    action: AuditAction,
+    outcome: AuditOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    operation: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bundle_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preview_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<&'a str>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    summary: BTreeMap<String, i64>,
+}
+
+/// One remote action, described well enough to reconstruct later.
+#[derive(Debug, Default)]
+pub struct AuditRecord<'a> {
+    pub operation: Option<&'a str>,
+    pub source_id: Option<&'a str>,
+    pub bundle_id: Option<&'a str>,
+    pub preview_id: Option<&'a str>,
+    pub detail: Option<&'a str>,
+    pub summary: BTreeMap<String, i64>,
+}
+
+pub struct RemoteAuditLog {
+    path: PathBuf,
+    /// Serializes appends so two concurrent applies cannot interleave a line.
+    write_lock: Mutex<()>,
+}
+
+impl RemoteAuditLog {
+    pub fn new(cache_root: impl AsRef<Path>) -> Self {
+        Self {
+            path: cache_root.as_ref().join("remote-sync-audit.jsonl"),
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn record(
+        &self,
+        catalog_id: &str,
+        action: AuditAction,
+        outcome: AuditOutcome,
+        record: AuditRecord<'_>,
+    ) {
+        let entry = AuditEntry {
+            at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            catalog_id,
+            action,
+            outcome,
+            operation: record.operation,
+            source_id: record.source_id,
+            bundle_id: record.bundle_id,
+            preview_id: record.preview_id,
+            detail: record.detail,
+            summary: record.summary,
+        };
+        tracing::info!(
+            "remote sync {:?} {:?} for db={} operation={} detail={}",
+            entry.action,
+            entry.outcome,
+            catalog_id,
+            entry.operation.unwrap_or("-"),
+            entry.detail.unwrap_or("-")
+        );
+        if let Err(error) = self.append(&entry) {
+            // The audit file is a record, not a gate. Losing a line must not
+            // fail the request the operator is waiting on, but it should be
+            // loud enough to notice in the log.
+            tracing::warn!(
+                "could not write the remote sync audit log {}: {error}",
+                self.path.display()
+            );
+        }
+    }
+
+    fn append(&self, entry: &AuditEntry<'_>) -> std::io::Result<()> {
+        let mut line = serde_json::to_vec(entry)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        line.push(b'\n');
+        let _guard = self
+            .write_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        self.roll_if_large();
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        file.write_all(&line)?;
+        Ok(())
+    }
+
+    fn roll_if_large(&self) {
+        let Ok(metadata) = fs::metadata(&self.path) else {
+            return;
+        };
+        if metadata.len() < MAX_LOG_BYTES {
+            return;
+        }
+        let _ = fs::rename(&self.path, self.path.with_extension("jsonl.1"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn every_outcome_lands_on_its_own_line() {
+        let directory = tempdir().unwrap();
+        let log = RemoteAuditLog::new(directory.path().join("cache"));
+        log.record(
+            "catalog",
+            AuditAction::Apply,
+            AuditOutcome::Ok,
+            AuditRecord {
+                operation: Some("push_planning"),
+                summary: BTreeMap::from([("total_updated".into(), 5)]),
+                ..Default::default()
+            },
+        );
+        log.record(
+            "catalog",
+            AuditAction::Apply,
+            AuditOutcome::Refused,
+            AuditRecord {
+                operation: Some("push_planning"),
+                detail: Some("destination changed"),
+                ..Default::default()
+            },
+        );
+
+        let contents = fs::read_to_string(log.path()).unwrap();
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(lines.len(), 2, "{contents}");
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["outcome"], "ok");
+        assert_eq!(first["summary"]["total_updated"], 5);
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second["outcome"], "refused");
+        assert_eq!(second["detail"], "destination changed");
+        // A refused action has nothing to summarize; the key stays off the wire.
+        assert!(second.get("summary").is_none(), "{second}");
+    }
+
+    #[test]
+    fn a_full_log_rolls_to_one_previous_generation() {
+        let directory = tempdir().unwrap();
+        let log = RemoteAuditLog::new(directory.path());
+        fs::write(log.path(), vec![b'x'; MAX_LOG_BYTES as usize]).unwrap();
+        log.record(
+            "catalog",
+            AuditAction::Export,
+            AuditOutcome::Ok,
+            AuditRecord::default(),
+        );
+
+        let rolled = log.path().with_extension("jsonl.1");
+        assert_eq!(fs::metadata(&rolled).unwrap().len(), MAX_LOG_BYTES);
+        let contents = fs::read_to_string(log.path()).unwrap();
+        assert_eq!(contents.lines().count(), 1, "{contents}");
+    }
+}

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -40,6 +40,7 @@ use crate::server::{
     },
     database_context::DatabaseContext,
     handlers::{execute_scheduler_sync_paths, AppError, SyncGuardMode},
+    remote_audit::{AuditAction, AuditOutcome, AuditRecord},
     state::AppState,
 };
 
@@ -49,6 +50,9 @@ const PROTOCOL_VERSION: u32 = 1;
 /// How long a built export stays fetchable, matching the preview lifetime.
 const EXPORT_LIFETIME_SECS: i64 = 30 * 60;
 const MAX_RETAINED_EXPORTS: usize = 16;
+/// Stands in for the catalog in an audit entry written before the token
+/// identified one — a bad token names no database.
+const UNKNOWN_CATALOG: &str = "-";
 const PLANNING_TABLES: &[&str] = &[
     "exposuretemplate",
     "project",
@@ -65,6 +69,11 @@ const MERGE_TABLES: &[&str] = &[
     "acquiredimage",
     "imagedata",
 ];
+/// A grade push reads its source rows through the scheduler's own
+/// project/target join, so the bundle has to carry those two tables even
+/// though nothing in them is ever written. Without them the materialized
+/// source is not a Target Scheduler database and the read fails outright.
+const GRADE_TABLES: &[&str] = &["project", "target", "acquiredimage"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -260,7 +269,7 @@ pub async fn capabilities(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<Json<ApiResponse<SyncCapabilities>>, AppError> {
-    let catalog = authenticated_catalog(&state, &headers)?;
+    let catalog = authenticated_catalog(&state, &headers, AuditAction::Capabilities)?;
     Ok(Json(ApiResponse::success(SyncCapabilities {
         protocol_version: PROTOCOL_VERSION,
         product: "PSF Guard",
@@ -270,6 +279,7 @@ pub async fn capabilities(
             "push_planning",
             "push_grades",
             "preview_apply",
+            "preview_refresh",
             "exports",
             "image_upload",
         ],
@@ -287,20 +297,49 @@ pub async fn create_preview(
     headers: HeaderMap,
     Json(request): Json<CreatePreviewRequest>,
 ) -> Result<Json<ApiResponse<SyncPreview>>, AppError> {
-    let catalog = authenticated_catalog(&state, &headers)?;
+    let catalog = authenticated_catalog(&state, &headers, AuditAction::Preview)?;
+    let operation = request.operation;
+    // Copy the identifiers the audit log needs before the bundle moves, so
+    // auditing never forces the whole payload to be cloned.
+    let bundle_id = request.bundle.bundle_id.clone();
+    let source_id = request.bundle.source.id.clone();
+    let audit = |outcome,
+                 detail: Option<&str>,
+                 preview_id: Option<&str>,
+                 summary: BTreeMap<String, i64>| {
+        state.remote_audit.record(
+            &catalog.id,
+            AuditAction::Preview,
+            outcome,
+            AuditRecord {
+                operation: Some(operation_label(operation)),
+                source_id: Some(&source_id),
+                bundle_id: Some(&bundle_id),
+                preview_id,
+                detail,
+                summary,
+            },
+        );
+    };
+    let refuse = |message: String| {
+        audit(AuditOutcome::Refused, Some(&message), None, BTreeMap::new());
+        AppError::BadRequest(message)
+    };
     require_protocol(request.protocol_version)?;
     require_catalog(&catalog, &request.catalog_id)?;
-    if request.operation != request.bundle.operation {
-        return Err(AppError::BadRequest(
+    if operation != request.bundle.operation {
+        return Err(refuse(
             "request operation does not match bundle operation".into(),
         ));
     }
-    validate_bundle(&request.bundle)?;
+    if let Err(error) = validate_bundle(&request.bundle) {
+        return Err(match error {
+            AppError::BadRequest(message) => refuse(message),
+            other => other,
+        });
+    }
 
     let destination_path = PathBuf::from(&catalog.database_path);
-    let bundle = request.bundle;
-    let source_id = bundle.source.id.clone();
-    let operation = request.operation;
     let snapshot_file = state
         .sync_previews
         .create_empty_source_snapshot()
@@ -311,6 +350,7 @@ pub async fn create_preview(
         .map_err(internal)?;
     let materialize_path = snapshot_path.clone();
     let template_path = destination_path.clone();
+    let bundle = request.bundle;
     if let Err(error) = tokio::task::spawn_blocking(move || {
         materialize_bundle(&materialize_path, &template_path, &bundle)
     })
@@ -318,9 +358,7 @@ pub async fn create_preview(
     .map_err(|error| AppError::InternalError(format!("bundle task failed: {error}")))?
     {
         state.sync_previews.remove_source_snapshot(&snapshot_file);
-        return Err(AppError::BadRequest(format!(
-            "invalid catalog bundle: {error:#}"
-        )));
+        return Err(refuse(format!("invalid catalog bundle: {error:#}")));
     }
 
     let sync_request = scheduler_request(operation, source_id.clone(), true);
@@ -328,7 +366,7 @@ pub async fn create_preview(
         &state,
         snapshot_path,
         destination_path,
-        source_id,
+        source_id.clone(),
         catalog.id.clone(),
         sync_request.clone(),
         SyncGuardMode::Preview,
@@ -339,6 +377,12 @@ pub async fn create_preview(
         Ok(_) => unreachable!("preview execution returns a fingerprint"),
         Err(error) => {
             state.sync_previews.remove_source_snapshot(&snapshot_file);
+            audit(
+                outcome_of(&error),
+                Some(&detail_of(&error)),
+                None,
+                BTreeMap::new(),
+            );
             return Err(error);
         }
     };
@@ -355,11 +399,13 @@ pub async fn create_preview(
             state.sync_previews.remove_source_snapshot(&snapshot_file);
             internal(error)
         })?;
+    let summary = result_summary(&result);
+    audit(AuditOutcome::Ok, None, Some(&record.id), summary.clone());
     Ok(Json(ApiResponse::success(SyncPreview {
         preview_id: record.id,
         state: "ready",
         expires_at: unix_timestamp(record.expires_at),
-        summary: result_summary(&result),
+        summary,
     })))
 }
 
@@ -368,7 +414,7 @@ pub async fn get_preview(
     headers: HeaderMap,
     Path(preview_id): Path<String>,
 ) -> Result<Json<ApiResponse<SyncPreview>>, AppError> {
-    let catalog = authenticated_catalog(&state, &headers)?;
+    let catalog = authenticated_catalog(&state, &headers, AuditAction::Preview)?;
     let record = state
         .sync_previews
         .get(&preview_id)
@@ -388,18 +434,41 @@ pub async fn apply_preview(
     headers: HeaderMap,
     Path(preview_id): Path<String>,
 ) -> Result<Json<ApiResponse<SyncApplyResult>>, AppError> {
-    let catalog = authenticated_catalog(&state, &headers)?;
+    let catalog = authenticated_catalog(&state, &headers, AuditAction::Apply)?;
+    let audit = |outcome, operation, detail: Option<&str>, summary| {
+        state.remote_audit.record(
+            &catalog.id,
+            AuditAction::Apply,
+            outcome,
+            AuditRecord {
+                operation,
+                preview_id: Some(&preview_id),
+                detail,
+                summary,
+                ..Default::default()
+            },
+        );
+    };
     let _apply_guard = state.sync_apply_lock.lock().await;
-    let record = state
+    let Some(record) = state
         .sync_previews
         .claim(&preview_id, &catalog.id)
         .map_err(internal)?
-        .ok_or(AppError::NotFound)?;
+    else {
+        audit(
+            AuditOutcome::Refused,
+            None,
+            Some("no such preview"),
+            BTreeMap::new(),
+        );
+        return Err(unknown_preview());
+    };
+    let operation = Some(kind_label(record.request.kind));
     let source_path = state
         .sync_previews
         .source_snapshot_path(&record)
         .map_err(internal)?;
-    let mut request = record.request;
+    let mut request = record.request.clone();
     request.dry_run = false;
     let result = execute_scheduler_sync_paths(
         &state,
@@ -409,18 +478,127 @@ pub async fn apply_preview(
         catalog.id.clone(),
         request,
         SyncGuardMode::Apply {
-            destination_fingerprint: record.destination_fingerprint,
+            destination_fingerprint: record.destination_fingerprint.clone(),
         },
     )
     .await
     .map(|(result, _)| result);
+
+    let result = match result {
+        Ok(result) => result,
+        Err(error) => {
+            // The apply wrote nothing, so the preview is still good source
+            // data. Keep it: for a remote client, discarding it here means
+            // re-uploading the whole bundle to get back to this point. A stale
+            // destination is fixed by refreshing this same preview.
+            if let Err(restore_error) = state.sync_previews.restore(&record) {
+                tracing::warn!("could not restore sync preview {preview_id}: {restore_error:#}");
+            }
+            audit(
+                outcome_of(&error),
+                operation,
+                Some(&detail_of(&error)),
+                BTreeMap::new(),
+            );
+            return Err(error);
+        }
+    };
     state
         .sync_previews
         .remove_source_snapshot(&record.source_snapshot_file);
-    let result = result?;
+    let summary = result_summary(&result);
+    audit(AuditOutcome::Ok, operation, None, summary.clone());
     Ok(Json(ApiResponse::success(SyncApplyResult {
         state: "applied",
-        summary: result_summary(&result),
+        summary,
+    })))
+}
+
+/// Re-run a kept preview against the destination as it now stands.
+///
+/// The path back from a stale-preview conflict. Apply refuses when the
+/// destination moved under a preview, and the client must review the merge
+/// again — but the source data is already on the server, so make it re-review
+/// that, not re-upload it.
+pub async fn refresh_preview(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(preview_id): Path<String>,
+) -> Result<Json<ApiResponse<SyncPreview>>, AppError> {
+    let catalog = authenticated_catalog(&state, &headers, AuditAction::PreviewRefresh)?;
+    let audit = |outcome, operation, detail: Option<&str>, summary| {
+        state.remote_audit.record(
+            &catalog.id,
+            AuditAction::PreviewRefresh,
+            outcome,
+            AuditRecord {
+                operation,
+                preview_id: Some(&preview_id),
+                detail,
+                summary,
+                ..Default::default()
+            },
+        );
+    };
+    // Refresh rewrites a record an apply may be claiming, so it takes the same
+    // lock, and takes it before reading. Creating a preview needs none of this
+    // — that record is new and nothing else can be holding it.
+    let _apply_guard = state.sync_apply_lock.lock().await;
+    let Some(record) = state
+        .sync_previews
+        .get(&preview_id)
+        .map_err(internal)?
+        .filter(|record| record.local_db_id == catalog.id)
+    else {
+        audit(
+            AuditOutcome::Refused,
+            None,
+            Some("no such preview"),
+            BTreeMap::new(),
+        );
+        return Err(unknown_preview());
+    };
+    let operation = Some(kind_label(record.request.kind));
+    let source_path = state
+        .sync_previews
+        .source_snapshot_path(&record)
+        .map_err(internal)?;
+    let mut request = record.request.clone();
+    request.dry_run = true;
+    let execution = execute_scheduler_sync_paths(
+        &state,
+        source_path,
+        PathBuf::from(&catalog.database_path),
+        request.peer_db_id.clone(),
+        catalog.id.clone(),
+        request,
+        SyncGuardMode::Preview,
+    )
+    .await;
+    let (result, fingerprint) = match execution {
+        Ok((result, Some(fingerprint))) => (result, fingerprint),
+        Ok(_) => unreachable!("preview execution returns a fingerprint"),
+        Err(error) => {
+            audit(
+                outcome_of(&error),
+                operation,
+                Some(&detail_of(&error)),
+                BTreeMap::new(),
+            );
+            return Err(error);
+        }
+    };
+    let refreshed = state
+        .sync_previews
+        .refresh(&record, fingerprint, result.clone())
+        .map_err(internal)?;
+    let summary = result_summary(&result);
+    audit(AuditOutcome::Ok, operation, None, summary.clone());
+    Ok(Json(ApiResponse::success(SyncPreview {
+        preview_id: refreshed.id,
+        state: "ready",
+        expires_at: unix_timestamp(refreshed.expires_at),
+        summary,
     })))
 }
 
@@ -429,19 +607,44 @@ pub async fn create_export(
     headers: HeaderMap,
     Json(request): Json<CreateExportRequest>,
 ) -> Result<Json<ApiResponse<SyncExport>>, AppError> {
-    let catalog = authenticated_catalog(&state, &headers)?;
+    let catalog = authenticated_catalog(&state, &headers, AuditAction::Export)?;
     require_protocol(request.protocol_version)?;
     require_catalog(&catalog, &request.catalog_id)?;
     let database_path = PathBuf::from(&catalog.database_path);
     let catalog_id = catalog.id.clone();
     let operation = request.operation;
     let reviewed_only = request.reviewed_only;
-    let bundle = tokio::task::spawn_blocking(move || {
+    let audit = |outcome, detail: Option<&str>, summary| {
+        state.remote_audit.record(
+            &catalog.id,
+            AuditAction::Export,
+            outcome,
+            AuditRecord {
+                operation: Some(operation_label(operation)),
+                detail,
+                summary,
+                ..Default::default()
+            },
+        );
+    };
+    let bundle = match tokio::task::spawn_blocking(move || {
         export_bundle(&database_path, &catalog_id, operation, reviewed_only)
     })
     .await
     .map_err(|error| AppError::InternalError(format!("export task failed: {error}")))?
-    .map_err(|error| AppError::BadRequest(format!("creating export: {error:#}")))?;
+    {
+        Ok(bundle) => bundle,
+        Err(error) => {
+            let message = format!("creating export: {error:#}");
+            audit(AuditOutcome::Failed, Some(&message), BTreeMap::new());
+            return Err(AppError::BadRequest(message));
+        }
+    };
+    let summary = bundle
+        .tables
+        .iter()
+        .map(|(name, table)| (format!("{name}_rows"), table.rows.len() as i64))
+        .collect();
     let export = SyncExport {
         export_id: Uuid::new_v4().to_string(),
         state: "ready",
@@ -451,6 +654,7 @@ pub async fn create_export(
     state
         .remote_exports
         .insert(catalog.id.clone(), export.clone())?;
+    audit(AuditOutcome::Ok, Some(&export.export_id), summary);
     Ok(Json(ApiResponse::success(export)))
 }
 
@@ -459,7 +663,7 @@ pub async fn get_export(
     headers: HeaderMap,
     Path(export_id): Path<String>,
 ) -> Result<Json<ApiResponse<SyncExport>>, AppError> {
-    let catalog = authenticated_catalog(&state, &headers)?;
+    let catalog = authenticated_catalog(&state, &headers, AuditAction::Export)?;
     let export = state
         .remote_exports
         .get(&export_id, &catalog.id)?
@@ -476,16 +680,30 @@ pub async fn get_export(
 fn authenticated_catalog(
     state: &AppState,
     headers: &HeaderMap,
+    action: AuditAction,
 ) -> Result<Arc<DatabaseContext>, AppError> {
-    let header = headers
+    // A caller who fails here has no catalog to attribute the attempt to, but
+    // the attempt is exactly what an operator wants to see: a run of these is
+    // what a guessed or stolen token looks like from the server side.
+    let refuse = |catalog_id: &str, message: &str| {
+        state.remote_audit.record(
+            catalog_id,
+            action,
+            AuditOutcome::Refused,
+            AuditRecord {
+                detail: Some(message),
+                ..Default::default()
+            },
+        );
+        AppError::Forbidden(message.to_string())
+    };
+    let token = headers
         .get(AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
-        .ok_or_else(|| AppError::Forbidden("Bearer token required".into()))?;
-    let token = header
-        .strip_prefix("Bearer ")
+        .and_then(|header| header.strip_prefix("Bearer "))
         .map(str::trim)
         .filter(|token| !token.is_empty())
-        .ok_or_else(|| AppError::Forbidden("Bearer token required".into()))?;
+        .ok_or_else(|| refuse(UNKNOWN_CATALOG, "Bearer token required"))?;
     let mut matches = state.all_databases().into_iter().filter(|catalog| {
         catalog
             .remote_image_upload
@@ -494,10 +712,11 @@ fn authenticated_catalog(
     });
     let catalog = matches
         .next()
-        .ok_or_else(|| AppError::Forbidden("Invalid API token".into()))?;
+        .ok_or_else(|| refuse(UNKNOWN_CATALOG, "Invalid API token"))?;
     if matches.next().is_some() {
-        return Err(AppError::Forbidden(
-            "API token is configured for more than one database".into(),
+        return Err(refuse(
+            &catalog.id,
+            "API token is configured for more than one database",
         ));
     }
     // Sync is a separate grant from image upload. A key configured before
@@ -508,8 +727,9 @@ fn authenticated_catalog(
         .as_ref()
         .is_some_and(|config| config.sync_enabled)
     {
-        return Err(AppError::Forbidden(
-            "remote scheduler sync is disabled for this database".into(),
+        return Err(refuse(
+            &catalog.id,
+            "remote scheduler sync is disabled for this database",
         ));
     }
     Ok(catalog)
@@ -536,6 +756,12 @@ fn require_catalog(catalog: &DatabaseContext, requested: &str) -> Result<(), App
 }
 
 fn validate_bundle(bundle: &CatalogBundle) -> Result<(), AppError> {
+    validate_bundle_within(bundle, MAX_BUNDLE_ROWS)
+}
+
+/// The row budget is a parameter so a test can exercise the limit without
+/// building a million rows.
+fn validate_bundle_within(bundle: &CatalogBundle, max_rows: usize) -> Result<(), AppError> {
     require_protocol(bundle.protocol_version)?;
     Uuid::parse_str(&bundle.bundle_id)
         .map_err(|_| AppError::BadRequest("bundle_id must be a UUID".into()))?;
@@ -582,9 +808,9 @@ fn validate_bundle(bundle: &CatalogBundle) -> Result<(), AppError> {
         }
         row_count = row_count.saturating_add(table.rows.len());
     }
-    if row_count > MAX_BUNDLE_ROWS {
+    if row_count > max_rows {
         return Err(AppError::BadRequest(format!(
-            "bundle exceeds the {MAX_BUNDLE_ROWS} row limit"
+            "bundle exceeds the {max_rows} row limit"
         )));
     }
     Ok(())
@@ -740,14 +966,13 @@ fn export_bundle(
     let mut tables = BTreeMap::new();
     let mut row_count = 0usize;
     for name in allowed_tables(operation) {
-        let selected = if operation == SyncOperation::PushGrades {
-            Some(&["guid", "gradingStatus", "rejectreason"][..])
-        } else {
-            None
-        };
-        let where_clause = (operation == SyncOperation::PushGrades && reviewed_only)
-            .then_some("gradingStatus <> 0");
-        let table = read_bundle_table(&connection, name, selected, where_clause)?;
+        // Only acquiredimage narrows: reviewed_only means "the rows I have
+        // actually graded". project and target ride along whole because the
+        // grade read joins against them.
+        let where_clause =
+            (operation == SyncOperation::PushGrades && reviewed_only && *name == "acquiredimage")
+                .then_some("gradingStatus <> 0");
+        let table = read_bundle_table(&connection, name, where_clause)?;
         // Bound the export the same way we bound an import. A merge pulls
         // every acquiredimage row and every imagedata blob, so an unbounded
         // build is how the server runs itself out of memory answering one
@@ -782,12 +1007,11 @@ fn export_bundle(
 fn read_bundle_table(
     connection: &Connection,
     name: &str,
-    selected: Option<&[&str]>,
     where_clause: Option<&str>,
 ) -> anyhow::Result<BundleTable> {
     let mut schema_statement =
         connection.prepare(&format!("PRAGMA table_info({})", quote_identifier(name)))?;
-    let all_columns = schema_statement
+    let columns = schema_statement
         .query_map([], |row| {
             Ok(BundleColumn {
                 name: row.get(1)?,
@@ -797,20 +1021,6 @@ fn read_bundle_table(
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
-    let columns = if let Some(selected) = selected {
-        selected
-            .iter()
-            .map(|wanted| {
-                all_columns
-                    .iter()
-                    .find(|column| column.name.eq_ignore_ascii_case(wanted))
-                    .cloned()
-                    .ok_or_else(|| anyhow::anyhow!("table {name} is missing column {wanted}"))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?
-    } else {
-        all_columns
-    };
     anyhow::ensure!(!columns.is_empty(), "table {name} is missing");
     let select = columns
         .iter()
@@ -924,11 +1134,64 @@ fn add_table_summary(
     summary.insert(format!("{name}_skipped"), counts.skipped as i64);
 }
 
+fn operation_label(operation: SyncOperation) -> &'static str {
+    match operation {
+        SyncOperation::Merge => "merge",
+        SyncOperation::PushPlanning => "push_planning",
+        SyncOperation::PushGrades => "push_grades",
+    }
+}
+
+/// The stored preview keeps the engine's own `SchedulerSyncKind`, so map back
+/// to the protocol name the client used.
+fn kind_label(kind: SchedulerSyncKind) -> &'static str {
+    match kind {
+        SchedulerSyncKind::Pull => "merge",
+        SchedulerSyncKind::PushPlanning => "push_planning",
+        SchedulerSyncKind::PushGrades => "push_grades",
+    }
+}
+
+/// A 404 that says why, since "not found" on a preview usually means it
+/// expired or was already applied — not that the token is wrong.
+fn unknown_preview() -> AppError {
+    AppError::NotFoundMessage(
+        "no such preview. Previews last 30 minutes and each applies once, so \
+         create a new preview."
+            .into(),
+    )
+}
+
+/// Whether the server turned this request away on purpose, or broke.
+fn outcome_of(error: &AppError) -> AuditOutcome {
+    match error {
+        AppError::BadRequest(_)
+        | AppError::Conflict(_)
+        | AppError::Forbidden(_)
+        | AppError::NotFound
+        | AppError::NotFoundMessage(_) => AuditOutcome::Refused,
+        _ => AuditOutcome::Failed,
+    }
+}
+
+fn detail_of(error: &AppError) -> String {
+    match error {
+        AppError::NotFound => "not found".into(),
+        AppError::NotFoundMessage(message)
+        | AppError::DatabaseError(message)
+        | AppError::BadRequest(message)
+        | AppError::Conflict(message)
+        | AppError::Forbidden(message)
+        | AppError::InternalError(message) => message.clone(),
+        AppError::NotImplemented => "not implemented".into(),
+    }
+}
+
 fn allowed_tables(operation: SyncOperation) -> &'static [&'static str] {
     match operation {
         SyncOperation::Merge => MERGE_TABLES,
         SyncOperation::PushPlanning => PLANNING_TABLES,
-        SyncOperation::PushGrades => &["acquiredimage"],
+        SyncOperation::PushGrades => GRADE_TABLES,
     }
 }
 
@@ -939,7 +1202,7 @@ fn required_tables(operation: SyncOperation) -> &'static [&'static str] {
     match operation {
         SyncOperation::Merge => &["project", "target", "acquiredimage"],
         SyncOperation::PushPlanning => &["project", "target", "exposureplan"],
-        SyncOperation::PushGrades => &["acquiredimage"],
+        SyncOperation::PushGrades => GRADE_TABLES,
     }
 }
 
@@ -1022,20 +1285,29 @@ mod tests {
         serde_json::from_str(&json).unwrap()
     }
 
-    const ACQUIRED_IMAGE: &str = r#"{
-        "acquiredimage":{
-            "columns":[{"name":"guid","declared_type":"TEXT","not_null":false,"primary_key":false}],
-            "rows":[{"values":[{"kind":"text","value":"a-guid"}]}]
-        }
-    }"#;
+    const GUID_COLUMN: &str =
+        r#"{"name":"guid","declared_type":"TEXT","not_null":false,"primary_key":false}"#;
+    const GUID_ROW: &str = r#"{"values":[{"kind":"text","value":"a-guid"}]}"#;
+
+    /// Every table a grade push needs: the two it joins against, and the one
+    /// it actually reads.
+    fn grade_tables() -> String {
+        format!(
+            r#"{{
+            "project":{{"columns":[{GUID_COLUMN}],"rows":[{GUID_ROW}]}},
+            "target":{{"columns":[{GUID_COLUMN}],"rows":[{GUID_ROW}]}},
+            "acquiredimage":{{"columns":[{GUID_COLUMN}],"rows":[{GUID_ROW}]}}
+        }}"#
+        )
+    }
 
     #[test]
     fn accepts_a_bundle_whose_digest_is_absent_or_stale() {
         // The digest is advisory. A plugin that omits it, or that computes it
         // over a different JSON encoding than ours, still syncs.
-        validate_bundle(&grades_bundle(ACQUIRED_IMAGE, "")).unwrap();
+        validate_bundle(&grades_bundle(&grade_tables(), "")).unwrap();
         validate_bundle(&grades_bundle(
-            ACQUIRED_IMAGE,
+            &grade_tables(),
             r#","payload_sha256":"0000000000000000000000000000000000000000000000000000000000000000""#,
         ))
         .unwrap();
@@ -1043,7 +1315,15 @@ mod tests {
 
     #[test]
     fn rejects_a_bundle_missing_the_table_its_operation_needs() {
-        let error = validate_bundle(&grades_bundle("{}", "")).unwrap_err();
+        // A grade push without acquiredimage would apply cleanly and change
+        // nothing, which reads to the client as a successful sync.
+        let tables = format!(
+            r#"{{
+            "project":{{"columns":[{GUID_COLUMN}],"rows":[]}},
+            "target":{{"columns":[{GUID_COLUMN}],"rows":[]}}
+        }}"#
+        );
+        let error = validate_bundle(&grades_bundle(&tables, "")).unwrap_err();
         assert!(
             matches!(&error, AppError::BadRequest(message) if message.contains("acquiredimage")),
             "expected a 400 naming the table, got {error:?}"
@@ -1051,17 +1331,62 @@ mod tests {
     }
 
     #[test]
-    fn rejects_a_table_outside_the_operation() {
-        let error = validate_bundle(&grades_bundle(
-            r#"{
-                "project":{"columns":[{"name":"guid","declared_type":"TEXT","not_null":false,"primary_key":false}],"rows":[]},
-                "acquiredimage":{"columns":[{"name":"guid","declared_type":"TEXT","not_null":false,"primary_key":false}],"rows":[]}
-            }"#,
-            "",
+    fn counts_rows_across_every_table_against_the_budget() {
+        // Two tables of one row each: within a budget of two, over a budget
+        // of one. The bound has to be the bundle's total, not any one table's.
+        let bundle: CatalogBundle = serde_json::from_str(&format!(
+            r#"{{
+            "protocol_version":1,
+            "bundle_id":"b03b8ab1-ce43-4a87-a4fb-68497394cedb",
+            "created_at_utc":"2026-07-23T12:00:00+00:00",
+            "operation":"push_planning",
+            "source":{{"id":"s","product":"p","product_version":"1","schema_version":23}},
+            "tables":{{
+                "project":{{"columns":[{GUID_COLUMN}],"rows":[{GUID_ROW}]}},
+                "target":{{"columns":[{GUID_COLUMN}],"rows":[{GUID_ROW}]}},
+                "exposureplan":{{"columns":[{GUID_COLUMN}],"rows":[]}}
+            }}
+        }}"#
         ))
-        .unwrap_err();
+        .unwrap();
+
+        validate_bundle_within(&bundle, 2).unwrap();
+        let error = validate_bundle_within(&bundle, 1).unwrap_err();
         assert!(
-            matches!(&error, AppError::BadRequest(message) if message.contains("project")),
+            matches!(&error, AppError::BadRequest(message) if message.contains("row limit")),
+            "expected a 400 about the row limit, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn stored_previews_report_the_operation_the_client_asked_for() {
+        // The audit log names the protocol operation, but a stored preview
+        // only kept the engine's own kind. Round-trip every operation so a
+        // merge is never recorded under the engine's name for it.
+        for operation in [
+            SyncOperation::Merge,
+            SyncOperation::PushPlanning,
+            SyncOperation::PushGrades,
+        ] {
+            let request = scheduler_request(operation, "source".into(), true);
+            assert_eq!(kind_label(request.kind), operation_label(operation));
+        }
+    }
+
+    #[test]
+    fn rejects_a_table_outside_the_operation() {
+        // exposureplan belongs to a planning push, never to a grade push.
+        let tables = format!(
+            r#"{{
+            "exposureplan":{{"columns":[{GUID_COLUMN}],"rows":[]}},
+            "project":{{"columns":[{GUID_COLUMN}],"rows":[]}},
+            "target":{{"columns":[{GUID_COLUMN}],"rows":[]}},
+            "acquiredimage":{{"columns":[{GUID_COLUMN}],"rows":[]}}
+        }}"#
+        );
+        let error = validate_bundle(&grades_bundle(&tables, "")).unwrap_err();
+        assert!(
+            matches!(&error, AppError::BadRequest(message) if message.contains("exposureplan")),
             "expected a 400 naming the table, got {error:?}"
         );
     }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -73,6 +73,9 @@ pub struct AppState {
     pub sync_apply_lock: tokio::sync::Mutex<()>,
     /// Export bundles built for remote sync clients, capacity- and time-bound.
     pub remote_exports: crate::server::remote_sync::ExportStore,
+    /// Append-only record of remote sync actions, so an operator can tell
+    /// afterwards which token-holder changed the scheduler database and when.
+    pub remote_audit: crate::server::remote_audit::RemoteAuditLog,
     /// Process-global Seiza catalogs and capability diagnostics. Catalogs are
     /// shared across databases and opened lazily on first use.
     pub astrometry: Arc<crate::astrometry::AstrometryContext>,
@@ -378,6 +381,7 @@ impl AppState {
             sync_previews: crate::server::sync_preview::SyncPreviewManager::new(&cache_dir),
             sync_apply_lock: tokio::sync::Mutex::new(()),
             remote_exports: crate::server::remote_sync::ExportStore::new(),
+            remote_audit: crate::server::remote_audit::RemoteAuditLog::new(&cache_dir),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::new(astrometry_config)),
             satellites: Arc::new(satellites),
         })
@@ -499,6 +503,7 @@ impl AppState {
             ),
             sync_apply_lock: tokio::sync::Mutex::new(()),
             remote_exports: crate::server::remote_sync::ExportStore::new(),
+            remote_audit: crate::server::remote_audit::RemoteAuditLog::new("/tmp/psf-guard-test"),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::default()),
             satellites: Arc::new(
                 crate::satellites::SatelliteContext::new(

--- a/src/server/sync_preview.rs
+++ b/src/server/sync_preview.rs
@@ -194,6 +194,49 @@ impl SyncPreviewManager {
         Ok(Some(record))
     }
 
+    /// Put a claimed preview back after an apply that changed nothing.
+    ///
+    /// Claiming is deliberately one-shot, but an apply that refuses (the
+    /// destination moved) or breaks (the file was locked) has written nothing,
+    /// so throwing the preview away costs the client its whole source snapshot
+    /// — for a remote client, a re-upload of the entire bundle. Restoring keeps
+    /// it, so the client can retry, or refresh the preview against the
+    /// destination as it now stands.
+    pub fn restore(&self, record: &SyncPreviewRecord) -> Result<()> {
+        if record.expires_at <= unix_seconds() {
+            self.remove_source_snapshot(&record.source_snapshot_file);
+            return Ok(());
+        }
+        write_record(&self.directory, record)?;
+        self.records
+            .lock()
+            .map_err(|error| anyhow::anyhow!("sync preview lock poisoned: {error}"))?
+            .insert(record.id.clone(), record.clone());
+        Ok(())
+    }
+
+    /// Re-run a preview in place: same ID, same source snapshot, new summary
+    /// and destination fingerprint. Lets a client whose preview went stale
+    /// review the merge again without re-sending the source data.
+    pub fn refresh(
+        &self,
+        record: &SyncPreviewRecord,
+        destination_fingerprint: String,
+        result: SchedulerSyncResponse,
+    ) -> Result<SyncPreviewRecord> {
+        let refreshed = SyncPreviewRecord {
+            destination_fingerprint,
+            result,
+            ..record.clone()
+        };
+        write_record(&self.directory, &refreshed)?;
+        self.records
+            .lock()
+            .map_err(|error| anyhow::anyhow!("sync preview lock poisoned: {error}"))?
+            .insert(refreshed.id.clone(), refreshed.clone());
+        Ok(refreshed)
+    }
+
     pub fn discard(&self, id: &str, local_db_id: &str) -> Result<bool> {
         let mut records = self
             .records
@@ -473,6 +516,114 @@ mod tests {
         assert!(manager.claim(&record.id, "source").unwrap().is_some());
         assert!(manager.claim(&record.id, "source").unwrap().is_none());
         assert!(manager.get(&record.id).unwrap().is_none());
+    }
+
+    /// Build a manager holding one preview over a throwaway source database.
+    fn stored_preview(directory: &Path) -> (SyncPreviewManager, SyncPreviewRecord) {
+        let manager = SyncPreviewManager::new(directory.join("cache"));
+        let source_path = directory.join("source.sqlite");
+        let source = Connection::open(&source_path).unwrap();
+        source
+            .execute_batch("CREATE TABLE sample (value TEXT);")
+            .unwrap();
+        drop(source);
+        let snapshot = manager.create_source_snapshot(&source_path).unwrap();
+        let record = manager
+            .store(
+                "catalog".into(),
+                request(),
+                snapshot,
+                "destination-fingerprint".into(),
+                response(),
+            )
+            .unwrap();
+        (manager, record)
+    }
+
+    #[test]
+    fn a_restored_preview_can_be_claimed_again() {
+        // An apply that refuses wrote nothing, so its preview is still valid
+        // source data. Losing it would cost a remote client the whole upload.
+        let directory = tempdir().unwrap();
+        let (manager, record) = stored_preview(directory.path());
+
+        let claimed = manager.claim(&record.id, "catalog").unwrap().unwrap();
+        assert!(manager.get(&record.id).unwrap().is_none());
+        manager.restore(&claimed).unwrap();
+
+        assert!(manager.get(&record.id).unwrap().is_some());
+        // Restoring survives a restart, so the record went back to disk too.
+        let reloaded = SyncPreviewManager::new(directory.path().join("cache"));
+        assert!(reloaded.get(&record.id).unwrap().is_some());
+        assert!(manager.claim(&record.id, "catalog").unwrap().is_some());
+    }
+
+    #[test]
+    fn restoring_an_expired_preview_drops_its_snapshot_instead() {
+        let directory = tempdir().unwrap();
+        let (manager, record) = stored_preview(directory.path());
+        let snapshot = manager.source_snapshot_path(&record).unwrap();
+        let expired = SyncPreviewRecord {
+            expires_at: unix_seconds() - 1,
+            ..manager.claim(&record.id, "catalog").unwrap().unwrap()
+        };
+
+        manager.restore(&expired).unwrap();
+
+        assert!(manager.get(&record.id).unwrap().is_none());
+        assert!(
+            !snapshot.exists(),
+            "an expired preview must not leak a file"
+        );
+    }
+
+    #[test]
+    fn refreshing_keeps_the_id_and_snapshot_but_takes_the_new_fingerprint() {
+        // The way back from a stale preview: re-review the same source data
+        // against the destination as it now stands.
+        let directory = tempdir().unwrap();
+        let (manager, record) = stored_preview(directory.path());
+
+        let refreshed = manager
+            .refresh(&record, "moved-destination".into(), response())
+            .unwrap();
+
+        assert_eq!(refreshed.id, record.id);
+        assert_eq!(refreshed.source_snapshot_file, record.source_snapshot_file);
+        assert_eq!(refreshed.destination_fingerprint, "moved-destination");
+        let reloaded = SyncPreviewManager::new(directory.path().join("cache"));
+        assert_eq!(
+            reloaded
+                .get(&record.id)
+                .unwrap()
+                .unwrap()
+                .destination_fingerprint,
+            "moved-destination"
+        );
+    }
+
+    #[test]
+    fn an_expired_preview_is_dropped_with_its_snapshot_on_load() {
+        let directory = tempdir().unwrap();
+        let (manager, record) = stored_preview(directory.path());
+        let snapshot = manager.source_snapshot_path(&record).unwrap();
+        let expired = SyncPreviewRecord {
+            expires_at: unix_seconds() - 1,
+            ..record.clone()
+        };
+        write_record(
+            &directory.path().join("cache").join("sync-previews"),
+            &expired,
+        )
+        .unwrap();
+
+        let reloaded = SyncPreviewManager::new(directory.path().join("cache"));
+
+        assert!(reloaded.get(&record.id).unwrap().is_none());
+        assert!(
+            !snapshot.exists(),
+            "an expired preview must not leak a file"
+        );
     }
 
     #[test]

--- a/static/src/components/SchedulerSyncControls.tsx
+++ b/static/src/components/SchedulerSyncControls.tsx
@@ -189,10 +189,11 @@ export default function SchedulerSyncControls({
       queryClient.invalidateQueries({ queryKey: ['databases'] });
       queryClient.invalidateQueries({ queryKey: ['db'] });
     } catch (error) {
+      // A refused apply wrote nothing and the server kept the preview, so
+      // keep it here too: retrying works for a transient failure, and a
+      // stale destination just needs a new preview, which is still offered.
       const detail = error instanceof Error ? error.message : String(error);
       setMessage(`Apply failed: ${detail}`);
-      sessionStorage.removeItem(STORED_PREVIEW_KEY);
-      setPending(null);
     } finally {
       setRunning(false);
     }

--- a/static/src/components/__tests__/SchedulerSyncControls.test.tsx
+++ b/static/src/components/__tests__/SchedulerSyncControls.test.tsx
@@ -302,7 +302,7 @@ describe('SchedulerSyncControls', () => {
     });
   });
 
-  it('drops a stale preview and requires a new preview', async () => {
+  it('keeps the preview when apply refuses a changed destination', async () => {
     const result = {
       kind: 'push_planning',
       dry_run: true,
@@ -365,8 +365,10 @@ describe('SchedulerSyncControls', () => {
 
     expect(await screen.findByText(/Apply failed: This preview is stale/))
       .toBeInTheDocument();
+    // The apply wrote nothing, so the reviewed preview survives the refusal
+    // rather than making the user rebuild it to try again.
     expect(
-      screen.queryByRole('button', { name: 'Apply this preview' })
-    ).not.toBeInTheDocument();
+      screen.getByRole('button', { name: 'Apply this preview' })
+    ).toBeInTheDocument();
   });
 });

--- a/tests/integration_remote_sync.rs
+++ b/tests/integration_remote_sync.rs
@@ -1,6 +1,6 @@
 //! Remote plugin protocol coverage: token scope, export, preview, and apply.
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use axum::{
     body::Body,
@@ -71,6 +71,10 @@ fn app(state: Arc<AppState>) -> Router {
             "/api/sync/v1/previews/{preview_id}/apply",
             post(remote_sync::apply_preview),
         )
+        .route(
+            "/api/sync/v1/previews/{preview_id}/refresh",
+            post(remote_sync::refresh_preview),
+        )
         .route("/api/sync/v1/exports", post(remote_sync::create_export))
         .route(
             "/api/sync/v1/exports/{export_id}",
@@ -109,69 +113,151 @@ async fn call(
     (status, value)
 }
 
+/// Two token-scoped catalogs wired to one router, the shape every remote sync
+/// exercise needs.
+struct Harness {
+    /// Held so the databases and cache outlive the test.
+    _directory: tempfile::TempDir,
+    state: Arc<AppState>,
+    router: Router,
+    destination_path: PathBuf,
+}
+
+impl Harness {
+    fn new(source_rows: &str, destination_rows: &str) -> Self {
+        let directory = tempdir().unwrap();
+        let source_path = directory.path().join("source.sqlite");
+        let destination_path = directory.path().join("destination.sqlite");
+        let image_path = directory.path().join("images");
+        std::fs::create_dir(&image_path).unwrap();
+        for (path, rows) in [
+            (&source_path, source_rows),
+            (&destination_path, destination_rows),
+        ] {
+            let connection = Connection::open(path).unwrap();
+            schema(&connection);
+            if !rows.trim().is_empty() {
+                connection.execute_batch(rows).unwrap();
+            }
+        }
+
+        let image_dirs = vec![image_path.to_string_lossy().into_owned()];
+        let state = Arc::new(
+            AppState::from_databases(
+                vec![
+                    DbEntry {
+                        id: "source".into(),
+                        name: "Source".into(),
+                        db_path: source_path.to_string_lossy().into_owned(),
+                        image_dirs: image_dirs.clone(),
+                        reject_archive: None,
+                        remote_image_upload: Some(api_config(SOURCE_TOKEN)),
+                    },
+                    DbEntry {
+                        id: "destination".into(),
+                        name: "Destination".into(),
+                        db_path: destination_path.to_string_lossy().into_owned(),
+                        image_dirs,
+                        reject_archive: None,
+                        remote_image_upload: Some(api_config(DESTINATION_TOKEN)),
+                    },
+                ],
+                directory
+                    .path()
+                    .join("cache")
+                    .to_string_lossy()
+                    .into_owned(),
+                PregenerationConfig::default(),
+            )
+            .unwrap(),
+        );
+        Self {
+            _directory: directory,
+            router: app(Arc::clone(&state)),
+            state,
+            destination_path,
+        }
+    }
+
+    /// Build a bundle on the source catalog, exactly as a remote client would.
+    async fn export(&self, operation: &str) -> Value {
+        let (status, exported) = call(
+            self.router.clone(),
+            "POST",
+            "/api/sync/v1/exports",
+            Some(SOURCE_TOKEN),
+            Some(json!({
+                "protocol_version": 1,
+                "catalog_id": "source",
+                "operation": operation,
+                "reviewed_only": false
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{exported:#}");
+        exported["data"]["bundle"].clone()
+    }
+
+    /// Upload a bundle against the destination catalog and return its ID.
+    async fn preview(&self, operation: &str, bundle: Value) -> String {
+        let (status, preview) = call(
+            self.router.clone(),
+            "POST",
+            "/api/sync/v1/previews",
+            Some(DESTINATION_TOKEN),
+            Some(json!({
+                "protocol_version": 1,
+                "catalog_id": "destination",
+                "operation": operation,
+                "bundle": bundle
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{preview:#}");
+        preview["data"]["preview_id"].as_str().unwrap().to_string()
+    }
+
+    async fn apply(&self, preview_id: &str) -> (StatusCode, Value) {
+        call(
+            self.router.clone(),
+            "POST",
+            &format!("/api/sync/v1/previews/{preview_id}/apply"),
+            Some(DESTINATION_TOKEN),
+            None,
+        )
+        .await
+    }
+
+    fn destination(&self) -> Connection {
+        Connection::open(&self.destination_path).unwrap()
+    }
+
+    /// Every audit line written so far, oldest first.
+    fn audit_entries(&self) -> Vec<Value> {
+        let contents = std::fs::read_to_string(self.state.remote_audit.path()).unwrap_or_default();
+        contents
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+}
+
 #[tokio::test]
 async fn token_scoped_export_previews_and_applies_to_the_selected_database() {
-    let directory = tempdir().unwrap();
-    let source_path = directory.path().join("source.sqlite");
-    let destination_path = directory.path().join("destination.sqlite");
-    let image_path = directory.path().join("images");
-    std::fs::create_dir(&image_path).unwrap();
-    let source = Connection::open(&source_path).unwrap();
-    let destination = Connection::open(&destination_path).unwrap();
-    schema(&source);
-    schema(&destination);
-    source
-        .execute_batch(
-            "INSERT INTO project VALUES (1,'p','M42','remote settings',2,8,'project-guid');
-             INSERT INTO target VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
-             INSERT INTO exposuretemplate VALUES (1,'p','Ha 300','Ha',120,'template-guid');
-             INSERT INTO exposureplan VALUES (1,'p',300,40,18,16,1,1,1,'plan-guid');
-             INSERT INTO ruleweight VALUES (1,'Priority',2.5,1);",
-        )
-        .unwrap();
-    destination
-        .execute_batch(
-            "INSERT INTO project VALUES (20,'p','M42','old settings',1,2,'project-guid');
-             INSERT INTO target VALUES (30,'Old target',1,5.4,-5.3,0,20,'target-guid');
-             INSERT INTO exposuretemplate VALUES (40,'p','Old Ha','Ha',100,'template-guid');
-             INSERT INTO exposureplan VALUES (50,'p',180,20,7,6,0,30,40,'plan-guid');
-             INSERT INTO ruleweight VALUES (60,'Priority',1.0,20);",
-        )
-        .unwrap();
-    drop(source);
-    drop(destination);
-
-    let entries = vec![
-        DbEntry {
-            id: "source".into(),
-            name: "Source".into(),
-            db_path: source_path.to_string_lossy().into_owned(),
-            image_dirs: vec![image_path.to_string_lossy().into_owned()],
-            reject_archive: None,
-            remote_image_upload: Some(api_config(SOURCE_TOKEN)),
-        },
-        DbEntry {
-            id: "destination".into(),
-            name: "Destination".into(),
-            db_path: destination_path.to_string_lossy().into_owned(),
-            image_dirs: vec![image_path.to_string_lossy().into_owned()],
-            reject_archive: None,
-            remote_image_upload: Some(api_config(DESTINATION_TOKEN)),
-        },
-    ];
-    let state = Arc::new(
-        AppState::from_databases(
-            entries,
-            directory
-                .path()
-                .join("cache")
-                .to_string_lossy()
-                .into_owned(),
-            PregenerationConfig::default(),
-        )
-        .unwrap(),
+    let harness = Harness::new(
+        "INSERT INTO project VALUES (1,'p','M42','remote settings',2,8,'project-guid');
+         INSERT INTO target VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
+         INSERT INTO exposuretemplate VALUES (1,'p','Ha 300','Ha',120,'template-guid');
+         INSERT INTO exposureplan VALUES (1,'p',300,40,18,16,1,1,1,'plan-guid');
+         INSERT INTO ruleweight VALUES (1,'Priority',2.5,1);",
+        "INSERT INTO project VALUES (20,'p','M42','old settings',1,2,'project-guid');
+         INSERT INTO target VALUES (30,'Old target',1,5.4,-5.3,0,20,'target-guid');
+         INSERT INTO exposuretemplate VALUES (40,'p','Old Ha','Ha',100,'template-guid');
+         INSERT INTO exposureplan VALUES (50,'p',180,20,7,6,0,30,40,'plan-guid');
+         INSERT INTO ruleweight VALUES (60,'Priority',1.0,20);",
     );
-    let router = app(state);
+    let destination_path = harness.destination_path.clone();
+    let router = harness.router.clone();
 
     let (status, capabilities) = call(
         router.clone(),
@@ -271,6 +357,248 @@ async fn token_scoped_export_previews_and_applies_to_the_selected_database() {
         .query_row("SELECT description FROM project", [], |row| row.get(0))
         .unwrap();
     assert_eq!(description, "remote settings");
+}
+
+/// Rows for a source catalog that has actually observed something.
+const OBSERVED: &str = "INSERT INTO project VALUES (1,'p','M42','remote settings',2,8,'project-guid');
+     INSERT INTO target VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
+     INSERT INTO exposuretemplate VALUES (1,'p','Ha 300','Ha',120,'template-guid');
+     INSERT INTO exposureplan VALUES (1,'p',300,40,18,16,1,1,1,'plan-guid');
+     INSERT INTO ruleweight VALUES (1,'Priority',2.5,1);
+     INSERT INTO acquiredimage VALUES (1,1,1,1750000000,'Ha',1,'{\"FileName\":\"one.fits\"}',NULL,'p',1,'image-one');
+     INSERT INTO acquiredimage VALUES (2,1,1,1750000600,'Ha',2,'{\"FileName\":\"two.fits\"}','clouds','p',1,'image-two');";
+
+#[tokio::test]
+async fn merge_brings_a_remote_catalogs_projects_targets_and_captures_across() {
+    let harness = Harness::new(OBSERVED, "");
+
+    let bundle = harness.export("merge").await;
+    // A merge has to carry the capture tables, not only the planning ones.
+    for table in ["project", "target", "acquiredimage", "imagedata"] {
+        assert!(
+            bundle["tables"].get(table).is_some(),
+            "merge bundle is missing {table}: {bundle:#}"
+        );
+    }
+    let preview_id = harness.preview("merge", bundle).await;
+
+    // Nothing lands until apply.
+    assert_eq!(count(&harness.destination(), "acquiredimage"), 0);
+
+    let (status, applied) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+    let destination = harness.destination();
+    assert_eq!(count(&destination, "project"), 1);
+    assert_eq!(count(&destination, "target"), 1);
+    assert_eq!(count(&destination, "acquiredimage"), 2);
+    let (grade, reason): (i64, Option<String>) = destination
+        .query_row(
+            "SELECT gradingStatus, rejectreason FROM acquiredimage WHERE guid = 'image-two'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(grade, 2, "a new image takes the remote catalog's grade");
+    assert_eq!(reason.as_deref(), Some("clouds"));
+}
+
+#[tokio::test]
+async fn a_second_merge_keeps_the_grade_the_local_reviewer_gave() {
+    // The merge contract: the telescope owns structure, this end owns grading.
+    // A re-merge must not undo a review done here.
+    let harness = Harness::new(OBSERVED, "");
+    let bundle = harness.export("merge").await;
+    let preview_id = harness.preview("merge", bundle).await;
+    let (status, applied) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+
+    harness
+        .destination()
+        .execute(
+            "UPDATE acquiredimage SET gradingStatus = 2, rejectreason = 'reviewed here' \
+             WHERE guid = 'image-one'",
+            [],
+        )
+        .unwrap();
+
+    let bundle = harness.export("merge").await;
+    let preview_id = harness.preview("merge", bundle).await;
+    let (status, applied) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+
+    let (grade, reason): (i64, Option<String>) = harness
+        .destination()
+        .query_row(
+            "SELECT gradingStatus, rejectreason FROM acquiredimage WHERE guid = 'image-one'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(grade, 2, "the remote catalog still says Accepted");
+    assert_eq!(reason.as_deref(), Some("reviewed here"));
+}
+
+#[tokio::test]
+async fn push_grades_moves_grading_state_and_leaves_planning_alone() {
+    let harness = Harness::new(
+        OBSERVED,
+        "INSERT INTO project VALUES (20,'p','M42','local settings',1,2,'project-guid');
+         INSERT INTO target VALUES (30,'M42',1,5.5,-5.4,0,20,'target-guid');
+         INSERT INTO exposuretemplate VALUES (40,'p','Ha 300','Ha',120,'template-guid');
+         INSERT INTO exposureplan VALUES (50,'p',300,40,18,16,1,30,40,'plan-guid');
+         INSERT INTO acquiredimage VALUES (60,20,30,1750000000,'Ha',0,'{\"FileName\":\"one.fits\"}',NULL,'p',50,'image-one');
+         INSERT INTO acquiredimage VALUES (61,20,30,1750000600,'Ha',0,'{\"FileName\":\"two.fits\"}',NULL,'p',50,'image-two');",
+    );
+
+    let bundle = harness.export("push_grades").await;
+    let preview_id = harness.preview("push_grades", bundle).await;
+    let (status, applied) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+    assert_eq!(applied["data"]["summary"]["grades_changed"], 2);
+
+    let destination = harness.destination();
+    let mut statement = destination
+        .prepare("SELECT guid, gradingStatus, rejectreason FROM acquiredimage ORDER BY guid")
+        .unwrap();
+    let grades: Vec<(String, i64, Option<String>)> = statement
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    assert_eq!(
+        grades,
+        vec![
+            ("image-one".to_string(), 1, None),
+            ("image-two".to_string(), 2, Some("clouds".to_string())),
+        ]
+    );
+    // A grade push must not touch planning, however different the two ends are.
+    let description: String = destination
+        .query_row("SELECT description FROM project", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(description, "local settings");
+}
+
+#[tokio::test]
+async fn a_destination_that_moved_refuses_the_apply_but_keeps_the_preview() {
+    let harness = Harness::new(
+        "INSERT INTO project VALUES (1,'p','M42','remote settings',2,8,'project-guid');
+         INSERT INTO target VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
+         INSERT INTO exposuretemplate VALUES (1,'p','Ha 300','Ha',120,'template-guid');
+         INSERT INTO exposureplan VALUES (1,'p',300,40,18,16,1,1,1,'plan-guid');",
+        "INSERT INTO project VALUES (20,'p','M42','old settings',1,2,'project-guid');
+         INSERT INTO target VALUES (30,'M42',1,5.4,-5.3,0,20,'target-guid');
+         INSERT INTO exposuretemplate VALUES (40,'p','Old Ha','Ha',100,'template-guid');
+         INSERT INTO exposureplan VALUES (50,'p',180,20,7,6,0,30,40,'plan-guid');",
+    );
+
+    let bundle = harness.export("push_planning").await;
+    let preview_id = harness.preview("push_planning", bundle).await;
+
+    // Somebody edits the destination between preview and apply.
+    harness
+        .destination()
+        .execute("UPDATE project SET priority = 9", [])
+        .unwrap();
+
+    let (status, refused) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::CONFLICT, "{refused:#}");
+    let description: String = harness
+        .destination()
+        .query_row("SELECT description FROM project", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        description, "old settings",
+        "a refused apply writes nothing"
+    );
+
+    // The point of the fix: the uploaded source data survives the refusal, so
+    // the client re-reviews rather than re-uploading a whole bundle.
+    let (status, kept) = call(
+        harness.router.clone(),
+        "GET",
+        &format!("/api/sync/v1/previews/{preview_id}"),
+        Some(DESTINATION_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{kept:#}");
+
+    let (status, refreshed) = call(
+        harness.router.clone(),
+        "POST",
+        &format!("/api/sync/v1/previews/{preview_id}/refresh"),
+        Some(DESTINATION_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{refreshed:#}");
+    assert_eq!(refreshed["data"]["preview_id"], preview_id);
+    assert_eq!(refreshed["data"]["summary"]["project_updated"], 1);
+
+    let (status, applied) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+    let description: String = harness
+        .destination()
+        .query_row("SELECT description FROM project", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(description, "remote settings");
+
+    // Applying twice is still impossible: the successful apply consumed it.
+    let (status, _) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // Every step of that is on the record, refusals included.
+    let entries = harness.audit_entries();
+    let applies: Vec<_> = entries
+        .iter()
+        .filter(|entry| entry["action"] == "apply")
+        .map(|entry| entry["outcome"].as_str().unwrap())
+        .collect();
+    assert_eq!(applies, vec!["refused", "ok", "refused"], "{entries:#?}");
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry["action"] == "preview_refresh" && entry["outcome"] == "ok"),
+        "{entries:#?}"
+    );
+    let applied_ok = entries
+        .iter()
+        .find(|entry| entry["action"] == "apply" && entry["outcome"] == "ok")
+        .unwrap();
+    assert_eq!(applied_ok["catalog_id"], "destination");
+    assert_eq!(applied_ok["operation"], "push_planning");
+    assert_eq!(applied_ok["summary"]["total_updated"], 4);
+}
+
+#[tokio::test]
+async fn a_rejected_token_is_recorded_without_naming_a_catalog() {
+    let harness = Harness::new("", "");
+
+    let (status, _) = call(
+        harness.router.clone(),
+        "GET",
+        "/api/sync/v1/capabilities",
+        Some("not-a-configured-token-000000000000"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+
+    let entries = harness.audit_entries();
+    assert_eq!(entries.len(), 1, "{entries:#?}");
+    assert_eq!(entries[0]["action"], "capabilities");
+    assert_eq!(entries[0]["outcome"], "refused");
+    assert_eq!(entries[0]["catalog_id"], "-");
+    assert_eq!(entries[0]["detail"], "Invalid API token");
+}
+
+fn count(connection: &Connection, table: &str) -> i64 {
+    connection
+        .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
+            row.get(0)
+        })
+        .unwrap()
 }
 
 /// A key that predates the sync protocol authenticates but reaches nothing.


### PR DESCRIPTION
Follow-up to #229, closing the three review items left open when it merged.

## A grade push that could never work

`push_grades` shipped three columns of a bare `acquiredimage` table. But the receiver reads its source rows through the scheduler's own project/target join, so every call failed with `no such table: project`. Confirmed by reverting the fix under the new test — a plain 400 on the first request.

Grade bundles now carry `project` and `target` alongside a full `acquiredimage`. Neither is ever written; they exist so the materialized source is a Target Scheduler database.

## Keeping a preview when apply refuses

Both apply paths deleted the source snapshot before looking at the result. A stale destination — or a locked file — destroyed a preview that had written nothing, and for a remote client that meant re-uploading the whole bundle to get back to the same point.

A failed apply now restores the preview. `POST /api/sync/v1/previews/{id}/refresh` re-runs it against the destination as it now stands, keeping the ID and the uploaded data, and returns a fresh summary to review. Only a successful apply consumes a preview. Refresh takes the apply lock before reading, so it cannot race a concurrent claim.

The Settings UI keeps its preview on a failed apply for the same reason.

## Audit log

Every remote action appends one JSON line to `remote-sync-audit.jsonl` under the cache root: when, which catalog, which action and operation, the outcome, and the row counts. Refusals are recorded too, including ones that never named a catalog — a run of rejected applies is what a stolen token looks like from the server side. No token, filesystem path, or row contents are written. The file rolls at 8 MiB, keeping one previous generation.

## Tests

Wire-level: merge, re-merge grade preservation, `push_grades`, and the full refuse → keep → refresh → apply sequence with its audit trail. Preview manager: restore, refresh, and expiry. The bundle row budget is now exercised through an injectable limit rather than a million real rows.

`cargo test` 411 + suites green, clippy clean, 142 vitest, 54 Playwright specs against a release build.