### PR TITLE
Sync two running instances end to end, images included

### DIFF
--- a/DATA_TRANSFER_DESIGN.md
+++ b/DATA_TRANSFER_DESIGN.md
@@ -301,6 +301,24 @@ Each database opts into this protocol on its own. Holding a valid key is not
 enough: the operator ticks **Accept remote scheduler sync** for that database,
 separately from **Accept remote image uploads**.
 
+### Granting access without a Settings panel
+
+The desktop app has Settings; a server run from the command line does not, and
+the route Settings uses is gated behind `--allow-database-management` — far too
+large a grant to demand for this, since it also lets a network caller name
+server filesystem paths. A headless deployment therefore takes both grants from
+`[[remote_sync]]` and `[[remote_upload]]` blocks in its `--config` file, each
+naming a registry slug and a key (inline, or `token_file` for systemd
+credentials and Docker secrets).
+
+They apply to the in-memory database list at startup and are never written back
+to the registry, so the config file stays the whole account of what a
+deployment allows and rotating a key is a restart. A database has one key,
+whichever grants it holds; two blocks naming it with different keys is refused
+rather than letting the later one silently disable the earlier. So is a block
+naming a database that is not registered — the alternative is a server that
+answers every remote request with 403 and cannot say why.
+
 ### Keeping a preview across a refusal
 
 Apply claims a preview once, so no two callers can apply the same one. But an

--- a/README.md
+++ b/README.md
@@ -165,6 +165,28 @@ configured database. Every remote action, refusals included, is appended to
 `remote-sync-audit.jsonl` in the cache directory, so you can tell afterwards
 what a key-holder did and when.
 
+A server run from the command line has no Settings panel, so it takes both
+grants from its `--config` file instead:
+
+```toml
+[[remote_sync]]
+database = "telescope"                       # registry slug
+token_file = "/run/secrets/psf-guard-key"    # or token = "..."
+
+[[remote_upload]]
+database = "telescope"
+image_dir = "/data/incoming"
+token_file = "/run/secrets/psf-guard-key"
+```
+
+These apply at startup and are never written back to the registry, so the
+config file stays the whole account of what a deployment allows and rotating a
+key is a restart. A database has one key, whichever grants it holds. Naming a
+database that is not registered stops the server rather than leaving you to
+guess why every request comes back 403. Neither block needs
+`--allow-database-management`: accepting a sync must not require the grant
+that lets a network caller name server filesystem paths.
+
 The Overview's **Plan & coordinates** dialog lets you correct imported names,
 coordinates, limits, and desired counts. See the
 **[import and planning guide](docs/IMPORTING.md)** for database paths, grouping

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -993,7 +993,18 @@ pub fn main() -> Result<()> {
             let server_port = app_config.get_port();
             let worker_policy = app_config.get_worker_policy();
             let site_banner = app_config.get_site_banner()?;
-            let databases = db_registry.databases.clone();
+            // Open the configured databases for remote sync and image upload.
+            // This edits the in-memory list only — the registry on disk keeps
+            // whatever the desktop Settings panel put there.
+            let mut databases = db_registry.databases.clone();
+            let remote_access = crate::config::apply_remote_access(
+                &mut databases,
+                &app_config.remote_sync,
+                &app_config.remote_upload,
+            )?;
+            if !remote_access.is_empty() {
+                eprintln!("Remote access enabled for: {}", remote_access.join(", "));
+            }
             let astrometry_config = db_registry.astrometry.clone();
 
             let runtime = tokio::runtime::Runtime::new()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,187 @@ pub struct Config {
     pub cache: CacheConfig,
     /// Optional pregeneration configuration
     pub pregeneration: Option<PregenerationConfig>,
+    /// Databases this server accepts remote scheduler sync for, one
+    /// `[[remote_sync]]` block each. See [`RemoteSyncConfig`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub remote_sync: Vec<RemoteSyncConfig>,
+    /// Databases this server accepts remote image uploads for, one
+    /// `[[remote_upload]]` block each. See [`RemoteUploadConfig`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub remote_upload: Vec<RemoteUploadConfig>,
+}
+
+/// Turn on the remote sync protocol for one already-registered database.
+///
+/// The desktop app configures this in Settings, but a headless
+/// `psf-guard server` has no Settings and should not have to open database
+/// management — a far larger grant, since that route lets a network caller
+/// name server filesystem paths — merely to accept a sync. An operator with
+/// shell access on the box writes this instead.
+///
+/// It is applied to the in-memory database list at startup and never written
+/// back to the registry, so the config file stays the whole truth for a
+/// deployment and rotating a token is a restart.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteSyncConfig {
+    /// Registry slug of the database to open for sync.
+    pub database: String,
+    /// Bearer token, in the clear. Prefer `token_file`: this one is readable
+    /// by anyone who can read the config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    /// File holding the bearer token, for systemd credentials, Docker
+    /// secrets, and the like. Leading and trailing whitespace is trimmed, so
+    /// the usual trailing newline is fine.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_file: Option<String>,
+}
+
+/// Accept remote image uploads for one already-registered database.
+///
+/// The image counterpart of [`RemoteSyncConfig`], and separate for the same
+/// reason the registry keeps the two grants apart: a telescope that ships
+/// frames need not also be allowed to merge into the catalog, or the reverse.
+/// A database named by both blocks must use the same key — one key per
+/// database is what the token check assumes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RemoteUploadConfig {
+    /// Registry slug of the database to receive frames for.
+    pub database: String,
+    /// Directory the received frames are written to. Created if absent.
+    pub image_dir: String,
+    /// Bearer token, in the clear. Prefer `token_file`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    /// File holding the bearer token. Whitespace-trimmed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_file: Option<String>,
+}
+
+/// Read a token supplied either inline or by file, naming the database in any
+/// complaint so an operator with several blocks knows which one is wrong.
+fn read_token(
+    database: &str,
+    block: &str,
+    inline: &Option<String>,
+    file: &Option<String>,
+) -> Result<String> {
+    match (inline, file) {
+        (Some(_), Some(_)) => anyhow::bail!(
+            "{block} for database '{database}' sets both token and token_file; use one"
+        ),
+        (Some(token), None) => Ok(token.trim().to_string()),
+        (None, Some(path)) => {
+            let contents = std::fs::read_to_string(path).with_context(|| {
+                format!("reading the {block} token for database '{database}' from {path}")
+            })?;
+            Ok(contents.trim().to_string())
+        }
+        (None, None) => {
+            anyhow::bail!("{block} for database '{database}' needs a token or a token_file")
+        }
+    }
+}
+
+/// Open the configured databases for remote access, in memory only.
+///
+/// Returns a line per database describing what was opened, for the startup
+/// log. An unknown slug is fatal: a typo would otherwise leave the operator
+/// with a server that answers every remote request with 403 and nothing to
+/// say why.
+pub fn apply_remote_access(
+    entries: &mut [crate::db_registry::DbEntry],
+    sync: &[RemoteSyncConfig],
+    upload: &[RemoteUploadConfig],
+) -> Result<Vec<String>> {
+    let mut opened: Vec<(String, Vec<&'static str>)> = Vec::new();
+    // Databases this config run has already keyed. The conflict check is
+    // between blocks the operator wrote together; replacing a key the desktop
+    // Settings panel left in the registry is the config file doing its job.
+    let mut keyed: Vec<(String, String)> = Vec::new();
+    for config in sync {
+        let token = read_token(
+            &config.database,
+            "remote_sync",
+            &config.token,
+            &config.token_file,
+        )?;
+        let access = open(entries, &config.database, &token, &mut keyed)?;
+        access.sync_enabled = true;
+        note(&mut opened, &config.database, "sync");
+    }
+    for config in upload {
+        let token = read_token(
+            &config.database,
+            "remote_upload",
+            &config.token,
+            &config.token_file,
+        )?;
+        std::fs::create_dir_all(&config.image_dir).with_context(|| {
+            format!(
+                "creating the remote upload directory {} for database '{}'",
+                config.image_dir, config.database
+            )
+        })?;
+        let access = open(entries, &config.database, &token, &mut keyed)?;
+        access.enabled = true;
+        access.image_dir = config.image_dir.clone();
+        note(&mut opened, &config.database, "image upload");
+    }
+    Ok(opened
+        .into_iter()
+        .map(|(database, grants)| format!("{database} ({})", grants.join(" + ")))
+        .collect())
+}
+
+/// Find the named database and set its key, leaving every other setting be.
+fn open<'a>(
+    entries: &'a mut [crate::db_registry::DbEntry],
+    database: &str,
+    token: &str,
+    keyed: &mut Vec<(String, String)>,
+) -> Result<&'a mut crate::db_registry::RemoteImageUploadConfig> {
+    // A database has one key. Two blocks naming it with different tokens
+    // would leave whichever ran first silently unusable.
+    if let Some((_, first)) = keyed.iter().find(|(name, _)| name == database)
+        && first != token
+    {
+        anyhow::bail!(
+            "database '{database}' is configured with two different remote keys; \
+             a database has one key, used by whichever grants it holds"
+        );
+    }
+    keyed.push((database.to_string(), token.to_string()));
+    let known = entries
+        .iter()
+        .map(|entry| entry.id.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let entry = entries
+        .iter_mut()
+        .find(|entry| entry.id == database)
+        .with_context(|| {
+            format!(
+                "remote access names database '{database}', which is not registered. \
+                 Configured: {known}"
+            )
+        })?;
+    let access = entry
+        .remote_image_upload
+        .get_or_insert_with(Default::default);
+    access
+        .set_token(token)
+        .with_context(|| format!("remote key for database '{database}'"))?;
+    Ok(access)
+}
+
+fn note(opened: &mut Vec<(String, Vec<&'static str>)>, database: &str, grant: &'static str) {
+    match opened.iter_mut().find(|(name, _)| name == database) {
+        Some((_, grants)) => grants.push(grant),
+        None => opened.push((database.to_string(), vec![grant])),
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -678,5 +859,216 @@ directory = "./cache"
             .unwrap_err()
             .to_string()
             .contains("Invalid file_ttl format"));
+    }
+
+    fn entry(id: &str) -> crate::db_registry::DbEntry {
+        crate::db_registry::DbEntry {
+            id: id.into(),
+            name: id.into(),
+            db_path: format!("/tmp/{id}.sqlite"),
+            image_dirs: vec![],
+            reject_archive: None,
+            remote_image_upload: None,
+        }
+    }
+
+    const TOKEN: &str = "a-remote-sync-token-long-enough";
+
+    #[test]
+    fn remote_sync_opens_only_the_named_database_and_only_for_sync() {
+        let config: Config = toml_edit::de::from_str(&format!(
+            r#"
+            [server]
+            [cache]
+            [[remote_sync]]
+            database = "telescope"
+            token = "{TOKEN}"
+            "#
+        ))
+        .unwrap();
+        let mut entries = vec![entry("telescope"), entry("review")];
+
+        let opened =
+            apply_remote_access(&mut entries, &config.remote_sync, &config.remote_upload).unwrap();
+
+        assert_eq!(opened, vec!["telescope (sync)".to_string()]);
+        let upload = entries[0].remote_image_upload.as_ref().unwrap();
+        assert!(upload.sync_enabled);
+        assert!(upload.token_matches(TOKEN));
+        assert!(
+            !upload.enabled,
+            "opening sync must not also accept image uploads"
+        );
+        assert!(
+            entries[1].remote_image_upload.is_none(),
+            "an unnamed database stays closed"
+        );
+    }
+
+    #[test]
+    fn remote_sync_keeps_an_existing_image_upload_grant() {
+        let mut existing = crate::db_registry::RemoteImageUploadConfig {
+            enabled: true,
+            image_dir: "/data/incoming".into(),
+            ..Default::default()
+        };
+        existing
+            .set_token("an-image-upload-token-long-enough")
+            .unwrap();
+        let mut entries = vec![entry("telescope")];
+        entries[0].remote_image_upload = Some(existing);
+
+        apply_remote_access(
+            &mut entries,
+            &[RemoteSyncConfig {
+                database: "telescope".into(),
+                token: Some(TOKEN.into()),
+                token_file: None,
+            }],
+            &[],
+        )
+        .unwrap();
+
+        let upload = entries[0].remote_image_upload.as_ref().unwrap();
+        assert!(upload.enabled, "the upload grant survives");
+        assert_eq!(upload.image_dir, "/data/incoming");
+        assert!(upload.sync_enabled);
+        // One key per database: the configured token replaces the old one.
+        assert!(upload.token_matches(TOKEN));
+    }
+
+    #[test]
+    fn a_token_file_is_read_and_trimmed() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), format!("{TOKEN}\n")).unwrap();
+        let mut entries = vec![entry("telescope")];
+
+        apply_remote_access(
+            &mut entries,
+            &[RemoteSyncConfig {
+                database: "telescope".into(),
+                token: None,
+                token_file: Some(file.path().to_string_lossy().into_owned()),
+            }],
+            &[],
+        )
+        .unwrap();
+
+        // The trailing newline every editor adds must not become part of the
+        // token, or the operator's key silently never matches.
+        assert!(entries[0]
+            .remote_image_upload
+            .as_ref()
+            .unwrap()
+            .token_matches(TOKEN));
+    }
+
+    #[test]
+    fn an_unregistered_database_is_fatal_and_says_what_is_configured() {
+        let mut entries = vec![entry("review")];
+        let error = apply_remote_access(
+            &mut entries,
+            &[RemoteSyncConfig {
+                database: "telescop".into(),
+                token: Some(TOKEN.into()),
+                token_file: None,
+            }],
+            &[],
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("telescop"), "{error}");
+        assert!(error.contains("review"), "{error}");
+    }
+
+    #[test]
+    fn a_remote_sync_block_without_a_token_is_refused() {
+        let error = apply_remote_access(
+            &mut [entry("telescope")],
+            &[RemoteSyncConfig {
+                database: "telescope".into(),
+                token: None,
+                token_file: None,
+            }],
+            &[],
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("token"), "{error}");
+    }
+
+    #[test]
+    fn a_short_token_is_refused_before_the_server_starts() {
+        let error = apply_remote_access(
+            &mut [entry("telescope")],
+            &[RemoteSyncConfig {
+                database: "telescope".into(),
+                token: Some("too-short".into()),
+                token_file: None,
+            }],
+            &[],
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("telescope"), "{error}");
+    }
+
+    #[test]
+    fn both_grants_can_be_configured_for_one_database() {
+        let directory = tempfile::tempdir().unwrap();
+        let image_dir = directory.path().join("incoming");
+        let mut entries = vec![entry("telescope")];
+
+        let opened = apply_remote_access(
+            &mut entries,
+            &[RemoteSyncConfig {
+                database: "telescope".into(),
+                token: Some(TOKEN.into()),
+                token_file: None,
+            }],
+            &[RemoteUploadConfig {
+                database: "telescope".into(),
+                image_dir: image_dir.to_string_lossy().into_owned(),
+                token: Some(TOKEN.into()),
+                token_file: None,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(opened, vec!["telescope (sync + image upload)".to_string()]);
+        let access = entries[0].remote_image_upload.as_ref().unwrap();
+        assert!(access.sync_enabled);
+        assert!(access.enabled);
+        assert_eq!(access.image_dir, image_dir.to_string_lossy());
+        assert!(access.token_matches(TOKEN));
+        // The receive directory is made ready at startup, not on the first
+        // upload, so a bad path fails while the operator is still watching.
+        assert!(image_dir.is_dir());
+    }
+
+    #[test]
+    fn two_grants_with_different_keys_are_refused() {
+        // Silently letting the second win would leave the first grant's key
+        // rejected with no hint as to why.
+        let directory = tempfile::tempdir().unwrap();
+        let error = apply_remote_access(
+            &mut [entry("telescope")],
+            &[RemoteSyncConfig {
+                database: "telescope".into(),
+                token: Some(TOKEN.into()),
+                token_file: None,
+            }],
+            &[RemoteUploadConfig {
+                database: "telescope".into(),
+                image_dir: directory.path().to_string_lossy().into_owned(),
+                token: Some("a-different-token-long-enough".into()),
+                token_file: None,
+            }],
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("one key"), "{error}");
     }
 }

--- a/src/server/remote_audit.rs
+++ b/src/server/remote_audit.rs
@@ -80,6 +80,7 @@ pub struct AuditRecord<'a> {
 
 pub struct RemoteAuditLog {
     path: PathBuf,
+    max_bytes: u64,
     /// Serializes appends so two concurrent applies cannot interleave a line.
     write_lock: Mutex<()>,
 }
@@ -88,7 +89,18 @@ impl RemoteAuditLog {
     pub fn new(cache_root: impl AsRef<Path>) -> Self {
         Self {
             path: cache_root.as_ref().join("remote-sync-audit.jsonl"),
+            max_bytes: MAX_LOG_BYTES,
             write_lock: Mutex::new(()),
+        }
+    }
+
+    /// A smaller roll threshold, so a test can prove rotation without writing
+    /// megabytes of filler.
+    #[cfg(test)]
+    fn with_max_bytes(cache_root: impl AsRef<Path>, max_bytes: u64) -> Self {
+        Self {
+            max_bytes,
+            ..Self::new(cache_root)
         }
     }
 
@@ -158,7 +170,7 @@ impl RemoteAuditLog {
         let Ok(metadata) = fs::metadata(&self.path) else {
             return;
         };
-        if metadata.len() < MAX_LOG_BYTES {
+        if metadata.len() < self.max_bytes {
             return;
         }
         let _ = fs::rename(&self.path, self.path.with_extension("jsonl.1"));
@@ -210,9 +222,10 @@ mod tests {
 
     #[test]
     fn a_full_log_rolls_to_one_previous_generation() {
+        const FULL: u64 = 64;
         let directory = tempdir().unwrap();
-        let log = RemoteAuditLog::new(directory.path());
-        fs::write(log.path(), vec![b'x'; MAX_LOG_BYTES as usize]).unwrap();
+        let log = RemoteAuditLog::with_max_bytes(directory.path(), FULL);
+        fs::write(log.path(), vec![b'x'; FULL as usize]).unwrap();
         log.record(
             "catalog",
             AuditAction::Export,
@@ -221,7 +234,7 @@ mod tests {
         );
 
         let rolled = log.path().with_extension("jsonl.1");
-        assert_eq!(fs::metadata(&rolled).unwrap().len(), MAX_LOG_BYTES);
+        assert_eq!(fs::metadata(&rolled).unwrap().len(), FULL);
         let contents = fs::read_to_string(log.path()).unwrap();
         assert_eq!(contents.lines().count(), 1, "{contents}");
     }

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -201,15 +201,20 @@ pub struct SyncExport {
 struct StoredExport {
     catalog_id: String,
     created_at: i64,
+    /// Insertion order. `created_at` is whole seconds, so a burst of exports
+    /// all carry the same one and cannot be ranked by it — ordering on the
+    /// timestamp alone would evict by UUID, which is to say at random.
+    sequence: u64,
     export: SyncExport,
 }
 
 /// Built export bundles, held so a client can re-fetch one it lost. Bundles
 /// carry whole tables, so this is capacity-bound and time-bound: expired
-/// entries go first, then the oldest, never an arbitrary hash-order victim.
+/// entries go first, then the least recently built.
 #[derive(Default)]
 pub struct ExportStore {
     entries: Mutex<HashMap<String, StoredExport>>,
+    next_sequence: std::sync::atomic::AtomicU64,
 }
 
 impl ExportStore {
@@ -219,12 +224,15 @@ impl ExportStore {
 
     fn insert(&self, catalog_id: String, export: SyncExport) -> Result<(), AppError> {
         let now = unix_seconds();
+        let sequence = self
+            .next_sequence
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let mut entries = self.lock()?;
         entries.retain(|_, stored| stored.created_at + EXPORT_LIFETIME_SECS > now);
         while entries.len() >= MAX_RETAINED_EXPORTS {
             let Some(oldest) = entries
                 .iter()
-                .min_by_key(|(id, stored)| (stored.created_at, (*id).clone()))
+                .min_by_key(|(_, stored)| stored.sequence)
                 .map(|(id, _)| id.clone())
             else {
                 break;
@@ -236,6 +244,7 @@ impl ExportStore {
             StoredExport {
                 catalog_id,
                 created_at: now,
+                sequence,
                 export,
             },
         );

--- a/static/e2e/fixtures/sync.ts
+++ b/static/e2e/fixtures/sync.ts
@@ -1,0 +1,247 @@
+import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TS_SCHEMA_DIR = path.resolve(__dirname, '../../../src/ts_schema');
+
+/**
+ * Bearer keys the running server accepts for `/api/sync/v1/*`. A key is scoped
+ * to one catalog, so a real telescope-to-review sync needs both: the exporting
+ * side presents one, the receiving side the other. Long enough to clear the
+ * registry's minimum, and fixed so specs can present them.
+ */
+export const TELESCOPE_TOKEN = 'e2e-remote-sync-telescope-token-01';
+export const REVIEW_TOKEN = 'e2e-remote-sync-review-token-0001';
+
+/** Registry slugs of the two catalogs the sync specs move data between. */
+export const TELESCOPE_DB = 'e2e-telescope';
+export const REVIEW_DB = 'e2e-review';
+
+/**
+ * Build a real Target Scheduler database from the SQL PSF Guard vendors.
+ *
+ * Hand-writing a cut-down schema here was tried and is a trap: the sync
+ * engine, the importer, and the upload path each read columns the shorthand
+ * did not have, and each failure looked like a product bug. Replaying the
+ * vendored initial schema and migrations keeps one source of truth, so these
+ * catalogs move with `src/ts_schema` instead of drifting from it.
+ */
+function applyRealSchema(db: InstanceType<typeof Database>): void {
+  db.exec(fs.readFileSync(path.join(TS_SCHEMA_DIR, 'initial_schema.sql'), 'utf8'));
+  const migrations = fs
+    .readdirSync(path.join(TS_SCHEMA_DIR, 'migrate'))
+    .filter((name) => name.endsWith('.sql'))
+    .map((name) => Number(name.replace('.sql', '')))
+    .sort((left, right) => left - right);
+  for (const version of migrations) {
+    db.exec(
+      fs.readFileSync(path.join(TS_SCHEMA_DIR, 'migrate', `${version}.sql`), 'utf8')
+    );
+    db.pragma(`user_version = ${version}`);
+  }
+}
+
+/** A night's work at the telescope, none of it reviewed yet. */
+const TELESCOPE_ROWS = `
+  INSERT INTO project (Id,profileId,name,description,state,priority,isMosaic,flatsHandling,guid)
+    VALUES (1,'default','Sync Nebula','fresh from the mount',1,5,0,0,'sync-project');
+  INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid)
+    VALUES (1,'Sync Nebula Core',1,5.5,-5.4,0,1,'sync-target');
+  INSERT INTO exposuretemplate (Id,profileId,name,filtername,gain,offset,bin,readoutmode,guid)
+    VALUES (1,'default','Ha 300','Ha',100,30,1,0,'sync-template');
+  INSERT INTO exposureplan (Id,profileId,exposure,desired,acquired,accepted,targetid,exposureTemplateId,enabled,guid)
+    VALUES (1,'default',300,40,2,2,1,1,1,'sync-plan');
+  INSERT INTO ruleweight (Id,name,weight,projectid) VALUES (1,'Priority',2.5,1);
+  INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,profileId,exposureId,guid)
+    VALUES (1,1,1,1750000000,'Ha',1,'{"FileName":"sync-one.fits"}','default',1,'sync-image-one');
+  INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,profileId,exposureId,guid)
+    VALUES (2,1,1,1750000600,'Ha',1,'{"FileName":"sync-two.fits"}','default',1,'sync-image-two');
+`;
+
+/**
+ * The review copy already holds the first frame and has rejected it. A merge
+ * must respect that; a grade push must be able to send it back.
+ */
+const REVIEW_ROWS = `
+  INSERT INTO project (Id,profileId,name,description,state,priority,isMosaic,flatsHandling,guid)
+    VALUES (10,'default','Sync Nebula','under review',1,5,0,0,'sync-project');
+  INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid)
+    VALUES (10,'Sync Nebula Core',1,5.5,-5.4,0,10,'sync-target');
+  INSERT INTO exposuretemplate (Id,profileId,name,filtername,gain,offset,bin,readoutmode,guid)
+    VALUES (10,'default','Ha 300','Ha',100,30,1,0,'sync-template');
+  INSERT INTO exposureplan (Id,profileId,exposure,desired,acquired,accepted,targetid,exposureTemplateId,enabled,guid)
+    VALUES (10,'default',300,40,1,1,10,10,1,'sync-plan');
+  INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,rejectreason,profileId,exposureId,guid)
+    VALUES (10,10,10,1750000000,'Ha',2,'{"FileName":"sync-one.fits"}','reviewed here','default',10,'sync-image-one');
+`;
+
+const FITS_CARD_BYTES = 80;
+const FITS_BLOCK_BYTES = 2880;
+
+/**
+ * A small but real FITS light frame. The upload endpoint reads headers to
+ * place the frame, so a stub of zeroes would not do; this carries the cards
+ * the importer looks at and a 10x10 16-bit image.
+ */
+export function fitsLight(object: string, dateObs: string): Buffer {
+  const cards = [
+    'SIMPLE  =                    T',
+    'BITPIX  =                   16',
+    'NAXIS   =                    2',
+    'NAXIS1  =                   10',
+    'NAXIS2  =                   10',
+    "IMAGETYP= 'LIGHT   '",
+    `OBJECT  = '${object}'`,
+    "FILTER  = 'Ha      '",
+    `DATE-OBS= '${dateObs}'`,
+    'EXPTIME =                300.0',
+    'GAIN    =                  100',
+    'OFFSET  =                   30',
+    'END',
+  ];
+  const headerBlocks = Math.ceil(
+    (cards.length * FITS_CARD_BYTES) / FITS_BLOCK_BYTES
+  );
+  const header = Buffer.alloc(headerBlocks * FITS_BLOCK_BYTES, 0x20);
+  cards.forEach((card, index) =>
+    header.write(card.padEnd(FITS_CARD_BYTES, ' '), index * FITS_CARD_BYTES, 'ascii')
+  );
+  // 10x10 big-endian 16-bit pixels, one block, zero-padded.
+  const data = Buffer.alloc(FITS_BLOCK_BYTES);
+  for (let pixel = 0; pixel < 100; pixel += 1) {
+    data.writeInt16BE(100 + pixel, pixel * 2);
+  }
+  return Buffer.concat([header, data]);
+}
+
+/** Everything one of the two sync instances is started with. */
+export interface SyncInstance {
+  configPath: string;
+  registryPath: string;
+  cacheDir: string;
+  databasePath: string;
+}
+
+export interface SyncFixture {
+  /** Directory holding both catalogs and both server configs. */
+  directory: string;
+  telescope: SyncInstance;
+  review: SyncInstance;
+  /** Where the review instance writes frames it receives. */
+  uploadDir: string;
+}
+
+/**
+ * Install the fixture two PSF Guard instances need to sync with each other:
+ * one scheduler catalog each, and one config file each opening it for remote
+ * access.
+ *
+ * These get their own instances rather than sharing the main e2e server on
+ * purpose. Specs that exercise the database CRUD UI reset that server's
+ * database list to empty, which would take the sync catalogs with it — and a
+ * re-added entry would come back without the grant its config file gave it,
+ * since that is applied at startup.
+ *
+ * Everything lives beside the run directory rather than inside it, because
+ * global setup wipes the run directory while these servers are already up and
+ * still opening their catalogs by path for every sync. Playwright config
+ * calls this before any server starts; a second call is a no-op.
+ */
+export function installSyncFixture(tmpBase: string): SyncFixture {
+  const directory = `${tmpBase}-sync`;
+  const uploadDir = path.join(directory, 'incoming');
+  const instance = (name: string): SyncInstance => ({
+    configPath: path.join(directory, `${name}.toml`),
+    registryPath: path.join(directory, `${name}-registry.json`),
+    cacheDir: path.join(directory, `${name}-cache`),
+    databasePath: path.join(directory, `${name}.sqlite`),
+  });
+  const telescope = instance('telescope');
+  const review = instance('review');
+  if (fs.existsSync(telescope.databasePath)) {
+    return { directory, telescope, review, uploadDir };
+  }
+
+  fs.rmSync(directory, { recursive: true, force: true });
+  fs.mkdirSync(directory, { recursive: true });
+  // The review instance's config also creates this at startup, but the
+  // telescope has no upload grant and its registry still has to name a
+  // directory that exists.
+  fs.mkdirSync(uploadDir, { recursive: true });
+  for (const [target, rows] of [
+    [telescope, TELESCOPE_ROWS],
+    [review, REVIEW_ROWS],
+  ] as const) {
+    const db = new Database(target.databasePath);
+    applyRealSchema(db);
+    db.exec(rows);
+    db.close();
+  }
+
+  const writeRegistry = (
+    target: SyncInstance,
+    id: string,
+    name: string,
+    imageDir: string
+  ) =>
+    fs.writeFileSync(
+      target.registryPath,
+      `${JSON.stringify(
+        {
+          schema_version: 2,
+          databases: [
+            { id, name, db_path: target.databasePath, image_dirs: [imageDir] },
+          ],
+        },
+        null,
+        2
+      )}\n`
+    );
+  writeRegistry(telescope, TELESCOPE_DB, 'E2E telescope', directory);
+  writeRegistry(review, REVIEW_DB, 'E2E review copy', uploadDir);
+
+  // A headless server has no Settings panel, so config blocks are how an
+  // operator opens a catalog for remote access. One config per instance,
+  // exactly as two machines would have.
+  const reviewTokenFile = path.join(directory, 'review.token');
+  fs.writeFileSync(reviewTokenFile, `${REVIEW_TOKEN}\n`);
+  fs.writeFileSync(
+    telescope.configPath,
+    [
+      '[server]',
+      '',
+      '[cache]',
+      '',
+      '[[remote_sync]]',
+      `database = "${TELESCOPE_DB}"`,
+      `token = "${TELESCOPE_TOKEN}"`,
+      '',
+    ].join('\n')
+  );
+  fs.writeFileSync(
+    review.configPath,
+    [
+      '[server]',
+      '',
+      '[cache]',
+      '',
+      '[[remote_sync]]',
+      `database = "${REVIEW_DB}"`,
+      // token_file is the form a deployment actually uses: systemd
+      // credentials, Docker secrets, and the like.
+      `token_file = "${reviewTokenFile}"`,
+      '',
+      // The same key also lets the telescope ship frames here. Catalog rows
+      // and pixels travel by different routes and are separate grants.
+      '[[remote_upload]]',
+      `database = "${REVIEW_DB}"`,
+      `image_dir = "${uploadDir}"`,
+      `token_file = "${reviewTokenFile}"`,
+      '',
+    ].join('\n')
+  );
+
+  return { directory, telescope, review, uploadDir };
+}

--- a/static/e2e/sync-api.spec.ts
+++ b/static/e2e/sync-api.spec.ts
@@ -1,0 +1,327 @@
+import {
+  expect,
+  request as playwrightRequest,
+  test,
+  type APIRequestContext,
+} from '@playwright/test';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  fitsLight,
+  REVIEW_DB,
+  REVIEW_TOKEN,
+  TELESCOPE_DB,
+  TELESCOPE_TOKEN,
+} from './fixtures/sync';
+
+/**
+ * Two PSF Guard instances syncing with each other.
+ *
+ * Every other sync test stops short of this: the Rust suites drive the
+ * handlers in-process, and the Settings specs mock the responses. Here two
+ * separate `psf-guard server` processes, each with its own registry, cache,
+ * and catalog, move a night's work between them over HTTP — and the result is
+ * read back through the ordinary API, so a break anywhere between the token
+ * check and the committed row fails these.
+ *
+ * PSF Guard ships no client for its own protocol; the plugin at the telescope
+ * plays that part. These specs stand in for it, pulling a bundle from one
+ * instance and posting it to the other, which is exactly the traffic a
+ * coordinator generates.
+ *
+ * Neither grant comes from the Settings UI. Both instances are opened by
+ * config-file blocks, and the receiving one deliberately runs without
+ * `--allow-database-management`: accepting a sync must not require the grant
+ * that lets a caller name server filesystem paths.
+ */
+
+const AS_TELESCOPE = { Authorization: `Bearer ${TELESCOPE_TOKEN}` };
+const AS_REVIEW = { Authorization: `Bearer ${REVIEW_TOKEN}` };
+
+/** The two sync instances, each addressed on its own port. */
+let telescope: APIRequestContext;
+let review: APIRequestContext;
+
+test.beforeAll(async () => {
+  telescope = await playwrightRequest.newContext({
+    baseURL: process.env.PSF_GUARD_E2E_TELESCOPE_URL,
+  });
+  review = await playwrightRequest.newContext({
+    baseURL: process.env.PSF_GUARD_E2E_REVIEW_URL,
+  });
+});
+
+test.afterAll(async () => {
+  await Promise.all([telescope.dispose(), review.dispose()]);
+});
+
+/** Pull a bundle off the telescope instance, as a coordinator would. */
+async function exportFromTelescope(operation: string) {
+  const response = await telescope.post('/api/sync/v1/exports', {
+    headers: AS_TELESCOPE,
+    data: {
+      protocol_version: 1,
+      catalog_id: TELESCOPE_DB,
+      operation,
+      reviewed_only: false,
+    },
+  });
+  expect(response.status(), await response.text()).toBe(200);
+  return (await response.json()).data.bundle;
+}
+
+/** Post it to the review instance and return the preview it holds. */
+async function previewOnReview(
+  operation: string,
+  bundle: unknown
+): Promise<string> {
+  const response = await review.post('/api/sync/v1/previews', {
+    headers: AS_REVIEW,
+    data: {
+      protocol_version: 1,
+      catalog_id: REVIEW_DB,
+      operation,
+      bundle,
+    },
+  });
+  expect(response.status(), await response.text()).toBe(200);
+  return (await response.json()).data.preview_id;
+}
+
+/** Read the review instance's catalog the way its own UI would. */
+async function reviewImages() {
+  const response = await review.get(
+    `/api/db/${REVIEW_DB}/images?project_id=10&target_id=10`
+  );
+  expect(response.status(), await response.text()).toBe(200);
+  return (await response.json()).data as Array<{
+    id: number;
+    grading_status: number;
+    reject_reason: string | null;
+  }>;
+}
+
+test('each instance answers for its own catalog and no other', async () => {
+  const near = await telescope.get('/api/sync/v1/capabilities', {
+    headers: AS_TELESCOPE,
+  });
+  expect(near.status(), await near.text()).toBe(200);
+  const capabilities = (await near.json()).data;
+  expect(capabilities.protocol_version).toBe(1);
+  expect(capabilities.capabilities).toEqual(
+    expect.arrayContaining(['merge', 'push_grades', 'preview_refresh'])
+  );
+  expect(capabilities.catalogs).toHaveLength(1);
+  expect(capabilities.catalogs[0].id).toBe(TELESCOPE_DB);
+
+  // The review instance's key came from token_file, so this also proves the
+  // server read the file and trimmed its trailing newline.
+  const far = await review.get('/api/sync/v1/capabilities', {
+    headers: AS_REVIEW,
+  });
+  expect(far.status(), await far.text()).toBe(200);
+  expect((await far.json()).data.catalogs[0].id).toBe(REVIEW_DB);
+
+  // Neither instance's key opens the other.
+  expect(
+    (await review.get('/api/sync/v1/capabilities', { headers: AS_TELESCOPE }))
+      .status()
+  ).toBe(403);
+  expect(
+    (await telescope.get('/api/sync/v1/capabilities', { headers: AS_REVIEW }))
+      .status()
+  ).toBe(403);
+  expect((await telescope.get('/api/sync/v1/capabilities')).status()).toBe(403);
+});
+
+test('a merge moves a night from one instance to the other', async () => {
+  const before = await reviewImages();
+  expect(before, 'the review copy starts with one reviewed frame').toHaveLength(1);
+
+  const bundle = await exportFromTelescope('merge');
+  expect(bundle.payload_sha256).toHaveLength(64);
+  const previewId = await previewOnReview('merge', bundle);
+
+  // A preview writes nothing.
+  expect(await reviewImages()).toHaveLength(1);
+
+  const applied = await review.post(
+    `/api/sync/v1/previews/${previewId}/apply`,
+    { headers: AS_REVIEW }
+  );
+  expect(applied.status(), await applied.text()).toBe(200);
+  expect((await applied.json()).data.state).toBe('applied');
+
+  const after = await reviewImages();
+  expect(after).toHaveLength(2);
+  const rejected = after.filter((image) => image.grading_status === 2);
+  expect(
+    rejected,
+    'the review done on this side must survive the merge'
+  ).toHaveLength(1);
+  expect(rejected[0].reject_reason).toBe('reviewed here');
+
+  // One apply per preview.
+  const again = await review.post(
+    `/api/sync/v1/previews/${previewId}/apply`,
+    { headers: AS_REVIEW }
+  );
+  expect(again.status()).toBe(404);
+});
+
+test('a destination that moved refuses the apply, then refreshes and applies', async () => {
+  const bundle = await exportFromTelescope('merge');
+  const previewId = await previewOnReview('merge', bundle);
+
+  // Somebody regrades on the review instance between preview and apply,
+  // through its ordinary UI route.
+  const images = await reviewImages();
+  const regraded = await review.put(
+    `/api/db/${REVIEW_DB}/images/${images[0].id}/grade`,
+    { data: { status: 'pending' } }
+  );
+  expect(regraded.status(), await regraded.text()).toBe(200);
+
+  const stale = await review.post(`/api/sync/v1/previews/${previewId}/apply`, {
+    headers: AS_REVIEW,
+  });
+  expect(stale.status()).toBe(409);
+
+  // The refused apply kept the preview, so the coordinator re-reviews rather
+  // than re-uploading its bundle.
+  const kept = await review.get(`/api/sync/v1/previews/${previewId}`, {
+    headers: AS_REVIEW,
+  });
+  expect(kept.status(), await kept.text()).toBe(200);
+
+  const refreshed = await review.post(
+    `/api/sync/v1/previews/${previewId}/refresh`,
+    { headers: AS_REVIEW }
+  );
+  expect(refreshed.status(), await refreshed.text()).toBe(200);
+  expect((await refreshed.json()).data.preview_id).toBe(previewId);
+
+  const applied = await review.post(
+    `/api/sync/v1/previews/${previewId}/apply`,
+    { headers: AS_REVIEW }
+  );
+  expect(applied.status(), await applied.text()).toBe(200);
+});
+
+test('an export can be fetched again by ID', async () => {
+  const created = await telescope.post('/api/sync/v1/exports', {
+    headers: AS_TELESCOPE,
+    data: {
+      protocol_version: 1,
+      catalog_id: TELESCOPE_DB,
+      operation: 'push_grades',
+      reviewed_only: true,
+    },
+  });
+  expect(created.status(), await created.text()).toBe(200);
+  const { export_id: exportId, bundle } = (await created.json()).data;
+
+  const refetched = await telescope.get(`/api/sync/v1/exports/${exportId}`, {
+    headers: AS_TELESCOPE,
+  });
+  expect(refetched.status(), await refetched.text()).toBe(200);
+  expect((await refetched.json()).data.bundle).toEqual(bundle);
+
+  const unknown = await telescope.get(
+    '/api/sync/v1/exports/2b3c4d5e-0000-0000-0000-000000000000',
+    { headers: AS_TELESCOPE }
+  );
+  expect(unknown.status()).toBe(404);
+});
+
+test('pixels travel by their own route, not inside the catalog bundle', async () => {
+  // A catalog sync carries rows and any thumbnails stored in the database. It
+  // does not carry acquisition files — those go through the image upload
+  // grant, which the review instance holds separately.
+  const filename = '2026-07-25_sync-nebula_Ha_300s.fits';
+  const frame = fitsLight('Sync Nebula Core', '2026-07-25T22:14:00.000');
+  const digest = crypto.createHash('sha256').update(frame).digest('hex');
+
+  const uploaded = await review.post(`/api/db/${REVIEW_DB}/images/upload`, {
+    headers: {
+      ...AS_REVIEW,
+      'x-content-sha256': digest,
+      'x-psf-guard-database-id': REVIEW_DB,
+    },
+    multipart: {
+      image: { name: filename, mimeType: 'application/fits', buffer: frame },
+    },
+  });
+  expect(uploaded.status(), await uploaded.text()).toBe(200);
+  const result = (await uploaded.json()).data;
+  expect(result.sha256).toBe(digest);
+  expect(result.bytes).toBe(frame.length);
+
+  // The bytes landed where the config said they should.
+  const landed = path.join(process.env.PSF_GUARD_E2E_SYNC_UPLOAD_DIR!, filename);
+  expect(fs.existsSync(landed), `expected ${landed}`).toBe(true);
+  expect(fs.readFileSync(landed).equals(frame)).toBe(true);
+
+  // A key without the upload grant cannot ship frames, even to a catalog it
+  // is otherwise allowed to sync.
+  const refused = await review.post(`/api/db/${REVIEW_DB}/images/upload`, {
+    headers: {
+      Authorization: `Bearer ${TELESCOPE_TOKEN}`,
+      'x-content-sha256': digest,
+      'x-psf-guard-database-id': REVIEW_DB,
+    },
+    multipart: {
+      image: { name: filename, mimeType: 'application/fits', buffer: frame },
+    },
+  });
+  expect(refused.status()).toBe(403);
+});
+
+test('the receiving instance records what the remote client did', async () => {
+  // The audit trail is the operator's only account of a remote write, so
+  // prove a running server writes it rather than trusting the writer's own
+  // unit test.
+  const auditPath = path.join(
+    process.env.PSF_GUARD_E2E_REVIEW_CACHE!,
+    'remote-sync-audit.jsonl'
+  );
+
+  const bundle = await exportFromTelescope('push_planning');
+  await previewOnReview('push_planning', bundle);
+  await review.get('/api/sync/v1/capabilities', {
+    headers: { Authorization: 'Bearer not-a-configured-sync-token-00' },
+  });
+
+  await expect
+    .poll(
+      () =>
+        fs.existsSync(auditPath)
+          ? fs
+              .readFileSync(auditPath, 'utf8')
+              .trim()
+              .split('\n')
+              .map((line) => JSON.parse(line))
+          : [],
+      { timeout: 5_000 }
+    )
+    .toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'preview',
+          outcome: 'ok',
+          operation: 'push_planning',
+          catalog_id: REVIEW_DB,
+          // The entry names the catalog the bundle came from, which is how an
+          // operator ties a change back to the instance that sent it.
+          source_id: TELESCOPE_DB,
+        }),
+        // A rejected key names no catalog but is still on the record.
+        expect.objectContaining({
+          action: 'capabilities',
+          outcome: 'refused',
+          catalog_id: '-',
+        }),
+      ])
+    );
+});

--- a/static/playwright.config.ts
+++ b/static/playwright.config.ts
@@ -2,19 +2,46 @@ import { defineConfig, devices } from '@playwright/test';
 import * as os from 'os';
 import * as path from 'path';
 import { installAstrometryFixture } from './e2e/fixtures/astrometry';
+import { installSyncFixture } from './e2e/fixtures/sync';
 
 const PORT = Number(process.env.PSF_GUARD_E2E_PORT ?? 13099);
+// The sync pair: two more `psf-guard server` processes, each with its own
+// registry, cache, and catalog, standing in for two machines syncing with
+// each other.
+const TELESCOPE_PORT = PORT + 1;
+const REVIEW_PORT = PORT + 2;
 
-// Per-process tmp directory for the registry, cache, and fixture SQLite. The
-// global setup wipes and recreates this; `webServer` below points the
-// `psf-guard server` instance at it via --registry / --cache-dir so the test
-// run never touches the user's real config.
-const TMP_BASE = path.join(os.tmpdir(), `psf-guard-e2e-${process.pid}`);
+// Per-run tmp directory for the registry, cache, and fixture SQLite. The
+// global setup wipes and recreates this; the `webServer` entries below point
+// each `psf-guard server` instance at it via --registry / --cache-dir so the
+// test run never touches the user's real config.
+//
+// Playwright re-evaluates this config in every worker process, where
+// `process.pid` is the worker's. Honour the variable global setup exports so
+// workers resolve the same directory the servers were started against
+// instead of inventing an empty one of their own.
+const TMP_BASE =
+  process.env.PSF_GUARD_E2E_TMP ??
+  path.join(os.tmpdir(), `psf-guard-e2e-${process.pid}`);
 
 // `webServer` starts before Playwright's global setup. Seed the process-global
 // astrometry registry while evaluating the config so the Rust server sees it
 // during startup; global setup restores the same fixture after its reset.
 installAstrometryFixture(TMP_BASE);
+
+// One scheduler catalog and one config per sync instance. Seeded here, not in
+// global setup, because each server reads its registry and config at startup.
+const syncFixture = installSyncFixture(TMP_BASE);
+// Specs read these from the runner's own environment; webServer `env` only
+// reaches the server child processes.
+process.env.PSF_GUARD_E2E_TELESCOPE_URL = `http://127.0.0.1:${TELESCOPE_PORT}`;
+process.env.PSF_GUARD_E2E_REVIEW_URL = `http://127.0.0.1:${REVIEW_PORT}`;
+process.env.PSF_GUARD_E2E_SYNC_UPLOAD_DIR = syncFixture.uploadDir;
+process.env.PSF_GUARD_E2E_REVIEW_CACHE = syncFixture.review.cacheDir;
+
+const serverCommand =
+  process.env.PSF_GUARD_E2E_BINARY ??
+  'cd .. && cargo run --release --bin psf-guard --';
 
 // macOS local dev needs OpenCV's libclang.dylib reachable; CI / Linux usually
 // doesn't. Pass through whatever the parent shell has set; if nothing's set
@@ -52,28 +79,51 @@ export default defineConfig({
     },
   ],
 
-  webServer: {
-    // Run the CLI server against an isolated registry and cache directory.
-    // --allow-database-management lets the e2e specs exercise the CRUD UI.
-    //
-    // PSF_GUARD_E2E_BINARY (set in CI) skips the cargo build and points
-    // straight at a prebuilt binary. Locally, leave it unset and we'll
-    // `cargo run --release` from the repo root.
-    command:
-      `${process.env.PSF_GUARD_E2E_BINARY ?? 'cd .. && cargo run --release --bin psf-guard --'} ` +
-      `server ` +
-      `--port ${PORT} ` +
-      `--registry ${path.join(TMP_BASE, 'registry.json')} ` +
-      `--cache-dir ${path.join(TMP_BASE, 'cache')} ` +
-      `--allow-database-management`,
-    url: `http://127.0.0.1:${PORT}/api/info`,
-    timeout: 180_000,
-    reuseExistingServer: !process.env.CI,
-    env: {
-      ...(dyldFallback ? { DYLD_FALLBACK_LIBRARY_PATH: dyldFallback } : {}),
-      // Expose the tmp base to specs so they can reach the fixture files.
-      PSF_GUARD_E2E_TMP: TMP_BASE,
-      RUST_LOG: 'info',
+  webServer: [
+    {
+      // Run the CLI server against an isolated registry and cache directory.
+      // --allow-database-management lets the e2e specs exercise the CRUD UI.
+      //
+      // PSF_GUARD_E2E_BINARY (set in CI) skips the cargo build and points
+      // straight at a prebuilt binary. Locally, leave it unset and we'll
+      // `cargo run --release` from the repo root.
+      command:
+        `${serverCommand} server ` +
+        `--port ${PORT} ` +
+        `--registry ${path.join(TMP_BASE, 'registry.json')} ` +
+        `--cache-dir ${path.join(TMP_BASE, 'cache')} ` +
+        `--allow-database-management`,
+      url: `http://127.0.0.1:${PORT}/api/info`,
+      timeout: 180_000,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        ...(dyldFallback ? { DYLD_FALLBACK_LIBRARY_PATH: dyldFallback } : {}),
+        // Expose the tmp base to specs so they can reach the fixture files.
+        PSF_GUARD_E2E_TMP: TMP_BASE,
+        RUST_LOG: 'info',
+      },
     },
-  },
+    // The two ends of a sync. Neither takes --allow-database-management: a
+    // server that accepts remote sync must not need the CRUD grant to do it,
+    // and that is part of what these specs check. They are also kept off the
+    // main instance because the CRUD specs reset its database list.
+    ...[
+      { port: TELESCOPE_PORT, instance: syncFixture.telescope },
+      { port: REVIEW_PORT, instance: syncFixture.review },
+    ].map(({ port, instance }) => ({
+      command:
+        `${serverCommand} server ` +
+        `--port ${port} ` +
+        `--registry ${instance.registryPath} ` +
+        `--cache-dir ${instance.cacheDir} ` +
+        `--config ${instance.configPath}`,
+      url: `http://127.0.0.1:${port}/api/info`,
+      timeout: 180_000,
+      reuseExistingServer: !process.env.CI,
+      env: {
+        ...(dyldFallback ? { DYLD_FALLBACK_LIBRARY_PATH: dyldFallback } : {}),
+        RUST_LOG: 'info',
+      },
+    })),
+  ],
 });

--- a/tests/integration_remote_sync.rs
+++ b/tests/integration_remote_sync.rs
@@ -593,6 +593,174 @@ async fn a_rejected_token_is_recorded_without_naming_a_catalog() {
     assert_eq!(entries[0]["detail"], "Invalid API token");
 }
 
+#[tokio::test]
+async fn merge_carries_image_data_blobs_across() {
+    // imagedata is the only table whose payload is not text or numbers, so the
+    // base64 wire encoding is reachable through merge and nothing else.
+    let harness = Harness::new(
+        &format!(
+            "{OBSERVED}
+         INSERT INTO imagedata VALUES (1,'thumb',X'89504E470D0A1A0A0000FFFE',1,64,48);"
+        ),
+        "",
+    );
+
+    let bundle = harness.export("merge").await;
+    let preview_id = harness.preview("merge", bundle).await;
+    let (status, applied) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+
+    let destination = harness.destination();
+    let (blob, image_id): (Vec<u8>, i64) = destination
+        .query_row(
+            "SELECT imagedata, acquiredimageid FROM imagedata",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        blob,
+        vec![0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0xff, 0xfe],
+        "a blob must survive base64 without gaining or losing a byte"
+    );
+    let owner: String = destination
+        .query_row(
+            "SELECT guid FROM acquiredimage WHERE Id = ?1",
+            [image_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        owner, "image-one",
+        "the thumbnail must follow its remapped Id"
+    );
+}
+
+#[tokio::test]
+async fn a_bundle_that_omits_optional_tables_still_merges() {
+    // What a third-party plugin sends: the tables the operation needs and
+    // nothing else. The receiver creates the rest empty from its own schema.
+    let harness = Harness::new(OBSERVED, "");
+    let mut bundle = harness.export("merge").await;
+    bundle["tables"]
+        .as_object_mut()
+        .unwrap()
+        .retain(|name, _| ["project", "target", "acquiredimage"].contains(&name.as_str()));
+
+    let preview_id = harness.preview("merge", bundle).await;
+    let (status, applied) = harness.apply(&preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+    let destination = harness.destination();
+    assert_eq!(count(&destination, "acquiredimage"), 2);
+    assert_eq!(count(&destination, "project"), 1);
+    // Nothing invents rows for the tables the client left out.
+    assert_eq!(count(&destination, "ruleweight"), 0);
+    assert_eq!(count(&destination, "imagedata"), 0);
+}
+
+#[tokio::test]
+async fn an_export_is_refetchable_only_with_the_token_that_built_it() {
+    let harness = Harness::new(OBSERVED, "");
+
+    let (status, exported) = call(
+        harness.router.clone(),
+        "POST",
+        "/api/sync/v1/exports",
+        Some(SOURCE_TOKEN),
+        Some(json!({
+            "protocol_version": 1,
+            "catalog_id": "source",
+            "operation": "merge",
+            "reviewed_only": false
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{exported:#}");
+    let export_id = exported["data"]["export_id"].as_str().unwrap();
+
+    // A client that dropped the response can ask for the same bundle again.
+    let (status, refetched) = call(
+        harness.router.clone(),
+        "GET",
+        &format!("/api/sync/v1/exports/{export_id}"),
+        Some(SOURCE_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{refetched:#}");
+    assert_eq!(refetched["data"]["bundle"], exported["data"]["bundle"]);
+
+    // The other catalog's key must not read it, even with the right ID.
+    let (status, _) = call(
+        harness.router.clone(),
+        "GET",
+        &format!("/api/sync/v1/exports/{export_id}"),
+        Some(DESTINATION_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // The store is capped, so a client that keeps building loses its oldest.
+    // Say so in the 404 rather than leaving it looking like an auth failure.
+    for _ in 0..16 {
+        let (status, _) = call(
+            harness.router.clone(),
+            "POST",
+            "/api/sync/v1/exports",
+            Some(SOURCE_TOKEN),
+            Some(json!({
+                "protocol_version": 1,
+                "catalog_id": "source",
+                "operation": "merge",
+                "reviewed_only": false
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+    let (status, dropped) = call(
+        harness.router.clone(),
+        "GET",
+        &format!("/api/sync/v1/exports/{export_id}"),
+        Some(SOURCE_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(
+        dropped["error"]
+            .as_str()
+            .unwrap()
+            .contains("create a new export"),
+        "{dropped:#}"
+    );
+}
+
+#[tokio::test]
+async fn a_reviewed_only_grade_export_still_carries_the_tables_it_joins_against() {
+    // reviewed_only narrows the captures, not the structure the read needs.
+    let harness = Harness::new(OBSERVED, "");
+    let (status, exported) = call(
+        harness.router.clone(),
+        "POST",
+        "/api/sync/v1/exports",
+        Some(SOURCE_TOKEN),
+        Some(json!({
+            "protocol_version": 1,
+            "catalog_id": "source",
+            "operation": "push_grades",
+            "reviewed_only": true
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{exported:#}");
+    let tables = &exported["data"]["bundle"]["tables"];
+    assert_eq!(tables["project"]["rows"].as_array().unwrap().len(), 1);
+    assert_eq!(tables["target"]["rows"].as_array().unwrap().len(), 1);
+    assert_eq!(tables["acquiredimage"]["rows"].as_array().unwrap().len(), 2);
+}
+
 fn count(connection: &Connection, table: &str) -> i64 {
     connection
         .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {

--- a/tests/integration_remote_sync_real_schema.rs
+++ b/tests/integration_remote_sync_real_schema.rs
@@ -1,0 +1,335 @@
+//! Remote sync against the real vendored Target Scheduler schema.
+//!
+//! Every other sync test builds a seven-table shorthand of the scheduler
+//! database. That shorthand cannot catch anything that depends on the real
+//! shape: columns added by later migrations, NOT NULL columns a client has
+//! never heard of, or foreign keys between the tables a bundle materializes.
+//! These tests run the same protocol against `ts_schema`, so they move with
+//! the schema the plugin actually talks to.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::DefaultBodyLimit,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use http_body_util::BodyExt;
+use psf_guard::{
+    cli::PregenerationConfig,
+    db_registry::{DbEntry, RemoteImageUploadConfig},
+    server::{remote_sync, state::AppState},
+};
+use rusqlite::Connection;
+use serde_json::{json, Value};
+use tempfile::tempdir;
+use tower::ServiceExt;
+
+const SOURCE_TOKEN: &str = "source-remote-api-key-1234567890";
+const DESTINATION_TOKEN: &str = "destination-remote-api-key-123456";
+
+/// One observed target, written through named columns so the row survives
+/// migrations that add or reorder fields.
+const TELESCOPE_ROWS: &str = "
+    INSERT INTO project (Id,profileId,name,description,state,priority,isMosaic,flatsHandling,guid)
+        VALUES (1,'profile','M42','telescope settings',2,8,0,0,'project-guid');
+    INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid)
+        VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
+    INSERT INTO exposuretemplate (Id,profileId,name,filtername,gain,guid)
+        VALUES (1,'profile','Ha 300','Ha',120,'template-guid');
+    INSERT INTO exposureplan (Id,profileId,exposure,desired,acquired,accepted,targetid,exposureTemplateId,enabled,guid)
+        VALUES (1,'profile',300,40,18,16,1,1,1,'plan-guid');
+    INSERT INTO ruleweight (Id,name,weight,projectid) VALUES (1,'Priority',2.5,1);
+    INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,profileId,exposureId,guid)
+        VALUES (1,1,1,1750000000,'Ha',1,'{\"FileName\":\"one.fits\"}','profile',1,'image-one');
+    INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,rejectreason,profileId,exposureId,guid)
+        VALUES (2,1,1,1750000600,'Ha',2,'{\"FileName\":\"two.fits\"}','clouds','profile',1,'image-two');
+    INSERT INTO imagedata (Id,tag,imagedata,acquiredimageid,width,height)
+        VALUES (1,'thumb',X'89504E470D0A1A0A',1,64,48);";
+
+struct Harness {
+    _directory: tempfile::TempDir,
+    router: Router,
+    destination_path: std::path::PathBuf,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let directory = tempdir().unwrap();
+        let source_path = directory.path().join("telescope.sqlite");
+        let destination_path = directory.path().join("review.sqlite");
+        let image_path = directory.path().join("images");
+        std::fs::create_dir(&image_path).unwrap();
+        for path in [&source_path, &destination_path] {
+            let connection = Connection::open(path).unwrap();
+            psf_guard::ts_schema::apply_schema(&connection).unwrap();
+        }
+        Connection::open(&source_path)
+            .unwrap()
+            .execute_batch(TELESCOPE_ROWS)
+            .unwrap();
+
+        let image_dirs = vec![image_path.to_string_lossy().into_owned()];
+        let state = Arc::new(
+            AppState::from_databases(
+                vec![
+                    DbEntry {
+                        id: "source".into(),
+                        name: "Telescope".into(),
+                        db_path: source_path.to_string_lossy().into_owned(),
+                        image_dirs: image_dirs.clone(),
+                        reject_archive: None,
+                        remote_image_upload: Some(config(SOURCE_TOKEN)),
+                    },
+                    DbEntry {
+                        id: "destination".into(),
+                        name: "Review copy".into(),
+                        db_path: destination_path.to_string_lossy().into_owned(),
+                        image_dirs,
+                        reject_archive: None,
+                        remote_image_upload: Some(config(DESTINATION_TOKEN)),
+                    },
+                ],
+                directory
+                    .path()
+                    .join("cache")
+                    .to_string_lossy()
+                    .into_owned(),
+                PregenerationConfig::default(),
+            )
+            .unwrap(),
+        );
+        Self {
+            _directory: directory,
+            router: Router::new()
+                .route(
+                    "/api/sync/v1/previews",
+                    post(remote_sync::create_preview)
+                        .layer(DefaultBodyLimit::max(remote_sync::MAX_SYNC_BODY_BYTES)),
+                )
+                .route(
+                    "/api/sync/v1/previews/{preview_id}/apply",
+                    post(remote_sync::apply_preview),
+                )
+                .route("/api/sync/v1/exports", post(remote_sync::create_export))
+                .route(
+                    "/api/sync/v1/exports/{export_id}",
+                    get(remote_sync::get_export),
+                )
+                .with_state(state),
+            destination_path,
+        }
+    }
+
+    async fn export(&self, operation: &str) -> Value {
+        let (status, exported) = call(
+            self.router.clone(),
+            "POST",
+            "/api/sync/v1/exports",
+            SOURCE_TOKEN,
+            Some(json!({
+                "protocol_version": 1,
+                "catalog_id": "source",
+                "operation": operation,
+                "reviewed_only": false
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{exported:#}");
+        exported["data"]["bundle"].clone()
+    }
+
+    async fn apply(&self, operation: &str, bundle: Value) -> Value {
+        let (status, preview) = call(
+            self.router.clone(),
+            "POST",
+            "/api/sync/v1/previews",
+            DESTINATION_TOKEN,
+            Some(json!({
+                "protocol_version": 1,
+                "catalog_id": "destination",
+                "operation": operation,
+                "bundle": bundle
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{preview:#}");
+        let preview_id = preview["data"]["preview_id"].as_str().unwrap();
+        let (status, applied) = call(
+            self.router.clone(),
+            "POST",
+            &format!("/api/sync/v1/previews/{preview_id}/apply"),
+            DESTINATION_TOKEN,
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{applied:#}");
+        applied
+    }
+
+    fn destination(&self) -> Connection {
+        Connection::open(&self.destination_path).unwrap()
+    }
+}
+
+fn config(token: &str) -> RemoteImageUploadConfig {
+    let mut config = RemoteImageUploadConfig {
+        enabled: false,
+        sync_enabled: true,
+        ..Default::default()
+    };
+    config.set_token(token).unwrap();
+    config
+}
+
+async fn call(
+    app: Router,
+    method: &str,
+    uri: &str,
+    token: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"));
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let response = app
+        .oneshot(
+            builder
+                .body(body.map_or_else(Body::empty, |value| {
+                    Body::from(serde_json::to_vec(&value).unwrap())
+                }))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+#[tokio::test]
+async fn a_merge_round_trips_through_the_real_scheduler_schema() {
+    let harness = Harness::new();
+
+    let bundle = harness.export("merge").await;
+    assert_eq!(
+        bundle["source"]["schema_version"],
+        psf_guard::ts_schema::TS_SCHEMA_VERSION
+    );
+    harness.apply("merge", bundle).await;
+
+    let destination = harness.destination();
+    let (name, mosaic): (String, i64) = destination
+        .query_row("SELECT name, isMosaic FROM project", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .unwrap();
+    assert_eq!(name, "M42");
+    assert_eq!(mosaic, 0);
+    let images: i64 = destination
+        .query_row("SELECT count(*) FROM acquiredimage", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(images, 2);
+    let blob: Vec<u8> = destination
+        .query_row("SELECT imagedata FROM imagedata", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(blob, vec![0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+}
+
+#[tokio::test]
+async fn a_client_that_predates_a_column_still_merges() {
+    // A plugin built against an older Target Scheduler sends rows without the
+    // columns later migrations added — including NOT NULL ones. Those must
+    // fall back to the destination's own defaults, not fail the insert.
+    let harness = Harness::new();
+    let mut bundle = harness.export("merge").await;
+    drop_columns(&mut bundle, "project", &["isMosaic", "flatsHandling"]);
+
+    harness.apply("merge", bundle).await;
+
+    let destination = harness.destination();
+    let (name, mosaic, flats): (String, Option<i64>, Option<i64>) = destination
+        .query_row(
+            "SELECT name, isMosaic, flatsHandling FROM project",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(name, "M42", "the row the client did send still lands");
+    assert_eq!(mosaic, Some(0), "the schema default fills the gap");
+    assert_eq!(flats, Some(0));
+}
+
+#[tokio::test]
+async fn a_grade_push_reads_the_real_schemas_join() {
+    // The join a grade push depends on runs against the real table shapes,
+    // not the shorthand the other tests declare.
+    let harness = Harness::new();
+    harness
+        .destination()
+        .execute_batch(
+            "INSERT INTO project (Id,profileId,name,isMosaic,flatsHandling,guid)
+                VALUES (7,'profile','M42',0,0,'project-guid');
+             INSERT INTO target (Id,name,active,epochcode,projectid,guid)
+                VALUES (7,'M42',1,0,7,'target-guid');
+             INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,profileId,guid)
+                VALUES (7,7,7,1750000600,'Ha',0,'{}','profile','image-two');",
+        )
+        .unwrap();
+
+    let bundle = harness.export("push_grades").await;
+    let applied = harness.apply("push_grades", bundle).await;
+    assert_eq!(applied["data"]["summary"]["grades_changed"], 1);
+
+    let (grade, reason): (i64, Option<String>) = harness
+        .destination()
+        .query_row(
+            "SELECT gradingStatus, rejectreason FROM acquiredimage WHERE guid = 'image-two'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(grade, 2);
+    assert_eq!(reason.as_deref(), Some("clouds"));
+}
+
+/// Remove named columns from one bundle table, values included, the way a
+/// client that has never heard of them would have built it.
+fn drop_columns(bundle: &mut Value, table: &str, unknown: &[&str]) {
+    let table = bundle["tables"][table].as_object_mut().unwrap();
+    let dropped: Vec<usize> = table["columns"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .enumerate()
+        .filter(|(_, column)| unknown.contains(&column["name"].as_str().unwrap()))
+        .map(|(index, _)| index)
+        .collect();
+    assert_eq!(dropped.len(), unknown.len(), "column names must all exist");
+    let keep = |values: &Vec<Value>| -> Vec<Value> {
+        values
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !dropped.contains(index))
+            .map(|(_, value)| value.clone())
+            .collect()
+    };
+    let columns = keep(table["columns"].as_array().unwrap());
+    let rows: Vec<Value> = table["rows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| json!({ "values": keep(row["values"].as_array().unwrap()) }))
+        .collect();
+    table.insert("columns".into(), Value::Array(columns));
+    table.insert("rows".into(), Value::Array(rows));
+}

--- a/tests/integration_sync_api.rs
+++ b/tests/integration_sync_api.rs
@@ -343,3 +343,163 @@ async fn planning_and_grade_pushes_preview_before_writing() {
         2
     );
 }
+
+/// The direction the UI runs most: bring new structure and captures down from
+/// the telescope copy. Every other test here pushes, so nothing exercised the
+/// pull path, its image-data option, or its preview guard through the API.
+#[tokio::test]
+async fn a_pull_brings_structure_and_captures_down_and_keeps_local_grades() {
+    let dir = tempdir().unwrap();
+    let local_path = dir.path().join("local.sqlite");
+    let telescope_path = dir.path().join("telescope.sqlite");
+    let local = Connection::open(&local_path).unwrap();
+    let telescope = Connection::open(&telescope_path).unwrap();
+    schema(&local);
+    schema(&telescope);
+    telescope
+        .execute_batch(
+            "INSERT INTO project VALUES (1,'p','M42','telescope settings',2,8,'project-guid');
+             INSERT INTO target VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
+             INSERT INTO exposuretemplate VALUES (1,'p','Ha 300','Ha',120,'template-guid');
+             INSERT INTO exposureplan VALUES (1,'p',300,40,18,16,1,1,1,'plan-guid');
+             INSERT INTO ruleweight VALUES (1,'Priority',2.5,1);
+             INSERT INTO acquiredimage VALUES (1,1,1,1000,'Ha',1,'{}',NULL,'p',1,'known-image');
+             INSERT INTO acquiredimage VALUES (2,1,1,2000,'Ha',1,'{}',NULL,'p',1,'fresh-image');
+             INSERT INTO imagedata VALUES (1,'thumb',X'89504E47',1,64,48);",
+        )
+        .unwrap();
+    // The reviewer has already rejected one of those frames here.
+    local
+        .execute_batch(
+            "INSERT INTO project VALUES (9,'p','M42','local settings',1,2,'project-guid');
+             INSERT INTO target VALUES (9,'M42',1,5.5,-5.4,0,9,'target-guid');
+             INSERT INTO exposuretemplate VALUES (9,'p','Ha 300','Ha',120,'template-guid');
+             INSERT INTO exposureplan VALUES (9,'p',300,40,2,2,1,9,9,'plan-guid');
+             INSERT INTO acquiredimage VALUES (9,9,9,1000,'Ha',2,'{}','reviewed here','p',9,'known-image');",
+        )
+        .unwrap();
+    drop(local);
+    drop(telescope);
+
+    let image_dir = dir.path().join("images");
+    std::fs::create_dir(&image_dir).unwrap();
+    let image_dirs = vec![image_dir.to_string_lossy().into_owned()];
+    let state = Arc::new(
+        AppState::from_databases(
+            vec![
+                DbEntry {
+                    id: "local".into(),
+                    name: "Review copy".into(),
+                    db_path: local_path.to_string_lossy().into_owned(),
+                    image_dirs: image_dirs.clone(),
+                    reject_archive: None,
+                    remote_image_upload: None,
+                },
+                DbEntry {
+                    id: "scope".into(),
+                    name: "Telescope".into(),
+                    db_path: telescope_path.to_string_lossy().into_owned(),
+                    image_dirs,
+                    reject_archive: None,
+                    remote_image_upload: None,
+                },
+            ],
+            dir.path().join("cache").to_string_lossy().into_owned(),
+            PregenerationConfig::default(),
+        )
+        .unwrap(),
+    );
+    let app = Router::new()
+        .route(
+            "/api/databases/{db_id}/sync/preview",
+            post(handlers::preview_sync_database_route),
+        )
+        .route(
+            "/api/databases/{db_id}/sync/previews/{preview_id}/apply",
+            post(handlers::apply_sync_database_preview_route),
+        )
+        .with_state(state);
+
+    let (status, preview) = request(
+        app.clone(),
+        "/api/databases/local/sync/preview",
+        json!({ "peer_db_id": "scope", "kind": "pull" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{preview:#}");
+    assert_eq!(preview["data"]["result"]["dry_run"], true);
+    assert_eq!(preview["data"]["result"]["acquiredimage"]["inserted"], 1);
+    let preview_id = preview["data"]["preview_id"].as_str().unwrap().to_string();
+
+    // A preview writes nothing, image data included.
+    let local = Connection::open(&local_path).unwrap();
+    assert_eq!(
+        local
+            .query_row("SELECT count(*) FROM imagedata", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    drop(local);
+
+    let (status, applied) = request(
+        app,
+        &format!("/api/databases/local/sync/previews/{preview_id}/apply"),
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+    assert_eq!(applied["data"]["dry_run"], false);
+
+    let local = Connection::open(&local_path).unwrap();
+    assert_eq!(
+        local
+            .query_row("SELECT description FROM project", [], |row| row
+                .get::<_, String>(0))
+            .unwrap(),
+        "telescope settings",
+        "the telescope owns structure"
+    );
+    assert_eq!(
+        local
+            .query_row(
+                "SELECT gradingStatus FROM acquiredimage WHERE guid = 'known-image'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        2,
+        "a review done here survives the pull"
+    );
+    assert_eq!(
+        local
+            .query_row(
+                "SELECT gradingStatus FROM acquiredimage WHERE guid = 'fresh-image'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        1,
+        "a new capture takes the telescope's grade"
+    );
+    // Thumbnails come across with their rows, re-keyed onto the local image Id.
+    let (blob, image_id): (Vec<u8>, i64) = local
+        .query_row(
+            "SELECT d.imagedata, d.acquiredimageid FROM imagedata d",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(blob, vec![0x89, 0x50, 0x4e, 0x47]);
+    let owner: String = local
+        .query_row(
+            "SELECT guid FROM acquiredimage WHERE Id = ?1",
+            [image_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        owner, "known-image",
+        "imagedata must follow the remapped Id"
+    );
+}


### PR DESCRIPTION
Answers the two gaps left open in #235: nothing tested sync against a running server, and the browser specs mocked every response.

## Granting remote access without a Settings panel

Both remote grants could only be switched on from the desktop Settings panel, and the route it uses sits behind `--allow-database-management` — far too large a grant to demand for this, since it also lets a network caller name server filesystem paths. A headless server had no way to accept a sync at all.

It now takes both from its `--config` file:

```toml
[[remote_sync]]
database = "telescope"
token_file = "/run/secrets/psf-guard-key"

[[remote_upload]]
database = "telescope"
image_dir = "/data/incoming"
token_file = "/run/secrets/psf-guard-key"
```

Applied at startup, never written back to the registry, so the config file stays the whole account of what a deployment allows and rotating a key is a restart. A database has one key whichever grants it holds: two blocks disagreeing about it, or a block naming a database that is not registered, stops the server rather than leaving every remote request to fail with 403 and nothing to say why.

## Two instances, actually syncing

Two more `psf-guard server` processes, each with its own registry, cache, catalog, and config, stand in for two machines. A spec plays the coordinator, pulling a bundle from one over HTTP and posting it to the other, then reading the result back through the ordinary API.

Worth stating plainly: **PSF Guard ships no client for its own protocol** — `reqwest` is not even a dependency. It only receives; the N.I.N.A. plugin is meant to be the other end. The spec stands in for it, which is exactly the traffic a coordinator generates.

Covered: capability scoping in both directions, a merge that preserves a review done locally, the stale-refuse → refresh → apply path, export re-fetch, and the audit trail the receiving instance writes (naming the catalog the bundle came from). The receiving instance runs **without** `--allow-database-management`, so the claim that accepting a sync needs no CRUD grant is now tested rather than asserted.

## Image transfer

A catalog sync carries rows and any thumbnails held in the database. Acquisition files travel by their own route under their own grant, so the suite ships a real FITS to the second instance, checks the bytes land where its config said, and checks a key without the upload grant cannot.

## Two things that fell out of building it

- The sync pair needs its own instances: the CRUD specs reset the main server's database list, which would take the catalogs with it, and a re-added entry comes back without the grant its config gave it.
- The fixtures replay the vendored `src/ts_schema` SQL instead of a hand-written shorthand. The shorthand failed three separate times against real code paths — the sync engine, the importer, the upload path — each looking like a product bug.

`cargo test` 419 + suites green, clippy clean, 60 Playwright specs against a release build.

Note: an earlier run showed 12 unrelated failures; `/tmp` had filled with leftover fixture directories from previous runs. All 60 pass with space free.