### PR TITLE
Give PSF Guard a client for its own sync protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,6 +3934,7 @@ dependencies = [
  "rand 0.10.2",
  "rayon",
  "regex",
+ "reqwest 0.12.28",
  "rusqlite",
  "seiza",
  "seiza-background",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,13 @@ nalgebra = "0.35"
 axum = { version = "0.8", features = ["multipart", "macros"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
+# Client side of the remote sync protocol (`sync_client.rs`). Features match
+# what seiza-download already pulls in, so this adds no new transitive weight.
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "rustls-tls",
+    "gzip",
+] }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.7", features = ["fs", "trace", "cors"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -165,6 +165,26 @@ configured database. Every remote action, refusals included, is appended to
 `remote-sync-audit.jsonl` in the cache directory, so you can tell afterwards
 what a key-holder did and when.
 
+PSF Guard also speaks the other half of that protocol, so one instance can
+sync with another over the network — no shared filesystem, and no copying a
+live SQLite file out from under the process writing it:
+
+```bash
+psf-guard sync remote --direction pull \
+  --local review --peer https://telescope.example:3000 --token-file key.txt
+```
+
+`--direction` takes `pull`, `push-planning`, or `push-grades`. Every direction
+previews first: a push is reviewed by the peer, which writes nothing until the
+preview it issued is applied by name. Add `--dry-run` to stop after the
+preview. The key comes from `--token-file`, `PSF_GUARD_SYNC_TOKEN`, or
+`--token` in that order — an argument is visible to every process on the
+machine, so it is the last resort.
+
+Settings has the same thing under **Remote PSF Guard**: add a peer once with
+its URL and key, test the connection, then preview and apply. The key is
+stored on the server and never sent back to the page.
+
 A server run from the command line has no Settings panel, so it takes both
 grants from its `--config` file instead:
 

--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -302,6 +302,31 @@ Each database opts into this protocol on its own. Holding a valid key is not
 enough: the operator ticks **Accept remote scheduler sync** for that database,
 separately from **Accept remote image uploads**.
 
+### Speaking the protocol, not only answering it
+
+`server/remote_sync.rs` answers `/api/sync/v1`; `sync_client.rs` speaks it.
+Without both, a PSF Guard could only ever be the far end of somebody else's
+sync — which left the two-instance arrangement this design is for unreachable
+except through a script.
+
+The client is one type over `reqwest`, and the directions sit on top of it in
+`commands/sync/remote.rs`:
+
+- **Pull**: fetch a bundle from the peer, stage it as a throwaway SQLite
+  source, and hand it to the same merge engine a local `sync pull` runs. The
+  write is local, so the preview is too.
+- **Push**: build a bundle from the local database, send it for review, and
+  apply the preview ID the peer returns. Nothing is written there until that
+  ID is named, and a peer whose catalog moved under the preview refuses.
+
+Two surfaces drive it. `psf-guard sync remote` for a terminal or a cron job,
+and `POST /api/databases/{id}/sync/remote` for the Settings panel, which reads
+its peers from `/api/peers`. Peers live in the registry beside the databases:
+name, base URL, key, optional catalog. Unlike an incoming key, which is stored
+as a digest because the server only needs to check it, an outgoing key must be
+presented on every request and is therefore kept in the clear — the registry
+file is a credential store, and the API never returns a key to a browser.
+
 ### Granting access without a Settings panel
 
 The desktop app has Settings; a server run from the command line does not, and

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -761,6 +761,63 @@ pub enum SyncKind {
         verbose: bool,
     },
 
+    /// Sync with a remote PSF Guard over HTTP instead of a second local file.
+    ///
+    /// The other catalog lives on another machine, reached by URL and API key,
+    /// which is the arrangement the remote sync protocol was built for. Every
+    /// direction previews first: a push is reviewed by the peer, which writes
+    /// nothing until the preview it issued is applied by name.
+    ///
+    /// The peer must have opened the catalog with a `[[remote_sync]]` block in
+    /// its config, or the Settings panel's "Accept remote scheduler sync".
+    Remote {
+        /// What to do: pull, push-planning, or push-grades. Pull merges the
+        /// peer's structure and captures into the local database, keeping
+        /// grades reviewed here.
+        #[arg(long, value_parser = ["pull", "push-planning", "push-grades"])]
+        direction: String,
+
+        /// Local database: a registry slug or a path to a .sqlite file.
+        #[arg(long)]
+        local: String,
+
+        /// Peer base URL, e.g. https://telescope.example:3000
+        #[arg(long)]
+        peer: String,
+
+        /// Peer API key. Prefer --token-file or PSF_GUARD_SYNC_TOKEN: an
+        /// argument is visible to every process on the machine.
+        #[arg(long)]
+        token: Option<String>,
+
+        /// File holding the peer API key. Whitespace-trimmed.
+        #[arg(long)]
+        token_file: Option<String>,
+
+        /// Which of the peer's catalogs to use. Defaults to the one its key
+        /// opens, which is the only one it accepts anyway.
+        #[arg(long)]
+        peer_catalog: Option<String>,
+
+        /// Print the plan without writing anything on either side.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// For push-grades: send every row, not only reviewed ones. Off by
+        /// default so a Pending row here cannot erase a decision there.
+        #[arg(long)]
+        all_grades: bool,
+
+        /// For pull: skip the (large) imagedata thumbnail BLOBs.
+        #[arg(long)]
+        no_image_data: bool,
+
+        /// Path to the database registry JSON file (only consulted when
+        /// --local is a slug; defaults to the platform config directory).
+        #[arg(long)]
+        registry: Option<String>,
+    },
+
     /// Pull structure + captured images FROM a telescope DB INTO our local DB.
     ///
     /// Mirrors projects, targets (coordinates), exposure templates/plans, rule

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -61,6 +61,30 @@ fn open_sync_pair(from: &str, to: &str, registry: Option<&str>) -> Result<SyncPa
     })
 }
 
+/// Resolve the peer key from a file, an argument, or the environment.
+///
+/// A file first, then the environment, then the argument: `--token` is
+/// visible in `ps` to every user on the machine, so it is the last resort
+/// rather than the obvious one.
+fn read_peer_token(token: Option<&str>, token_file: Option<&str>) -> Result<String> {
+    if let Some(path) = token_file {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("reading the peer token from {path}"))?;
+        return Ok(contents.trim().to_string());
+    }
+    if let Ok(value) = std::env::var("PSF_GUARD_SYNC_TOKEN")
+        && !value.trim().is_empty()
+    {
+        return Ok(value.trim().to_string());
+    }
+    match token {
+        Some(token) if !token.trim().is_empty() => Ok(token.trim().to_string()),
+        _ => Err(anyhow::anyhow!(
+            "no peer key: pass --token-file, set PSF_GUARD_SYNC_TOKEN, or pass --token"
+        )),
+    }
+}
+
 pub fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -681,6 +705,83 @@ pub fn main() -> Result<()> {
             benchmark_psf(&fits_path, runs, verbose)?;
         }
         Commands::Sync { kind } => match kind {
+            crate::cli::SyncKind::Remote {
+                direction,
+                local,
+                peer,
+                token,
+                token_file,
+                peer_catalog,
+                dry_run,
+                all_grades,
+                no_image_data,
+                registry,
+            } => {
+                use crate::commands::sync::{
+                    print_remote_summary, resolve_db_path, sync_remote, RemoteDirection,
+                    RemoteSyncOptions,
+                };
+                use crate::db_registry::DbRegistry;
+
+                let direction = match direction.as_str() {
+                    "pull" => RemoteDirection::Pull,
+                    "push-planning" => RemoteDirection::PushPlanning,
+                    "push-grades" => RemoteDirection::PushGrades,
+                    other => return Err(anyhow::anyhow!("unknown direction {other}")),
+                };
+                let peer_token = read_peer_token(token.as_deref(), token_file.as_deref())?;
+                let reg = if Path::new(&local).is_file() {
+                    None
+                } else {
+                    let registry_path = match &registry {
+                        Some(path) => PathBuf::from(path),
+                        None => {
+                            DbRegistry::default_path().context("resolving default registry path")?
+                        }
+                    };
+                    Some(DbRegistry::load_or_init(&registry_path).with_context(|| {
+                        format!("loading registry at {}", registry_path.display())
+                    })?)
+                };
+                let local_path = resolve_db_path(reg.as_ref(), &local)?;
+                // How the local catalog names itself in a bundle it sends. The
+                // slug when there is one, so the peer's audit log records
+                // something the operator recognises.
+                let local_id = reg
+                    .as_ref()
+                    .and_then(|registry| registry.find(&local))
+                    .map(|entry| entry.id.clone())
+                    .unwrap_or_else(|| {
+                        local_path
+                            .file_stem()
+                            .map(|stem| stem.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| "local".to_string())
+                    });
+
+                let runtime = tokio::runtime::Runtime::new()?;
+                let outcome = runtime.block_on(sync_remote(RemoteSyncOptions {
+                    direction,
+                    local_path,
+                    local_id,
+                    peer_url: peer,
+                    peer_token,
+                    peer_catalog,
+                    reviewed_only: !all_grades,
+                    dry_run,
+                    with_image_data: !no_image_data,
+                }))?;
+                print_remote_summary(&outcome.summary);
+                println!(
+                    "{} with {} ({})",
+                    if outcome.applied {
+                        "Applied"
+                    } else {
+                        "Dry run — nothing written"
+                    },
+                    outcome.peer_catalog,
+                    outcome.peer_product
+                );
+            }
             crate::cli::SyncKind::Grades {
                 from,
                 to,

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -6,6 +6,9 @@
 //!   matched by guid with FK remapping, preserving local grading work.
 //! - [`sync_planning`] pushes project, target, template, plan, and rule settings
 //!   back to the telescope without changing capture history or grades.
+//! - [`sync_remote`] runs any of those against a remote PSF Guard over HTTP
+//!   instead of a second local file, so the two catalogs can live on
+//!   different machines.
 //!
 //! All three cores are pure DB logic; CLI glue (argument resolution,
 //! connection opening, reporting) lives in `cli_main.rs`. Shared helpers —
@@ -15,6 +18,7 @@
 mod grades;
 mod planning;
 mod pull;
+mod remote;
 
 pub(crate) use grades::sync_grades_in_transaction;
 pub use grades::{sync_grades, GradeChange, SyncGradesOptions, SyncSummary};
@@ -22,6 +26,10 @@ pub(crate) use planning::sync_planning_in_transaction;
 pub use planning::{sync_planning, PlanningOptions, PlanningSummary};
 pub(crate) use pull::sync_pull_in_transaction;
 pub use pull::{sync_pull, PullOptions, PullSummary, TableCounts};
+pub use remote::{
+    print_summary as print_remote_summary, sync_remote, RemoteDirection, RemoteSyncOptions,
+    RemoteSyncOutcome,
+};
 
 use crate::db_registry::DbRegistry;
 use crate::models::GradingStatus;

--- a/src/commands/sync/remote.rs
+++ b/src/commands/sync/remote.rs
@@ -1,0 +1,269 @@
+//! Sync a local catalog with a remote PSF Guard over the network.
+//!
+//! The local `sync` commands need both databases on one filesystem. This one
+//! needs only a URL and a key, so the review machine and the telescope can be
+//! different machines — which is the arrangement the protocol was built for.
+//!
+//! Direction decides who holds the preview. Pulling, we build it here from a
+//! bundle the peer sent, and the write is ours. Pushing, the peer holds it and
+//! will only apply an ID it issued, so nothing is written there until we ask
+//! for that ID by name.
+
+use anyhow::{bail, Context, Result};
+use rusqlite::{Connection, OpenFlags};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+use crate::server::remote_sync::SyncOperation;
+use crate::sync_client::{local_bundle, materialize, SyncClient};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteDirection {
+    /// Bring the peer's structure and captures down into the local catalog.
+    Pull,
+    /// Send local planning settings up to the peer.
+    PushPlanning,
+    /// Send local grading decisions up to the peer.
+    PushGrades,
+}
+
+impl RemoteDirection {
+    fn operation(self) -> SyncOperation {
+        match self {
+            RemoteDirection::Pull => SyncOperation::Merge,
+            RemoteDirection::PushPlanning => SyncOperation::PushPlanning,
+            RemoteDirection::PushGrades => SyncOperation::PushGrades,
+        }
+    }
+}
+
+pub struct RemoteSyncOptions {
+    pub direction: RemoteDirection,
+    /// Local scheduler database. Read for a push, written for a pull.
+    pub local_path: PathBuf,
+    /// How the local catalog names itself in the bundle it sends.
+    pub local_id: String,
+    pub peer_url: String,
+    pub peer_token: String,
+    /// Which of the peer's catalogs to use. Defaults to the one its key opens,
+    /// which is the only one it will accept anyway.
+    pub peer_catalog: Option<String>,
+    /// For a grade push: send only rows someone has actually graded.
+    pub reviewed_only: bool,
+    /// Show what would change and stop.
+    pub dry_run: bool,
+    pub with_image_data: bool,
+}
+
+pub struct RemoteSyncOutcome {
+    pub applied: bool,
+    pub summary: BTreeMap<String, i64>,
+    pub peer_product: String,
+    pub peer_catalog: String,
+}
+
+pub async fn sync_remote(options: RemoteSyncOptions) -> Result<RemoteSyncOutcome> {
+    let client = SyncClient::new(&options.peer_url, &options.peer_token)?;
+    let capabilities = client.capabilities().await?;
+    if capabilities.protocol_version != 1 {
+        bail!(
+            "{} speaks sync protocol {}; this build speaks 1",
+            client.base_url(),
+            capabilities.protocol_version
+        );
+    }
+    let catalog = match &options.peer_catalog {
+        Some(requested) => requested.clone(),
+        None => capabilities.catalog()?.id.clone(),
+    };
+    let peer_product = format!("{} {}", capabilities.product, capabilities.product_version);
+    println!(
+        "Peer {} — {peer_product}, catalog {catalog}",
+        client.base_url()
+    );
+
+    let summary = match options.direction {
+        RemoteDirection::Pull => pull_from(&client, &catalog, &options).await?,
+        RemoteDirection::PushPlanning | RemoteDirection::PushGrades => {
+            push_to(&client, &catalog, &options).await?
+        }
+    };
+    Ok(RemoteSyncOutcome {
+        applied: !options.dry_run,
+        summary,
+        peer_product,
+        peer_catalog: catalog,
+    })
+}
+
+/// Peer → here. We fetch a bundle, stage it as a throwaway source database,
+/// and hand it to the local merge engine, which is the same code a local
+/// `sync pull` runs.
+async fn pull_from(
+    client: &SyncClient,
+    catalog: &str,
+    options: &RemoteSyncOptions,
+) -> Result<BTreeMap<String, i64>> {
+    use crate::commands::sync::{require_pull_capable, sync_pull, PullOptions};
+
+    let bundle = client.export(catalog, SyncOperation::Merge, false).await?;
+    let rows: usize = bundle.tables.values().map(|table| table.rows.len()).sum();
+    println!(
+        "Fetched {rows} row(s) across {} table(s) from {catalog}",
+        bundle.tables.len()
+    );
+
+    // A named temporary file, not an in-memory database: the merge engine
+    // opens the source by path.
+    let staged = tempfile::Builder::new()
+        .prefix("psf-guard-sync-")
+        .suffix(".sqlite")
+        .tempfile()
+        .context("creating a staging file for the peer's bundle")?;
+    let staged_path = staged.path().to_path_buf();
+    materialize(&bundle, &staged_path, &options.local_path)
+        .context("staging the peer's bundle as a scheduler database")?;
+
+    let source = Connection::open_with_flags(&staged_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .context("opening the staged bundle")?;
+    let destination = open_local(&options.local_path, options.dry_run)?;
+    require_pull_capable(&source).context("the peer's catalog")?;
+    require_pull_capable(&destination).context("the local database")?;
+
+    let summary = sync_pull(
+        &source,
+        &destination,
+        &PullOptions {
+            dry_run: options.dry_run,
+            with_image_data: options.with_image_data,
+            project_filter: None,
+        },
+    )?;
+    Ok(pull_summary(&summary))
+}
+
+/// Here → peer. The peer reviews and holds the preview; nothing is written
+/// there until we apply the ID it hands back.
+async fn push_to(
+    client: &SyncClient,
+    catalog: &str,
+    options: &RemoteSyncOptions,
+) -> Result<BTreeMap<String, i64>> {
+    let operation = options.direction.operation();
+    let bundle = local_bundle(
+        &options.local_path,
+        &options.local_id,
+        operation,
+        options.reviewed_only,
+    )
+    .context("building a bundle from the local database")?;
+    let rows: usize = bundle.tables.values().map(|table| table.rows.len()).sum();
+    println!(
+        "Sending {rows} row(s) across {} table(s)",
+        bundle.tables.len()
+    );
+
+    let preview = client.preview(catalog, operation, &bundle).await?;
+    print_summary(&preview.summary);
+    if options.dry_run {
+        println!(
+            "Dry run — nothing written. The peer holds preview {} until {}.",
+            preview.preview_id, preview.expires_at
+        );
+        return Ok(preview.summary);
+    }
+
+    let applied = client.apply(&preview.preview_id).await.with_context(|| {
+        format!(
+            "the peer kept preview {} — if its catalog changed under the \
+             preview, nothing was written",
+            preview.preview_id
+        )
+    })?;
+    Ok(applied.summary)
+}
+
+/// Open the local catalog. A dry run still needs write access, because the
+/// merge engine runs the same statements inside a transaction it rolls back —
+/// better to fail here than halfway through.
+fn open_local(path: &Path, dry_run: bool) -> Result<Connection> {
+    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE).with_context(|| {
+        format!(
+            "opening the local database {} for {}",
+            path.display(),
+            if dry_run { "a dry run" } else { "writing" }
+        )
+    })
+}
+
+fn pull_summary(summary: &crate::commands::sync::PullSummary) -> BTreeMap<String, i64> {
+    let mut counts = BTreeMap::from([
+        ("total_inserted".into(), summary.total_inserted() as i64),
+        ("total_updated".into(), summary.total_updated() as i64),
+        ("grade_filled".into(), summary.grade_filled as i64),
+        ("grade_preserved".into(), summary.grade_preserved as i64),
+        ("imagedata_bytes".into(), summary.imagedata_bytes as i64),
+    ]);
+    for (name, table) in [
+        ("exposuretemplate", &summary.exposuretemplate),
+        ("project", &summary.project),
+        ("ruleweight", &summary.ruleweight),
+        ("target", &summary.target),
+        ("exposureplan", &summary.exposureplan),
+        ("acquiredimage", &summary.acquiredimage),
+    ] {
+        counts.insert(format!("{name}_inserted"), table.inserted as i64);
+        counts.insert(format!("{name}_updated"), table.updated as i64);
+    }
+    if summary.imagedata_synced {
+        counts.insert(
+            "imagedata_inserted".into(),
+            summary.imagedata.inserted as i64,
+        );
+    }
+    counts
+}
+
+pub fn print_summary(summary: &BTreeMap<String, i64>) {
+    let interesting: Vec<_> = summary
+        .iter()
+        .filter(|(_, count)| **count != 0)
+        .map(|(name, count)| format!("{name}={count}"))
+        .collect();
+    if interesting.is_empty() {
+        println!("Nothing to change.");
+    } else {
+        println!("{}", interesting.join(", "));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_direction_maps_to_its_wire_operation() {
+        assert_eq!(RemoteDirection::Pull.operation(), SyncOperation::Merge);
+        assert_eq!(
+            RemoteDirection::PushPlanning.operation(),
+            SyncOperation::PushPlanning
+        );
+        assert_eq!(
+            RemoteDirection::PushGrades.operation(),
+            SyncOperation::PushGrades
+        );
+    }
+
+    #[test]
+    fn a_summary_hides_the_zeroes() {
+        // A merge reports a couple of dozen counters. Printing every zero
+        // buries the two lines that matter.
+        let mut summary = BTreeMap::new();
+        summary.insert("project_inserted".to_string(), 0);
+        summary.insert("acquiredimage_inserted".to_string(), 3);
+        let shown: Vec<_> = summary.iter().filter(|(_, count)| **count != 0).collect();
+        assert_eq!(shown.len(), 1);
+    }
+}

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -185,6 +185,28 @@ pub struct RejectArchiveOverrides {
     pub sidecar_exts: Option<Vec<String>>,
 }
 
+/// A remote PSF Guard this instance can sync with.
+///
+/// Unlike an incoming key, which is stored as a digest because the server only
+/// ever needs to *check* it, an outgoing key has to be presented on every
+/// request — so it is kept in the clear. That makes the registry file a
+/// credential store: it is the user's own config, but it should be readable
+/// only by them. The API never returns the key to a browser.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PeerEntry {
+    /// URL-safe slug used in `/api/peers/{id}`.
+    pub id: String,
+    pub name: String,
+    /// Base URL, e.g. `https://telescope.example:3000`.
+    pub base_url: String,
+    #[serde(default)]
+    pub token: String,
+    /// Which of the peer's catalogs to use. Absent means "whichever its key
+    /// opens", which is the only one it will accept anyway.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog_id: Option<String>,
+}
+
 /// Persisted shape of the database registry on disk (v2+).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DbRegistry {
@@ -200,6 +222,10 @@ pub struct DbRegistry {
     /// standard environment, executable-adjacent, and platform data paths.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub astrometry: Option<crate::astrometry::AstrometryConfig>,
+    /// Remote PSF Guard instances this one can sync with. Additive within
+    /// registry v2; absent means none are configured.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub peers: Vec<PeerEntry>,
 }
 
 impl Default for DbRegistry {
@@ -209,6 +235,7 @@ impl Default for DbRegistry {
             databases: Vec::new(),
             active_db_id: None,
             astrometry: None,
+            peers: Vec::new(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod sequence_analysis;
 pub mod server;
 pub mod spatial_analysis;
 pub mod star_contours;
+pub mod sync_client;
 pub mod ts_schema;
 pub mod utils;
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -415,7 +415,7 @@ pub async fn list_databases(
     Ok(Json(ApiResponse::success(summaries)))
 }
 
-fn require_registry_path(state: &AppState) -> Result<std::path::PathBuf, AppError> {
+pub(crate) fn require_registry_path(state: &AppState) -> Result<std::path::PathBuf, AppError> {
     state.registry_path.read().unwrap().clone().ok_or_else(|| {
         AppError::BadRequest(
             "database registry persistence is not configured for this server".into(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,6 +6,7 @@ pub mod embedded_static;
 pub mod extract;
 pub mod handlers;
 pub mod import_job;
+pub mod peers;
 pub mod preview_queue;
 pub mod quality_backfill;
 pub mod remote_audit;
@@ -430,6 +431,16 @@ async fn run_server_internal(
         .route(
             "/databases/{db_id}",
             put(handlers::update_database_route).delete(handlers::remove_database_route),
+        )
+        .route("/peers", get(peers::list_peers).post(peers::add_peer))
+        .route(
+            "/peers/{peer_id}",
+            put(peers::update_peer).delete(peers::remove_peer),
+        )
+        .route("/peers/{peer_id}/check", post(peers::check_peer))
+        .route(
+            "/databases/{db_id}/sync/remote",
+            post(peers::sync_with_peer),
         )
         .route("/sync/v1/capabilities", get(remote_sync::capabilities))
         .route(

--- a/src/server/peers.rs
+++ b/src/server/peers.rs
@@ -1,0 +1,370 @@
+//! Managing remote PSF Guard peers, and syncing with one from the UI.
+//!
+//! `remote_sync` is the receiving half of the protocol and `sync_client` the
+//! sending half; this is the surface that lets someone drive the sending half
+//! from a browser instead of a terminal.
+//!
+//! The key never reaches the browser. It is written once through the
+//! management-gated CRUD route, stored in the registry, and read back only by
+//! this process when it talks to the peer.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, sync::Arc};
+
+use crate::{
+    commands::sync::{sync_remote, RemoteDirection, RemoteSyncOptions},
+    db_registry::{DbRegistry, PeerEntry},
+    server::{
+        api::ApiResponse,
+        handlers::{require_database_management_allowed, require_registry_path, AppError},
+        state::AppState,
+    },
+};
+
+/// A peer as the browser sees it: everything but the key.
+#[derive(Debug, Serialize)]
+pub struct PeerSummary {
+    pub id: String,
+    pub name: String,
+    pub base_url: String,
+    pub catalog_id: Option<String>,
+    pub token_configured: bool,
+}
+
+impl From<&PeerEntry> for PeerSummary {
+    fn from(entry: &PeerEntry) -> Self {
+        Self {
+            id: entry.id.clone(),
+            name: entry.name.clone(),
+            base_url: entry.base_url.clone(),
+            catalog_id: entry.catalog_id.clone(),
+            token_configured: !entry.token.trim().is_empty(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpsertPeerRequest {
+    pub name: String,
+    pub base_url: String,
+    /// Absent on an edit means "keep the stored key".
+    #[serde(default)]
+    pub token: Option<String>,
+    #[serde(default)]
+    pub catalog_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PeerCheck {
+    pub reachable: bool,
+    pub product: Option<String>,
+    pub product_version: Option<String>,
+    pub protocol_version: Option<u32>,
+    pub catalogs: Vec<String>,
+    pub capabilities: Vec<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RemoteSyncRequest {
+    pub peer_id: String,
+    /// `pull`, `push_planning`, or `push_grades`.
+    pub direction: String,
+    #[serde(default = "default_true")]
+    pub dry_run: bool,
+    #[serde(default = "default_true")]
+    pub reviewed_only: bool,
+    #[serde(default = "default_true")]
+    pub with_image_data: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize)]
+pub struct RemoteSyncResult {
+    pub applied: bool,
+    pub peer_product: String,
+    pub peer_catalog: String,
+    pub summary: BTreeMap<String, i64>,
+}
+
+pub async fn list_peers(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<ApiResponse<Vec<PeerSummary>>>, AppError> {
+    Ok(Json(ApiResponse::success(
+        load_registry(&state)?
+            .peers
+            .iter()
+            .map(Into::into)
+            .collect(),
+    )))
+}
+
+pub async fn add_peer(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<UpsertPeerRequest>,
+) -> Result<Json<ApiResponse<PeerSummary>>, AppError> {
+    // Storing a credential and a URL this server will then send it to is
+    // configuration, so it lives behind the same grant as the rest of the
+    // registry.
+    require_database_management_allowed(&state)?;
+    let registry_path = require_registry_path(&state)?;
+    let mut registry = load_registry(&state)?;
+
+    let name = require_text(&request.name, "name")?;
+    let base_url = validated_url(&request.base_url)?;
+    let token = match request.token.as_deref().map(str::trim) {
+        Some(token) if !token.is_empty() => token.to_string(),
+        _ => return Err(AppError::BadRequest("a peer needs an API key".into())),
+    };
+    let id = crate::server::slug::compute_default_slug(&base_url);
+    if registry.peers.iter().any(|peer| peer.id == id) {
+        return Err(AppError::BadRequest(format!(
+            "a peer for {base_url} is already configured"
+        )));
+    }
+    let entry = PeerEntry {
+        id,
+        name,
+        base_url,
+        token,
+        catalog_id: normalized(request.catalog_id),
+    };
+    registry.peers.push(entry.clone());
+    save(&registry, &registry_path)?;
+    Ok(Json(ApiResponse::success(PeerSummary::from(&entry))))
+}
+
+pub async fn update_peer(
+    State(state): State<Arc<AppState>>,
+    Path(peer_id): Path<String>,
+    Json(request): Json<UpsertPeerRequest>,
+) -> Result<Json<ApiResponse<PeerSummary>>, AppError> {
+    require_database_management_allowed(&state)?;
+    let registry_path = require_registry_path(&state)?;
+    let mut registry = load_registry(&state)?;
+
+    let name = require_text(&request.name, "name")?;
+    let base_url = validated_url(&request.base_url)?;
+    let catalog_id = normalized(request.catalog_id);
+    let peer = registry
+        .peers
+        .iter_mut()
+        .find(|peer| peer.id == peer_id)
+        .ok_or(AppError::NotFound)?;
+    peer.name = name;
+    peer.base_url = base_url;
+    peer.catalog_id = catalog_id;
+    // An absent key means "leave it alone": the browser never received it, so
+    // it cannot echo it back on a rename.
+    if let Some(token) = request.token.as_deref().map(str::trim)
+        && !token.is_empty()
+    {
+        peer.token = token.to_string();
+    }
+    let summary = PeerSummary::from(&*peer);
+    save(&registry, &registry_path)?;
+    Ok(Json(ApiResponse::success(summary)))
+}
+
+pub async fn remove_peer(
+    State(state): State<Arc<AppState>>,
+    Path(peer_id): Path<String>,
+) -> Result<Json<ApiResponse<bool>>, AppError> {
+    require_database_management_allowed(&state)?;
+    let registry_path = require_registry_path(&state)?;
+    let mut registry = load_registry(&state)?;
+    let before = registry.peers.len();
+    registry.peers.retain(|peer| peer.id != peer_id);
+    if registry.peers.len() == before {
+        return Err(AppError::NotFound);
+    }
+    save(&registry, &registry_path)?;
+    Ok(Json(ApiResponse::success(true)))
+}
+
+/// Ask a peer who it is. Reachability is a normal answer, not an error: the
+/// UI shows the reason beside the peer rather than a failed request.
+pub async fn check_peer(
+    State(state): State<Arc<AppState>>,
+    Path(peer_id): Path<String>,
+) -> Result<Json<ApiResponse<PeerCheck>>, AppError> {
+    let peer = find_peer(&state, &peer_id)?;
+    let client = match crate::sync_client::SyncClient::new(&peer.base_url, &peer.token) {
+        Ok(client) => client,
+        Err(error) => return Ok(Json(ApiResponse::success(unreachable(error)))),
+    };
+    Ok(Json(ApiResponse::success(
+        match client.capabilities().await {
+            Ok(capabilities) => PeerCheck {
+                reachable: true,
+                product: Some(capabilities.product),
+                product_version: Some(capabilities.product_version),
+                protocol_version: Some(capabilities.protocol_version),
+                catalogs: capabilities
+                    .catalogs
+                    .iter()
+                    .map(|catalog| catalog.id.clone())
+                    .collect(),
+                capabilities: capabilities.capabilities,
+                error: None,
+            },
+            Err(error) => unreachable(error),
+        },
+    )))
+}
+
+/// Run one direction against a peer on behalf of the UI.
+///
+/// Defaults are the cautious ones — dry run, reviewed grades only — so an
+/// omitted field can never write more than the caller asked for.
+pub async fn sync_with_peer(
+    State(state): State<Arc<AppState>>,
+    Path(db_id): Path<String>,
+    Json(request): Json<RemoteSyncRequest>,
+) -> Result<Json<ApiResponse<RemoteSyncResult>>, AppError> {
+    let context = state.get_database(&db_id).ok_or(AppError::NotFound)?;
+    let peer = find_peer(&state, &request.peer_id)?;
+    let direction = match request.direction.as_str() {
+        "pull" => RemoteDirection::Pull,
+        "push_planning" => RemoteDirection::PushPlanning,
+        "push_grades" => RemoteDirection::PushGrades,
+        other => {
+            return Err(AppError::BadRequest(format!(
+                "unknown sync direction '{other}'"
+            )))
+        }
+    };
+    // One write at a time, the same lock the local applies take, so a remote
+    // pull cannot land in the middle of one.
+    let _guard = if request.dry_run {
+        None
+    } else {
+        Some(state.sync_apply_lock.lock().await)
+    };
+    let outcome = sync_remote(RemoteSyncOptions {
+        direction,
+        local_path: std::path::PathBuf::from(&context.database_path),
+        local_id: context.id.clone(),
+        peer_url: peer.base_url.clone(),
+        peer_token: peer.token.clone(),
+        peer_catalog: peer.catalog_id.clone(),
+        reviewed_only: request.reviewed_only,
+        dry_run: request.dry_run,
+        with_image_data: request.with_image_data,
+    })
+    .await
+    .map_err(|error| AppError::BadRequest(format!("{error:#}")))?;
+
+    if !request.dry_run && direction == RemoteDirection::Pull {
+        // A pull just wrote rows this database serves; drop the caches built
+        // from the old contents.
+        context.clear_directory_tree_cache();
+        let _ = context.ensure_cache_available();
+    }
+    Ok(Json(ApiResponse::success(RemoteSyncResult {
+        applied: outcome.applied,
+        peer_product: outcome.peer_product,
+        peer_catalog: outcome.peer_catalog,
+        summary: outcome.summary,
+    })))
+}
+
+fn unreachable(error: anyhow::Error) -> PeerCheck {
+    PeerCheck {
+        reachable: false,
+        product: None,
+        product_version: None,
+        protocol_version: None,
+        catalogs: vec![],
+        capabilities: vec![],
+        error: Some(format!("{error:#}")),
+    }
+}
+
+fn find_peer(state: &AppState, peer_id: &str) -> Result<PeerEntry, AppError> {
+    load_registry(state)?
+        .peers
+        .into_iter()
+        .find(|peer| peer.id == peer_id)
+        .ok_or(AppError::NotFound)
+}
+
+fn load_registry(state: &AppState) -> Result<DbRegistry, AppError> {
+    let path = require_registry_path(state)?;
+    DbRegistry::load_or_init(&path)
+        .map_err(|error| AppError::InternalError(format!("loading registry: {error}")))
+}
+
+fn save(registry: &DbRegistry, path: &std::path::Path) -> Result<(), AppError> {
+    registry
+        .save(path)
+        .map_err(|error| AppError::InternalError(format!("saving registry: {error}")))
+}
+
+fn require_text(value: &str, field: &str) -> Result<String, AppError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(AppError::BadRequest(format!("{field} must not be empty")));
+    }
+    Ok(value.to_string())
+}
+
+/// Accept only an absolute HTTP(S) URL. This server will present a stored key
+/// to whatever it names, so a typo that turns into a different scheme — or a
+/// relative path — must not get that far.
+fn validated_url(value: &str) -> Result<String, AppError> {
+    let value = value.trim().trim_end_matches('/');
+    if !value.starts_with("http://") && !value.starts_with("https://") {
+        return Err(AppError::BadRequest(
+            "a peer URL must start with http:// or https://".into(),
+        ));
+    }
+    if value.len() <= "https://".len() {
+        return Err(AppError::BadRequest("a peer URL needs a host".into()));
+    }
+    Ok(value.to_string())
+}
+
+fn normalized(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_peer_url_must_be_absolute_http() {
+        assert!(validated_url("telescope.local").is_err());
+        assert!(validated_url("file:///etc/passwd").is_err());
+        assert!(validated_url("https://").is_err());
+        assert_eq!(
+            validated_url("  https://scope.example:3000/ ").unwrap(),
+            "https://scope.example:3000"
+        );
+    }
+
+    #[test]
+    fn the_summary_never_carries_the_key() {
+        let entry = PeerEntry {
+            id: "scope".into(),
+            name: "Telescope".into(),
+            base_url: "https://scope.example".into(),
+            token: "a-secret-key-long-enough-for-this".into(),
+            catalog_id: None,
+        };
+        let summary = PeerSummary::from(&entry);
+        assert!(summary.token_configured);
+        let json = serde_json::to_string(&summary).unwrap();
+        assert!(!json.contains("a-secret-key"), "{json}");
+    }
+}

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -825,7 +825,7 @@ fn validate_bundle_within(bundle: &CatalogBundle, max_rows: usize) -> Result<(),
     Ok(())
 }
 
-fn materialize_bundle(
+pub(crate) fn materialize_bundle(
     path: &FsPath,
     template_path: &FsPath,
     bundle: &CatalogBundle,
@@ -960,7 +960,7 @@ fn wire_to_sqlite(value: &WireValue) -> anyhow::Result<Value> {
     })
 }
 
-fn export_bundle(
+pub(crate) fn export_bundle(
     database_path: &FsPath,
     catalog_id: &str,
     operation: SyncOperation,
@@ -1080,7 +1080,7 @@ fn sqlite_to_wire(value: ValueRef<'_>) -> WireValue {
     WireValue { kind, value }
 }
 
-fn scheduler_request(
+pub(crate) fn scheduler_request(
     operation: SyncOperation,
     source_id: String,
     dry_run: bool,
@@ -1101,7 +1101,7 @@ fn scheduler_request(
     }
 }
 
-fn result_summary(result: &SchedulerSyncResponse) -> BTreeMap<String, i64> {
+pub(crate) fn result_summary(result: &SchedulerSyncResponse) -> BTreeMap<String, i64> {
     let mut summary = BTreeMap::from([
         ("total_inserted".into(), result.total_inserted as i64),
         ("total_updated".into(), result.total_updated as i64),
@@ -1143,7 +1143,7 @@ fn add_table_summary(
     summary.insert(format!("{name}_skipped"), counts.skipped as i64);
 }
 
-fn operation_label(operation: SyncOperation) -> &'static str {
+pub(crate) fn operation_label(operation: SyncOperation) -> &'static str {
     match operation {
         SyncOperation::Merge => "merge",
         SyncOperation::PushPlanning => "push_planning",

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -1,0 +1,317 @@
+//! Client side of the remote sync protocol.
+//!
+//! `server::remote_sync` answers `/api/sync/v1`; this speaks it. With both,
+//! one PSF Guard can sync with another over the network the same way a
+//! N.I.N.A. plugin would — no shared filesystem, no copying a live SQLite
+//! file out from under the process writing it.
+//!
+//! Every direction is preview-first, because the remote holds the preview and
+//! will only apply an ID it issued. A caller therefore always sees the counts
+//! before anything is written, and a plain dry run is just a preview it never
+//! applies.
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::{collections::BTreeMap, path::Path, time::Duration};
+
+use crate::server::remote_sync::{CatalogBundle, SyncOperation};
+
+/// Long enough for a large merge bundle to cross a domestic uplink, short
+/// enough that an unreachable peer fails while someone is still watching.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// The envelope every PSF Guard endpoint answers in.
+#[derive(Debug, Deserialize)]
+struct ApiEnvelope<T> {
+    success: bool,
+    data: Option<T>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemoteCatalog {
+    pub id: String,
+    pub name: String,
+    pub readable: bool,
+    pub writable: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemoteCapabilities {
+    pub protocol_version: u32,
+    pub product: String,
+    pub product_version: String,
+    pub capabilities: Vec<String>,
+    pub catalogs: Vec<RemoteCatalog>,
+}
+
+impl RemoteCapabilities {
+    /// The one catalog this key opens. The protocol scopes a key to exactly
+    /// one, so anything else means the peer changed under us.
+    pub fn catalog(&self) -> Result<&RemoteCatalog> {
+        match self.catalogs.as_slice() {
+            [catalog] => Ok(catalog),
+            [] => bail!("the peer's key opens no catalog"),
+            many => bail!(
+                "the peer's key opens {} catalogs; this protocol scopes a key to one",
+                many.len()
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemotePreview {
+    pub preview_id: String,
+    pub expires_at: String,
+    pub summary: BTreeMap<String, i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemoteApplied {
+    pub state: String,
+    pub summary: BTreeMap<String, i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteExport {
+    bundle: Option<CatalogBundle>,
+    error: Option<String>,
+}
+
+/// One authenticated PSF Guard peer.
+#[derive(Debug)]
+pub struct SyncClient {
+    base_url: String,
+    token: String,
+    http: reqwest::Client,
+}
+
+impl SyncClient {
+    pub fn new(base_url: &str, token: &str) -> Result<Self> {
+        let base_url = base_url.trim_end_matches('/').to_string();
+        if !base_url.starts_with("http://") && !base_url.starts_with("https://") {
+            bail!("peer URL must start with http:// or https:// (got {base_url})");
+        }
+        if base_url.starts_with("http://")
+            && !base_url.starts_with("http://127.0.0.1")
+            && !base_url.starts_with("http://localhost")
+        {
+            // The key travels in a header on every request. Over plain HTTP it
+            // travels in the clear, so say so rather than let it happen
+            // quietly.
+            tracing::warn!(
+                "syncing with {base_url} over plain HTTP — the API key is sent \
+                 unencrypted. Use https:// for anything off this machine."
+            );
+        }
+        Ok(Self {
+            base_url,
+            token: token.trim().to_string(),
+            http: reqwest::Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .build()
+                .context("building the sync HTTP client")?,
+        })
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub async fn capabilities(&self) -> Result<RemoteCapabilities> {
+        self.get("/api/sync/v1/capabilities")
+            .await
+            .with_context(|| format!("asking {} what it supports", self.base_url))
+    }
+
+    /// Ask the peer to build a bundle of its own catalog.
+    pub async fn export(
+        &self,
+        catalog_id: &str,
+        operation: SyncOperation,
+        reviewed_only: bool,
+    ) -> Result<CatalogBundle> {
+        let export: RemoteExport = self
+            .post(
+                "/api/sync/v1/exports",
+                &serde_json::json!({
+                    "protocol_version": 1,
+                    "catalog_id": catalog_id,
+                    "operation": operation,
+                    "reviewed_only": reviewed_only,
+                }),
+            )
+            .await
+            .with_context(|| format!("asking {} for a bundle", self.base_url))?;
+        match export.bundle {
+            Some(bundle) => Ok(bundle),
+            None => bail!(
+                "{} could not build a bundle: {}",
+                self.base_url,
+                export.error.unwrap_or_else(|| "no reason given".into())
+            ),
+        }
+    }
+
+    /// Send a bundle for the peer to review. Writes nothing there.
+    pub async fn preview(
+        &self,
+        catalog_id: &str,
+        operation: SyncOperation,
+        bundle: &CatalogBundle,
+    ) -> Result<RemotePreview> {
+        self.post(
+            "/api/sync/v1/previews",
+            &serde_json::json!({
+                "protocol_version": 1,
+                "catalog_id": catalog_id,
+                "operation": operation,
+                "bundle": bundle,
+            }),
+        )
+        .await
+        .with_context(|| format!("sending a bundle to {} for review", self.base_url))
+    }
+
+    /// Commit a preview the peer is holding.
+    pub async fn apply(&self, preview_id: &str) -> Result<RemoteApplied> {
+        self.post_empty(&format!("/api/sync/v1/previews/{preview_id}/apply"))
+            .await
+            .with_context(|| format!("applying preview {preview_id} on {}", self.base_url))
+    }
+
+    /// Re-review a kept preview against the peer as it now stands. The way
+    /// back from a stale-preview refusal without re-sending the bundle.
+    pub async fn refresh(&self, preview_id: &str) -> Result<RemotePreview> {
+        self.post_empty(&format!("/api/sync/v1/previews/{preview_id}/refresh"))
+            .await
+            .with_context(|| format!("refreshing preview {preview_id} on {}", self.base_url))
+    }
+
+    async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let response = self
+            .http
+            .get(format!("{}{path}", self.base_url))
+            .bearer_auth(&self.token)
+            .send()
+            .await?;
+        Self::unwrap_envelope(response).await
+    }
+
+    async fn post<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<T> {
+        let response = self
+            .http
+            .post(format!("{}{path}", self.base_url))
+            .bearer_auth(&self.token)
+            .json(body)
+            .send()
+            .await?;
+        Self::unwrap_envelope(response).await
+    }
+
+    async fn post_empty<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let response = self
+            .http
+            .post(format!("{}{path}", self.base_url))
+            .bearer_auth(&self.token)
+            .send()
+            .await?;
+        Self::unwrap_envelope(response).await
+    }
+
+    /// Turn one response into either the payload or an error worth reading.
+    ///
+    /// The peer's own message matters more than the status line here: it is
+    /// the half of the exchange the operator cannot see.
+    async fn unwrap_envelope<T: serde::de::DeserializeOwned>(
+        response: reqwest::Response,
+    ) -> Result<T> {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        let envelope: ApiEnvelope<T> = match serde_json::from_str(&body) {
+            Ok(envelope) => envelope,
+            Err(error) => {
+                bail!(
+                    "peer returned {status} that is not a PSF Guard response \
+                     ({error}). Check the URL points at a PSF Guard server: {}",
+                    body.chars().take(200).collect::<String>()
+                )
+            }
+        };
+        if let Some(data) = envelope.data.filter(|_| envelope.success) {
+            return Ok(data);
+        }
+        let detail = envelope
+            .error
+            .unwrap_or_else(|| "no reason given".to_string());
+        match status.as_u16() {
+            401 | 403 => bail!("peer refused the key: {detail}"),
+            409 => bail!("{detail}"),
+            _ => bail!("peer returned {status}: {detail}"),
+        }
+    }
+}
+
+/// Build a bundle from a local scheduler database, to send to a peer.
+pub fn local_bundle(
+    database_path: &Path,
+    catalog_id: &str,
+    operation: SyncOperation,
+    reviewed_only: bool,
+) -> Result<CatalogBundle> {
+    crate::server::remote_sync::export_bundle(database_path, catalog_id, operation, reviewed_only)
+}
+
+/// Write a bundle received from a peer into a throwaway SQLite source the
+/// local sync engine can read, borrowing DDL from `template_path` for any
+/// table the peer left out.
+pub fn materialize(bundle: &CatalogBundle, into: &Path, template_path: &Path) -> Result<()> {
+    crate::server::remote_sync::materialize_bundle(into, template_path, bundle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_peer_url_must_name_a_scheme() {
+        let error = SyncClient::new("telescope.local:3000", "a-token-long-enough-for-this")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("http://"), "{error}");
+    }
+
+    #[test]
+    fn a_trailing_slash_does_not_double_up_in_paths() {
+        let client =
+            SyncClient::new("https://scope.example/", "a-token-long-enough-for-this").unwrap();
+        assert_eq!(client.base_url(), "https://scope.example");
+    }
+
+    #[test]
+    fn one_catalog_per_key_is_the_contract() {
+        let capabilities = |count: usize| RemoteCapabilities {
+            protocol_version: 1,
+            product: "PSF Guard".into(),
+            product_version: "0.5.0".into(),
+            capabilities: vec![],
+            catalogs: (0..count)
+                .map(|index| RemoteCatalog {
+                    id: format!("catalog-{index}"),
+                    name: "Catalog".into(),
+                    readable: true,
+                    writable: true,
+                })
+                .collect(),
+        };
+
+        assert_eq!(capabilities(1).catalog().unwrap().id, "catalog-0");
+        assert!(capabilities(0).catalog().is_err());
+        assert!(capabilities(2).catalog().is_err());
+    }
+}

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -527,6 +527,7 @@ mod tests {
             }],
             active_db_id: None,
             astrometry: None,
+            peers: Vec::new(),
         }
     }
 

--- a/static/e2e/sync-client.spec.ts
+++ b/static/e2e/sync-client.spec.ts
@@ -1,0 +1,210 @@
+import {
+  expect,
+  request as playwrightRequest,
+  test,
+  type APIRequestContext,
+} from '@playwright/test';
+import {
+  REVIEW_DB,
+  TELESCOPE_DB,
+  TELESCOPE_TOKEN,
+} from './fixtures/sync';
+
+/**
+ * PSF Guard syncing with PSF Guard, using its own client.
+ *
+ * `sync-api.spec.ts` drives the wire protocol directly, which proves the
+ * server half. These prove the other half: the review instance configures the
+ * telescope as a peer, then does the whole exchange itself — capabilities,
+ * export, preview, apply — with the test only asking for the result and
+ * reading it back through the ordinary API.
+ *
+ * The telescope runs without `--allow-database-management`. Accepting a sync
+ * must never need the grant that lets a caller name server filesystem paths;
+ * only the machine configuring a peer does, because storing one is registry
+ * work.
+ */
+
+/** The instance someone sits at. It holds the peer list and drives the sync. */
+let reviewer: APIRequestContext;
+
+test.beforeAll(async () => {
+  reviewer = await playwrightRequest.newContext({
+    baseURL: process.env.PSF_GUARD_E2E_REVIEW_URL,
+  });
+});
+
+test.afterAll(async () => {
+  await reviewer.dispose();
+});
+
+/** Configure the telescope as a peer, or return the one already configured. */
+async function ensurePeer(): Promise<string> {
+  const existing = await reviewer.get('/api/peers');
+  expect(existing.status(), await existing.text()).toBe(200);
+  const peers = (await existing.json()).data as Array<{ id: string }>;
+  if (peers.length > 0) {
+    return peers[0].id;
+  }
+  const created = await reviewer.post('/api/peers', {
+    data: {
+      name: 'E2E telescope',
+      base_url: process.env.PSF_GUARD_E2E_TELESCOPE_URL,
+      token: TELESCOPE_TOKEN,
+    },
+  });
+  expect(created.status(), await created.text()).toBe(200);
+  return (await created.json()).data.id;
+}
+
+interface ImageRow {
+  id: number;
+  grading_status: number;
+  reject_reason: string | null;
+  metadata: { FileName?: string };
+}
+
+async function reviewImages(): Promise<ImageRow[]> {
+  const response = await reviewer.get(
+    `/api/db/${REVIEW_DB}/images?project_id=10&target_id=10`
+  );
+  expect(response.status(), await response.text()).toBe(200);
+  return (await response.json()).data as ImageRow[];
+}
+
+/** Find a frame by the filename in its metadata, which is stable across specs
+ *  in a way row IDs and grades are not — these specs share two catalogs and
+ *  each leaves the previous one's writes behind. */
+function byFile(images: ImageRow[], filename: string): ImageRow {
+  const found = images.find((image) => image.metadata?.FileName === filename);
+  expect(found, `no frame named ${filename} in ${JSON.stringify(images)}`).toBeTruthy();
+  return found!;
+}
+
+test('a configured peer reports who it is and what it offers', async () => {
+  const peerId = await ensurePeer();
+
+  // The key was written once and never comes back.
+  const listed = await reviewer.get('/api/peers');
+  const peers = (await listed.json()).data as Array<Record<string, unknown>>;
+  expect(peers[0].token_configured).toBe(true);
+  expect(JSON.stringify(peers)).not.toContain(TELESCOPE_TOKEN);
+
+  const checked = await reviewer.post(`/api/peers/${peerId}/check`);
+  expect(checked.status(), await checked.text()).toBe(200);
+  const check = (await checked.json()).data;
+  expect(check.reachable).toBe(true);
+  expect(check.product).toBe('PSF Guard');
+  expect(check.protocol_version).toBe(1);
+  expect(check.catalogs).toEqual([TELESCOPE_DB]);
+  expect(check.capabilities).toContain('merge');
+});
+
+test('an unreachable peer is a state, not a failed request', async () => {
+  const created = await reviewer.post('/api/peers', {
+    data: {
+      name: 'Nowhere',
+      // A port nothing is listening on, so the client has to report a refusal
+      // rather than hang or throw its way out of the handler.
+      base_url: 'http://127.0.0.1:9',
+      token: 'a-key-long-enough-to-be-accepted',
+    },
+  });
+  expect(created.status(), await created.text()).toBe(200);
+  const peerId = (await created.json()).data.id;
+
+  const checked = await reviewer.post(`/api/peers/${peerId}/check`);
+  expect(checked.status(), await checked.text()).toBe(200);
+  const check = (await checked.json()).data;
+  expect(check.reachable).toBe(false);
+  expect(check.error).toBeTruthy();
+
+  const removed = await reviewer.delete(`/api/peers/${peerId}`);
+  expect(removed.status()).toBe(200);
+});
+
+test('this instance pulls a night off the telescope itself', async () => {
+  const peerId = await ensurePeer();
+  const before = await reviewImages();
+
+  // A dry run writes nothing anywhere.
+  const previewed = await reviewer.post(`/api/databases/${REVIEW_DB}/sync/remote`, {
+    data: { peer_id: peerId, direction: 'pull', dry_run: true },
+  });
+  expect(previewed.status(), await previewed.text()).toBe(200);
+  const preview = (await previewed.json()).data;
+  expect(preview.applied).toBe(false);
+  expect(preview.peer_catalog).toBe(TELESCOPE_DB);
+  expect(await reviewImages()).toHaveLength(before.length);
+
+  const applied = await reviewer.post(`/api/databases/${REVIEW_DB}/sync/remote`, {
+    data: { peer_id: peerId, direction: 'pull', dry_run: false },
+  });
+  expect(applied.status(), await applied.text()).toBe(200);
+  expect((await applied.json()).data.applied).toBe(true);
+
+  // Both of the telescope's frames are now here, whatever was here before.
+  const after = await reviewImages();
+  byFile(after, 'sync-one.fits');
+  byFile(after, 'sync-two.fits');
+
+  // And a pull is idempotent: running it again changes nothing.
+  const again = await reviewer.post(`/api/databases/${REVIEW_DB}/sync/remote`, {
+    data: { peer_id: peerId, direction: 'pull', dry_run: true },
+  });
+  expect((await again.json()).data.summary.acquiredimage_inserted ?? 0).toBe(0);
+});
+
+test('this instance sends its grades back to the telescope', async () => {
+  const peerId = await ensurePeer();
+  // Both sides must know the frame before a grade can travel by GUID.
+  await reviewer.post(`/api/databases/${REVIEW_DB}/sync/remote`, {
+    data: { peer_id: peerId, direction: 'pull', dry_run: false },
+  });
+
+  const reason = `reviewed here at ${Date.now()}`;
+  const frame = byFile(await reviewImages(), 'sync-two.fits');
+  const regraded = await reviewer.put(
+    `/api/db/${REVIEW_DB}/images/${frame.id}/grade`,
+    { data: { status: 'rejected', reason } }
+  );
+  expect(regraded.status(), await regraded.text()).toBe(200);
+
+  const pushed = await reviewer.post(`/api/databases/${REVIEW_DB}/sync/remote`, {
+    data: {
+      peer_id: peerId,
+      direction: 'push_grades',
+      dry_run: false,
+      reviewed_only: true,
+    },
+  });
+  expect(pushed.status(), await pushed.text()).toBe(200);
+  const result = (await pushed.json()).data;
+  expect(result.applied).toBe(true);
+
+  // Read it back off the telescope, which knows nothing about this test.
+  const telescope = await playwrightRequest.newContext({
+    baseURL: process.env.PSF_GUARD_E2E_TELESCOPE_URL,
+  });
+  try {
+    const response = await telescope.get(
+      `/api/db/${TELESCOPE_DB}/images?project_id=1&target_id=1`
+    );
+    expect(response.status(), await response.text()).toBe(200);
+    const remote = (await response.json()).data as ImageRow[];
+    const landed = byFile(remote, 'sync-two.fits');
+    expect(landed.grading_status).toBe(2);
+    expect(landed.reject_reason).toBe(reason);
+  } finally {
+    await telescope.dispose();
+  }
+});
+
+test('a sync names a direction it understands or refuses', async () => {
+  const peerId = await ensurePeer();
+  const response = await reviewer.post(`/api/databases/${REVIEW_DB}/sync/remote`, {
+    data: { peer_id: peerId, direction: 'delete_everything', dry_run: true },
+  });
+  expect(response.status()).toBe(400);
+  expect((await response.json()).error).toContain('delete_everything');
+});

--- a/static/playwright.config.ts
+++ b/static/playwright.config.ts
@@ -103,20 +103,24 @@ export default defineConfig({
         RUST_LOG: 'info',
       },
     },
-    // The two ends of a sync. Neither takes --allow-database-management: a
-    // server that accepts remote sync must not need the CRUD grant to do it,
-    // and that is part of what these specs check. They are also kept off the
-    // main instance because the CRUD specs reset its database list.
+    // The two ends of a sync, kept off the main instance because the CRUD
+    // specs reset its database list.
+    //
+    // Only the review copy — the machine someone sits at — takes
+    // --allow-database-management, because configuring a peer is registry
+    // work. The telescope has none, which is how the specs show that
+    // *accepting* a sync never needs that grant.
     ...[
-      { port: TELESCOPE_PORT, instance: syncFixture.telescope },
-      { port: REVIEW_PORT, instance: syncFixture.review },
-    ].map(({ port, instance }) => ({
+      { port: TELESCOPE_PORT, instance: syncFixture.telescope, manage: false },
+      { port: REVIEW_PORT, instance: syncFixture.review, manage: true },
+    ].map(({ port, instance, manage }) => ({
       command:
         `${serverCommand} server ` +
         `--port ${port} ` +
         `--registry ${instance.registryPath} ` +
         `--cache-dir ${instance.cacheDir} ` +
-        `--config ${instance.configPath}`,
+        `--config ${instance.configPath}` +
+        (manage ? ' --allow-database-management' : ''),
       url: `http://127.0.0.1:${port}/api/info`,
       timeout: 180_000,
       reuseExistingServer: !process.env.CI,

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -59,6 +59,10 @@ import type {
   CalibrationLibraryDetails,
   CalibrationLibrarySummary,
   CalibrationMutationOutcome,
+  PeerSummary,
+  PeerCheck,
+  RemoteSyncRequest,
+  RemoteSyncResult,
 } from './types';
 
 // Store the initialized API instance and server URL
@@ -244,6 +248,68 @@ export const apiClient = {
       req
     );
     if (!data.data) throw new Error(data.error || 'Failed to sync databases');
+    return data.data;
+  },
+
+  /** Remote PSF Guard peers this instance can sync with. */
+  getPeers: async (): Promise<PeerSummary[]> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<PeerSummary[]>>('/peers');
+    return data.data ?? [];
+  },
+
+  addPeer: async (req: {
+    name: string;
+    base_url: string;
+    token: string;
+    catalog_id?: string | null;
+  }): Promise<PeerSummary> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<PeerSummary>>('/peers', req);
+    if (!data.data) throw new Error(data.error || 'Failed to add peer');
+    return data.data;
+  },
+
+  /** Omit `token` to keep the stored key: the browser never receives it. */
+  updatePeer: async (
+    peerId: string,
+    req: { name: string; base_url: string; token?: string; catalog_id?: string | null }
+  ): Promise<PeerSummary> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.put<ApiResponse<PeerSummary>>(
+      `/peers/${encodeURIComponent(peerId)}`,
+      req
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to update peer');
+    return data.data;
+  },
+
+  removePeer: async (peerId: string): Promise<void> => {
+    const apiInstance = await getApi();
+    await apiInstance.delete(`/peers/${encodeURIComponent(peerId)}`);
+  },
+
+  /** Ask a peer who it is. An unreachable peer is a normal answer. */
+  checkPeer: async (peerId: string): Promise<PeerCheck> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<PeerCheck>>(
+      `/peers/${encodeURIComponent(peerId)}/check`
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to reach peer');
+    return data.data;
+  },
+
+  /** Sync one local catalog with a peer over HTTP. Dry run unless told otherwise. */
+  syncWithPeer: async (
+    dbId: string,
+    req: RemoteSyncRequest
+  ): Promise<RemoteSyncResult> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<RemoteSyncResult>>(
+      `/databases/${encodeURIComponent(dbId)}/sync/remote`,
+      req
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to sync with the peer');
     return data.data;
   },
 

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1365,3 +1365,39 @@ export interface ImageQualityResponse {
   sequence_image_count?: number;
   reference_values?: ReferenceValues;
 }
+
+/** A remote PSF Guard this instance can sync with. The key never leaves the server. */
+export interface PeerSummary {
+  id: string;
+  name: string;
+  base_url: string;
+  catalog_id: string | null;
+  token_configured: boolean;
+}
+
+export interface PeerCheck {
+  reachable: boolean;
+  product: string | null;
+  product_version: string | null;
+  protocol_version: number | null;
+  catalogs: string[];
+  capabilities: string[];
+  error: string | null;
+}
+
+export type RemoteSyncDirection = 'pull' | 'push_planning' | 'push_grades';
+
+export interface RemoteSyncRequest {
+  peer_id: string;
+  direction: RemoteSyncDirection;
+  dry_run: boolean;
+  reviewed_only?: boolean;
+  with_image_data?: boolean;
+}
+
+export interface RemoteSyncResult {
+  applied: boolean;
+  peer_product: string;
+  peer_catalog: string;
+  summary: Record<string, number>;
+}

--- a/static/src/components/RemotePeerSync.tsx
+++ b/static/src/components/RemotePeerSync.tsx
@@ -1,0 +1,352 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { apiClient } from '../api/client';
+import type { PeerCheck, RemoteSyncDirection, RemoteSyncResult } from '../api/types';
+import type { DbEntry } from '../utils/tauri';
+
+interface RemotePeerSyncProps {
+  databases: DbEntry[];
+  disabled?: boolean;
+}
+
+const DIRECTIONS: Array<{ value: RemoteSyncDirection; label: string; note: string }> = [
+  {
+    value: 'pull',
+    label: 'Pull from peer',
+    note: 'Brings the peer’s projects, targets, and captures here. Grades reviewed here are kept.',
+  },
+  {
+    value: 'push_planning',
+    label: 'Send planning',
+    note: 'Sends projects, targets, templates, and plans. Capture history and grades there are untouched.',
+  },
+  {
+    value: 'push_grades',
+    label: 'Send grades',
+    note: 'Sends grading decisions and reject reasons, matched by image GUID.',
+  },
+];
+
+/** Counts worth showing: a merge reports dozens, nearly all of them zero. */
+function summaryLine(summary: Record<string, number>): string {
+  const shown = Object.entries(summary)
+    .filter(([, count]) => count !== 0)
+    .map(([name, count]) => `${name.replace(/_/g, ' ')} ${count}`);
+  return shown.length ? shown.join(', ') : 'nothing to change';
+}
+
+export default function RemotePeerSync({ databases, disabled }: RemotePeerSyncProps) {
+  const queryClient = useQueryClient();
+  const peers = useQuery({
+    queryKey: ['peers'],
+    queryFn: () => apiClient.getPeers(),
+    staleTime: 60_000,
+  });
+
+  const [peerId, setPeerId] = useState('');
+  const [localDbId, setLocalDbId] = useState('');
+  const [direction, setDirection] = useState<RemoteSyncDirection>('pull');
+  const [allGrades, setAllGrades] = useState(false);
+  const [check, setCheck] = useState<PeerCheck | null>(null);
+  const [preview, setPreview] = useState<RemoteSyncResult | null>(null);
+  const [message, setMessage] = useState('');
+
+  const [adding, setAdding] = useState(false);
+  const [formName, setFormName] = useState('');
+  const [formUrl, setFormUrl] = useState('https://');
+  const [formToken, setFormToken] = useState('');
+
+  const peerList = peers.data ?? [];
+  const selectedPeer = peerList.find((peer) => peer.id === peerId) ?? peerList[0];
+  const selectedDb =
+    databases.find((database) => database.id === localDbId) ?? databases[0];
+  const busy = disabled || peers.isLoading;
+
+  /** Any change to what would be sent invalidates a preview taken before it. */
+  const invalidatePreview = () => {
+    setPreview(null);
+    setMessage('');
+  };
+
+  const addPeer = useMutation({
+    mutationFn: () =>
+      apiClient.addPeer({
+        name: formName.trim(),
+        base_url: formUrl.trim(),
+        token: formToken.trim(),
+      }),
+    onSuccess: (peer) => {
+      setAdding(false);
+      setFormName('');
+      setFormUrl('https://');
+      setFormToken('');
+      setPeerId(peer.id);
+      setMessage(`Added ${peer.name}.`);
+      queryClient.invalidateQueries({ queryKey: ['peers'] });
+    },
+    onError: (error: Error) => setMessage(`Could not add the peer: ${error.message}`),
+  });
+
+  const removePeer = useMutation({
+    mutationFn: (id: string) => apiClient.removePeer(id),
+    onSuccess: () => {
+      setPeerId('');
+      setCheck(null);
+      invalidatePreview();
+      queryClient.invalidateQueries({ queryKey: ['peers'] });
+    },
+    onError: (error: Error) => setMessage(`Could not remove the peer: ${error.message}`),
+  });
+
+  const checkPeer = useMutation({
+    mutationFn: (id: string) => apiClient.checkPeer(id),
+    onSuccess: (result) => {
+      setCheck(result);
+      setMessage(
+        result.reachable
+          ? `${result.product ?? 'Peer'} ${result.product_version ?? ''} — catalog ${
+              result.catalogs[0] ?? 'unknown'
+            }`.trim()
+          : `Could not reach the peer: ${result.error ?? 'no reason given'}`
+      );
+    },
+    onError: (error: Error) => setMessage(`Could not reach the peer: ${error.message}`),
+  });
+
+  const run = useMutation({
+    mutationFn: ({ dryRun }: { dryRun: boolean }) =>
+      apiClient.syncWithPeer(selectedDb!.id, {
+        peer_id: selectedPeer!.id,
+        direction,
+        dry_run: dryRun,
+        reviewed_only: !allGrades,
+        with_image_data: true,
+      }),
+    onSuccess: (result) => {
+      if (result.applied) {
+        setPreview(null);
+        setMessage(`Applied: ${summaryLine(result.summary)}.`);
+        queryClient.invalidateQueries({ queryKey: ['databases'] });
+        queryClient.invalidateQueries({ queryKey: ['db'] });
+      } else {
+        setPreview(result);
+        setMessage('');
+      }
+    },
+    onError: (error: Error) => {
+      // A refused apply wrote nothing on either side; keep the preview so the
+      // operator can read what it said and decide.
+      setMessage(`Sync failed: ${error.message}`);
+    },
+  });
+
+  if (databases.length === 0) {
+    return (
+      <div className="scheduler-sync-empty muted">
+        Add a catalog before syncing with a remote PSF Guard.
+      </div>
+    );
+  }
+
+  return (
+    <section className="settings-section remote-peer-sync">
+      <div className="scheduler-sync-heading">
+        <div>
+          <h3>Remote PSF Guard</h3>
+          <p>
+            Sync with another PSF Guard over the network. Preview is always required
+            before Apply, and the API key stays on this server.
+          </p>
+        </div>
+        <span className="scheduler-sync-safety">Preview first</span>
+      </div>
+
+      <div className="remote-peer-list">
+        <label>
+          <span>Peer</span>
+          <select
+            aria-label="Remote peer"
+            value={selectedPeer?.id ?? ''}
+            onChange={(event) => {
+              setPeerId(event.target.value);
+              setCheck(null);
+              invalidatePreview();
+            }}
+            disabled={busy || peerList.length === 0}
+          >
+            {peerList.length === 0 && <option value="">No peers configured</option>}
+            {peerList.map((peer) => (
+              <option key={peer.id} value={peer.id}>
+                {peer.name}
+              </option>
+            ))}
+          </select>
+          {selectedPeer && <small>{selectedPeer.base_url}</small>}
+        </label>
+
+        <div className="remote-peer-actions">
+          <button
+            type="button"
+            onClick={() => selectedPeer && checkPeer.mutate(selectedPeer.id)}
+            disabled={busy || !selectedPeer || checkPeer.isPending}
+          >
+            {checkPeer.isPending ? 'Checking…' : 'Test connection'}
+          </button>
+          <button type="button" onClick={() => setAdding((open) => !open)} disabled={busy}>
+            {adding ? 'Cancel' : 'Add peer'}
+          </button>
+          {selectedPeer && (
+            <button
+              type="button"
+              className="danger"
+              onClick={() => removePeer.mutate(selectedPeer.id)}
+              disabled={busy || removePeer.isPending}
+            >
+              Remove
+            </button>
+          )}
+        </div>
+      </div>
+
+      {adding && (
+        <div className="remote-peer-form">
+          <label>
+            <span>Name</span>
+            <input
+              value={formName}
+              onChange={(event) => setFormName(event.target.value)}
+              placeholder="Telescope"
+            />
+          </label>
+          <label>
+            <span>Base URL</span>
+            <input
+              value={formUrl}
+              onChange={(event) => setFormUrl(event.target.value)}
+              placeholder="https://telescope.example:3000"
+            />
+          </label>
+          <label>
+            <span>API key</span>
+            <input
+              type="password"
+              value={formToken}
+              onChange={(event) => setFormToken(event.target.value)}
+              placeholder="The key that peer issued for its catalog"
+            />
+          </label>
+          {/* Outside the label: help text inside one becomes part of the
+              field's accessible name. */}
+          <small>
+            The key is stored on this server and sent to the peer on every request. It
+            is never returned to this page.
+          </small>
+          <button
+            type="button"
+            className="save-button"
+            onClick={() => addPeer.mutate()}
+            disabled={
+              addPeer.isPending ||
+              !formName.trim() ||
+              !formToken.trim() ||
+              !/^https?:\/\/.+/.test(formUrl.trim())
+            }
+          >
+            {addPeer.isPending ? 'Adding…' : 'Save peer'}
+          </button>
+        </div>
+      )}
+
+      {check?.reachable && (
+        <p className="remote-peer-check muted">
+          Speaks protocol {check.protocol_version}; offers{' '}
+          {check.capabilities.join(', ') || 'nothing'}.
+        </p>
+      )}
+
+      <div className="scheduler-sync-operation" role="group" aria-label="Sync direction">
+        {DIRECTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            className={direction === option.value ? 'active' : ''}
+            aria-pressed={direction === option.value}
+            onClick={() => {
+              setDirection(option.value);
+              invalidatePreview();
+            }}
+            disabled={busy}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+      <p className="muted">{DIRECTIONS.find((o) => o.value === direction)?.note}</p>
+
+      <label className="remote-peer-local">
+        <span>Local catalog</span>
+        <select
+          aria-label="Local catalog"
+          value={selectedDb?.id ?? ''}
+          onChange={(event) => {
+            setLocalDbId(event.target.value);
+            invalidatePreview();
+          }}
+          disabled={busy}
+        >
+          {databases.map((database) => (
+            <option key={database.id} value={database.id}>
+              {database.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {direction === 'push_grades' && (
+        <label className="remote-peer-toggle">
+          <input
+            type="checkbox"
+            checked={allGrades}
+            onChange={(event) => {
+              setAllGrades(event.target.checked);
+              invalidatePreview();
+            }}
+            disabled={busy}
+          />
+          <span>
+            Send every grade, not only reviewed ones. Off by default, so a Pending row
+            here cannot erase a decision there.
+          </span>
+        </label>
+      )}
+
+      <div className="remote-peer-run">
+        <button
+          type="button"
+          onClick={() => run.mutate({ dryRun: true })}
+          disabled={busy || !selectedPeer || !selectedDb || run.isPending}
+        >
+          {run.isPending ? 'Working…' : 'Preview changes'}
+        </button>
+        {preview && (
+          <button
+            type="button"
+            className="save-button"
+            onClick={() => run.mutate({ dryRun: false })}
+            disabled={run.isPending}
+          >
+            Apply this preview
+          </button>
+        )}
+      </div>
+
+      {preview && (
+        <div className="remote-peer-preview" role="status">
+          <strong>{preview.peer_product}</strong> — catalog {preview.peer_catalog}
+          <p>{summaryLine(preview.summary)}</p>
+        </div>
+      )}
+      {message && <p className="remote-peer-message">{message}</p>}
+    </section>
+  );
+}

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -1216,3 +1216,79 @@
     grid-column: 1;
   }
 }
+
+/* Remote PSF Guard peers — the sending half of the sync protocol. */
+.remote-peer-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.remote-peer-list > label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 16rem;
+  flex: 1 1 16rem;
+}
+
+.remote-peer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.remote-peer-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+  border: 1px solid var(--border-color, #333);
+  border-radius: 6px;
+}
+
+.remote-peer-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.remote-peer-local {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-width: 24rem;
+  margin: 0.75rem 0;
+}
+
+.remote-peer-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.remote-peer-run {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.remote-peer-preview {
+  margin-top: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border-left: 3px solid var(--accent-color, #4a9eff);
+  background: rgba(74, 158, 255, 0.08);
+}
+
+.remote-peer-preview p {
+  margin: 0.35rem 0 0;
+}
+
+.remote-peer-check,
+.remote-peer-message {
+  margin: 0.5rem 0 0;
+}

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -6,6 +6,7 @@ import { apiClient } from '../api/client';
 import type { DatabaseSummary } from '../api/types';
 import { describeImportProgress, useImportJob } from '../hooks/useImportJob';
 import QualityBackfillControls from './QualityBackfillControls';
+import RemotePeerSync from './RemotePeerSync';
 import SchedulerSyncControls from './SchedulerSyncControls';
 import SeizaCatalogControls from './SeizaCatalogControls';
 import CalibrationLibrarySummary from './CalibrationLibrarySummary';
@@ -581,7 +582,10 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
           {managementAllowed && <SeizaCatalogControls />}
 
           {managementAllowed && (
-            <SchedulerSyncControls databases={databases} disabled={isApplying} />
+            <>
+              <SchedulerSyncControls databases={databases} disabled={isApplying} />
+              <RemotePeerSync databases={databases} disabled={isApplying} />
+            </>
           )}
 
           <div className="settings-section">

--- a/static/src/components/__tests__/RemotePeerSync.test.tsx
+++ b/static/src/components/__tests__/RemotePeerSync.test.tsx
@@ -1,0 +1,186 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server } from '../../test/msw-server';
+import RemotePeerSync from '../RemotePeerSync';
+
+const local = {
+  id: 'local',
+  name: 'Review copy',
+  db_path: '/tmp/local.sqlite',
+  image_dirs: ['/images/local'],
+};
+
+const peer = {
+  id: 'scope-peer',
+  name: 'Telescope',
+  base_url: 'https://scope.example:3000',
+  catalog_id: null,
+  token_configured: true,
+};
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function withPeers(peers: unknown[]) {
+  server.use(
+    http.get('/api/peers', () =>
+      HttpResponse.json({ success: true, data: peers, error: null, status: 'ok' })
+    )
+  );
+}
+
+describe('RemotePeerSync', () => {
+  it('previews before it offers to apply', async () => {
+    withPeers([peer]);
+    let applied = false;
+    server.use(
+      http.post('/api/databases/local/sync/remote', async ({ request }) => {
+        const body = (await request.json()) as { dry_run: boolean };
+        applied = applied || !body.dry_run;
+        return HttpResponse.json({
+          success: true,
+          data: {
+            applied: !body.dry_run,
+            peer_product: 'PSF Guard 0.5.0',
+            peer_catalog: 'scope',
+            summary: { acquiredimage_inserted: 4, project_updated: 0 },
+          },
+          error: null,
+          status: 'ok',
+        });
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<RemotePeerSync databases={[local]} />, { wrapper: wrapper() });
+
+    // Nothing can be applied until something has been previewed.
+    expect(
+      screen.queryByRole('button', { name: 'Apply this preview' })
+    ).not.toBeInTheDocument();
+
+    await user.click(await screen.findByRole('button', { name: 'Preview changes' }));
+    expect(await screen.findByText(/acquiredimage inserted 4/)).toBeInTheDocument();
+    // A zero counter would bury the one line that matters.
+    expect(screen.queryByText(/project updated 0/)).not.toBeInTheDocument();
+    expect(applied).toBe(false);
+
+    await user.click(screen.getByRole('button', { name: 'Apply this preview' }));
+    await waitFor(() => expect(applied).toBe(true));
+    expect(await screen.findByText(/^Applied:/)).toBeInTheDocument();
+  });
+
+  it('drops a preview when the direction changes under it', async () => {
+    withPeers([peer]);
+    server.use(
+      http.post('/api/databases/local/sync/remote', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            applied: false,
+            peer_product: 'PSF Guard 0.5.0',
+            peer_catalog: 'scope',
+            summary: { acquiredimage_inserted: 4 },
+          },
+          error: null,
+          status: 'ok',
+        })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<RemotePeerSync databases={[local]} />, { wrapper: wrapper() });
+    await user.click(await screen.findByRole('button', { name: 'Preview changes' }));
+    expect(
+      await screen.findByRole('button', { name: 'Apply this preview' })
+    ).toBeInTheDocument();
+
+    // The preview describes one direction. Switching must not leave an Apply
+    // button that would send something else.
+    await user.click(screen.getByRole('button', { name: 'Send grades' }));
+    expect(
+      screen.queryByRole('button', { name: 'Apply this preview' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('reports an unreachable peer without failing the page', async () => {
+    withPeers([peer]);
+    server.use(
+      http.post('/api/peers/scope-peer/check', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            reachable: false,
+            product: null,
+            product_version: null,
+            protocol_version: null,
+            catalogs: [],
+            capabilities: [],
+            error: 'connection refused',
+          },
+          error: null,
+          status: 'ok',
+        })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<RemotePeerSync databases={[local]} />, { wrapper: wrapper() });
+    await user.click(await screen.findByRole('button', { name: 'Test connection' }));
+
+    expect(await screen.findByText(/connection refused/)).toBeInTheDocument();
+    // Still usable: an unreachable peer is a state, not a crash.
+    expect(screen.getByRole('button', { name: 'Preview changes' })).toBeEnabled();
+  });
+
+  it('says so when no peer is configured', async () => {
+    withPeers([]);
+    render(<RemotePeerSync databases={[local]} />, { wrapper: wrapper() });
+    expect(await screen.findByText('No peers configured')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Preview changes' })).toBeDisabled();
+  });
+
+  it('never asks the server for a key it already holds', async () => {
+    // The browser is not given the key, so an edit that does not set one must
+    // leave the stored key alone rather than blanking it.
+    withPeers([peer]);
+    let posted: Record<string, unknown> | null = null;
+    server.use(
+      http.post('/api/peers', async ({ request }) => {
+        posted = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          success: true,
+          data: { ...peer, id: 'new-peer', name: 'Second scope' },
+          error: null,
+          status: 'ok',
+        });
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<RemotePeerSync databases={[local]} />, { wrapper: wrapper() });
+    await user.click(await screen.findByRole('button', { name: 'Add peer' }));
+    await user.type(screen.getByLabelText('Name'), 'Second scope');
+    await user.clear(screen.getByLabelText('Base URL'));
+    await user.type(screen.getByLabelText('Base URL'), 'https://second.example');
+    await user.type(screen.getByLabelText('API key'), 'a-key-long-enough-for-the-peer');
+    await user.click(screen.getByRole('button', { name: 'Save peer' }));
+
+    await waitFor(() => expect(posted).not.toBeNull());
+    expect(posted).toMatchObject({
+      name: 'Second scope',
+      base_url: 'https://second.example',
+      token: 'a-key-long-enough-for-the-peer',
+    });
+  });
+});

--- a/tests/integration_cli_sync.rs
+++ b/tests/integration_cli_sync.rs
@@ -1,0 +1,476 @@
+//! End-to-end coverage of the `sync` commands, run as the built binary.
+//!
+//! Everything else tests the sync engine through library calls. These run
+//! `psf-guard` itself, so argument parsing, registry and path resolution, the
+//! read-only/read-write split, token precedence, and the exit codes are all
+//! under test — the layer a user actually touches, and the one nothing
+//! reached before.
+//!
+//! The remote test also starts a real `psf-guard server` and syncs against it
+//! over HTTP, which is the whole point of the client: two machines, no shared
+//! filesystem.
+
+use std::{
+    io::Write,
+    net::TcpListener,
+    path::Path,
+    process::{Child, Command, Output, Stdio},
+    time::{Duration, Instant},
+};
+
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+const TELESCOPE_TOKEN: &str = "cli-e2e-remote-sync-token-000001";
+
+/// A night at the telescope: two frames, neither reviewed.
+const TELESCOPE_ROWS: &str = "
+    INSERT INTO project (Id,profileId,name,description,state,priority,isMosaic,flatsHandling,guid)
+        VALUES (1,'profile','Sync Nebula','from the mount',1,5,0,0,'project-guid');
+    INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid)
+        VALUES (1,'Sync Nebula Core',1,5.5,-5.4,0,1,'target-guid');
+    INSERT INTO exposuretemplate (Id,profileId,name,filtername,gain,offset,bin,readoutmode,guid)
+        VALUES (1,'profile','Ha 300','Ha',100,30,1,0,'template-guid');
+    INSERT INTO exposureplan (Id,profileId,exposure,desired,acquired,accepted,targetid,exposureTemplateId,enabled,guid)
+        VALUES (1,'profile',300,40,2,2,1,1,1,'plan-guid');
+    INSERT INTO ruleweight (Id,name,weight,projectid) VALUES (1,'Priority',2.5,1);
+    INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,profileId,exposureId,guid)
+        VALUES (1,1,1,1750000000,'Ha',1,'{\"FileName\":\"one.fits\"}','profile',1,'image-one');
+    INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,profileId,exposureId,guid)
+        VALUES (2,1,1,1750000600,'Ha',1,'{\"FileName\":\"two.fits\"}','profile',1,'image-two');";
+
+/// The review copy: the same project, edited here, and one frame already
+/// rejected by a reviewer.
+const REVIEW_ROWS: &str = "
+    INSERT INTO project (Id,profileId,name,description,state,priority,isMosaic,flatsHandling,guid)
+        VALUES (10,'profile','Sync Nebula','edited here',1,9,0,0,'project-guid');
+    INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid)
+        VALUES (10,'Sync Nebula Core',1,5.5,-5.4,0,10,'target-guid');
+    INSERT INTO exposuretemplate (Id,profileId,name,filtername,gain,offset,bin,readoutmode,guid)
+        VALUES (10,'profile','Ha 300','Ha',100,30,1,0,'template-guid');
+    INSERT INTO exposureplan (Id,profileId,exposure,desired,acquired,accepted,targetid,exposureTemplateId,enabled,guid)
+        VALUES (10,'profile',300,60,0,0,10,10,1,'plan-guid');
+    INSERT INTO acquiredimage (Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata,rejectreason,profileId,exposureId,guid)
+        VALUES (10,10,10,1750000000,'Ha',2,'{\"FileName\":\"one.fits\"}','reviewed here','profile',10,'image-one');";
+
+fn scheduler_db(path: &Path, rows: &str) {
+    let connection = Connection::open(path).unwrap();
+    psf_guard::ts_schema::apply_schema(&connection).unwrap();
+    connection.execute_batch(rows).unwrap();
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_psf-guard"))
+        .args(args)
+        .output()
+        .expect("running psf-guard")
+}
+
+/// Run and insist it worked, showing both streams when it did not — a bare
+/// exit code tells you nothing about which argument the CLI disliked.
+fn run_ok(args: &[&str]) -> String {
+    let output = run(args);
+    assert!(
+        output.status.success(),
+        "psf-guard {args:?} failed ({})\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn query<T: rusqlite::types::FromSql>(path: &Path, sql: &str) -> T {
+    Connection::open(path)
+        .unwrap()
+        .query_row(sql, [], |row| row.get(0))
+        .unwrap()
+}
+
+#[test]
+fn the_local_sync_commands_move_captures_grades_and_planning() {
+    let directory = TempDir::new().unwrap();
+    let telescope = directory.path().join("telescope.sqlite");
+    let review = directory.path().join("review.sqlite");
+    scheduler_db(&telescope, TELESCOPE_ROWS);
+    scheduler_db(&review, REVIEW_ROWS);
+    let (telescope_arg, review_arg) = (path_arg(&telescope), path_arg(&review));
+
+    // A dry run reports the plan and writes nothing.
+    let planned = run_ok(&[
+        "sync",
+        "pull",
+        "--from",
+        &telescope_arg,
+        "--to",
+        &review_arg,
+        "--dry-run",
+    ]);
+    assert!(planned.to_lowercase().contains("dry"), "{planned}");
+    assert_eq!(count(&review, "acquiredimage"), 1, "a dry run wrote rows");
+
+    run_ok(&[
+        "sync",
+        "pull",
+        "--from",
+        &telescope_arg,
+        "--to",
+        &review_arg,
+    ]);
+    assert_eq!(count(&review, "acquiredimage"), 2);
+    assert_eq!(
+        query::<i64>(
+            &review,
+            "SELECT gradingStatus FROM acquiredimage WHERE guid = 'image-one'"
+        ),
+        2,
+        "a pull must keep the grade a reviewer set here"
+    );
+    assert_eq!(
+        query::<String>(&review, "SELECT description FROM project"),
+        "from the mount",
+        "the telescope owns structure"
+    );
+
+    // Reject the second frame here, then send both decisions back.
+    Connection::open(&review)
+        .unwrap()
+        .execute(
+            "UPDATE acquiredimage SET gradingStatus = 2, rejectreason = 'cli reviewed' \
+             WHERE guid = 'image-two'",
+            [],
+        )
+        .unwrap();
+    let pushed = run_ok(&[
+        "sync",
+        "grades",
+        "--from",
+        &review_arg,
+        "--to",
+        &telescope_arg,
+    ]);
+    assert!(pushed.to_lowercase().contains("changed"), "{pushed}");
+    assert_eq!(
+        query::<String>(
+            &telescope,
+            "SELECT rejectreason FROM acquiredimage WHERE guid = 'image-two'"
+        ),
+        "cli reviewed"
+    );
+
+    // Planning goes the same way, and must not disturb capture progress.
+    Connection::open(&review)
+        .unwrap()
+        .execute("UPDATE exposureplan SET desired = 99", [])
+        .unwrap();
+    run_ok(&[
+        "sync",
+        "planning",
+        "--from",
+        &review_arg,
+        "--to",
+        &telescope_arg,
+    ]);
+    assert_eq!(
+        query::<i64>(&telescope, "SELECT desired FROM exposureplan"),
+        99
+    );
+    assert_eq!(
+        query::<i64>(&telescope, "SELECT acquired FROM exposureplan"),
+        2,
+        "a planning push must not rewrite what the telescope has captured"
+    );
+}
+
+#[test]
+fn syncing_a_database_with_itself_is_refused() {
+    let directory = TempDir::new().unwrap();
+    let catalog = directory.path().join("catalog.sqlite");
+    scheduler_db(&catalog, TELESCOPE_ROWS);
+    let arg = path_arg(&catalog);
+
+    let output = run(&["sync", "pull", "--from", &arg, "--to", &arg]);
+    assert!(!output.status.success(), "syncing onto itself should fail");
+    let message = String::from_utf8_lossy(&output.stderr).to_lowercase();
+    assert!(message.contains("same database"), "{message}");
+}
+
+#[test]
+fn the_remote_sync_command_talks_to_a_running_server() {
+    let directory = TempDir::new().unwrap();
+    let telescope = directory.path().join("telescope.sqlite");
+    let review = directory.path().join("review.sqlite");
+    scheduler_db(&telescope, TELESCOPE_ROWS);
+    scheduler_db(&review, REVIEW_ROWS);
+    let server = Server::start(directory.path(), &telescope);
+    let review_arg = path_arg(&review);
+    let token_file = directory.path().join("token");
+    std::fs::write(&token_file, format!("{TELESCOPE_TOKEN}\n")).unwrap();
+    let token_arg = path_arg(&token_file);
+
+    // A dry run reaches the peer, reports, and writes nothing.
+    let planned = run_ok(&[
+        "sync",
+        "remote",
+        "--direction",
+        "pull",
+        "--local",
+        &review_arg,
+        "--peer",
+        &server.url,
+        "--token-file",
+        &token_arg,
+        "--dry-run",
+    ]);
+    assert!(planned.contains("PSF Guard"), "{planned}");
+    assert_eq!(count(&review, "acquiredimage"), 1, "a dry run wrote rows");
+
+    run_ok(&[
+        "sync",
+        "remote",
+        "--direction",
+        "pull",
+        "--local",
+        &review_arg,
+        "--peer",
+        &server.url,
+        "--token-file",
+        &token_arg,
+    ]);
+    assert_eq!(count(&review, "acquiredimage"), 2);
+    assert_eq!(
+        query::<i64>(
+            &review,
+            "SELECT gradingStatus FROM acquiredimage WHERE guid = 'image-one'"
+        ),
+        2,
+        "a remote pull must keep the grade a reviewer set here"
+    );
+
+    // Send a decision back the other way, and read it off the server's database.
+    Connection::open(&review)
+        .unwrap()
+        .execute(
+            "UPDATE acquiredimage SET gradingStatus = 2, rejectreason = 'sent over http' \
+             WHERE guid = 'image-two'",
+            [],
+        )
+        .unwrap();
+    run_ok(&[
+        "sync",
+        "remote",
+        "--direction",
+        "push-grades",
+        "--local",
+        &review_arg,
+        "--peer",
+        &server.url,
+        "--token-file",
+        &token_arg,
+    ]);
+    assert_eq!(
+        query::<String>(
+            &telescope,
+            "SELECT rejectreason FROM acquiredimage WHERE guid = 'image-two'"
+        ),
+        "sent over http"
+    );
+    drop(server);
+}
+
+#[test]
+fn a_remote_sync_without_a_key_stops_before_it_reaches_the_peer() {
+    let directory = TempDir::new().unwrap();
+    let review = directory.path().join("review.sqlite");
+    scheduler_db(&review, REVIEW_ROWS);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_psf-guard"))
+        .args([
+            "sync",
+            "remote",
+            "--direction",
+            "pull",
+            "--local",
+            &path_arg(&review),
+            "--peer",
+            "http://127.0.0.1:9",
+        ])
+        // The variable is a supported way to supply the key, so an inherited
+        // one would make this pass for the wrong reason.
+        .env_remove("PSF_GUARD_SYNC_TOKEN")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let message = String::from_utf8_lossy(&output.stderr);
+    assert!(message.contains("--token-file"), "{message}");
+}
+
+#[test]
+fn a_peer_url_without_a_scheme_is_refused_before_any_request() {
+    let directory = TempDir::new().unwrap();
+    let review = directory.path().join("review.sqlite");
+    scheduler_db(&review, REVIEW_ROWS);
+
+    let output = run(&[
+        "sync",
+        "remote",
+        "--direction",
+        "pull",
+        "--local",
+        &path_arg(&review),
+        "--peer",
+        "telescope.local:3000",
+        "--token",
+        TELESCOPE_TOKEN,
+    ]);
+    assert!(!output.status.success());
+    let message = String::from_utf8_lossy(&output.stderr);
+    assert!(message.contains("http://"), "{message}");
+}
+
+fn count(path: &Path, table: &str) -> i64 {
+    query(path, &format!("SELECT count(*) FROM {table}"))
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+/// A real `psf-guard server` on a free port, opened for remote sync by a
+/// config file — the only way a headless instance grants it.
+struct Server {
+    child: Child,
+    url: String,
+}
+
+impl Server {
+    fn start(directory: &Path, database: &Path) -> Self {
+        // Bind port 0 to have the OS name a free one, then release it. A racing
+        // process could still take it; the readiness wait below turns that into
+        // a clear timeout rather than a confusing refusal later.
+        let port = TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let images = directory.join("images");
+        std::fs::create_dir_all(&images).unwrap();
+        let registry = directory.join("registry.json");
+        std::fs::write(
+            &registry,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 2,
+                "databases": [{
+                    "id": "telescope",
+                    "name": "Telescope",
+                    "db_path": database,
+                    "image_dirs": [images],
+                }],
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let config = directory.join("psf-guard.toml");
+        let mut file = std::fs::File::create(&config).unwrap();
+        writeln!(
+            file,
+            "[server]\n\n[cache]\n\n[[remote_sync]]\ndatabase = \"telescope\"\ntoken = \"{TELESCOPE_TOKEN}\"\n"
+        )
+        .unwrap();
+
+        let child = Command::new(env!("CARGO_BIN_EXE_psf-guard"))
+            .args([
+                "server",
+                "--port",
+                &port.to_string(),
+                "--host",
+                "127.0.0.1",
+                "--registry",
+                &path_arg(&registry),
+                "--cache-dir",
+                &path_arg(&directory.join("cache")),
+                "--config",
+                &path_arg(&config),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("starting psf-guard server");
+
+        let server = Self {
+            child,
+            url: format!("http://127.0.0.1:{port}"),
+        };
+        server.wait_until_ready();
+        server
+    }
+
+    fn wait_until_ready(&self) {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            if TcpListener::bind(("127.0.0.1", self.port())).is_err() {
+                // Something is listening. Give it a moment to finish binding
+                // its routes before the first request.
+                std::thread::sleep(Duration::from_millis(200));
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        panic!("psf-guard server did not start on {}", self.url);
+    }
+
+    fn port(&self) -> u16 {
+        self.url.rsplit(':').next().unwrap().parse().unwrap()
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        // A leaked server would hold the temporary directory's database open
+        // and keep a port bound for the rest of the run.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Paths built from a `TempDir` are absolute, so `psf-guard` must not consult
+/// the registry for them at all — which is what lets these tests run without
+/// touching the user's real config.
+#[test]
+fn a_path_argument_never_needs_the_registry() {
+    let directory = TempDir::new().unwrap();
+    let telescope = directory.path().join("telescope.sqlite");
+    let review = directory.path().join("review.sqlite");
+    scheduler_db(&telescope, TELESCOPE_ROWS);
+    scheduler_db(&review, REVIEW_ROWS);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_psf-guard"))
+        .args([
+            "sync",
+            "pull",
+            "--from",
+            &path_arg(&telescope),
+            "--to",
+            &path_arg(&review),
+            "--dry-run",
+            // A registry path that does not exist: reaching for it would fail.
+            "--registry",
+            &path_arg(&directory.path().join("nowhere/registry.json")),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Guard against the binary silently losing the subcommand.
+#[test]
+fn the_remote_command_is_reachable_from_the_help() {
+    let help = run_ok(&["sync", "--help"]);
+    assert!(help.contains("remote"), "{help}");
+}


### PR DESCRIPTION
Re-targets #240, which was merged into `agent/sync-e2e` after #239 had already been squash-merged to main — so the client commit never reached main. This is the same commit replayed onto current main; a PR from the old branch would also revert the screenshot refresh from #236.

Content is unchanged from #240:

PSF Guard could answer `/api/sync/v1` but never speak it, so the two-instance arrangement the protocol was designed for was unreachable without a script.

- **`sync_client.rs`** — one type over `reqwest` (already in the tree via seiza-download; `Cargo.lock` gains no packages): capabilities, export, preview, apply, refresh.
- **`commands/sync/remote.rs`** — pull stages the peer's bundle as a throwaway SQLite source and hands it to the same merge engine a local `sync pull` runs; push sends a bundle for review and applies the preview ID the peer returns.
- **`psf-guard sync remote --direction pull|push-planning|push-grades`**, key from `--token-file`, `PSF_GUARD_SYNC_TOKEN`, or `--token` in that order.
- **`/api/peers`** CRUD and connection check, plus `POST /api/databases/{id}/sync/remote`. Outgoing keys are stored in the clear because they must be presented on every request, and never returned to a browser.
- **Remote PSF Guard panel** in Settings: add a peer, test, preview, apply.
- **`sync-client.spec.ts`** — the review instance configures the telescope as a peer and runs the exchange itself, verified by reading back off the telescope.

426 Rust tests, 147 vitest, clippy clean on this branch. Playwright was green on the identical tree as #240.