### PR TITLE
Align Dependabot and Rust toolchain policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,21 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
+  - package-ecosystem: cargo
+    directory: /
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    reviewers:
-      - "atrus"
-    
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: weekly
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    reviewers:
-      - "atrus"
+      interval: weekly
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       shell: bash
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@1.97.1
       with:
         toolchain: ${{ steps.rust-toolchain.outputs.channel }}
         components: rustfmt, clippy
@@ -251,7 +251,7 @@ jobs:
       shell: bash
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@1.97.1
       with:
         toolchain: ${{ steps.rust-toolchain.outputs.channel }}
         components: rustfmt, clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       shell: bash
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@1.97.1
       with:
         toolchain: ${{ steps.rust-toolchain.outputs.channel }}
         components: rustfmt, clippy

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           toolchain: ${{ steps.rust-toolchain.outputs.channel }}
       


### PR DESCRIPTION
## What changed

- group weekly Cargo and GitHub Actions dependency updates
- exclude `dtolnay/rust-toolchain` from Dependabot updates
- pin all Rust setup actions to the repository's Rust 1.97.1 toolchain

## Why

This aligns psf-guard with the shared dependency-update and Rust toolchain policy used across the Seiza repositories without changing its declared crate MSRV.

## Validation

- `cargo fmt --all --check`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo test --locked`
