### PR TITLE
Exercise the sync paths nothing was reaching

### DIFF
--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -201,15 +201,20 @@ pub struct SyncExport {
 struct StoredExport {
     catalog_id: String,
     created_at: i64,
+    /// Insertion order. `created_at` is whole seconds, so a burst of exports
+    /// all carry the same one and cannot be ranked by it — ordering on the
+    /// timestamp alone would evict by UUID, which is to say at random.
+    sequence: u64,
     export: SyncExport,
 }
 
 /// Built export bundles, held so a client can re-fetch one it lost. Bundles
 /// carry whole tables, so this is capacity-bound and time-bound: expired
-/// entries go first, then the oldest, never an arbitrary hash-order victim.
+/// entries go first, then the least recently built.
 #[derive(Default)]
 pub struct ExportStore {
     entries: Mutex<HashMap<String, StoredExport>>,
+    next_sequence: std::sync::atomic::AtomicU64,
 }
 
 impl ExportStore {
@@ -219,12 +224,15 @@ impl ExportStore {
 
     fn insert(&self, catalog_id: String, export: SyncExport) -> Result<(), AppError> {
         let now = unix_seconds();
+        let sequence = self
+            .next_sequence
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let mut entries = self.lock()?;
         entries.retain(|_, stored| stored.created_at + EXPORT_LIFETIME_SECS > now);
         while entries.len() >= MAX_RETAINED_EXPORTS {
             let Some(oldest) = entries
                 .iter()
-                .min_by_key(|(id, stored)| (stored.created_at, (*id).clone()))
+                .min_by_key(|(_, stored)| stored.sequence)
                 .map(|(id, _)| id.clone())
             else {
                 break;
@@ -236,6 +244,7 @@ impl ExportStore {
             StoredExport {
                 catalog_id,
                 created_at: now,
+                sequence,
                 export,
             },
         );

--- a/tests/integration_remote_sync.rs
+++ b/tests/integration_remote_sync.rs
@@ -593,6 +593,174 @@ async fn a_rejected_token_is_recorded_without_naming_a_catalog() {
     assert_eq!(entries[0]["detail"], "Invalid API token");
 }
 
+#[tokio::test]
+async fn merge_carries_image_data_blobs_across() {
+    // imagedata is the only table whose payload is not text or numbers, so the
+    // base64 wire encoding is reachable through merge and nothing else.
+    let harness = Harness::new(
+        &format!(
+            "{OBSERVED}
+         INSERT INTO imagedata VALUES (1,'thumb',X'89504E470D0A1A0A0000FFFE',1,64,48);"
+        ),
+        "",
+    );
+
+    let bundle = harness.export("merge").await;
+    let preview_id = harness.preview("merge", bundle).await;
+    let (status, applied) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+
+    let destination = harness.destination();
+    let (blob, image_id): (Vec<u8>, i64) = destination
+        .query_row(
+            "SELECT imagedata, acquiredimageid FROM imagedata",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        blob,
+        vec![0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0xff, 0xfe],
+        "a blob must survive base64 without gaining or losing a byte"
+    );
+    let owner: String = destination
+        .query_row(
+            "SELECT guid FROM acquiredimage WHERE Id = ?1",
+            [image_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        owner, "image-one",
+        "the thumbnail must follow its remapped Id"
+    );
+}
+
+#[tokio::test]
+async fn a_bundle_that_omits_optional_tables_still_merges() {
+    // What a third-party plugin sends: the tables the operation needs and
+    // nothing else. The receiver creates the rest empty from its own schema.
+    let harness = Harness::new(OBSERVED, "");
+    let mut bundle = harness.export("merge").await;
+    bundle["tables"]
+        .as_object_mut()
+        .unwrap()
+        .retain(|name, _| ["project", "target", "acquiredimage"].contains(&name.as_str()));
+
+    let preview_id = harness.preview("merge", bundle).await;
+    let (status, applied) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+    let destination = harness.destination();
+    assert_eq!(count(&destination, "acquiredimage"), 2);
+    assert_eq!(count(&destination, "project"), 1);
+    // Nothing invents rows for the tables the client left out.
+    assert_eq!(count(&destination, "ruleweight"), 0);
+    assert_eq!(count(&destination, "imagedata"), 0);
+}
+
+#[tokio::test]
+async fn an_export_is_refetchable_only_with_the_token_that_built_it() {
+    let harness = Harness::new(OBSERVED, "");
+
+    let (status, exported) = call(
+        harness.router.clone(),
+        "POST",
+        "/api/sync/v1/exports",
+        Some(SOURCE_TOKEN),
+        Some(json!({
+            "protocol_version": 1,
+            "catalog_id": "source",
+            "operation": "merge",
+            "reviewed_only": false
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{exported:#}");
+    let export_id = exported["data"]["export_id"].as_str().unwrap();
+
+    // A client that dropped the response can ask for the same bundle again.
+    let (status, refetched) = call(
+        harness.router.clone(),
+        "GET",
+        &format!("/api/sync/v1/exports/{export_id}"),
+        Some(SOURCE_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{refetched:#}");
+    assert_eq!(refetched["data"]["bundle"], exported["data"]["bundle"]);
+
+    // The other catalog's key must not read it, even with the right ID.
+    let (status, _) = call(
+        harness.router.clone(),
+        "GET",
+        &format!("/api/sync/v1/exports/{export_id}"),
+        Some(DESTINATION_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // The store is capped, so a client that keeps building loses its oldest.
+    // Say so in the 404 rather than leaving it looking like an auth failure.
+    for _ in 0..16 {
+        let (status, _) = call(
+            harness.router.clone(),
+            "POST",
+            "/api/sync/v1/exports",
+            Some(SOURCE_TOKEN),
+            Some(json!({
+                "protocol_version": 1,
+                "catalog_id": "source",
+                "operation": "merge",
+                "reviewed_only": false
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+    let (status, dropped) = call(
+        harness.router.clone(),
+        "GET",
+        &format!("/api/sync/v1/exports/{export_id}"),
+        Some(SOURCE_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(
+        dropped["error"]
+            .as_str()
+            .unwrap()
+            .contains("create a new export"),
+        "{dropped:#}"
+    );
+}
+
+#[tokio::test]
+async fn a_reviewed_only_grade_export_still_carries_the_tables_it_joins_against() {
+    // reviewed_only narrows the captures, not the structure the read needs.
+    let harness = Harness::new(OBSERVED, "");
+    let (status, exported) = call(
+        harness.router.clone(),
+        "POST",
+        "/api/sync/v1/exports",
+        Some(SOURCE_TOKEN),
+        Some(json!({
+            "protocol_version": 1,
+            "catalog_id": "source",
+            "operation": "push_grades",
+            "reviewed_only": true
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{exported:#}");
+    let tables = &exported["data"]["bundle"]["tables"];
+    assert_eq!(tables["project"]["rows"].as_array().unwrap().len(), 1);
+    assert_eq!(tables["target"]["rows"].as_array().unwrap().len(), 1);
+    assert_eq!(tables["acquiredimage"]["rows"].as_array().unwrap().len(), 2);
+}
+
 fn count(connection: &Connection, table: &str) -> i64 {
     connection
         .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {

--- a/tests/integration_remote_sync_real_schema.rs
+++ b/tests/integration_remote_sync_real_schema.rs
@@ -1,0 +1,335 @@
+//! Remote sync against the real vendored Target Scheduler schema.
+//!
+//! Every other sync test builds a seven-table shorthand of the scheduler
+//! database. That shorthand cannot catch anything that depends on the real
+//! shape: columns added by later migrations, NOT NULL columns a client has
+//! never heard of, or foreign keys between the tables a bundle materializes.
+//! These tests run the same protocol against `ts_schema`, so they move with
+//! the schema the plugin actually talks to.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::DefaultBodyLimit,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use http_body_util::BodyExt;
+use psf_guard::{
+    cli::PregenerationConfig,
+    db_registry::{DbEntry, RemoteImageUploadConfig},
+    server::{remote_sync, state::AppState},
+};
+use rusqlite::Connection;
+use serde_json::{json, Value};
+use tempfile::tempdir;
+use tower::ServiceExt;
+
+const SOURCE_TOKEN: &str = "source-remote-api-key-1234567890";
+const DESTINATION_TOKEN: &str = "destination-remote-api-key-123456";
+
+/// One observed target, written through named columns so the row survives
+/// migrations that add or reorder fields.
+const TELESCOPE_ROWS: &str = "
+    INSERT INTO project (Id,profileId,name,description,state,priority,isMosaic,flatsHandling,guid)
+        VALUES (1,'profile','M42','telescope settings',2,8,0,0,'project-guid');
+    INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid)
+        VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
+    INSERT INTO exposuretemplate (Id,profileId,name,filtername,gain,guid)
+        VALUES (1,'profile','Ha 300','Ha',120,'template-guid');
+    INSERT INTO exposureplan (Id,profileId,exposure,desired,acquired,accepted,targetid,exposureTemplateId,enabled,guid)
+        VALUES (1,'profile',300,40,18,16,1,1,1,'plan-guid');
+    INSERT INTO ruleweight (Id,name,weight,projectid) VALUES (1,'Priority',2.5,1);
+    INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,profileId,exposureId,guid)
+        VALUES (1,1,1,1750000000,'Ha',1,'{\"FileName\":\"one.fits\"}','profile',1,'image-one');
+    INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,rejectreason,profileId,exposureId,guid)
+        VALUES (2,1,1,1750000600,'Ha',2,'{\"FileName\":\"two.fits\"}','clouds','profile',1,'image-two');
+    INSERT INTO imagedata (Id,tag,imagedata,acquiredimageid,width,height)
+        VALUES (1,'thumb',X'89504E470D0A1A0A',1,64,48);";
+
+struct Harness {
+    _directory: tempfile::TempDir,
+    router: Router,
+    destination_path: std::path::PathBuf,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let directory = tempdir().unwrap();
+        let source_path = directory.path().join("telescope.sqlite");
+        let destination_path = directory.path().join("review.sqlite");
+        let image_path = directory.path().join("images");
+        std::fs::create_dir(&image_path).unwrap();
+        for path in [&source_path, &destination_path] {
+            let connection = Connection::open(path).unwrap();
+            psf_guard::ts_schema::apply_schema(&connection).unwrap();
+        }
+        Connection::open(&source_path)
+            .unwrap()
+            .execute_batch(TELESCOPE_ROWS)
+            .unwrap();
+
+        let image_dirs = vec![image_path.to_string_lossy().into_owned()];
+        let state = Arc::new(
+            AppState::from_databases(
+                vec![
+                    DbEntry {
+                        id: "source".into(),
+                        name: "Telescope".into(),
+                        db_path: source_path.to_string_lossy().into_owned(),
+                        image_dirs: image_dirs.clone(),
+                        reject_archive: None,
+                        remote_image_upload: Some(config(SOURCE_TOKEN)),
+                    },
+                    DbEntry {
+                        id: "destination".into(),
+                        name: "Review copy".into(),
+                        db_path: destination_path.to_string_lossy().into_owned(),
+                        image_dirs,
+                        reject_archive: None,
+                        remote_image_upload: Some(config(DESTINATION_TOKEN)),
+                    },
+                ],
+                directory
+                    .path()
+                    .join("cache")
+                    .to_string_lossy()
+                    .into_owned(),
+                PregenerationConfig::default(),
+            )
+            .unwrap(),
+        );
+        Self {
+            _directory: directory,
+            router: Router::new()
+                .route(
+                    "/api/sync/v1/previews",
+                    post(remote_sync::create_preview)
+                        .layer(DefaultBodyLimit::max(remote_sync::MAX_SYNC_BODY_BYTES)),
+                )
+                .route(
+                    "/api/sync/v1/previews/{preview_id}/apply",
+                    post(remote_sync::apply_preview),
+                )
+                .route("/api/sync/v1/exports", post(remote_sync::create_export))
+                .route(
+                    "/api/sync/v1/exports/{export_id}",
+                    get(remote_sync::get_export),
+                )
+                .with_state(state),
+            destination_path,
+        }
+    }
+
+    async fn export(&self, operation: &str) -> Value {
+        let (status, exported) = call(
+            self.router.clone(),
+            "POST",
+            "/api/sync/v1/exports",
+            SOURCE_TOKEN,
+            Some(json!({
+                "protocol_version": 1,
+                "catalog_id": "source",
+                "operation": operation,
+                "reviewed_only": false
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{exported:#}");
+        exported["data"]["bundle"].clone()
+    }
+
+    async fn apply(&self, operation: &str, bundle: Value) -> Value {
+        let (status, preview) = call(
+            self.router.clone(),
+            "POST",
+            "/api/sync/v1/previews",
+            DESTINATION_TOKEN,
+            Some(json!({
+                "protocol_version": 1,
+                "catalog_id": "destination",
+                "operation": operation,
+                "bundle": bundle
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{preview:#}");
+        let preview_id = preview["data"]["preview_id"].as_str().unwrap();
+        let (status, applied) = call(
+            self.router.clone(),
+            "POST",
+            &format!("/api/sync/v1/previews/{preview_id}/apply"),
+            DESTINATION_TOKEN,
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{applied:#}");
+        applied
+    }
+
+    fn destination(&self) -> Connection {
+        Connection::open(&self.destination_path).unwrap()
+    }
+}
+
+fn config(token: &str) -> RemoteImageUploadConfig {
+    let mut config = RemoteImageUploadConfig {
+        enabled: false,
+        sync_enabled: true,
+        ..Default::default()
+    };
+    config.set_token(token).unwrap();
+    config
+}
+
+async fn call(
+    app: Router,
+    method: &str,
+    uri: &str,
+    token: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"));
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let response = app
+        .oneshot(
+            builder
+                .body(body.map_or_else(Body::empty, |value| {
+                    Body::from(serde_json::to_vec(&value).unwrap())
+                }))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+#[tokio::test]
+async fn a_merge_round_trips_through_the_real_scheduler_schema() {
+    let harness = Harness::new();
+
+    let bundle = harness.export("merge").await;
+    assert_eq!(
+        bundle["source"]["schema_version"],
+        psf_guard::ts_schema::TS_SCHEMA_VERSION
+    );
+    harness.apply("merge", bundle).await;
+
+    let destination = harness.destination();
+    let (name, mosaic): (String, i64) = destination
+        .query_row("SELECT name, isMosaic FROM project", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .unwrap();
+    assert_eq!(name, "M42");
+    assert_eq!(mosaic, 0);
+    let images: i64 = destination
+        .query_row("SELECT count(*) FROM acquiredimage", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(images, 2);
+    let blob: Vec<u8> = destination
+        .query_row("SELECT imagedata FROM imagedata", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(blob, vec![0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+}
+
+#[tokio::test]
+async fn a_client_that_predates_a_column_still_merges() {
+    // A plugin built against an older Target Scheduler sends rows without the
+    // columns later migrations added — including NOT NULL ones. Those must
+    // fall back to the destination's own defaults, not fail the insert.
+    let harness = Harness::new();
+    let mut bundle = harness.export("merge").await;
+    drop_columns(&mut bundle, "project", &["isMosaic", "flatsHandling"]);
+
+    harness.apply("merge", bundle).await;
+
+    let destination = harness.destination();
+    let (name, mosaic, flats): (String, Option<i64>, Option<i64>) = destination
+        .query_row(
+            "SELECT name, isMosaic, flatsHandling FROM project",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(name, "M42", "the row the client did send still lands");
+    assert_eq!(mosaic, Some(0), "the schema default fills the gap");
+    assert_eq!(flats, Some(0));
+}
+
+#[tokio::test]
+async fn a_grade_push_reads_the_real_schemas_join() {
+    // The join a grade push depends on runs against the real table shapes,
+    // not the shorthand the other tests declare.
+    let harness = Harness::new();
+    harness
+        .destination()
+        .execute_batch(
+            "INSERT INTO project (Id,profileId,name,isMosaic,flatsHandling,guid)
+                VALUES (7,'profile','M42',0,0,'project-guid');
+             INSERT INTO target (Id,name,active,epochcode,projectid,guid)
+                VALUES (7,'M42',1,0,7,'target-guid');
+             INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,profileId,guid)
+                VALUES (7,7,7,1750000600,'Ha',0,'{}','profile','image-two');",
+        )
+        .unwrap();
+
+    let bundle = harness.export("push_grades").await;
+    let applied = harness.apply("push_grades", bundle).await;
+    assert_eq!(applied["data"]["summary"]["grades_changed"], 1);
+
+    let (grade, reason): (i64, Option<String>) = harness
+        .destination()
+        .query_row(
+            "SELECT gradingStatus, rejectreason FROM acquiredimage WHERE guid = 'image-two'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(grade, 2);
+    assert_eq!(reason.as_deref(), Some("clouds"));
+}
+
+/// Remove named columns from one bundle table, values included, the way a
+/// client that has never heard of them would have built it.
+fn drop_columns(bundle: &mut Value, table: &str, unknown: &[&str]) {
+    let table = bundle["tables"][table].as_object_mut().unwrap();
+    let dropped: Vec<usize> = table["columns"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .enumerate()
+        .filter(|(_, column)| unknown.contains(&column["name"].as_str().unwrap()))
+        .map(|(index, _)| index)
+        .collect();
+    assert_eq!(dropped.len(), unknown.len(), "column names must all exist");
+    let keep = |values: &Vec<Value>| -> Vec<Value> {
+        values
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !dropped.contains(index))
+            .map(|(_, value)| value.clone())
+            .collect()
+    };
+    let columns = keep(table["columns"].as_array().unwrap());
+    let rows: Vec<Value> = table["rows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| json!({ "values": keep(row["values"].as_array().unwrap()) }))
+        .collect();
+    table.insert("columns".into(), Value::Array(columns));
+    table.insert("rows".into(), Value::Array(rows));
+}

--- a/tests/integration_sync_api.rs
+++ b/tests/integration_sync_api.rs
@@ -343,3 +343,163 @@ async fn planning_and_grade_pushes_preview_before_writing() {
         2
     );
 }
+
+/// The direction the UI runs most: bring new structure and captures down from
+/// the telescope copy. Every other test here pushes, so nothing exercised the
+/// pull path, its image-data option, or its preview guard through the API.
+#[tokio::test]
+async fn a_pull_brings_structure_and_captures_down_and_keeps_local_grades() {
+    let dir = tempdir().unwrap();
+    let local_path = dir.path().join("local.sqlite");
+    let telescope_path = dir.path().join("telescope.sqlite");
+    let local = Connection::open(&local_path).unwrap();
+    let telescope = Connection::open(&telescope_path).unwrap();
+    schema(&local);
+    schema(&telescope);
+    telescope
+        .execute_batch(
+            "INSERT INTO project VALUES (1,'p','M42','telescope settings',2,8,'project-guid');
+             INSERT INTO target VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
+             INSERT INTO exposuretemplate VALUES (1,'p','Ha 300','Ha',120,'template-guid');
+             INSERT INTO exposureplan VALUES (1,'p',300,40,18,16,1,1,1,'plan-guid');
+             INSERT INTO ruleweight VALUES (1,'Priority',2.5,1);
+             INSERT INTO acquiredimage VALUES (1,1,1,1000,'Ha',1,'{}',NULL,'p',1,'known-image');
+             INSERT INTO acquiredimage VALUES (2,1,1,2000,'Ha',1,'{}',NULL,'p',1,'fresh-image');
+             INSERT INTO imagedata VALUES (1,'thumb',X'89504E47',1,64,48);",
+        )
+        .unwrap();
+    // The reviewer has already rejected one of those frames here.
+    local
+        .execute_batch(
+            "INSERT INTO project VALUES (9,'p','M42','local settings',1,2,'project-guid');
+             INSERT INTO target VALUES (9,'M42',1,5.5,-5.4,0,9,'target-guid');
+             INSERT INTO exposuretemplate VALUES (9,'p','Ha 300','Ha',120,'template-guid');
+             INSERT INTO exposureplan VALUES (9,'p',300,40,2,2,1,9,9,'plan-guid');
+             INSERT INTO acquiredimage VALUES (9,9,9,1000,'Ha',2,'{}','reviewed here','p',9,'known-image');",
+        )
+        .unwrap();
+    drop(local);
+    drop(telescope);
+
+    let image_dir = dir.path().join("images");
+    std::fs::create_dir(&image_dir).unwrap();
+    let image_dirs = vec![image_dir.to_string_lossy().into_owned()];
+    let state = Arc::new(
+        AppState::from_databases(
+            vec![
+                DbEntry {
+                    id: "local".into(),
+                    name: "Review copy".into(),
+                    db_path: local_path.to_string_lossy().into_owned(),
+                    image_dirs: image_dirs.clone(),
+                    reject_archive: None,
+                    remote_image_upload: None,
+                },
+                DbEntry {
+                    id: "scope".into(),
+                    name: "Telescope".into(),
+                    db_path: telescope_path.to_string_lossy().into_owned(),
+                    image_dirs,
+                    reject_archive: None,
+                    remote_image_upload: None,
+                },
+            ],
+            dir.path().join("cache").to_string_lossy().into_owned(),
+            PregenerationConfig::default(),
+        )
+        .unwrap(),
+    );
+    let app = Router::new()
+        .route(
+            "/api/databases/{db_id}/sync/preview",
+            post(handlers::preview_sync_database_route),
+        )
+        .route(
+            "/api/databases/{db_id}/sync/previews/{preview_id}/apply",
+            post(handlers::apply_sync_database_preview_route),
+        )
+        .with_state(state);
+
+    let (status, preview) = request(
+        app.clone(),
+        "/api/databases/local/sync/preview",
+        json!({ "peer_db_id": "scope", "kind": "pull" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{preview:#}");
+    assert_eq!(preview["data"]["result"]["dry_run"], true);
+    assert_eq!(preview["data"]["result"]["acquiredimage"]["inserted"], 1);
+    let preview_id = preview["data"]["preview_id"].as_str().unwrap().to_string();
+
+    // A preview writes nothing, image data included.
+    let local = Connection::open(&local_path).unwrap();
+    assert_eq!(
+        local
+            .query_row("SELECT count(*) FROM imagedata", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    drop(local);
+
+    let (status, applied) = request(
+        app,
+        &format!("/api/databases/local/sync/previews/{preview_id}/apply"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+    assert_eq!(applied["data"]["dry_run"], false);
+
+    let local = Connection::open(&local_path).unwrap();
+    assert_eq!(
+        local
+            .query_row("SELECT description FROM project", [], |row| row
+                .get::<_, String>(0))
+            .unwrap(),
+        "telescope settings",
+        "the telescope owns structure"
+    );
+    assert_eq!(
+        local
+            .query_row(
+                "SELECT gradingStatus FROM acquiredimage WHERE guid = 'known-image'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        2,
+        "a review done here survives the pull"
+    );
+    assert_eq!(
+        local
+            .query_row(
+                "SELECT gradingStatus FROM acquiredimage WHERE guid = 'fresh-image'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        1,
+        "a new capture takes the telescope's grade"
+    );
+    // Thumbnails come across with their rows, re-keyed onto the local image Id.
+    let (blob, image_id): (Vec<u8>, i64) = local
+        .query_row(
+            "SELECT d.imagedata, d.acquiredimageid FROM imagedata d",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(blob, vec![0x89, 0x50, 0x4e, 0x47]);
+    let owner: String = local
+        .query_row(
+            "SELECT guid FROM acquiredimage WHERE Id = ?1",
+            [image_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        owner, "known-image",
+        "imagedata must follow the remapped Id"
+    );
+}


### PR DESCRIPTION
The `push_grades` bug in #233 was a path no test ever drove end to end. This sweeps the other paths of that shape.

## Bug found: export eviction was random

`ExportStore` documents itself as dropping the least recently built export, but ordered on `created_at`, which is whole seconds. A burst of exports all share one timestamp, so the tiebreak fell through to the UUID — a client could lose the export it built a moment ago while older ones survived. Entries now carry a monotonic insertion sequence. Caught by the new re-fetch test, which expected the first of seventeen exports to be gone and found it still there.

## Paths probed and found clean

Reporting these because "we checked" is worth as much as "we fixed", and each now has a test:

- **imagedata blobs through a merge.** Base64 is the only non-text wire encoding, and merge is the only operation carrying it. Bytes survive, and the thumbnail follows its remapped image Id.
- **A bundle omitting the optional tables** — what a third-party plugin sends, and what `DATA_TRANSFER_DESIGN.md` promises works. The receiver builds the missing tables from its own schema.
- **`reviewed_only` on a grade export.** Narrows the captures without dropping the tables the read joins against.
- **The local API's pull direction.** Every other test of that route pushes. Structure comes down, a local review survives, and thumbnails re-key onto local Ids.
- **The real Target Scheduler schema.** Every sync test until now declared a seven-table shorthand. A new file runs the protocol against the vendored `ts_schema`, so these tests move with the schema the plugin actually talks to — including a client that predates a NOT NULL column, whose gaps fall back to the destination's defaults rather than failing the insert.

## Answering "do we test sync end to end?"

Not in one piece, and worth knowing:

- The **engine** has 30 unit tests over pull, planning, and grades.
- The **HTTP layer** is covered by the Rust integration tests, now including both directions and the real schema.
- The **browser e2e specs mock every sync response** via `page.route`. Nothing drives UI → real server → real SQLite → assert rows changed.
- The **CLI commands** (`psf-guard sync grades|pull|planning`) have no test at all above the engine functions. Registry slug resolution, the READ_ONLY/READ_WRITE split, and the same-path refusal are unexercised.

The last two are the remaining gaps. Neither is addressed here.

`cargo test` green, clippy clean.