### PR TITLE
Show one-shot-color frames in colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -916,6 +916,7 @@ size:
 [server]
 preview_format = "jpeg"      # "png" (default) or "jpeg"
 preview_jpeg_quality = 88    # 50–100, ignored for PNG
+preview_color = true         # colour by default for OSC frames
 ```
 
 On a realistic stretched sub, JPEG at the default quality is roughly a third
@@ -930,6 +931,13 @@ The two formats use different file extensions, so both can sit in the cache at
 once. Changing the setting leaves existing artifacts alone and regenerates on
 demand; changing it back finds the originals still valid. An artifact is always
 served as whatever it was written as, not as whatever the setting says now.
+Nothing removes the old set — the server reports how much of the cache is in
+the other format at startup, and deleting it is yours to decide.
+
+`preview_color` also decides which rendition background pre-generation warms.
+A viewer that disagrees with it still gets what it asked for, generated on
+demand; on a site whose observers prefer luminance, setting it false keeps the
+warmed cache and the default view pointing at the same artifact.
 
 Star-annotated images follow the same setting. Their markers are line art,
 where JPEG rings hardest, so that is the first place to look if a marker seems

--- a/README.md
+++ b/README.md
@@ -885,10 +885,12 @@ curl -X POST \
 A raw OSC file with a recognized `BAYERPAT` header is debayered, and what
 happens next depends on whether you are looking or measuring.
 
-**Looking.** The image viewer shows colour by default. Press `C` or use the
-**Color** button for the luminance rendition instead. Stacks of OSC frames are
-colour throughout: the stacker debayers on ingest and integrates all three
-channels, so the preview and the exported FITS are RGB.
+**Looking.** Colour is on by default, in the grid, the overview, and the image
+viewer alike. Press `C` or use the **Color** button for the luminance
+rendition instead; the choice is shared across every view and remembered, so a
+frame does not change appearance on the way into the detail view. Stacks of OSC
+frames are colour throughout: the stacker debayers on ingest and integrates all
+three channels, so the preview and the exported FITS are RGB.
 
 **Measuring.** Grading and quality metrics use luminance, always. Star metrics
 on a bare colour filter array are distorted by the per-channel sampling, and

--- a/README.md
+++ b/README.md
@@ -906,6 +906,35 @@ all three toward a common median and wash the frame out.
 A frame with no `BAYERPAT` — a mono camera behind a filter wheel — has no
 colour to recover and renders greyscale either way.
 
+## Preview cache format
+
+Generated previews and annotated images are PNG by default — exact, and the
+same pixels the stretch produced. A server short of disk can trade that for
+size:
+
+```toml
+[server]
+preview_format = "jpeg"      # "png" (default) or "jpeg"
+preview_jpeg_quality = 88    # 50–100, ignored for PNG
+```
+
+On a realistic stretched sub, JPEG at the default quality is roughly a third
+the size of PNG. It is lossy in exactly the places this tool asks you to look:
+it smooths the faint, high-frequency detail that noise, hot pixels, and
+marginal stars live in, so a frame can look cleaner in the viewer than it is on
+disk. Grading measurements are taken from the FITS and never from a preview, so
+nothing scored changes — what changes is what your eye is given to check the
+score against.
+
+The two formats use different file extensions, so both can sit in the cache at
+once. Changing the setting leaves existing artifacts alone and regenerates on
+demand; changing it back finds the originals still valid. An artifact is always
+served as whatever it was written as, not as whatever the setting says now.
+
+Star-annotated images follow the same setting. Their markers are line art,
+where JPEG rings hardest, so that is the first place to look if a marker seems
+to have a halo.
+
 ## ⚠️ Known limitations
 
 - **Path assumptions.** Directory layouts matching

--- a/README.md
+++ b/README.md
@@ -880,12 +880,32 @@ curl -X POST \
   "localhost:3000/api/databases/my-db/sync/previews/<preview_id>/apply"
 ```
 
+## One-shot-color frames
+
+A raw OSC file with a recognized `BAYERPAT` header is debayered, and what
+happens next depends on whether you are looking or measuring.
+
+**Looking.** The image viewer shows colour by default. Press `C` or use the
+**Color** button for the luminance rendition instead. Stacks of OSC frames are
+colour throughout: the stacker debayers on ingest and integrates all three
+channels, so the preview and the exported FITS are RGB.
+
+**Measuring.** Grading and quality metrics use luminance, always. Star metrics
+on a bare colour filter array are distorted by the per-channel sampling, and
+N.I.N.A. measures the debayered frame, so this keeps our numbers comparable to
+the ones Target Scheduler recorded. Switching the viewer to colour changes what
+you see and nothing that is scored.
+
+The colour stretch is measured once on luminance and applied identically to
+red, green, and blue. That keeps the ratios between channels, and with them the
+colour balance — stretching each channel against its own statistics would pull
+all three toward a common median and wash the frame out.
+
+A frame with no `BAYERPAT` — a mono camera behind a filter wheel — has no
+colour to recover and renders greyscale either way.
+
 ## ⚠️ Known limitations
 
-- **OSC display is luminance-first.** Raw one-shot-color FITS files with a
-  recognized `BAYERPAT` header are debayered, then reduced to luminance for
-  grading and quality measurements. The single-frame grader does not yet
-  provide a full-color rendition of an OSC exposure.
 - **Path assumptions.** Directory layouts matching
   `%DATEMINUS12%/%TARGETNAME%/%DATEMINUS12%/LIGHT/...` (with or without the
   leading date) are detected reliably. Other patterns may need support; open

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -993,6 +993,7 @@ pub fn main() -> Result<()> {
             let server_port = app_config.get_port();
             let worker_policy = app_config.get_worker_policy();
             let preview_encoding = app_config.server.preview_encoding()?;
+            let preview_color_default = app_config.server.preview_color();
             let site_banner = app_config.get_site_banner()?;
             // Open the configured databases for remote sync and image upload.
             // This edits the in-memory list only — the registry on disk keeps
@@ -1022,6 +1023,7 @@ pub fn main() -> Result<()> {
                     site_banner,
                     worker_policy,
                     preview_encoding,
+                    preview_color_default,
                     astrometry_config,
                 )
                 .await

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -992,6 +992,7 @@ pub fn main() -> Result<()> {
             let server_host = app_config.get_host();
             let server_port = app_config.get_port();
             let worker_policy = app_config.get_worker_policy();
+            let preview_encoding = app_config.server.preview_encoding()?;
             let site_banner = app_config.get_site_banner()?;
             // Open the configured databases for remote sync and image upload.
             // This edits the in-memory list only — the registry on disk keeps
@@ -1020,6 +1021,7 @@ pub fn main() -> Result<()> {
                     allow_database_management,
                     site_banner,
                     worker_policy,
+                    preview_encoding,
                     astrometry_config,
                 )
                 .await

--- a/src/commands/stretch_to_png.rs
+++ b/src/commands/stretch_to_png.rs
@@ -25,9 +25,9 @@ pub fn stretch_to_png(
     )
 }
 
-/// Render a one-shot-color frame in colour, or report that it is not a mosaic.
+/// Render a one-shot-color frame in colour, or report that it cannot.
 ///
-/// Returns `Ok(false)` for a frame with no `BAYERPAT`, leaving the caller to
+/// Returns `Ok(false)` when the frame is not a mosaic, leaving the caller to
 /// fall back to the greyscale path — a mono camera has no colour to show, and
 /// refusing outright would make the option useless on a mixed rig.
 ///
@@ -37,7 +37,7 @@ pub fn stretch_to_png(
 /// red, green, and blue: that keeps the ratios between channels, and with
 /// them the colour. Stretching each channel against its own statistics would
 /// pull all three toward a common median and wash the image out.
-pub fn color_to_png_with_resize(
+pub fn render_color_preview(
     fits_path: &str,
     output: Option<String>,
     midtone_factor: f64,
@@ -71,13 +71,16 @@ pub fn color_to_png_with_resize(
         shadows_clip: shadow_clipping,
     };
 
-    let planes: Vec<Vec<u16>> = (0..3)
-        .map(|channel| stretch_u16_to_u16(&frame.channel(channel), &statistics, &params))
-        .collect();
-    let mut interleaved = Vec::with_capacity(frame.width * frame.height * 3);
-    for pixel in 0..frame.width * frame.height {
-        for plane in &planes {
-            interleaved.push((plane[pixel] >> 8) as u8);
+    // One channel at a time, written straight into the interleaved output.
+    // Holding all three stretched planes at once costs three more copies of a
+    // full frame, which on a 60-megapixel sub is most of the memory budget a
+    // preview worker is allowed.
+    let pixels = frame.width * frame.height;
+    let mut interleaved = vec![0u8; pixels * 3];
+    for channel in 0..3 {
+        let stretched = stretch_u16_to_u16(&frame.channel(channel), &statistics, &params);
+        for (pixel, value) in stretched.iter().enumerate() {
+            interleaved[pixel * 3 + channel] = (value >> 8) as u8;
         }
     }
 
@@ -131,7 +134,7 @@ pub fn stretch_to_png_with_resize(
     invert: bool,
     max_dimensions: Option<(u32, u32)>,
 ) -> Result<()> {
-    stretch_to_png_with_format(
+    render_preview(
         fits_path,
         output,
         midtone_factor,
@@ -146,7 +149,7 @@ pub fn stretch_to_png_with_resize(
 /// As above, in a chosen format. The CLI writes PNG; the server writes
 /// whatever its configuration says.
 #[allow(clippy::too_many_arguments)]
-pub fn stretch_to_png_with_format(
+pub fn render_preview(
     fits_path: &str,
     output: Option<String>,
     midtone_factor: f64,

--- a/src/commands/stretch_to_png.rs
+++ b/src/commands/stretch_to_png.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 
-use crate::image_analysis::FitsImage;
+use crate::image_analysis::{ColorFrame, FitsImage};
 
 pub fn stretch_to_png(
     fits_path: &str,
@@ -24,6 +24,111 @@ pub fn stretch_to_png(
         logarithmic,
         invert,
         None, // No resize
+    )
+}
+
+/// Render a one-shot-color frame in colour, or report that it is not a mosaic.
+///
+/// Returns `Ok(false)` for a frame with no `BAYERPAT`, leaving the caller to
+/// fall back to the greyscale path — a mono camera has no colour to show, and
+/// refusing outright would make the option useless on a mixed rig.
+///
+/// The transfer is the same midtone stretch the greyscale preview uses, so a
+/// colour and a mono rendition of the same exposure sit at the same
+/// brightness. It is measured once on luminance and applied identically to
+/// red, green, and blue: that keeps the ratios between channels, and with
+/// them the colour. Stretching each channel against its own statistics would
+/// pull all three toward a common median and wash the image out.
+pub fn color_to_png_with_resize(
+    fits_path: &str,
+    output: Option<String>,
+    midtone_factor: f64,
+    shadow_clipping: f64,
+    max_dimensions: Option<(u32, u32)>,
+) -> Result<bool> {
+    use seiza_stretch::{stretch_u16_to_u16, StretchParams};
+
+    let path = Path::new(fits_path);
+    let Some(frame) = ColorFrame::from_file(path)
+        .with_context(|| format!("Failed to load FITS file: {}", path.display()))?
+    else {
+        return Ok(false);
+    };
+
+    // Statistics come from luminance so every channel shares one transfer.
+    let luminance = FitsImage {
+        width: frame.width,
+        height: frame.height,
+        data: frame.luminance(),
+        raw_min: 0.0,
+        raw_scale: 1.0,
+        bzero: 0.0,
+    };
+    let statistics = luminance
+        .calculate_basic_statistics()
+        .to_stretch_statistics();
+    let params = StretchParams {
+        target_median: midtone_factor,
+        shadows_clip: shadow_clipping,
+    };
+
+    let planes: Vec<Vec<u16>> = (0..3)
+        .map(|channel| stretch_u16_to_u16(&frame.channel(channel), &statistics, &params))
+        .collect();
+    let mut interleaved = Vec::with_capacity(frame.width * frame.height * 3);
+    for pixel in 0..frame.width * frame.height {
+        for plane in &planes {
+            interleaved.push((plane[pixel] >> 8) as u8);
+        }
+    }
+
+    let buffer = image::RgbImage::from_raw(frame.width as u32, frame.height as u32, interleaved)
+        .context("Failed to create colour image buffer")?;
+    let buffer = match max_dimensions {
+        Some((max_width, max_height)) => resize_to_fit(buffer, max_width, max_height),
+        None => buffer,
+    };
+
+    let output_path = output.map_or_else(
+        || {
+            let mut path = path.to_path_buf();
+            path.set_extension("png");
+            path
+        },
+        PathBuf::from,
+    );
+    let file = File::create(&output_path)
+        .with_context(|| format!("Failed to create output file: {}", output_path.display()))?;
+    PngEncoder::new_with_quality(
+        BufWriter::new(file),
+        CompressionType::Fast,
+        FilterType::NoFilter,
+    )
+    .write_image(
+        buffer.as_raw(),
+        buffer.width(),
+        buffer.height(),
+        ColorType::Rgb8.into(),
+    )
+    .context("Failed to encode colour PNG")?;
+    Ok(true)
+}
+
+/// Scale down to fit a box, keeping the aspect ratio. Never scales up: an
+/// enlarged preview costs bytes and shows nothing extra.
+fn resize_to_fit(buffer: image::RgbImage, max_width: u32, max_height: u32) -> image::RgbImage {
+    let scale =
+        (max_width as f32 / buffer.width() as f32).min(max_height as f32 / buffer.height() as f32);
+    if scale >= 1.0 {
+        return buffer;
+    }
+    let width = ((buffer.width() as f32 * scale) as u32).max(1);
+    let height = ((buffer.height() as f32 * scale) as u32).max(1);
+    image::imageops::resize(
+        &buffer,
+        width,
+        height,
+        image::imageops::FilterType::Lanczos3,
     )
 }
 

--- a/src/commands/stretch_to_png.rs
+++ b/src/commands/stretch_to_png.rs
@@ -89,11 +89,9 @@ pub fn color_to_png_with_resize(
     };
 
     let output_path = output.map_or_else(
-        || {
-            let mut path = path.to_path_buf();
-            path.set_extension("png");
-            path
-        },
+        // Name the file after what is about to be written to it, not after
+        // the format this function used to be able to produce.
+        || path.with_extension(encoding.extension()),
         PathBuf::from,
     );
     encoding.write(

--- a/src/commands/stretch_to_png.rs
+++ b/src/commands/stretch_to_png.rs
@@ -1,12 +1,10 @@
 use anyhow::{Context, Result};
-use image::codecs::png::{CompressionType, FilterType, PngEncoder};
-use image::{ColorType, ImageEncoder};
+use image::ColorType;
 use image::{ImageBuffer, Luma};
-use std::fs::File;
-use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 
 use crate::image_analysis::{ColorFrame, FitsImage};
+use crate::preview_format::PreviewEncoding;
 
 pub fn stretch_to_png(
     fits_path: &str,
@@ -45,6 +43,7 @@ pub fn color_to_png_with_resize(
     midtone_factor: f64,
     shadow_clipping: f64,
     max_dimensions: Option<(u32, u32)>,
+    encoding: PreviewEncoding,
 ) -> Result<bool> {
     use seiza_stretch::{stretch_u16_to_u16, StretchParams};
 
@@ -97,20 +96,13 @@ pub fn color_to_png_with_resize(
         },
         PathBuf::from,
     );
-    let file = File::create(&output_path)
-        .with_context(|| format!("Failed to create output file: {}", output_path.display()))?;
-    PngEncoder::new_with_quality(
-        BufWriter::new(file),
-        CompressionType::Fast,
-        FilterType::NoFilter,
-    )
-    .write_image(
+    encoding.write(
+        &output_path,
         buffer.as_raw(),
         buffer.width(),
         buffer.height(),
-        ColorType::Rgb8.into(),
-    )
-    .context("Failed to encode colour PNG")?;
+        ColorType::Rgb8,
+    )?;
     Ok(true)
 }
 
@@ -140,6 +132,31 @@ pub fn stretch_to_png_with_resize(
     logarithmic: bool,
     invert: bool,
     max_dimensions: Option<(u32, u32)>,
+) -> Result<()> {
+    stretch_to_png_with_format(
+        fits_path,
+        output,
+        midtone_factor,
+        shadow_clipping,
+        logarithmic,
+        invert,
+        max_dimensions,
+        PreviewEncoding::png(),
+    )
+}
+
+/// As above, in a chosen format. The CLI writes PNG; the server writes
+/// whatever its configuration says.
+#[allow(clippy::too_many_arguments)]
+pub fn stretch_to_png_with_format(
+    fits_path: &str,
+    output: Option<String>,
+    midtone_factor: f64,
+    shadow_clipping: f64,
+    logarithmic: bool,
+    invert: bool,
+    max_dimensions: Option<(u32, u32)>,
+    encoding: PreviewEncoding,
 ) -> Result<()> {
     // Load FITS file
     let fits_path = Path::new(fits_path);
@@ -217,23 +234,13 @@ pub fn stretch_to_png_with_resize(
         img_buffer
     };
 
-    // Save PNG with compression
-    let file = File::create(&output_path)
-        .with_context(|| format!("Failed to create output file: {}", output_path.display()))?;
-    let writer = BufWriter::new(file);
-
-    // Create PNG encoder with best compression
-    let encoder = PngEncoder::new_with_quality(writer, CompressionType::Best, FilterType::Adaptive);
-
-    // Write the image data
-    encoder
-        .write_image(
-            &final_buffer,
-            final_buffer.width(),
-            final_buffer.height(),
-            ColorType::L8.into(),
-        )
-        .with_context(|| format!("Failed to write PNG image to {}", output_path.display()))?;
+    encoding.write(
+        &output_path,
+        &final_buffer,
+        final_buffer.width(),
+        final_buffer.height(),
+        ColorType::L8,
+    )?;
 
     println!("Saved stretched image to: {}", output_path.display());
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,6 +228,34 @@ pub struct ServerConfig {
     /// Optional notice shown below the application header on every page.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub banner: Option<SiteBannerConfig>,
+    /// File format for generated preview and annotated images: `png`
+    /// (default, exact) or `jpeg` (smaller cache, lossy). See
+    /// [`crate::preview_format`] for what the trade costs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preview_format: Option<String>,
+    /// JPEG quality, 50–100, when `preview_format = "jpeg"`. Ignored for PNG.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preview_jpeg_quality: Option<u8>,
+}
+
+impl ServerConfig {
+    /// How generated previews are encoded. An unreadable format name is an
+    /// error rather than a silent fall back to PNG: an operator who set it
+    /// meant something by it.
+    pub fn preview_encoding(&self) -> Result<crate::preview_format::PreviewEncoding> {
+        use crate::preview_format::{PreviewEncoding, PreviewFormat, DEFAULT_JPEG_QUALITY};
+
+        let format = match &self.preview_format {
+            Some(name) => PreviewFormat::parse(name).context("server.preview_format")?,
+            None => return Ok(PreviewEncoding::png()),
+        };
+        Ok(match format {
+            PreviewFormat::Png => PreviewEncoding::png(),
+            PreviewFormat::Jpeg => {
+                PreviewEncoding::jpeg(self.preview_jpeg_quality.unwrap_or(DEFAULT_JPEG_QUALITY))
+            }
+        })
+    }
 }
 
 /// Plain-text site notice configured by the server administrator.
@@ -351,6 +379,8 @@ impl Default for ServerConfig {
             scan_worker_ratio: None,
             background_worker_ratio: None,
             banner: None,
+            preview_format: None,
+            preview_jpeg_quality: None,
         }
     }
 }
@@ -873,6 +903,51 @@ directory = "./cache"
     }
 
     const TOKEN: &str = "a-remote-sync-token-long-enough";
+
+    #[test]
+    fn the_preview_format_is_png_unless_asked_otherwise() {
+        use crate::preview_format::{PreviewFormat, DEFAULT_JPEG_QUALITY};
+
+        let config: Config = toml_edit::de::from_str("[server]\n\n[cache]\n").unwrap();
+        assert_eq!(
+            config.server.preview_encoding().unwrap().format,
+            PreviewFormat::Png
+        );
+
+        let config: Config = toml_edit::de::from_str(
+            "[server]\npreview_format = \"jpeg\"\npreview_jpeg_quality = 70\n\n[cache]\n",
+        )
+        .unwrap();
+        let encoding = config.server.preview_encoding().unwrap();
+        assert_eq!(encoding.format, PreviewFormat::Jpeg);
+        assert_eq!(encoding.jpeg_quality, 70);
+
+        // A quality with no format named is not a request for JPEG.
+        let config: Config =
+            toml_edit::de::from_str("[server]\npreview_jpeg_quality = 70\n\n[cache]\n").unwrap();
+        assert_eq!(
+            config.server.preview_encoding().unwrap().format,
+            PreviewFormat::Png
+        );
+
+        // And JPEG with no quality takes the default rather than zero.
+        let config: Config =
+            toml_edit::de::from_str("[server]\npreview_format = \"jpg\"\n\n[cache]\n").unwrap();
+        assert_eq!(
+            config.server.preview_encoding().unwrap().jpeg_quality,
+            DEFAULT_JPEG_QUALITY
+        );
+    }
+
+    #[test]
+    fn an_unknown_preview_format_stops_the_server() {
+        // Falling back to PNG would leave an operator who asked for a smaller
+        // cache with a full-size one and no indication why.
+        let config: Config =
+            toml_edit::de::from_str("[server]\npreview_format = \"webp\"\n\n[cache]\n").unwrap();
+        let error = config.server.preview_encoding().unwrap_err().to_string();
+        assert!(error.contains("preview_format"), "{error}");
+    }
 
     #[test]
     fn remote_sync_opens_only_the_named_database_and_only_for_sync() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,9 +236,23 @@ pub struct ServerConfig {
     /// JPEG quality, 50–100, when `preview_format = "jpeg"`. Ignored for PNG.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preview_jpeg_quality: Option<u8>,
+    /// Whether one-shot-color frames are shown in colour unless a viewer says
+    /// otherwise. Default true.
+    ///
+    /// This also decides which rendition background pre-generation warms, so
+    /// on a site whose observers prefer luminance, setting it false keeps the
+    /// warmed cache and the viewer asking for the same thing. Mono rigs are
+    /// unaffected either way.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preview_color: Option<bool>,
 }
 
 impl ServerConfig {
+    /// Whether previews default to colour.
+    pub fn preview_color(&self) -> bool {
+        self.preview_color.unwrap_or(true)
+    }
+
     /// How generated previews are encoded. An unreadable format name is an
     /// error rather than a silent fall back to PNG: an operator who set it
     /// meant something by it.
@@ -381,6 +395,7 @@ impl Default for ServerConfig {
             banner: None,
             preview_format: None,
             preview_jpeg_quality: None,
+            preview_color: None,
         }
     }
 }

--- a/src/image_analysis.rs
+++ b/src/image_analysis.rs
@@ -49,6 +49,62 @@ pub struct FitsImage {
     pub bzero: f64,
 }
 
+/// A debayered one-shot-color frame, kept in colour.
+///
+/// [`FitsImage::from_file`] deliberately collapses a mosaic to luminance,
+/// because that is what the measurements want. Display wants the opposite, so
+/// this is the other half of the same decision rather than a replacement for
+/// it: nothing that grades an image goes through here.
+pub struct ColorFrame {
+    pub width: usize,
+    pub height: usize,
+    /// `width * height * 3` samples, RGB interleaved, row-major.
+    pub data: Vec<u16>,
+}
+
+impl ColorFrame {
+    /// Load a frame as colour, or `None` when it is not a mosaic.
+    ///
+    /// A camera without a `BAYERPAT` header — a mono camera behind a filter
+    /// wheel — has no colour to recover, and answering `None` lets the caller
+    /// fall back to the ordinary greyscale rendition rather than inventing
+    /// one.
+    pub fn from_file(path: &Path) -> Result<Option<Self>> {
+        let fits = seiza_fits::FitsImage::open(path)
+            .map_err(|e| anyhow::anyhow!("Failed to open FITS file {}: {e:?}", path.display()))?;
+        Ok(fits.debayer().map(|rgb| Self {
+            width: rgb.width,
+            height: rgb.height,
+            data: rgb.data,
+        }))
+    }
+
+    /// The luminance the stretch is measured on.
+    ///
+    /// One transfer derived from luminance and applied to all three channels
+    /// keeps their ratios, and so the colour balance. Stretching each channel
+    /// against its own statistics would drag the three towards a common
+    /// median and grey the image out — which is the usual way a colour
+    /// autostretch goes wrong.
+    pub fn luminance(&self) -> Vec<u16> {
+        self.data
+            .chunks_exact(3)
+            .map(|pixel| {
+                ((u32::from(pixel[0]) + 2 * u32::from(pixel[1]) + u32::from(pixel[2])) / 4) as u16
+            })
+            .collect()
+    }
+
+    /// View one channel as a plane, for handing to a transfer that works on
+    /// single-channel data.
+    pub fn channel(&self, index: usize) -> Vec<u16> {
+        self.data
+            .chunks_exact(3)
+            .map(|pixel| pixel[index])
+            .collect()
+    }
+}
+
 impl FitsImage {
     /// Extract temperature from FITS headers
     pub fn extract_temperature(path: &Path) -> Option<f64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod image_analysis;
 pub mod models;
 pub mod nina_star_detection;
 pub mod photometry;
+pub mod preview_format;
 pub mod psf_fitting;
 pub mod satellites;
 pub mod sequence_analysis;

--- a/src/preview_format.rs
+++ b/src/preview_format.rs
@@ -1,0 +1,273 @@
+//! The file format generated previews are cached in.
+//!
+//! PNG is exact and the default. JPEG trades that for size: a night's worth
+//! of previews is the largest thing PSF Guard writes, and an operator short of
+//! disk may prefer a cache a fraction of the size.
+//!
+//! The trade is real and worth stating plainly. JPEG is lossy in exactly the
+//! places this tool asks you to look — it smooths the faint, high-frequency
+//! detail that noise, hot pixels, and marginal stars live in, so a frame can
+//! look cleaner in the viewer than it is on disk. Grading measurements are
+//! taken from the FITS and never from a preview, so nothing scored changes;
+//! what changes is what your eye is given to check the score against.
+
+use anyhow::{Context, Result};
+use image::{codecs::jpeg::JpegEncoder, ColorType, ImageEncoder};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::File,
+    io::BufWriter,
+    path::{Path, PathBuf},
+};
+
+/// Quality when none is configured. High enough that the artifacts stay out
+/// of the way at normal viewing scales, and still a small fraction of PNG.
+pub const DEFAULT_JPEG_QUALITY: u8 = 88;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PreviewFormat {
+    /// Exact by default: a viewer should not quietly show something other
+    /// than what the pixels say unless someone asked for that trade.
+    #[default]
+    Png,
+    Jpeg,
+}
+
+impl PreviewFormat {
+    /// Parse a configured name, listing what is accepted when it is not one.
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "png" => Ok(Self::Png),
+            "jpeg" | "jpg" => Ok(Self::Jpeg),
+            other => anyhow::bail!("unknown preview format '{other}'; use png or jpeg"),
+        }
+    }
+
+    /// File extension. Formats differ here so both can sit in the cache at
+    /// once: changing the setting cannot serve one as the other, and reverting
+    /// finds the old artifacts still valid.
+    pub fn extension(self) -> &'static str {
+        match self {
+            Self::Png => "png",
+            Self::Jpeg => "jpg",
+        }
+    }
+
+    pub fn content_type(self) -> &'static str {
+        match self {
+            Self::Png => "image/png",
+            Self::Jpeg => "image/jpeg",
+        }
+    }
+
+    /// The format an artifact already on disk is in, read from its name
+    /// rather than from configuration — what was written is what must be
+    /// served, whatever the setting says now.
+    pub fn of_path(path: &Path) -> Self {
+        match path.extension().and_then(|value| value.to_str()) {
+            Some(extension) if extension.eq_ignore_ascii_case("jpg") => Self::Jpeg,
+            Some(extension) if extension.eq_ignore_ascii_case("jpeg") => Self::Jpeg,
+            _ => Self::Png,
+        }
+    }
+
+    /// Swap a path's extension for this format's.
+    pub fn with_extension(self, path: &Path) -> PathBuf {
+        path.with_extension(self.extension())
+    }
+}
+
+/// How previews are encoded: the format, and JPEG's quality when it applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreviewEncoding {
+    pub format: PreviewFormat,
+    pub jpeg_quality: u8,
+}
+
+impl Default for PreviewEncoding {
+    fn default() -> Self {
+        Self {
+            format: PreviewFormat::default(),
+            jpeg_quality: DEFAULT_JPEG_QUALITY,
+        }
+    }
+}
+
+impl PreviewEncoding {
+    pub fn png() -> Self {
+        Self::default()
+    }
+
+    pub fn jpeg(quality: u8) -> Self {
+        Self {
+            format: PreviewFormat::Jpeg,
+            // Below about 50 the ringing around stars is bad enough to read as
+            // a feature; above 100 is not a thing.
+            jpeg_quality: quality.clamp(50, 100),
+        }
+    }
+
+    pub fn extension(self) -> &'static str {
+        self.format.extension()
+    }
+
+    /// Write one already-rendered 8-bit image.
+    ///
+    /// PNG keeps its best compression: the cost is CPU at generation time,
+    /// paid once, against bytes on disk kept for as long as the cache lives.
+    pub fn write(
+        self,
+        path: &Path,
+        samples: &[u8],
+        width: u32,
+        height: u32,
+        color: ColorType,
+    ) -> Result<()> {
+        let file = File::create(path)
+            .with_context(|| format!("Failed to create output file: {}", path.display()))?;
+        let writer = BufWriter::new(file);
+        match self.format {
+            PreviewFormat::Png => {
+                use image::codecs::png::{CompressionType, FilterType, PngEncoder};
+                PngEncoder::new_with_quality(writer, CompressionType::Best, FilterType::Adaptive)
+                    .write_image(samples, width, height, color.into())
+                    .with_context(|| format!("Failed to write PNG {}", path.display()))
+            }
+            PreviewFormat::Jpeg => {
+                // JPEG has no greyscale-with-alpha or 16-bit form; everything
+                // reaching here is L8 or RGB8, which it does have.
+                JpegEncoder::new_with_quality(writer, self.jpeg_quality)
+                    .write_image(samples, width, height, color.into())
+                    .with_context(|| format!("Failed to write JPEG {}", path.display()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_configured_name_is_read_generously_and_refused_clearly() {
+        assert_eq!(PreviewFormat::parse("PNG").unwrap(), PreviewFormat::Png);
+        assert_eq!(PreviewFormat::parse(" jpg ").unwrap(), PreviewFormat::Jpeg);
+        assert_eq!(PreviewFormat::parse("jpeg").unwrap(), PreviewFormat::Jpeg);
+        let error = PreviewFormat::parse("webp").unwrap_err().to_string();
+        assert!(error.contains("png or jpeg"), "{error}");
+    }
+
+    #[test]
+    fn an_artifact_is_served_as_what_it_was_written_as() {
+        // Changing the setting must not relabel files already on disk.
+        assert_eq!(
+            PreviewFormat::of_path(Path::new("/cache/a.png")),
+            PreviewFormat::Png
+        );
+        assert_eq!(
+            PreviewFormat::of_path(Path::new("/cache/a.jpg")),
+            PreviewFormat::Jpeg
+        );
+        assert_eq!(
+            PreviewFormat::of_path(Path::new("/cache/a.JPEG")),
+            PreviewFormat::Jpeg
+        );
+    }
+
+    #[test]
+    fn the_two_formats_never_share_a_path() {
+        // So switching the setting misses rather than serving the wrong bytes,
+        // and switching back finds the originals intact.
+        let key = Path::new("/cache/previews/42_screen_stretch");
+        assert_ne!(
+            PreviewFormat::Png.with_extension(key),
+            PreviewFormat::Jpeg.with_extension(key)
+        );
+    }
+
+    #[test]
+    fn jpeg_quality_stays_in_a_range_that_can_be_looked_at() {
+        assert_eq!(PreviewEncoding::jpeg(10).jpeg_quality, 50);
+        assert_eq!(PreviewEncoding::jpeg(200).jpeg_quality, 100);
+        assert_eq!(PreviewEncoding::jpeg(85).jpeg_quality, 85);
+    }
+
+    /// A stretched sub as the viewer sees one: smooth sky, real noise, a few
+    /// stars. Not flat — PNG would crush that and prove nothing — and not
+    /// pure noise either, which is JPEG's worst case and equally unlike the
+    /// thing being cached.
+    fn stretched_frame(width: u32, height: u32) -> Vec<u8> {
+        (0..width * height)
+            .map(|index| {
+                let (x, y) = (index % width, index / width);
+                let mut hash = index.wrapping_mul(0x9E37_79B1);
+                hash ^= hash >> 15;
+                hash = hash.wrapping_mul(0x85EB_CA6B);
+                hash ^= hash >> 13;
+                let noise = (hash & 0x1F) as f32 - 15.0;
+                let gradient = 40.0 + (x as f32 + y as f32) * 0.05;
+                let star = STAR_SITES
+                    .iter()
+                    .map(|&(sx, sy)| {
+                        let (dx, dy) = (x as f32 - sx, y as f32 - sy);
+                        200.0 * (-(dx * dx + dy * dy) / 8.0).exp()
+                    })
+                    .sum::<f32>();
+                (gradient + noise + star).clamp(0.0, 255.0) as u8
+            })
+            .collect()
+    }
+
+    const STAR_SITES: [(f32, f32); 6] = [
+        (40.0, 60.0),
+        (120.0, 30.0),
+        (200.0, 150.0),
+        (70.0, 190.0),
+        (170.0, 90.0),
+        (230.0, 220.0),
+    ];
+
+    #[test]
+    fn jpeg_is_smaller_than_png_for_the_same_frame() {
+        // The whole reason for the option.
+        let directory = tempfile::tempdir().unwrap();
+        let (width, height) = (256u32, 256u32);
+        let samples = stretched_frame(width, height);
+
+        let png = directory.path().join("a.png");
+        let jpeg = directory.path().join("a.jpg");
+        PreviewEncoding::png()
+            .write(&png, &samples, width, height, ColorType::L8)
+            .unwrap();
+        PreviewEncoding::jpeg(DEFAULT_JPEG_QUALITY)
+            .write(&jpeg, &samples, width, height, ColorType::L8)
+            .unwrap();
+
+        let (png_bytes, jpeg_bytes) = (
+            std::fs::metadata(&png).unwrap().len(),
+            std::fs::metadata(&jpeg).unwrap().len(),
+        );
+        println!("png {png_bytes} bytes, jpeg {jpeg_bytes} bytes");
+        assert!(
+            jpeg_bytes < png_bytes,
+            "jpeg {jpeg_bytes} should be smaller than png {png_bytes}"
+        );
+    }
+
+    #[test]
+    fn colour_previews_encode_in_both_formats() {
+        let directory = tempfile::tempdir().unwrap();
+        let (width, height) = (16u32, 16u32);
+        let samples = vec![120u8; (width * height * 3) as usize];
+        for encoding in [PreviewEncoding::png(), PreviewEncoding::jpeg(88)] {
+            let path = directory.path().join(format!("c.{}", encoding.extension()));
+            encoding
+                .write(&path, &samples, width, height, ColorType::Rgb8)
+                .unwrap();
+            let decoded = image::open(&path).unwrap();
+            assert_eq!(decoded.width(), width);
+            assert_eq!(decoded.height(), height);
+        }
+    }
+}

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -237,6 +237,13 @@ pub struct PreviewOptions {
     pub midtone: Option<f64>,
     pub shadow: Option<f64>,
     pub max_stars: Option<u32>, // Max number of stars to annotate
+    /// Render a one-shot-color mosaic in colour instead of luminance.
+    ///
+    /// On by default — a colour camera's frame should look like what it
+    /// recorded. Pass `color=false` for the luminance rendition, which is
+    /// what the grader measures. A frame with no `BAYERPAT` has no colour to
+    /// show and renders greyscale either way.
+    pub color: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -2575,18 +2575,25 @@ fn annotated_cache_key(
 
 /// Resolve the on-disk cache path for a preview/annotated artifact, creating
 /// the category dir. `category` is `"previews"` or `"annotated"`.
+/// Where an artifact lives, in the format new ones are written in.
+///
+/// The extension differs per format, so a PNG cache and a JPEG cache coexist:
+/// changing the setting misses and regenerates rather than serving one as the
+/// other, and changing it back finds the originals still valid.
 fn artifact_cache_path(
     ctx: &DatabaseContext,
     category: &str,
     key: &str,
+    encoding: crate::preview_format::PreviewEncoding,
 ) -> Result<PathBuf, AppError> {
     let cm = crate::server::cache::CacheManager::new(PathBuf::from(&ctx.cache_dir));
     cm.ensure_category_dir(category)
         .map_err(|e| AppError::InternalError(format!("Failed to create cache directory: {}", e)))?;
-    Ok(cm.get_cached_path(category, key, "png"))
+    Ok(cm.get_cached_path(category, key, encoding.extension()))
 }
 
-/// Serve a cached PNG from disk.
+/// Serve a cached image, labelled as whatever it was written as rather than as
+/// whatever the setting says now.
 async fn serve_cached_png(cache_path: &std::path::Path) -> Result<Response, AppError> {
     let buffer = tokio::fs::read(cache_path)
         .await
@@ -2594,7 +2601,10 @@ async fn serve_cached_png(cache_path: &std::path::Path) -> Result<Response, AppE
     Ok((
         StatusCode::OK,
         [
-            (CONTENT_TYPE, "image/png"),
+            (
+                CONTENT_TYPE,
+                crate::preview_format::PreviewFormat::of_path(cache_path).content_type(),
+            ),
             (CACHE_CONTROL, "max-age=86400"),
         ],
         buffer,
@@ -2636,7 +2646,7 @@ pub async fn get_image_preview(
 
     let (image, file_only, target_name) = resolve_image_meta(&ctx, image_id)?;
     let cache_key = preview_cache_key(&image, &file_only, size, stretch, midtone, shadow, color);
-    let cache_path = artifact_cache_path(&ctx, "previews", &cache_key)?;
+    let cache_path = artifact_cache_path(&ctx, "previews", &cache_key, state.preview_encoding())?;
 
     if cache_path.exists() {
         return serve_cached_png(&cache_path).await;
@@ -2654,6 +2664,7 @@ pub async fn get_image_preview(
             max_dimensions: crate::server::preview_queue::max_dimensions_for_size(size),
             color,
         },
+        encoding: state.preview_encoding(),
     });
     Ok(generating_response())
 }
@@ -2933,7 +2944,7 @@ pub async fn get_annotated_image(
 
     let (image, file_only, target_name) = resolve_image_meta(&ctx, image_id)?;
     let cache_key = annotated_cache_key(&image, &file_only, size, max_stars);
-    let cache_path = artifact_cache_path(&ctx, "annotated", &cache_key)?;
+    let cache_path = artifact_cache_path(&ctx, "annotated", &cache_key, state.preview_encoding())?;
 
     if cache_path.exists() {
         return serve_cached_png(&cache_path).await;
@@ -2947,6 +2958,7 @@ pub async fn get_annotated_image(
             max_stars,
             size: size.to_string(),
         },
+        encoding: state.preview_encoding(),
     });
     Ok(generating_response())
 }
@@ -3048,6 +3060,9 @@ fn status_for_item(
         state: GenerationState::Error,
         error: Some(msg.to_string()),
     };
+    // One read, used for both the path this polls and the job it may enqueue,
+    // so a setting change mid-request cannot split the two.
+    let encoding = state.preview_encoding();
 
     let Some(image) = images_by_id.get(&item.image_id) else {
         return err("image not found");
@@ -3064,7 +3079,7 @@ fn status_for_item(
         Some("annotated") => {
             let max_stars = item.max_stars.unwrap_or(1000) as usize;
             let key = annotated_cache_key(image, &file_only, &size, max_stars);
-            match artifact_cache_path(ctx, "annotated", &key) {
+            match artifact_cache_path(ctx, "annotated", &key, encoding) {
                 Ok(p) => (
                     p,
                     GenKind::Annotated {
@@ -3081,7 +3096,7 @@ fn status_for_item(
             let shadow = item.shadow.unwrap_or(-2.8);
             let color = item.color.unwrap_or(true);
             let key = preview_cache_key(image, &file_only, &size, stretch, midtone, shadow, color);
-            match artifact_cache_path(ctx, "previews", &key) {
+            match artifact_cache_path(ctx, "previews", &key, encoding) {
                 Ok(p) => (
                     p,
                     GenKind::Preview {
@@ -3109,6 +3124,7 @@ fn status_for_item(
                 fits_path,
                 cache_path,
                 kind,
+                encoding,
             });
             GenerationStatus {
                 state: GenerationState::Generating,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -2522,6 +2522,7 @@ fn resolve_image_meta(
 /// Cache key for a stretched preview PNG. Must stay identical between the
 /// preview handler, the status endpoint, and the pre-generation path so all
 /// three address the same file.
+#[allow(clippy::too_many_arguments)]
 fn preview_cache_key(
     image: &crate::models::AcquiredImage,
     file_only: &str,
@@ -2529,9 +2530,12 @@ fn preview_cache_key(
     stretch: bool,
     midtone: f64,
     shadow: f64,
+    color: bool,
 ) -> String {
+    // The colour marker only appears when colour was asked for, so every
+    // greyscale preview already on disk keeps its key and stays valid.
     format!(
-        "{}_{}_{}_{}_{}_{}_{}_{}_{}",
+        "{}_{}_{}_{}_{}_{}_{}_{}_{}{}",
         image.id,
         image.project_id,
         image.target_id,
@@ -2541,6 +2545,7 @@ fn preview_cache_key(
         if stretch { "stretch" } else { "linear" },
         (midtone * 10000.0) as i32,
         (shadow * 10000.0) as i32,
+        if color { "_color" } else { "" },
     )
 }
 
@@ -2622,9 +2627,10 @@ pub async fn get_image_preview(
     let stretch = options.stretch.unwrap_or(true);
     let midtone = options.midtone.unwrap_or(0.2);
     let shadow = options.shadow.unwrap_or(-2.8);
+    let color = options.color.unwrap_or(true);
 
     let (image, file_only, target_name) = resolve_image_meta(&ctx, image_id)?;
-    let cache_key = preview_cache_key(&image, &file_only, size, stretch, midtone, shadow);
+    let cache_key = preview_cache_key(&image, &file_only, size, stretch, midtone, shadow, color);
     let cache_path = artifact_cache_path(&ctx, "previews", &cache_key)?;
 
     if cache_path.exists() {
@@ -2641,6 +2647,7 @@ pub async fn get_image_preview(
             midtone,
             shadow,
             max_dimensions: crate::server::preview_queue::max_dimensions_for_size(size),
+            color,
         },
     });
     Ok(generating_response())
@@ -2957,6 +2964,10 @@ pub struct GenStatusItem {
     pub shadow: Option<f64>,
     #[serde(default)]
     pub max_stars: Option<u32>,
+    /// Must match the flag the `<img>` requested, or the poll would report on
+    /// a different artifact than the one the browser is waiting for.
+    #[serde(default)]
+    pub color: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3063,7 +3074,8 @@ fn status_for_item(
             let stretch = item.stretch.unwrap_or(true);
             let midtone = item.midtone.unwrap_or(0.2);
             let shadow = item.shadow.unwrap_or(-2.8);
-            let key = preview_cache_key(image, &file_only, &size, stretch, midtone, shadow);
+            let color = item.color.unwrap_or(true);
+            let key = preview_cache_key(image, &file_only, &size, stretch, midtone, shadow, color);
             match artifact_cache_path(ctx, "previews", &key) {
                 Ok(p) => (
                     p,
@@ -3073,6 +3085,7 @@ fn status_for_item(
                         max_dimensions: crate::server::preview_queue::max_dimensions_for_size(
                             &size,
                         ),
+                        color,
                     },
                 ),
                 Err(_) => return err("cache error"),

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -2642,7 +2642,9 @@ pub async fn get_image_preview(
     let stretch = options.stretch.unwrap_or(true);
     let midtone = options.midtone.unwrap_or(0.2);
     let shadow = options.shadow.unwrap_or(-2.8);
-    let color = options.color.unwrap_or(true);
+    let color = options
+        .color
+        .unwrap_or_else(|| state.preview_color_default());
 
     let (image, file_only, target_name) = resolve_image_meta(&ctx, image_id)?;
     let cache_key = preview_cache_key(&image, &file_only, size, stretch, midtone, shadow, color);
@@ -3060,9 +3062,10 @@ fn status_for_item(
         state: GenerationState::Error,
         error: Some(msg.to_string()),
     };
-    // One read, used for both the path this polls and the job it may enqueue,
-    // so a setting change mid-request cannot split the two.
+    // One read of each, used for both the path this polls and the job it may
+    // enqueue, so a setting change mid-request cannot split the two.
     let encoding = state.preview_encoding();
+    let color_default = state.preview_color_default();
 
     let Some(image) = images_by_id.get(&item.image_id) else {
         return err("image not found");
@@ -3094,7 +3097,7 @@ fn status_for_item(
             let stretch = item.stretch.unwrap_or(true);
             let midtone = item.midtone.unwrap_or(0.2);
             let shadow = item.shadow.unwrap_or(-2.8);
-            let color = item.color.unwrap_or(true);
+            let color = item.color.unwrap_or(color_default);
             let key = preview_cache_key(image, &file_only, &size, stretch, midtone, shadow, color);
             match artifact_cache_path(ctx, "previews", &key, encoding) {
                 Ok(p) => (
@@ -4590,17 +4593,25 @@ mod preview_cache_key_tests {
         // drifted the moment colour arrived: it wrote a colour PNG under the
         // greyscale key, so the viewer never found what had been warmed and
         // anything asking for greyscale was served colour.
-        let warmed = preview_cache_key(
-            &image(),
-            "one.fits",
-            "screen",
-            true,
-            crate::server::PREGENERATE_MIDTONE,
-            crate::server::PREGENERATE_SHADOW,
-            crate::server::PREGENERATE_COLOR,
-        );
-        // What `get_image_preview` computes for a caller taking every default.
-        let requested = preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, true);
-        assert_eq!(warmed, requested);
+        //
+        // Both renditions are checked, because the colour default is now a
+        // server setting: whichever one this server serves, that is the one
+        // pre-generation must warm.
+        for color in [true, false] {
+            let warmed = preview_cache_key(
+                &image(),
+                "one.fits",
+                "screen",
+                true,
+                crate::server::PREGENERATE_MIDTONE,
+                crate::server::PREGENERATE_SHADOW,
+                color,
+            );
+            // What `get_image_preview` computes for a caller taking every
+            // default on a server configured that way.
+            let requested =
+                preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, color);
+            assert_eq!(warmed, requested);
+        }
     }
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -2522,8 +2522,13 @@ fn resolve_image_meta(
 /// Cache key for a stretched preview PNG. Must stay identical between the
 /// preview handler, the status endpoint, and the pre-generation path so all
 /// three address the same file.
+/// Cache key for a preview PNG.
+///
+/// Shared with background pre-generation rather than reimplemented there:
+/// two constructions of one key drift, and when they do the mismatch is
+/// silent — the wrong artifact is served, or a warmed one is never found.
 #[allow(clippy::too_many_arguments)]
-fn preview_cache_key(
+pub(crate) fn preview_cache_key(
     image: &crate::models::AcquiredImage,
     file_only: &str,
     size: &str,
@@ -4520,5 +4525,66 @@ impl IntoResponse for AppError {
             Json(ApiResponse::<()>::error(error_message.to_string())),
         )
             .into_response()
+    }
+}
+
+#[cfg(test)]
+mod preview_cache_key_tests {
+    use super::preview_cache_key;
+    use crate::models::AcquiredImage;
+
+    fn image() -> AcquiredImage {
+        AcquiredImage {
+            id: 42,
+            project_id: 7,
+            target_id: 3,
+            acquired_date: Some(1_750_000_000),
+            filter_name: "OSC".into(),
+            grading_status: 0,
+            metadata: "{}".into(),
+            reject_reason: None,
+            profile_id: None,
+            guid: None,
+        }
+    }
+
+    #[test]
+    fn colour_and_greyscale_are_different_artifacts() {
+        // They are rendered differently, so serving one for the other shows
+        // the wrong pixels rather than a stale copy of the right ones.
+        let mono = preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, false);
+        let color = preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, true);
+        assert_ne!(mono, color);
+        assert!(color.ends_with("_color"), "{color}");
+    }
+
+    #[test]
+    fn greyscale_keys_are_unchanged_by_the_colour_option() {
+        // Previews already on disk were written before colour existed. The
+        // marker only appears on the colour variant so those stay valid.
+        assert!(
+            !preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, false)
+                .contains("color"),
+        );
+    }
+
+    #[test]
+    fn pre_generation_warms_the_key_the_request_path_looks_up() {
+        // Pre-generation used to build this key with its own `format!`, which
+        // drifted the moment colour arrived: it wrote a colour PNG under the
+        // greyscale key, so the viewer never found what had been warmed and
+        // anything asking for greyscale was served colour.
+        let warmed = preview_cache_key(
+            &image(),
+            "one.fits",
+            "screen",
+            true,
+            crate::server::PREGENERATE_MIDTONE,
+            crate::server::PREGENERATE_SHADOW,
+            crate::server::PREGENERATE_COLOR,
+        );
+        // What `get_image_preview` computes for a caller taking every default.
+        let requested = preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, true);
+        assert_eq!(warmed, requested);
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -839,6 +839,10 @@ async fn pregenerate_preview(
             midtone: 0.2,
             shadow: -2.8,
             max_dimensions,
+            // Warm what the viewer will actually ask for. A mono frame
+            // renders the same either way, so this costs those rigs nothing
+            // beyond the cache key.
+            color: true,
         },
     };
     tokio::task::spawn_blocking(move || crate::server::preview_queue::generate(&job)).await??;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -62,6 +62,8 @@ pub struct ServerConfig {
     /// How generated previews are encoded. PNG unless the TOML `[server]`
     /// section asks for JPEG.
     pub preview_encoding: crate::preview_format::PreviewEncoding,
+    /// Whether previews default to colour.
+    pub preview_color_default: bool,
     /// Process-global Seiza catalog configuration from the shared registry.
     pub astrometry_config: Option<crate::astrometry::AstrometryConfig>,
 }
@@ -79,6 +81,7 @@ pub async fn run_server(
     site_banner: Option<crate::config::SiteBannerConfig>,
     worker_policy: crate::concurrency::WorkerPolicy,
     preview_encoding: crate::preview_format::PreviewEncoding,
+    preview_color_default: bool,
     astrometry_config: Option<crate::astrometry::AstrometryConfig>,
 ) -> anyhow::Result<()> {
     // Initialize tracing with environment-based filtering (for CLI mode)
@@ -106,6 +109,7 @@ pub async fn run_server(
         site_banner,
         worker_policy,
         preview_encoding,
+        preview_color_default,
         astrometry_config,
     };
 
@@ -174,6 +178,7 @@ async fn run_server_internal(
             state.set_site_banner(config.site_banner.clone());
             state.set_worker_policy(config.worker_policy);
             state.set_preview_encoding(config.preview_encoding);
+            state.set_preview_color_default(config.preview_color_default);
             if let Some(banner) = &config.site_banner {
                 tracing::info!("📢 Site banner enabled: {}", banner.title);
             }
@@ -183,6 +188,7 @@ async fn run_server_internal(
                 config.worker_policy.background_ratio,
                 crate::concurrency::logical_cores()
             );
+            report_preview_settings(&state, &config);
             if config.allow_database_management {
                 tracing::warn!(
                     "⚠️ Database management via HTTP is ENABLED. Anyone who can reach \
@@ -759,17 +765,63 @@ async fn get_all_images_for_pregeneration(
     Ok(result)
 }
 
+/// Say what previews will be written as, and how much of the cache is in the
+/// other format.
+///
+/// Changing the format leaves the old artifacts in place on purpose — the two
+/// use different file names, so a change misses and regenerates rather than
+/// serving one as the other, and changing back finds the originals valid. The
+/// cost is that both sets sit on disk until somebody removes one, and an
+/// operator who switched to JPEG for the disk space should be told that the
+/// PNGs are still there rather than discovering it later.
+fn report_preview_settings(state: &AppState, config: &ServerConfig) {
+    let encoding = config.preview_encoding;
+    tracing::info!(
+        "🖼️ Previews: {} ({}), colour {} by default",
+        encoding.extension(),
+        match encoding.format {
+            crate::preview_format::PreviewFormat::Png => "exact".to_string(),
+            crate::preview_format::PreviewFormat::Jpeg =>
+                format!("lossy, quality {}", encoding.jpeg_quality),
+        },
+        if config.preview_color_default {
+            "on"
+        } else {
+            "off"
+        }
+    );
+
+    let stale = state
+        .all_databases()
+        .iter()
+        .map(|ctx| stale_format_bytes(&ctx.cache_dir, encoding.format))
+        .sum::<u64>();
+    if stale > 0 {
+        tracing::warn!(
+            "🖼️ {:.1} MiB of cached previews are in the other format and will \
+             not be served or reused. Remove them if the disk matters.",
+            stale as f64 / (1024.0 * 1024.0)
+        );
+    }
+}
+
+/// Bytes of cached preview artifacts that are *not* in the configured format.
+fn stale_format_bytes(cache_dir: &str, keeping: crate::preview_format::PreviewFormat) -> u64 {
+    ["previews", "annotated"]
+        .iter()
+        .flat_map(|category| std::fs::read_dir(std::path::Path::new(cache_dir).join(category)))
+        .flatten()
+        .flatten()
+        .filter(|entry| crate::preview_format::PreviewFormat::of_path(&entry.path()) != keeping)
+        .filter_map(|entry| entry.metadata().ok().map(|meta| meta.len()))
+        .sum()
+}
+
 /// Stretch settings background pre-generation warms. They match the request
 /// path's defaults, because an artifact generated with anything else is one
 /// the viewer will never ask for.
 pub(crate) const PREGENERATE_MIDTONE: f64 = 0.2;
 pub(crate) const PREGENERATE_SHADOW: f64 = -2.8;
-/// Warm the colour rendition, which is what the viewer asks for by default.
-/// A mono frame renders the same either way and costs these rigs nothing
-/// beyond the key it is filed under; a viewer that has opted out of colour
-/// finds nothing warmed and generates on demand.
-pub(crate) const PREGENERATE_COLOR: bool = true;
-
 async fn pregenerate_preview(
     state: &Arc<AppState>,
     ctx: &Arc<crate::server::database_context::DatabaseContext>,
@@ -811,7 +863,9 @@ async fn pregenerate_preview(
         true, // pre-generation always stretches
         PREGENERATE_MIDTONE,
         PREGENERATE_SHADOW,
-        PREGENERATE_COLOR,
+        // Warm whichever rendition this server serves by default, so the
+        // warmed artifact is the one the viewer will ask for.
+        state.preview_color_default(),
     );
 
     let cache_manager = CacheManager::new(std::path::PathBuf::from(&ctx.cache_dir));
@@ -856,7 +910,7 @@ async fn pregenerate_preview(
             midtone: PREGENERATE_MIDTONE,
             shadow: PREGENERATE_SHADOW,
             max_dimensions,
-            color: PREGENERATE_COLOR,
+            color: state.preview_color_default(),
         },
         encoding: state.preview_encoding(),
     };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -753,6 +753,17 @@ async fn get_all_images_for_pregeneration(
     Ok(result)
 }
 
+/// Stretch settings background pre-generation warms. They match the request
+/// path's defaults, because an artifact generated with anything else is one
+/// the viewer will never ask for.
+pub(crate) const PREGENERATE_MIDTONE: f64 = 0.2;
+pub(crate) const PREGENERATE_SHADOW: f64 = -2.8;
+/// Warm the colour rendition, which is what the viewer asks for by default.
+/// A mono frame renders the same either way and costs these rigs nothing
+/// beyond the key it is filed under; a viewer that has opted out of colour
+/// finds nothing warmed and generates on demand.
+pub(crate) const PREGENERATE_COLOR: bool = true;
+
 async fn pregenerate_preview(
     state: &Arc<AppState>,
     ctx: &Arc<crate::server::database_context::DatabaseContext>,
@@ -783,18 +794,18 @@ async fn pregenerate_preview(
             .ok_or_else(|| anyhow::anyhow!("Image not found: {}", image_id))?
     };
 
-    // Create cache key matching the on-demand format for consistency
-    let cache_key = format!(
-        "{}_{}_{}_{}_{}_{}_{}_{}_{}",
-        image_id,
-        image_data.project_id,
-        image_data.target_id,
-        image_data.acquired_date.unwrap_or(0),
-        file_only.replace(&['.', ' ', '-'][..], "_"),
+    // The same key the request path builds. This used to be a second
+    // `format!` kept in step by a comment, which is how pre-generation came to
+    // warm a colour PNG under the greyscale key: the viewer never found it,
+    // and anything asking for greyscale was served colour.
+    let cache_key = handlers::preview_cache_key(
+        &image_data,
+        file_only,
         size,
-        "stretch", // Pre-generation always uses stretch mode
-        2000,      // midtone 0.2 * 10000
-        -28000     // shadow -2.8 * 10000
+        true, // pre-generation always stretches
+        PREGENERATE_MIDTONE,
+        PREGENERATE_SHADOW,
+        PREGENERATE_COLOR,
     );
 
     let cache_manager = CacheManager::new(std::path::PathBuf::from(&ctx.cache_dir));
@@ -836,13 +847,10 @@ async fn pregenerate_preview(
         fits_path,
         cache_path,
         kind: crate::server::preview_queue::GenKind::Preview {
-            midtone: 0.2,
-            shadow: -2.8,
+            midtone: PREGENERATE_MIDTONE,
+            shadow: PREGENERATE_SHADOW,
             max_dimensions,
-            // Warm what the viewer will actually ask for. A mono frame
-            // renders the same either way, so this costs those rigs nothing
-            // beyond the cache key.
-            color: true,
+            color: PREGENERATE_COLOR,
         },
     };
     tokio::task::spawn_blocking(move || crate::server::preview_queue::generate(&job)).await??;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -59,6 +59,9 @@ pub struct ServerConfig {
     /// Tuning policy for the parallel scans and background pre-generation.
     /// See `concurrency::WorkerPolicy`.
     pub worker_policy: crate::concurrency::WorkerPolicy,
+    /// How generated previews are encoded. PNG unless the TOML `[server]`
+    /// section asks for JPEG.
+    pub preview_encoding: crate::preview_format::PreviewEncoding,
     /// Process-global Seiza catalog configuration from the shared registry.
     pub astrometry_config: Option<crate::astrometry::AstrometryConfig>,
 }
@@ -75,6 +78,7 @@ pub async fn run_server(
     allow_database_management: bool,
     site_banner: Option<crate::config::SiteBannerConfig>,
     worker_policy: crate::concurrency::WorkerPolicy,
+    preview_encoding: crate::preview_format::PreviewEncoding,
     astrometry_config: Option<crate::astrometry::AstrometryConfig>,
 ) -> anyhow::Result<()> {
     // Initialize tracing with environment-based filtering (for CLI mode)
@@ -101,6 +105,7 @@ pub async fn run_server(
         allow_database_management,
         site_banner,
         worker_policy,
+        preview_encoding,
         astrometry_config,
     };
 
@@ -168,6 +173,7 @@ async fn run_server_internal(
             state.set_allow_database_management(config.allow_database_management);
             state.set_site_banner(config.site_banner.clone());
             state.set_worker_policy(config.worker_policy);
+            state.set_preview_encoding(config.preview_encoding);
             if let Some(banner) = &config.site_banner {
                 tracing::info!("📢 Site banner enabled: {}", banner.title);
             }
@@ -852,6 +858,7 @@ async fn pregenerate_preview(
             max_dimensions,
             color: PREGENERATE_COLOR,
         },
+        encoding: state.preview_encoding(),
     };
     tokio::task::spawn_blocking(move || crate::server::preview_queue::generate(&job)).await??;
 
@@ -936,6 +943,7 @@ async fn pregenerate_annotated(
             max_stars: max_stars as usize,
             size: size.to_string(),
         },
+        encoding: state.preview_encoding(),
     };
     tokio::task::spawn_blocking(move || crate::server::preview_queue::generate(&job)).await??;
 

--- a/src/server/preview_queue.rs
+++ b/src/server/preview_queue.rs
@@ -52,6 +52,9 @@ pub struct GenJob {
     pub fits_path: PathBuf,
     pub cache_path: PathBuf,
     pub kind: GenKind,
+    /// Carried on the job rather than read from state at write time, so the
+    /// bytes written always match the extension the path was chosen for.
+    pub encoding: crate::preview_format::PreviewEncoding,
 }
 
 /// Readiness of a cache artifact, as reported to the polling frontend.
@@ -228,9 +231,10 @@ pub fn generate(job: &GenJob) -> anyhow::Result<()> {
             *shadow,
             *max_dimensions,
             *color,
+            job.encoding,
         ),
         GenKind::Annotated { max_stars, size } => {
-            generate_annotated(&job.fits_path, &tmp, size, *max_stars)
+            generate_annotated(&job.fits_path, &tmp, size, *max_stars, job.encoding)
         }
     };
 
@@ -246,6 +250,7 @@ pub fn generate(job: &GenJob) -> anyhow::Result<()> {
 }
 
 /// Render one preview, in colour when asked for it and the frame is a mosaic.
+#[allow(clippy::too_many_arguments)]
 fn generate_preview(
     fits_path: &Path,
     output: &Path,
@@ -253,6 +258,7 @@ fn generate_preview(
     shadow: f64,
     max_dimensions: Option<(u32, u32)>,
     color: bool,
+    encoding: crate::preview_format::PreviewEncoding,
 ) -> anyhow::Result<()> {
     let source = fits_path.to_string_lossy();
     let destination = output.to_string_lossy().into_owned();
@@ -263,11 +269,12 @@ fn generate_preview(
             midtone,
             shadow,
             max_dimensions,
+            encoding,
         )?
     {
         return Ok(());
     }
-    crate::commands::stretch_to_png::stretch_to_png_with_resize(
+    crate::commands::stretch_to_png::stretch_to_png_with_format(
         &source,
         Some(destination),
         midtone,
@@ -275,6 +282,7 @@ fn generate_preview(
         false, // logarithmic
         false, // invert
         max_dimensions,
+        encoding,
     )
 }
 
@@ -298,22 +306,22 @@ pub fn generate_annotated(
     out_path: &Path,
     size: &str,
     max_stars: usize,
+    encoding: crate::preview_format::PreviewEncoding,
 ) -> anyhow::Result<()> {
     use crate::commands::annotate_stars_common::create_annotated_image;
     use crate::image_analysis::FitsImage;
-    use image::codecs::png::{CompressionType, FilterType, PngEncoder};
-    use image::{ColorType, ImageEncoder, Rgb};
+    use image::{ColorType, Rgb};
 
     let fits = FitsImage::from_file(fits_path)?;
     let rgb = create_annotated_image(&fits, max_stars, 0.2, -2.8, Rgb([255, 255, 0]))?;
     let final_image = resize_rgb_for_size(rgb, fits.width, fits.height, size);
 
-    let file = std::fs::File::create(out_path)?;
-    let writer = std::io::BufWriter::new(file);
-    let encoder = PngEncoder::new_with_quality(writer, CompressionType::Best, FilterType::Adaptive);
     let (w, h) = final_image.dimensions();
-    encoder.write_image(&final_image, w, h, ColorType::Rgb8.into())?;
-    Ok(())
+    // The markers are line art, where JPEG rings hardest. An operator who
+    // chose JPEG for the cache gets it here too rather than a surprising
+    // exception, but that is the place to look first if a marker seems to
+    // have a halo.
+    encoding.write(out_path, &final_image, w, h, ColorType::Rgb8)
 }
 
 /// Resize an RGB image to the requested size bucket (matches the preview

--- a/src/server/preview_queue.rs
+++ b/src/server/preview_queue.rs
@@ -231,6 +231,11 @@ pub fn generate(job: &GenJob) -> anyhow::Result<()> {
             *shadow,
             *max_dimensions,
             *color,
+            // Neither is reachable from the API today. Passed through rather
+            // than hardcoded so that when one is, it arrives at a renderer
+            // that honours it instead of being dropped here.
+            false, // logarithmic
+            false, // invert
             job.encoding,
         ),
         GenKind::Annotated { max_stars, size } => {
@@ -258,12 +263,16 @@ fn generate_preview(
     shadow: f64,
     max_dimensions: Option<(u32, u32)>,
     color: bool,
+    logarithmic: bool,
+    invert: bool,
     encoding: crate::preview_format::PreviewEncoding,
 ) -> anyhow::Result<()> {
     let source = fits_path.to_string_lossy();
     let destination = output.to_string_lossy().into_owned();
     if color
-        && crate::commands::stretch_to_png::color_to_png_with_resize(
+        && !logarithmic
+        && !invert
+        && crate::commands::stretch_to_png::render_color_preview(
             &source,
             Some(destination.clone()),
             midtone,
@@ -274,13 +283,13 @@ fn generate_preview(
     {
         return Ok(());
     }
-    crate::commands::stretch_to_png::stretch_to_png_with_format(
+    crate::commands::stretch_to_png::render_preview(
         &source,
         Some(destination),
         midtone,
         shadow,
-        false, // logarithmic
-        false, // invert
+        logarithmic,
+        invert,
         max_dimensions,
         encoding,
     )

--- a/src/server/preview_queue.rs
+++ b/src/server/preview_queue.rs
@@ -35,6 +35,10 @@ pub enum GenKind {
         midtone: f64,
         shadow: f64,
         max_dimensions: Option<(u32, u32)>,
+        /// Render a one-shot-color mosaic in colour rather than luminance.
+        /// A frame with no `BAYERPAT` falls back to greyscale, so this can be
+        /// asked for on a mixed rig without breaking the mono frames.
+        color: bool,
     },
     Annotated {
         max_stars: usize,
@@ -216,14 +220,14 @@ pub fn generate(job: &GenJob) -> anyhow::Result<()> {
             midtone,
             shadow,
             max_dimensions,
-        } => crate::commands::stretch_to_png::stretch_to_png_with_resize(
-            &job.fits_path.to_string_lossy(),
-            Some(tmp.to_string_lossy().into_owned()),
+            color,
+        } => generate_preview(
+            &job.fits_path,
+            &tmp,
             *midtone,
             *shadow,
-            false, // logarithmic
-            false, // invert
             *max_dimensions,
+            *color,
         ),
         GenKind::Annotated { max_stars, size } => {
             generate_annotated(&job.fits_path, &tmp, size, *max_stars)
@@ -239,6 +243,39 @@ pub fn generate(job: &GenJob) -> anyhow::Result<()> {
             Err(e)
         }
     }
+}
+
+/// Render one preview, in colour when asked for it and the frame is a mosaic.
+fn generate_preview(
+    fits_path: &Path,
+    output: &Path,
+    midtone: f64,
+    shadow: f64,
+    max_dimensions: Option<(u32, u32)>,
+    color: bool,
+) -> anyhow::Result<()> {
+    let source = fits_path.to_string_lossy();
+    let destination = output.to_string_lossy().into_owned();
+    if color
+        && crate::commands::stretch_to_png::color_to_png_with_resize(
+            &source,
+            Some(destination.clone()),
+            midtone,
+            shadow,
+            max_dimensions,
+        )?
+    {
+        return Ok(());
+    }
+    crate::commands::stretch_to_png::stretch_to_png_with_resize(
+        &source,
+        Some(destination),
+        midtone,
+        shadow,
+        false, // logarithmic
+        false, // invert
+        max_dimensions,
+    )
 }
 
 /// Unique sibling temp path for atomic-rename generation.

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -53,6 +53,10 @@ pub struct AppState {
     /// How generated previews are encoded. PNG unless the TOML `[server]`
     /// section asks for JPEG.
     pub preview_encoding: RwLock<crate::preview_format::PreviewEncoding>,
+    /// Whether previews default to colour when a request does not say. Also
+    /// decides which rendition background pre-generation warms, so the warmed
+    /// cache and the default view stay the same artifact.
+    pub preview_color_default: RwLock<bool>,
     /// Count of interactive (user-triggered) CPU-heavy jobs currently running,
     /// process-wide. Background work reads this to yield: while it is nonzero,
     /// pre-generation pauses so it doesn't compete for cores or memory with a
@@ -378,6 +382,7 @@ impl AppState {
             site_banner: RwLock::new(None),
             worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
             preview_encoding: RwLock::new(crate::preview_format::PreviewEncoding::default()),
+            preview_color_default: RwLock::new(true),
             active_interactive_jobs: Arc::new(AtomicUsize::new(0)),
             preview_queue: crate::server::preview_queue::PreviewQueue::default(),
             stack_previews: crate::server::stack_preview::StackPreviewManager::default(),
@@ -436,6 +441,15 @@ impl AppState {
     /// format they were written in — see `PreviewFormat::of_path`.
     pub fn preview_encoding(&self) -> crate::preview_format::PreviewEncoding {
         *self.preview_encoding.read().unwrap()
+    }
+
+    pub fn set_preview_color_default(&self, color: bool) {
+        *self.preview_color_default.write().unwrap() = color;
+    }
+
+    /// Whether a request that says nothing about colour gets it.
+    pub fn preview_color_default(&self) -> bool {
+        *self.preview_color_default.read().unwrap()
     }
 
     /// Mark the start of an interactive CPU-heavy job (e.g. an occlusion
@@ -511,6 +525,7 @@ impl AppState {
             site_banner: RwLock::new(None),
             worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
             preview_encoding: RwLock::new(crate::preview_format::PreviewEncoding::default()),
+            preview_color_default: RwLock::new(true),
             active_interactive_jobs: Arc::new(AtomicUsize::new(0)),
             preview_queue: crate::server::preview_queue::PreviewQueue::default(),
             stack_previews: crate::server::stack_preview::StackPreviewManager::default(),

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -50,6 +50,9 @@ pub struct AppState {
     /// `concurrency::WorkerPolicy`). Process-global; sourced from the TOML
     /// `[server]` ratios, otherwise the compiled-in defaults.
     pub worker_policy: RwLock<crate::concurrency::WorkerPolicy>,
+    /// How generated previews are encoded. PNG unless the TOML `[server]`
+    /// section asks for JPEG.
+    pub preview_encoding: RwLock<crate::preview_format::PreviewEncoding>,
     /// Count of interactive (user-triggered) CPU-heavy jobs currently running,
     /// process-wide. Background work reads this to yield: while it is nonzero,
     /// pre-generation pauses so it doesn't compete for cores or memory with a
@@ -374,6 +377,7 @@ impl AppState {
             allow_database_management: RwLock::new(false),
             site_banner: RwLock::new(None),
             worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
+            preview_encoding: RwLock::new(crate::preview_format::PreviewEncoding::default()),
             active_interactive_jobs: Arc::new(AtomicUsize::new(0)),
             preview_queue: crate::server::preview_queue::PreviewQueue::default(),
             stack_previews: crate::server::stack_preview::StackPreviewManager::default(),
@@ -420,6 +424,18 @@ impl AppState {
     /// The worker tuning policy in effect.
     pub fn worker_policy(&self) -> crate::concurrency::WorkerPolicy {
         *self.worker_policy.read().unwrap()
+    }
+
+    /// Set how generated previews are encoded (from the TOML `[server]`
+    /// config).
+    pub fn set_preview_encoding(&self, encoding: crate::preview_format::PreviewEncoding) {
+        *self.preview_encoding.write().unwrap() = encoding;
+    }
+
+    /// How new previews will be encoded. Artifacts already cached keep the
+    /// format they were written in — see `PreviewFormat::of_path`.
+    pub fn preview_encoding(&self) -> crate::preview_format::PreviewEncoding {
+        *self.preview_encoding.read().unwrap()
     }
 
     /// Mark the start of an interactive CPU-heavy job (e.g. an occlusion
@@ -494,6 +510,7 @@ impl AppState {
             allow_database_management: RwLock::new(false),
             site_banner: RwLock::new(None),
             worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
+            preview_encoding: RwLock::new(crate::preview_format::PreviewEncoding::default()),
             active_interactive_jobs: Arc::new(AtomicUsize::new(0)),
             preview_queue: crate::server::preview_queue::PreviewQueue::default(),
             stack_previews: crate::server::stack_preview::StackPreviewManager::default(),

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -276,6 +276,7 @@ async fn start_server_for_tauri(
         // The desktop app has disk to spare and no operator to ask, so it
         // keeps the exact rendition.
         preview_encoding: crate::preview_format::PreviewEncoding::png(),
+        preview_color_default: true,
         astrometry_config,
     };
 

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -273,6 +273,9 @@ async fn start_server_for_tauri(
         // The desktop app does not read the server TOML.
         site_banner: None,
         worker_policy: config.get_worker_policy(),
+        // The desktop app has disk to spare and no operator to ask, so it
+        // keeps the exact rendition.
+        preview_encoding: crate::preview_format::PreviewEncoding::png(),
         astrometry_config,
     };
 

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -767,6 +767,7 @@ export const apiClient = {
         midtone: d.midtone,
         shadow: d.shadow,
         max_stars: d.maxStars,
+        color: d.color,
       })),
     };
     const { data } = await apiInstance.post<
@@ -782,6 +783,9 @@ export const apiClient = {
     if (options?.stretch !== undefined) params.append('stretch', String(options.stretch));
     if (options?.midtone !== undefined) params.append('midtone', String(options.midtone));
     if (options?.shadow !== undefined) params.append('shadow', String(options.shadow));
+    // Only sent when asked for, so a mono viewer's URLs — and the artifacts
+    // already cached against them — stay exactly as they were.
+    if (options?.color) params.append('color', 'true');
 
     const queryString = params.toString();
     const basePath = serverUrl ? `${serverUrl}/api` : '/api';

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -783,9 +783,9 @@ export const apiClient = {
     if (options?.stretch !== undefined) params.append('stretch', String(options.stretch));
     if (options?.midtone !== undefined) params.append('midtone', String(options.midtone));
     if (options?.shadow !== undefined) params.append('shadow', String(options.shadow));
-    // Only sent when asked for, so a mono viewer's URLs — and the artifacts
-    // already cached against them — stay exactly as they were.
-    if (options?.color) params.append('color', 'true');
+    // Sent explicitly either way, so the URL states what it wants rather than
+    // depending on the server's default staying put.
+    if (options?.color !== undefined) params.append('color', String(options.color));
 
     const queryString = params.toString();
     const basePath = serverUrl ? `${serverUrl}/api` : '/api';

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -267,6 +267,8 @@ export interface PreviewOptions {
   midtone?: number;
   shadow?: number;
   max_stars?: number;
+  /** Render a one-shot-color mosaic in colour. Mono frames ignore it. */
+  color?: boolean;
 }
 
 // Readiness of an on-demand preview/annotated artifact (the server generates
@@ -288,6 +290,12 @@ export interface PreviewDescriptor {
   midtone?: number;
   shadow?: number;
   maxStars?: number;
+  /**
+   * Must match the flag the `<img>` requested. The server keys colour and
+   * greyscale renditions separately, so polling without it would report on
+   * the wrong artifact.
+   */
+  color?: boolean;
 }
 
 export type StackJobState = 'queued' | 'running' | 'completed' | 'failed';

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -4,6 +4,7 @@ import type { Image, ImageQualityResult } from '../api/types';
 import { GradingStatus } from '../api/types';
 import { apiClient } from '../api/client';
 import PreviewImage from './PreviewImage';
+import { useColorPreview } from '../hooks/useColorPreview';
 import { ensurePreviewReady } from '../hooks/previewPoll';
 
 export interface ImageCardProps {
@@ -29,6 +30,7 @@ export default function ImageCard({
   selectionEffects = true,
   className = '',
 }: ImageCardProps) {
+  const color = useColorPreview();
   const shouldDeferPreview = lazyPreview && typeof IntersectionObserver !== 'undefined';
   const { ref: inViewRef, inView } = useInView({
     threshold: 0,
@@ -47,8 +49,8 @@ export default function ImageCard({
     if (selectionEffects && isSelected && image.id) {
       void ensurePreviewReady(
         dbId,
-        apiClient.getPreviewUrl(dbId, image.id, { size: 'large' }),
-        { imageId: image.id, kind: 'preview', size: 'large' }
+        apiClient.getPreviewUrl(dbId, image.id, { size: 'large', color }),
+        { imageId: image.id, kind: 'preview', size: 'large', color }
       );
     }
   }, [isSelected, image.id, dbId, selectionEffects]);
@@ -104,8 +106,8 @@ export default function ImageCard({
         {shouldLoadPreview ? (
           <PreviewImage
             dbId={dbId}
-            src={apiClient.getPreviewUrl(dbId, image.id, { size: 'screen' })}
-            descriptor={{ imageId: image.id, kind: 'preview', size: 'screen' }}
+            src={apiClient.getPreviewUrl(dbId, image.id, { size: 'screen', color })}
+            descriptor={{ imageId: image.id, kind: 'preview', size: 'screen', color }}
             alt={`${image.target_name} - ${image.filter_name || 'No filter'}`}
             loading="lazy"
           />

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -132,7 +132,7 @@ export default function ImageComparisonView({
     : apiClient.getPreviewUrl(dbId, leftImageId, { size: leftSize, color });
   const leftDescriptor: PreviewDescriptor = showStars
     ? { imageId: leftImageId, kind: 'annotated', size: leftSize, maxStars }
-    : { imageId: leftImageId, kind: 'preview', size: leftSize };
+    : { imageId: leftImageId, kind: 'preview', size: leftSize, color };
   const asyncLeft = useAsyncImage(dbId, leftSrc, leftDescriptor);
 
   const rightSize: 'large' | 'original' =
@@ -143,7 +143,7 @@ export default function ImageComparisonView({
     : apiClient.getPreviewUrl(dbId, rightIdForUrl, { size: rightSize, color });
   const rightDescriptor: PreviewDescriptor = showStars
     ? { imageId: rightIdForUrl, kind: 'annotated', size: rightSize, maxStars }
-    : { imageId: rightIdForUrl, kind: 'preview', size: rightSize };
+    : { imageId: rightIdForUrl, kind: 'preview', size: rightSize, color };
   const asyncRight = useAsyncImage(dbId, rightSrc, rightDescriptor);
   const hideLeftImage = asyncLeft.state !== 'ready' || loadedLeftSrc !== asyncLeft.src;
   const hideRightImage = asyncRight.state !== 'ready' || loadedRightSrc !== asyncRight.src;
@@ -240,7 +240,7 @@ export default function ImageComparisonView({
         : apiClient.getPreviewUrl(dbId, leftImageId, { size: 'original', color });
       const descriptor: PreviewDescriptor = showStars
         ? { imageId: leftImageId, kind: 'annotated', size: 'original', maxStars }
-        : { imageId: leftImageId, kind: 'preview', size: 'original' };
+        : { imageId: leftImageId, kind: 'preview', size: 'original', color };
 
       // Route through the interactive queue so an uncached 'original' is
       // generated (its 202 is not a failure); only flip once it's ready.
@@ -304,7 +304,7 @@ export default function ImageComparisonView({
         : apiClient.getPreviewUrl(dbId, rightImageId, { size: 'original', color });
       const descriptor: PreviewDescriptor = showStars
         ? { imageId: rightImageId, kind: 'annotated', size: 'original', maxStars }
-        : { imageId: rightImageId, kind: 'preview', size: 'original' };
+        : { imageId: rightImageId, kind: 'preview', size: 'original', color };
 
       void ensurePreviewReady(dbId, originalUrl, descriptor).then((ok) => {
         if (!ok) return;

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -6,6 +6,7 @@ import { GradingStatus, type Image, type PreviewDescriptor } from '../api/types'
 import { useImageZoom } from '../hooks/useImageZoom';
 import { useAsyncImage } from '../hooks/useAsyncImage';
 import { ensurePreviewReady } from '../hooks/previewPoll';
+import { useColorPreview } from '../hooks/useColorPreview';
 
 interface ImageComparisonViewProps {
   dbId: string;
@@ -33,6 +34,9 @@ export default function ImageComparisonView({
   onSwapImages,
 }: ImageComparisonViewProps) {
   const [showStars, setShowStars] = useState(false);
+  // Same shared preference as the grid and the detail view: comparing two
+  // frames is pointless if one arrives rendered differently from the other.
+  const color = useColorPreview();
   const [syncZoom, setSyncZoom] = useState(true);
   const [maxStars] = useState(1000);
   
@@ -125,7 +129,7 @@ export default function ImageComparisonView({
       : 'large';
   const leftSrc = showStars
     ? apiClient.getAnnotatedUrl(dbId, leftImageId, leftSize, maxStars)
-    : apiClient.getPreviewUrl(dbId, leftImageId, { size: leftSize });
+    : apiClient.getPreviewUrl(dbId, leftImageId, { size: leftSize, color });
   const leftDescriptor: PreviewDescriptor = showStars
     ? { imageId: leftImageId, kind: 'annotated', size: leftSize, maxStars }
     : { imageId: leftImageId, kind: 'preview', size: leftSize };
@@ -136,7 +140,7 @@ export default function ImageComparisonView({
   const rightIdForUrl = rightImageId ?? 0;
   const rightSrc = showStars
     ? apiClient.getAnnotatedUrl(dbId, rightIdForUrl, rightSize, maxStars)
-    : apiClient.getPreviewUrl(dbId, rightIdForUrl, { size: rightSize });
+    : apiClient.getPreviewUrl(dbId, rightIdForUrl, { size: rightSize, color });
   const rightDescriptor: PreviewDescriptor = showStars
     ? { imageId: rightIdForUrl, kind: 'annotated', size: rightSize, maxStars }
     : { imageId: rightIdForUrl, kind: 'preview', size: rightSize };
@@ -233,7 +237,7 @@ export default function ImageComparisonView({
       leftOriginalRef.current = new Image(); // guard: preload only once
       const originalUrl = showStars
         ? apiClient.getAnnotatedUrl(dbId, leftImageId, 'original', maxStars)
-        : apiClient.getPreviewUrl(dbId, leftImageId, { size: 'original' });
+        : apiClient.getPreviewUrl(dbId, leftImageId, { size: 'original', color });
       const descriptor: PreviewDescriptor = showStars
         ? { imageId: leftImageId, kind: 'annotated', size: 'original', maxStars }
         : { imageId: leftImageId, kind: 'preview', size: 'original' };
@@ -297,7 +301,7 @@ export default function ImageComparisonView({
       rightOriginalRef.current = new Image(); // guard: preload only once
       const originalUrl = showStars
         ? apiClient.getAnnotatedUrl(dbId, rightImageId, 'original', maxStars)
-        : apiClient.getPreviewUrl(dbId, rightImageId, { size: 'original' });
+        : apiClient.getPreviewUrl(dbId, rightImageId, { size: 'original', color });
       const descriptor: PreviewDescriptor = showStars
         ? { imageId: rightImageId, kind: 'annotated', size: 'original', maxStars }
         : { imageId: rightImageId, kind: 'preview', size: 'original' };

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -49,6 +49,10 @@ export default function ImageDetailView({
 }: ImageDetailViewProps) {
   const queryClient = useQueryClient();
   const [showStars, setShowStars] = useState(false);
+  // On by default: a colour camera's frame should look like what it recorded.
+  // Turning it off gives the luminance rendition the grader measures, and a
+  // mono frame looks the same either way.
+  const [showColor, setShowColor] = useState(true);
   const [showPsf, setShowPsf] = useState(false);
   const [psfImageLoading, setPsfImageLoading] = useState(false);
   const [maxStars] = useState(1000);
@@ -67,7 +71,9 @@ export default function ImageDetailView({
   const imageStateRef = useRef<'large' | 'switching-to-original' | 'original'>('large');
   // Guard: request original-resolution generation at most once per image.
   const originalRequestedRef = useRef(false);
-  const mainImageKey = `${dbId}:${imageId}:${showStars ? 'stars' : 'preview'}:${maxStars}`;
+  const mainImageKey = `${dbId}:${imageId}:${showStars ? 'stars' : 'preview'}:${maxStars}:${
+    showColor ? 'color' : 'mono'
+  }`;
   const mainImageKeyRef = useRef(mainImageKey);
   mainImageKeyRef.current = mainImageKey;
 
@@ -108,16 +114,19 @@ export default function ImageDetailView({
   // endpoint and is not queued here). On a cache miss the server returns 202
   // and this drives a "Generating…" indicator, then reloads when ready.
   const mainSize: 'large' | 'original' = useOriginalImage ? 'original' : 'large';
+  // The star overlay is drawn in colour, so it stays on a greyscale frame:
+  // markers over a colour image compete with the pixels they annotate.
+  const colorPreview = showColor && !showStars;
   const largeNonPsfSrc = showStars
     ? apiClient.getAnnotatedUrl(dbId, imageId, 'large', maxStars)
-    : apiClient.getPreviewUrl(dbId, imageId, { size: 'large' });
+    : apiClient.getPreviewUrl(dbId, imageId, { size: 'large', color: colorPreview });
   const originalNonPsfSrc = showStars
     ? apiClient.getAnnotatedUrl(dbId, imageId, 'original', maxStars)
-    : apiClient.getPreviewUrl(dbId, imageId, { size: 'original' });
+    : apiClient.getPreviewUrl(dbId, imageId, { size: 'original', color: colorPreview });
   const nonPsfSrc = mainSize === 'original' ? originalNonPsfSrc : largeNonPsfSrc;
   const nonPsfDescriptor: PreviewDescriptor = showStars
     ? { imageId, kind: 'annotated', size: mainSize, maxStars }
-    : { imageId, kind: 'preview', size: mainSize };
+    : { imageId, kind: 'preview', size: mainSize, color: colorPreview };
   const asyncImg = useAsyncImage(dbId, nonPsfSrc, nonPsfDescriptor);
   // `src` is what the <img> renders (may carry a `v=` cache-buster after a
   // generation-triggered reload); `baseSrc` is the stable identity used to
@@ -236,6 +245,9 @@ export default function ImageDetailView({
     setShowAstrometry(false);
     setShowSatellites(false);
   }, [showStars]);
+  // Colour is a view of the same exposure, not a different analysis, so it
+  // does not turn off the overlays the way stars and PSF turn off each other.
+  useHotkeys('c', () => setShowColor((color) => !color), []);
   useHotkeys('p', () => {
     const newPsfState = !showPsf;
     setShowPsf(newPsfState);
@@ -838,6 +850,19 @@ export default function ImageDetailView({
                   title="Zoom In (+)"
                 >
                   +
+                </button>
+                <button
+                  className={`zoom-btn-compact${showColor ? ' active' : ''}`}
+                  onClick={() => setShowColor((color) => !color)}
+                  aria-pressed={showColor}
+                  disabled={showStars}
+                  title={
+                    showStars
+                      ? 'Star markers are drawn over a greyscale frame'
+                      : 'One-shot-color rendition (C) — off shows the luminance the grader measures'
+                  }
+                >
+                  Color
                 </button>
               </div>
             </div>

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -321,10 +321,10 @@ export default function ImageDetailView({
       originalRequestedRef.current = true;
       const originalUrl = showStars
         ? apiClient.getAnnotatedUrl(dbId, imageId, 'original', maxStars)
-        : apiClient.getPreviewUrl(dbId, imageId, { size: 'original' });
+        : apiClient.getPreviewUrl(dbId, imageId, { size: 'original', color: colorPreview });
       const originalDescriptor: PreviewDescriptor = showStars
         ? { imageId, kind: 'annotated', size: 'original', maxStars }
-        : { imageId, kind: 'preview', size: 'original' };
+        : { imageId, kind: 'preview', size: 'original', color: colorPreview };
 
       const requestedKey = mainImageKey;
       void ensurePreviewReady(dbId, originalUrl, originalDescriptor).then((ok) => {

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -14,6 +14,11 @@ import AstrometryOverlay from './AstrometryOverlay';
 import SatellitePanel from './SatellitePanel';
 import SatelliteTrackOverlay from './SatelliteTrackOverlay';
 import ImageFileLocation from './ImageFileLocation';
+import {
+  colorPreviewEnabled,
+  setColorPreview,
+  useColorPreview,
+} from '../hooks/useColorPreview';
 
 interface ImageDetailViewProps {
   dbId: string;
@@ -49,10 +54,11 @@ export default function ImageDetailView({
 }: ImageDetailViewProps) {
   const queryClient = useQueryClient();
   const [showStars, setShowStars] = useState(false);
-  // On by default: a colour camera's frame should look like what it recorded.
-  // Turning it off gives the luminance rendition the grader measures, and a
-  // mono frame looks the same either way.
-  const [showColor, setShowColor] = useState(true);
+  // Shared with the grid and the overview, so a frame does not change
+  // appearance on the way into the detail view. On by default; off gives the
+  // luminance rendition the grader measures, and a mono frame looks the same
+  // either way.
+  const showColor = useColorPreview();
   const [showPsf, setShowPsf] = useState(false);
   const [psfImageLoading, setPsfImageLoading] = useState(false);
   const [maxStars] = useState(1000);
@@ -247,7 +253,7 @@ export default function ImageDetailView({
   }, [showStars]);
   // Colour is a view of the same exposure, not a different analysis, so it
   // does not turn off the overlays the way stars and PSF turn off each other.
-  useHotkeys('c', () => setShowColor((color) => !color), []);
+  useHotkeys('c', () => setColorPreview(!colorPreviewEnabled()), []);
   useHotkeys('p', () => {
     const newPsfState = !showPsf;
     setShowPsf(newPsfState);
@@ -853,7 +859,7 @@ export default function ImageDetailView({
                 </button>
                 <button
                   className={`zoom-btn-compact${showColor ? ' active' : ''}`}
-                  onClick={() => setShowColor((color) => !color)}
+                  onClick={() => setColorPreview(!showColor)}
                   aria-pressed={showColor}
                   disabled={showStars}
                   title={

--- a/static/src/components/Overview.tsx
+++ b/static/src/components/Overview.tsx
@@ -36,6 +36,7 @@ import {
 } from '../utils/projectNavigation';
 import ProjectSchedulerDialog from './ProjectSchedulerDialog';
 import PreviewImage from './PreviewImage';
+import { useColorPreview } from '../hooks/useColorPreview';
 import './Overview.css';
 
 /// Inline edit state for correcting imported groupings.
@@ -48,6 +49,7 @@ function recentImageKey(dbId: string, projectId: number, imageId: number): strin
 }
 
 export default function Overview() {
+  const color = useColorPreview();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [projectSearch, setProjectSearch] = useState('');
@@ -719,11 +721,13 @@ export default function Overview() {
                                   dbId={project.db_id}
                                   src={apiClient.getPreviewUrl(project.db_id, image.id, {
                                     size: 'screen',
+                                    color,
                                   })}
                                   descriptor={{
                                     imageId: image.id,
                                     kind: 'preview',
                                     size: 'screen',
+                                    color,
                                   }}
                                   alt={`${image.target_name}, ${filter}`}
                                   loading="lazy"

--- a/static/src/components/__tests__/ImageCard.color.test.tsx
+++ b/static/src/components/__tests__/ImageCard.color.test.tsx
@@ -1,0 +1,69 @@
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import ImageCard from '../ImageCard';
+import { setColorPreview } from '../../hooks/useColorPreview';
+import type { Image } from '../../api/types';
+
+/**
+ * The grid must ask for the rendition the shared preference names.
+ *
+ * Every view that shows a preview builds its own URL, and four of them were
+ * once left out of the colour preference — each silently falling back to a
+ * server default, so the grid and the detail view could disagree about the
+ * same frame. This pins the grid's half of that.
+ */
+
+const image = {
+  id: 42,
+  project_id: 1,
+  project_name: 'Sync Nebula',
+  project_display_name: 'Sync Nebula',
+  target_id: 1,
+  target_name: 'Core',
+  acquired_date: 1_750_000_000,
+  filter_name: 'OSC',
+  grading_status: 0,
+  reject_reason: null,
+  metadata: {},
+  filesystem_path: null,
+} as unknown as Image;
+
+function previewSrc(): string {
+  const img = screen.getByRole('img', { hidden: true }) as HTMLImageElement;
+  return img.getAttribute('src') ?? '';
+}
+
+describe('ImageCard colour preference', () => {
+  beforeEach(() => {
+    setColorPreview(true);
+  });
+
+  it('asks for colour while the preference is on', () => {
+    render(
+      <ImageCard
+        dbId="db"
+        image={image}
+        isSelected={false}
+        onClick={() => {}}
+        onDoubleClick={() => {}}
+      />
+    );
+    expect(previewSrc()).toContain('color=true');
+  });
+
+  it('follows the preference when it is turned off', () => {
+    render(
+      <ImageCard
+        dbId="db"
+        image={image}
+        isSelected={false}
+        onClick={() => {}}
+        onDoubleClick={() => {}}
+      />
+    );
+    act(() => setColorPreview(false));
+    // Explicit, not merely absent: a missing parameter would take the
+    // server's default, which is colour.
+    expect(previewSrc()).toContain('color=false');
+  });
+});

--- a/static/src/hooks/__tests__/previewDescriptorAgreement.test.ts
+++ b/static/src/hooks/__tests__/previewDescriptorAgreement.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { apiClient } from '../../api/client';
+import { descriptorKey } from '../previewPoll';
+import type { PreviewDescriptor } from '../../api/types';
+
+/**
+ * A preview `<img>` and the poll that waits for it must describe the same
+ * artifact.
+ *
+ * The URL and the descriptor are built separately at every call site, and the
+ * server keys colour and greyscale renditions apart. Three views have now
+ * shipped with `color` on one and not the other; each time the browser waited
+ * on an artifact nobody was generating, and only with the preference turned
+ * off, which is the case nobody clicks through.
+ *
+ * The check is that whatever the URL asks for appears in the descriptor too.
+ */
+function colorInUrl(url: string): boolean | undefined {
+  const value = new URL(url, 'http://localhost').searchParams.get('color');
+  return value === null ? undefined : value === 'true';
+}
+
+describe('preview URL and poll descriptor agreement', () => {
+  const cases: Array<{ name: string; color: boolean | undefined }> = [
+    { name: 'colour on', color: true },
+    { name: 'colour off', color: false },
+    { name: 'unstated', color: undefined },
+  ];
+
+  for (const { name, color } of cases) {
+    it(`carries the same colour choice into both, with ${name}`, () => {
+      const url = apiClient.getPreviewUrl('db', 7, { size: 'large', color });
+      const descriptor: PreviewDescriptor = {
+        imageId: 7,
+        kind: 'preview',
+        size: 'large',
+        color,
+      };
+      expect(colorInUrl(url)).toBe(descriptor.color);
+    });
+  }
+
+  it('gives colour and greyscale different descriptor keys', () => {
+    // If they collided, a poll for one would report the other ready and the
+    // <img> would reload into a 202 forever.
+    const base: PreviewDescriptor = { imageId: 7, kind: 'preview', size: 'large' };
+    expect(descriptorKey({ ...base, color: true })).not.toBe(
+      descriptorKey({ ...base, color: false })
+    );
+  });
+
+  it('gives colour and greyscale different URLs', () => {
+    expect(apiClient.getPreviewUrl('db', 7, { size: 'large', color: true })).not.toBe(
+      apiClient.getPreviewUrl('db', 7, { size: 'large', color: false })
+    );
+  });
+});

--- a/static/src/hooks/__tests__/useColorPreview.test.tsx
+++ b/static/src/hooks/__tests__/useColorPreview.test.tsx
@@ -1,0 +1,63 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  colorPreviewEnabled,
+  setColorPreview,
+  useColorPreview,
+} from '../useColorPreview';
+
+describe('useColorPreview', () => {
+  beforeEach(() => {
+    // The module reads storage once at import, so reset through the setter
+    // rather than by clearing storage behind its back.
+    setColorPreview(true);
+    window.localStorage.clear();
+  });
+
+  it('starts on, because a colour camera should look like what it recorded', () => {
+    const { result } = renderHook(() => useColorPreview());
+    expect(result.current).toBe(true);
+  });
+
+  it('keeps every view in step', () => {
+    // The grid, the overview, and the detail view render the same exposures.
+    // If they held the preference separately, a frame would change appearance
+    // on the way into the detail view.
+    const grid = renderHook(() => useColorPreview());
+    const detail = renderHook(() => useColorPreview());
+
+    act(() => setColorPreview(false));
+
+    expect(grid.result.current).toBe(false);
+    expect(detail.result.current).toBe(false);
+  });
+
+  it('remembers the choice', () => {
+    act(() => setColorPreview(false));
+    expect(window.localStorage.getItem('psf-guard.color-preview')).toBe('false');
+    expect(colorPreviewEnabled()).toBe(false);
+  });
+
+  it('stops listening once a view unmounts', () => {
+    const { result, unmount } = renderHook(() => useColorPreview());
+    unmount();
+    // A leaked subscriber would keep setting state on an unmounted component.
+    act(() => setColorPreview(false));
+    expect(result.current).toBe(true);
+  });
+
+  it('survives storage being unavailable', () => {
+    // Private browsing can refuse localStorage. The preference is a
+    // convenience; refusing to render would not be.
+    const original = window.localStorage.setItem;
+    window.localStorage.setItem = () => {
+      throw new Error('storage disabled');
+    };
+    try {
+      expect(() => setColorPreview(false)).not.toThrow();
+      expect(colorPreviewEnabled()).toBe(false);
+    } finally {
+      window.localStorage.setItem = original;
+    }
+  });
+});

--- a/static/src/hooks/previewPoll.ts
+++ b/static/src/hooks/previewPoll.ts
@@ -53,6 +53,7 @@ export function descriptorKey(d: PreviewDescriptor): string {
     d.midtone ?? '',
     d.shadow ?? '',
     d.maxStars ?? '',
+    d.color ? 'color' : '',
   ].join('|');
 }
 

--- a/static/src/hooks/useColorPreview.ts
+++ b/static/src/hooks/useColorPreview.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Whether one-shot-color frames are shown in colour, shared across every view.
+ *
+ * The grid, the overview, and the detail view all render the same exposures,
+ * so a preference held per component would let them disagree — the frame you
+ * clicked would change appearance on the way in. This keeps one answer, and
+ * remembers it, because it describes how someone likes to look at their data
+ * rather than anything about a particular image.
+ *
+ * Mono frames are unaffected either way: with no `BAYERPAT` there is no
+ * colour to recover.
+ */
+const STORAGE_KEY = 'psf-guard.color-preview';
+
+type Listener = (enabled: boolean) => void;
+
+const listeners = new Set<Listener>();
+
+function readStored(): boolean {
+  try {
+    // Default on: a colour camera's frame should look like what it recorded.
+    // Only an explicit opt-out turns it off.
+    return window.localStorage.getItem(STORAGE_KEY) !== 'false';
+  } catch {
+    // Private browsing and similar can refuse storage. The preference is a
+    // convenience, not something worth failing a render over.
+    return true;
+  }
+}
+
+let enabled = readStored();
+
+export function setColorPreview(next: boolean): void {
+  if (next === enabled) return;
+  enabled = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(next));
+  } catch {
+    // Keep the in-memory preference even when it cannot be persisted.
+  }
+  listeners.forEach((listener) => listener(next));
+}
+
+export function colorPreviewEnabled(): boolean {
+  return enabled;
+}
+
+/** Subscribe to the shared preference. Returns its current value. */
+export function useColorPreview(): boolean {
+  const [value, setValue] = useState(enabled);
+  useEffect(() => {
+    listeners.add(setValue);
+    // A change between the initial render and this effect would otherwise be
+    // missed.
+    setValue(enabled);
+    return () => {
+      listeners.delete(setValue);
+    };
+  }, []);
+  return value;
+}

--- a/static/src/hooks/useImagePreloader.ts
+++ b/static/src/hooks/useImagePreloader.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { apiClient } from '../api/client';
+import { colorPreviewEnabled } from './useColorPreview';
 import { ensurePreviewReady } from './previewPoll';
 
 /**
@@ -38,8 +39,10 @@ export function useImagePreloader(
     imagesToPreload.forEach((imageId) => {
       void ensurePreviewReady(
         dbId,
-        apiClient.getPreviewUrl(dbId, imageId, { size: imageSize }),
-        { imageId, kind: 'preview', size: imageSize }
+        // Read at call time rather than subscribing: warming is a side
+        // effect, and a preference change simply warms the next batch.
+        apiClient.getPreviewUrl(dbId, imageId, { size: imageSize, color: colorPreviewEnabled() }),
+        { imageId, kind: 'preview', size: imageSize, color: colorPreviewEnabled() }
       );
 
       // Optionally warm the annotated version (getAnnotatedUrl defaults to

--- a/static/src/hooks/useImageUrls.ts
+++ b/static/src/hooks/useImageUrls.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { apiClient } from '../api/client';
+import { colorPreviewEnabled } from './useColorPreview';
 import type { PreviewOptions } from '../api/types';
 
 export const useImageUrls = (dbId: string, imageId: number) => {
@@ -12,7 +13,11 @@ export const useImageUrls = (dbId: string, imageId: number) => {
     const loadUrls = async () => {
       try {
         const [preview, annotated, psf] = await Promise.all([
-          apiClient.getPreviewUrl(dbId, imageId, { size: 'screen', stretch: true }),
+          apiClient.getPreviewUrl(dbId, imageId, {
+            size: 'screen',
+            stretch: true,
+            color: colorPreviewEnabled(),
+          }),
           apiClient.getAnnotatedUrl(dbId, imageId, 'large'),
           apiClient.getPsfUrl(dbId, imageId),
         ]);

--- a/tests/integration_osc_color.rs
+++ b/tests/integration_osc_color.rs
@@ -1,0 +1,196 @@
+//! One-shot-color rendering: the display path keeps the colour that the
+//! measurement path deliberately throws away.
+//!
+//! `FitsImage::from_file` debayers and collapses to luminance, because star
+//! metrics on a bare colour filter array are distorted by the per-channel
+//! sampling. That is right for grading and wrong for looking, so the viewer
+//! has its own path — and these check the two have not been confused.
+
+use std::io::Write;
+
+/// Build a small OSC frame: an RGGB mosaic with a strong red bias, so a
+/// correct debayer is obvious in the output and a luminance collapse is too.
+/// Fixed star field: enough for the registration minimum, spread out so the
+/// matcher is not asked to disambiguate a cluster.
+const STAR_POSITIONS: [(f64, f64); 10] = [
+    (18.0, 22.0),
+    (40.0, 15.0),
+    (72.0, 30.0),
+    (100.0, 24.0),
+    (25.0, 58.0),
+    (60.0, 66.0),
+    (95.0, 74.0),
+    (30.0, 96.0),
+    (68.0, 104.0),
+    (105.0, 110.0),
+];
+
+fn write_fits(path: &std::path::Path, bayer: Option<&str>) {
+    const CARD: usize = 80;
+    const BLOCK: usize = 2880;
+    let (w, h) = (128usize, 128usize);
+    let mut cards = vec![
+        "SIMPLE  =                    T".to_string(),
+        "BITPIX  =                   16".to_string(),
+        "NAXIS   =                    2".to_string(),
+        format!("NAXIS1  = {:>20}", w),
+        format!("NAXIS2  = {:>20}", h),
+        "BZERO   =                32768".to_string(),
+        "BSCALE  =                    1".to_string(),
+    ];
+    if let Some(pattern) = bayer {
+        cards.push(format!("BAYERPAT= '{pattern:<8}'"));
+    }
+    cards.push("END".to_string());
+    let blocks = (cards.len() * CARD).div_ceil(BLOCK);
+    let mut header = vec![b' '; blocks * BLOCK];
+    for (i, c) in cards.iter().enumerate() {
+        header[i * CARD..i * CARD + c.len()].copy_from_slice(c.as_bytes());
+    }
+    // A realistic frame, not three spikes: a sky background with noise and a
+    // gentle gradient, tinted per channel. An autostretch derives its clip
+    // point from the noise, so a histogram with no width makes it crush
+    // everything below the brightest spike — pathological input, not a bug,
+    // but useless for checking that colour survives.
+    let mut data = Vec::new();
+    for y in 0..h {
+        for x in 0..w {
+            // Deterministic hash noise: no rand dependency, same every run.
+            let hash = ((x as u32).wrapping_mul(73_856_093) ^ (y as u32).wrapping_mul(19_349_663))
+                .wrapping_mul(2_654_435_761);
+            let noise = (hash >> 20) as f64 / 4096.0 * 900.0;
+            let background = 8000.0 + (x + y) as f64 * 12.0 + noise;
+            let tint = match (x % 2, y % 2) {
+                (0, 0) => 1.35, // red site
+                (1, 1) => 0.70, // blue site
+                _ => 1.0,       // green sites
+            };
+            // Stars, so the stacker has something to register on. They span
+            // several pixels and therefore land on red, green, and blue
+            // sites, which is what makes them survive the debayer as stars
+            // rather than as colour fringes.
+            let stars = STAR_POSITIONS
+                .iter()
+                .map(|&(sx, sy)| {
+                    let (dx, dy) = (x as f64 - sx, y as f64 - sy);
+                    22000.0 * (-(dx * dx + dy * dy) / (2.0 * 1.6 * 1.6)).exp()
+                })
+                .sum::<f64>();
+            let raw = ((background + stars) * tint).clamp(0.0, 65535.0) as u16;
+            data.extend_from_slice(&((raw as i32 - 32768) as i16).to_be_bytes());
+        }
+    }
+    data.resize(data.len().div_ceil(BLOCK) * BLOCK, 0);
+    let mut file = std::fs::File::create(path).unwrap();
+    file.write_all(&header).unwrap();
+    file.write_all(&data).unwrap();
+}
+
+#[test]
+fn colour_render_is_actually_coloured() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let fits = dir.path().join("osc.fits");
+    write_fits(&fits, Some("RGGB"));
+    let out = dir.path().join("osc.png");
+
+    let rendered = psf_guard::commands::stretch_to_png::color_to_png_with_resize(
+        &fits.to_string_lossy(),
+        Some(out.to_string_lossy().into_owned()),
+        0.2,
+        -2.8,
+        None,
+    )
+    .unwrap();
+    assert!(rendered, "a BAYERPAT frame should render in colour");
+
+    let img = image::open(&out).unwrap().to_rgb8();
+    let mid = img.get_pixel(img.width() / 2, img.height() / 2);
+    println!("centre pixel = {:?}", mid);
+    // The mosaic is R > G > B, and one shared transfer preserves that order.
+    // Per-channel statistics would flatten it towards grey, and a swapped
+    // pattern would reverse it.
+    assert!(mid[0] > mid[1], "red should lead green: {mid:?}");
+    assert!(mid[1] > mid[2], "green should lead blue: {mid:?}");
+    // A per-channel stretch would drag all three toward a common median and
+    // return something close to grey, which this spread rules out.
+    assert!(
+        i32::from(mid[0]) - i32::from(mid[2]) > 40,
+        "channels should stay clearly separated, not wash out to grey: {mid:?}"
+    );
+}
+
+#[test]
+fn a_mono_frame_reports_that_it_has_no_colour() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let fits = dir.path().join("mono.fits");
+    write_fits(&fits, None);
+
+    let rendered = psf_guard::commands::stretch_to_png::color_to_png_with_resize(
+        &fits.to_string_lossy(),
+        Some(dir.path().join("mono.png").to_string_lossy().into_owned()),
+        0.2,
+        -2.8,
+        None,
+    )
+    .unwrap();
+    assert!(
+        !rendered,
+        "a frame with no BAYERPAT has no colour to render, and the caller \
+         must be told so it can fall back to greyscale"
+    );
+}
+
+/// A stack of one-shot-color frames must come out in colour.
+///
+/// This is the contract `stack_preview.rs` relies on: it sizes its memory
+/// budget for three channels when the reference frame carries a bayer
+/// pattern, and its renderer emits RGB for a three-channel result. If the
+/// stacker ever stopped debayering on ingest, an OSC stack would silently
+/// become greyscale and the memory estimate would be three times too large,
+/// with nothing else failing.
+#[test]
+fn stacking_one_shot_color_frames_yields_three_channels() {
+    use seiza_stacking::{FitsFrame, LiveStacker, NormalizationMode, StackOptions};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let first = dir.path().join("osc-1.fits");
+    let second = dir.path().join("osc-2.fits");
+    write_fits(&first, Some("RGGB"));
+    write_fits(&second, Some("RGGB"));
+
+    let reference = FitsFrame::open(&first).unwrap();
+    assert!(
+        reference.bayer.is_some(),
+        "the stacker must recognise BAYERPAT, or nothing downstream debayers"
+    );
+    // The same test psf-guard makes when it plans the memory budget.
+    assert_eq!(
+        if reference.bayer.is_some() {
+            3
+        } else {
+            reference.image.channels
+        },
+        3
+    );
+
+    let mut stacker = LiveStacker::new(
+        reference,
+        Default::default(),
+        StackOptions {
+            normalization: NormalizationMode::Global,
+            ..StackOptions::default()
+        },
+    )
+    .unwrap();
+    stacker.push(FitsFrame::open(&second).unwrap()).unwrap();
+    let stacked = stacker.into_snapshot().unwrap().image;
+
+    assert_eq!(
+        stacked.channels, 3,
+        "an OSC stack must stay in colour, not collapse to luminance"
+    );
+    // And the colour must be the mosaic's, not an averaged grey.
+    let centre = (stacked.height / 2) * stacked.width + stacked.width / 2;
+    let pixel = &stacked.data[centre * 3..centre * 3 + 3];
+    assert!(pixel[0] > pixel[2], "red should lead blue: {pixel:?}");
+}

--- a/tests/integration_osc_color.rs
+++ b/tests/integration_osc_color.rs
@@ -99,6 +99,7 @@ fn colour_render_is_actually_coloured() {
         0.2,
         -2.8,
         None,
+        psf_guard::preview_format::PreviewEncoding::png(),
     )
     .unwrap();
     assert!(rendered, "a BAYERPAT frame should render in colour");
@@ -131,6 +132,7 @@ fn a_mono_frame_reports_that_it_has_no_colour() {
         0.2,
         -2.8,
         None,
+        psf_guard::preview_format::PreviewEncoding::png(),
     )
     .unwrap();
     assert!(

--- a/tests/integration_osc_color.rs
+++ b/tests/integration_osc_color.rs
@@ -93,7 +93,7 @@ fn colour_render_is_actually_coloured() {
     write_fits(&fits, Some("RGGB"));
     let out = dir.path().join("osc.png");
 
-    let rendered = psf_guard::commands::stretch_to_png::color_to_png_with_resize(
+    let rendered = psf_guard::commands::stretch_to_png::render_color_preview(
         &fits.to_string_lossy(),
         Some(out.to_string_lossy().into_owned()),
         0.2,
@@ -126,7 +126,7 @@ fn a_mono_frame_reports_that_it_has_no_colour() {
     let fits = dir.path().join("mono.fits");
     write_fits(&fits, None);
 
-    let rendered = psf_guard::commands::stretch_to_png::color_to_png_with_resize(
+    let rendered = psf_guard::commands::stretch_to_png::render_color_preview(
         &fits.to_string_lossy(),
         Some(dir.path().join("mono.png").to_string_lossy().into_owned()),
         0.2,


### PR DESCRIPTION
Answers "we should be able to see and generate color no? what about osc stacking?"

## OSC stacking already worked

Worth stating first, because it changes what needed building. `FitsFrame::open` reads `BAYERPAT`, `into_prepared()` debayers on ingest, the stack carries three channels, `stack_preview.rs` sizes its memory budget for them, and the renderer emits `ImageRgb8`. An OSC stack preview and its exported FITS have been colour all along.

It had no test, though, so this adds one: if the stacker ever stopped debayering, an OSC stack would quietly go greyscale while its memory estimate stayed three times too large, and nothing else would fail.

## The viewer was throwing the colour away

`FitsImage::from_file` debayers and then calls `to_luma_u16()`, discarding the RGB. Every preview goes through it, so OSC frames were grey in the grid and the detail view.

The reasoning behind that is sound for **measurement** — star metrics on a bare colour filter array are distorted by the per-channel sampling, and N.I.N.A. measures the debayered frame, so luminance keeps our numbers comparable to what Target Scheduler recorded. It was never an argument about **display**, which inherited the same code path by accident.

Now split: `ColorFrame` keeps the RGB for the viewer, `FitsImage::from_file` is untouched. Nothing that grades an image changes.

## Behaviour

- Colour **on by default**; `C` or the Color button gives the luminance rendition.
- The stretch is measured once on luminance and applied identically to R, G, and B. That preserves the ratios between channels and so the colour balance — per-channel statistics would drag all three toward a common median and wash the frame out.
- No `BAYERPAT` → greyscale either way, so a mixed rig needs no special handling.
- Star markers stay greyscale: the overlay is drawn in colour and would compete with the pixels it annotates.
- The cache marks only the colour variant, so greyscale artifacts already on disk keep their keys and remain valid for `color=false`.

## Tests

`tests/integration_osc_color.rs` builds a synthetic RGGB frame — sky background, noise, a gradient, and ten stars — and checks the render stays R > G > B with a real spread, which a washed-out per-channel stretch would fail. Also that a mono frame reports it has no colour, and that a two-frame OSC stack comes out three-channel and still red-dominant.

The first fixture I wrote was three flat values; the autostretch correctly crushed it to `[255,0,0]`, which proved nothing. Worth knowing if anyone touches it.

431 Rust tests, 142 vitest, clippy clean under `--all-targets --all-features -- -D warnings`.