### PR TITLE
Give the logo an intrinsic size, and stop pinning it in a test

### DIFF
--- a/static/e2e/empty-state.spec.ts
+++ b/static/e2e/empty-state.spec.ts
@@ -47,9 +47,33 @@ test('header shows the PSF Guard logo', async ({ page }) => {
     .locator('.brand-logo');
   await expect(logo).toBeVisible();
   await expect(logo).toHaveAttribute('src', '/psf-guard.svg');
+
+  // The logo declares its own size, and that size is square.
+  //
+  // Polling for a non-zero width first is not decoration: an <img> reports
+  // zero until it has decoded, so reading straight after the visibility check
+  // races the decode and fails intermittently.
+  //
+  // Squareness rather than a fixed number, because pinning the artwork's
+  // exact intrinsic width is what broke this test when the logo was redrawn.
+  // It still catches the thing that actually goes wrong — an SVG carrying
+  // only a viewBox declares no intrinsic size, and the browser reports either
+  // zero or its own 2:1 default in its place.
   await expect
     .poll(() => logo.evaluate((image: HTMLImageElement) => image.naturalWidth))
-    .toBe(64);
+    .toBeGreaterThan(0);
+  const intrinsic = await logo.evaluate((image: HTMLImageElement) => ({
+    width: image.naturalWidth,
+    height: image.naturalHeight,
+  }));
+  expect(intrinsic.width, 'the logo should declare a square intrinsic size').toBe(
+    intrinsic.height
+  );
+
+  // And it is laid out at the size the header gives it.
+  const box = await logo.boundingBox();
+  expect(box?.width).toBeCloseTo(32, 0);
+  expect(box?.height).toBeCloseTo(32, 0);
 });
 
 test('GET /api/info advertises database management is enabled', async ({

--- a/static/public/psf-guard.svg
+++ b/static/public/psf-guard.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="PSF Guard logo">
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="PSF Guard logo">
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#5eead4"/>


### PR DESCRIPTION
Fixes the Playwright failure on #241 — which does not come from that PR. CI has been red on `main` itself since #242, at `09df3f4` and `e258127`, and was green at `b878e4f` before them. #241 merged main in and inherited it.

## What broke

The redrawn logo carries a `viewBox` and no `width`/`height`, so it declares no intrinsic size and the browser substitutes its own: zero before decode, then a 2:1 default. `empty-state.spec.ts` asserted `naturalWidth === 64` and got 150 in CI, 0 locally.

The header sizes the logo with CSS, so nothing rendered wrong. Only the test noticed, and it noticed by way of a number that had nothing to do with what a reader sees.

## The fix

The SVG now states `width="128" height="128"` matching its viewBox — what an `<img>` source should do: self-describing, and no layout shift before the stylesheet lands. The artwork is unchanged.

The assertion no longer pins an exact intrinsic width; that coupling is what broke when the logo was redrawn. It checks the logo declares a **square** intrinsic size, which is the property the header depends on, and still fails on what actually goes wrong here.

It also polls for a non-zero width before reading. An `<img>` reports zero until it has decoded, so reading straight after the visibility check races that — my first attempt at this fix had exactly that flake, and it showed up as an inconsistency between CI's 150 and my local 0.

Verified in both directions: passing with the fix, failing with the size-less SVG restored. 60 Playwright specs green.