### PR TITLE
chore: prepare v0.6.0 release

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -30,6 +30,7 @@ This repository contains workflows for building both CLI and desktop versions of
      - **macOS**: `.dmg` installers, `.app` bundles (zipped)
      - **Updates**: signed Tauri payloads, `updater.json`, and `notice.json`
 
+The operator checklist lives in [`docs/RELEASING.md`](../docs/RELEASING.md).
 The update feeds and signing boundary are documented in
 [`docs/UPDATES.md`](../docs/UPDATES.md).
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,14 +114,10 @@ jobs:
         cargo tauri signer sign "$probe"
         test -s "$probe.sig"
 
-    - name: Check tag matches app version
+    - name: Check release versions and notes
       shell: bash
       run: |
-        version=$(node -p 'require("./tauri.conf.json").version')
-        if [ "$GITHUB_REF_NAME" != "v$version" ]; then
-          echo "::error::Tag $GITHUB_REF_NAME does not match app version $version."
-          exit 1
-        fi
+        version=$(node scripts/check-release-version.mjs "$GITHUB_REF_NAME")
         echo "APP_VERSION=$version" >> "$GITHUB_ENV"
 
     - name: Write signed updater build config
@@ -240,37 +236,7 @@ jobs:
         prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
         generate_release_notes: true
         name: PSF Guard ${{ github.ref_name }}
-        body: |
-          ## PSF Guard ${{ github.ref_name }}
-
-          ### Desktop Applications 🖥️
-          - **Linux**: `.deb` package and `.AppImage` for easy installation
-          - **Windows**: `.msi` installer and NSIS installer. The NSIS setup also
-            installs a console `psf-guard-cli.exe` next to the app and adds it to
-            your user `PATH`, so you can run `psf-guard-cli` from any terminal.
-          - **macOS**: `.dmg` installer and `.app` bundle (zipped)
-
-          ### Command Line Interface 🖥️
-          - **Linux**: `psf-guard-linux-x64` - standalone CLI binary
-          - **Windows**: `psf-guard-windows-x64.exe` - standalone CLI binary
-          - **macOS**: `psf-guard-macos-x64` - standalone CLI binary
-
-          ### Fedora packages 📦
-          - **Fedora 43 / 44**: `psf-guard-*.fc43.x86_64.rpm` / `*.fc44.x86_64.rpm`
-            install the CLI/server plus a `psf-guard.service` systemd unit
-            (`sudo dnf install ./psf-guard-*.rpm`)
-
-          ### Features
-          - 🖥️ **Smart Binary**: Single binary that automatically switches between GUI and CLI modes
-          - 📊 **N.I.N.A. Integration**: Direct support for N.I.N.A. scheduler databases
-          - 🌟 **Star Detection**: Advanced PSF fitting and analysis
-          - 📁 **File Management**: Comprehensive FITS file organization
-          - 🔄 **Cache System**: Intelligent file caching with real-time progress
-
-          **Desktop GUI**: Run without arguments to launch the desktop interface
-          **CLI Mode**: Run with `--help` or any arguments for command-line interface
-
-          Download the appropriate version for your platform and get started!
+        body_path: docs/releases/${{ github.ref_name }}.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -286,8 +252,8 @@ jobs:
       with:
         node-version: '24'
 
-    - name: Test update feed generation
-      run: node --test scripts/release-feeds.test.mjs
+    - name: Test release metadata and feed generation
+      run: node --test scripts/check-release-version.test.mjs scripts/release-feeds.test.mjs
 
     - name: Download signed updater assets
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not
@@ -30,7 +30,6 @@ anyhow = "1.0"
 chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 semver = "1"
 byteorder = "1.5"
 seiza = "0.12.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ work. Historical checklists record delivery; they do not track current work.
 
 ## Component-specific guides
 
+- [Release guide](RELEASING.md)
 - [App and server updates](UPDATES.md)
 - [RPM packaging](../packaging/rpm/README.md)
 - [Target Scheduler schema snapshot](../src/ts_schema/README.md)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,163 @@
+# Release guide
+
+This guide covers a normal PSF Guard desktop, CLI, package, and server release.
+Prepare the release in a pull request. Do not tag until that exact pull request
+has merged and all required checks have passed.
+
+## 1. Check the release boundary
+
+1. Fetch `origin/main` and the tags.
+2. Read the full change list from the last release:
+
+   ```bash
+   git log --oneline vPREVIOUS..origin/main
+   git diff --stat vPREVIOUS..origin/main
+   ```
+
+3. Choose the next semantic version. Use a patch release for compatible fixes,
+   a minor release for compatible features, and a major release for breaking
+   user-facing or data-format changes.
+4. Check open pull requests for a change that must ship with the release.
+5. Confirm that GitHub Actions lists the Apple signing secrets and the two
+   updater secrets: `TAURI_SIGNING_PRIVATE_KEY` and
+   `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`. Check names only; never print values.
+
+## 2. Prepare the release pull request
+
+Create an isolated worktree from current `origin/main`. Update:
+
+- `Cargo.toml` package version;
+- `Cargo.lock` root package version;
+- `tauri.conf.json` app version;
+- `packaging/rpm/psf-guard.spec` version and changelog; and
+- `docs/releases/vVERSION.md` release highlights.
+
+Search for the old version after the edit. Test fixtures and dependency versions
+may still use the same number; inspect each match instead of replacing all of
+them.
+
+The release workflow prepends the matching `docs/releases/vVERSION.md` file to
+GitHub's generated change list. A missing file makes the release job fail.
+
+## 3. Run local gates
+
+Run the same broad checks used by CI:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked
+cargo build --release --locked --bin psf-guard-cli
+node scripts/check-release-version.mjs vVERSION
+
+cd static
+npm ci
+npm run lint
+npx vitest run
+npm run build
+npm run test:release
+```
+
+Use Node 24, which is the version in CI. Parse `.github/workflows/ci.yml` and
+`.github/workflows/release.yml`, then run `git diff --check`. Build a local
+Tauri bundle when app, updater, packaging, or signing code changed.
+
+Commit only the release files and any release-blocking fix found during the
+audit. Push the branch and open a pull request. Record local checks in its body.
+
+## 4. Merge and tag the reviewed commit
+
+Immediately before merging, record the pull request head SHA and inspect
+`mergeStateStatus` and every required check. If the head changed, review the
+new diff and wait for checks on that SHA.
+
+```bash
+gh pr view PR --json headRefOid,mergeStateStatus,statusCheckRollup
+gh pr checks PR
+gh pr merge PR --squash --match-head-commit REVIEWED_HEAD_SHA
+```
+
+After merge:
+
+1. fetch `origin/main` again;
+2. record the merge SHA and confirm it contains the reviewed head;
+3. confirm `Cargo.toml`, `Cargo.lock`, `tauri.conf.json`, and the RPM spec all
+   carry the same version;
+4. create an annotated `vVERSION` tag on that merge SHA; and
+5. push only that tag.
+
+```bash
+git fetch origin
+git tag -a vVERSION MERGE_SHA -m "PSF Guard VERSION"
+git push origin vVERSION
+```
+
+Never move a published release tag. Fix a bad public release with a new version.
+
+## 5. Watch the hosted release
+
+The tag starts `.github/workflows/release.yml` and the RPM workflow. Watch all
+jobs for the exact tag SHA. The release workflow:
+
+1. signs a probe on each runner;
+2. builds the CLI and desktop packages;
+3. requires each Tauri updater payload and its `.sig` file;
+4. uploads platform assets;
+5. creates `updater.json` from the three payload signatures; and
+6. uploads `updater.json` and `notice.json` to the GitHub release.
+
+Tauri signs updater payloads, not the JSON manifest. The manifest carries the
+signature that the installed app checks with its embedded public key.
+
+Do not call the release complete because CI is green. Wait until GitHub shows a
+public, non-draft release and all expected assets.
+
+```bash
+gh run list --workflow release.yml --branch vVERSION
+gh run watch RUN_ID --exit-status
+gh release view vVERSION
+```
+
+## 6. Verify public artifacts
+
+Download the release into a new temporary directory. Check:
+
+- the tag and release target the recorded merge SHA;
+- all Windows, macOS, Linux, CLI, RPM, `updater.json`, and `notice.json` assets
+  exist and are non-empty;
+- every URL and signature in `updater.json` matches its public release asset;
+- the GitHub `releases/latest/download/updater.json` fallback works;
+- the CLI reports the new version on each platform available to you; and
+- package and app metadata carry the new version.
+
+```bash
+mkdir /tmp/psf-guard-vVERSION
+gh release download vVERSION --dir /tmp/psf-guard-vVERSION
+```
+
+On macOS, verify the DMG, notarization ticket, Gatekeeper result, deep code
+signature, architectures, and bundled app version:
+
+```bash
+hdiutil verify PSF.Guard_VERSION_*.dmg
+xcrun stapler validate PSF.Guard_VERSION_*.dmg
+spctl --assess --type open --context context:primary-signature -v *.dmg
+codesign --verify --deep --strict --verbose=2 /path/to/PSF\ Guard.app
+```
+
+Keep the downloaded files until the release record and update feeds have both
+been checked.
+
+## 7. Publish and check the website feeds
+
+The PSF Guard repository does not write to `updates.psf-guard.com`. Run the
+separate website sync after the GitHub assets pass verification. Copy
+`updater.json` and `notice.json` without changing their contents.
+
+Check both public URLs, then start or refresh a PSF Guard server. The server
+checks the notice feed at startup and caches it for 24 hours. A desktop app on
+the previous version should offer the signed update. A browser should show the
+notice but must not offer an install action.
+
+Record the tag SHA, workflow run, release URL, downloaded checks, and website
+feed checks in the release issue or operator notes.

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,44 @@
+# PSF Guard 0.6.0
+
+This release makes PSF Guard a full image catalog and review tool. It can build
+a catalog from FITS folders, use an existing Target Scheduler catalog, or keep
+two PSF Guard systems in sync.
+
+## Highlights
+
+- Import FITS folders into new or existing catalogs. PSF Guard derives targets,
+  projects, exposure plans, and templates from headers, then fills in slower
+  quality data in the background.
+- Export accepted light frames for other processing tools, with dry-run review
+  and optional calibration-frame selection.
+- Build per-filter stack previews, inspect the full-resolution result, and make
+  LRGB, RGB, OSC, or narrowband color previews. Stretch stages, background
+  removal, palette choice, and optional deconvolution remain editable.
+- Manage dark, flat, and bias frames by camera, telescope, filter, binning,
+  exposure, temperature, and date.
+- Predict satellite crossings on solved images and compare bright trail paths
+  with the pixels.
+- Pull projects and captures from another catalog, push grades and plans back,
+  or sync two running PSF Guard servers. Preview remains the default before any
+  write.
+- Install and manage Seiza star and astrometry catalogs from Settings.
+- Find active projects faster with recent-frame highlights, target and project
+  search, keyboard navigation, multi-select, and image-centered pinch zoom.
+
+## Performance and packaging
+
+- Star detection now uses the pure-Rust `seiza-imgproc` path instead of OpenCV,
+  with faster N.I.N.A. and HocusFocus processing and no OpenCV runtime package.
+- The app has refreshed icons and branding on every desktop platform.
+- Desktop releases now include signed Tauri updater payloads. The app and server
+  check a cached release notice; only the desktop app can install an update.
+
+## Download choices
+
+- Windows: NSIS setup or MSI, plus a stand-alone CLI.
+- macOS: DMG or zipped app, plus a stand-alone CLI.
+- Linux: Debian package, AppImage, Fedora RPM, or a stand-alone CLI.
+- Server: Docker image or the same CLI binary in `server` mode.
+
+Back up a Target Scheduler database before the first write. Import, export, and
+sync show a preview before wider changes.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -7,7 +7,7 @@
 %global debug_package %{nil}
 
 Name:           psf-guard
-Version:        0.5.0
+Version:        0.6.0
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -90,6 +90,10 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.0-1
+- Add FITS catalog import and export, stack and color previews, calibration
+  libraries, satellite trail checks, remote sync, and signed desktop updates
+
 * Sun Jul 19 2026 Yann Ramin <github@theatr.us> - 0.5.0-1
 - Add Seiza plate solving, astrometry overlays and evidence, off-target
   sequence grading, and astrometry-aware regrading

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -1,0 +1,63 @@
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+function capture(text, pattern, label) {
+  const match = text.match(pattern);
+  if (!match) throw new Error(`Could not read ${label}.`);
+  return match[1];
+}
+
+export async function checkReleaseVersion(repositoryRoot, expectedTag) {
+  const [cargoToml, cargoLock, tauriConfig, rpmSpec] = await Promise.all([
+    readFile(path.join(repositoryRoot, 'Cargo.toml'), 'utf8'),
+    readFile(path.join(repositoryRoot, 'Cargo.lock'), 'utf8'),
+    readFile(path.join(repositoryRoot, 'tauri.conf.json'), 'utf8'),
+    readFile(path.join(repositoryRoot, 'packaging/rpm/psf-guard.spec'), 'utf8'),
+  ]);
+
+  const packageSection = capture(
+    cargoToml,
+    /^\[package\]\s*\n([\s\S]*?)(?=\n\[|$)/,
+    'the Cargo package section',
+  );
+  const cargoVersion = capture(packageSection, /^version\s*=\s*"([^"]+)"/m, 'Cargo.toml version');
+  const lockPackage = cargoLock
+    .split('[[package]]')
+    .find((block) => /^name = "psf-guard"$/m.test(block));
+  if (!lockPackage) throw new Error('Could not find psf-guard in Cargo.lock.');
+  const lockVersion = capture(lockPackage, /^version = "([^"]+)"$/m, 'Cargo.lock version');
+  const tauriVersion = JSON.parse(tauriConfig).version;
+  const rpmVersion = capture(rpmSpec, /^Version:\s*(\S+)$/m, 'RPM version');
+
+  const versions = new Map([
+    ['Cargo.toml', cargoVersion],
+    ['Cargo.lock', lockVersion],
+    ['tauri.conf.json', tauriVersion],
+    ['RPM spec', rpmVersion],
+  ]);
+  const mismatches = [...versions].filter(([, version]) => version !== cargoVersion);
+  if (mismatches.length > 0) {
+    const detail = [...versions].map(([file, version]) => `${file}=${version}`).join(', ');
+    throw new Error(`Release versions do not match: ${detail}`);
+  }
+
+  const tag = `v${cargoVersion}`;
+  if (expectedTag && expectedTag !== tag) {
+    throw new Error(`Release tag ${expectedTag} does not match ${tag}.`);
+  }
+  const notesPath = path.join(repositoryRoot, 'docs/releases', `${tag}.md`);
+  const notes = await stat(notesPath);
+  if (!notes.isFile() || notes.size === 0) {
+    throw new Error(`Release notes are missing or empty: ${notesPath}`);
+  }
+  return cargoVersion;
+}
+
+async function main() {
+  const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const version = await checkReleaseVersion(repositoryRoot, process.argv[2]);
+  process.stdout.write(`${version}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) await main();

--- a/scripts/check-release-version.test.mjs
+++ b/scripts/check-release-version.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { checkReleaseVersion } from './check-release-version.mjs';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('release versions and notes agree', async () => {
+  const version = await checkReleaseVersion(repositoryRoot);
+  assert.match(version, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+  assert.equal(await checkReleaseVersion(repositoryRoot, `v${version}`), version);
+});
+
+test('rejects a tag that does not match the package version', async () => {
+  await assert.rejects(
+    checkReleaseVersion(repositoryRoot, 'v9.9.9'),
+    /does not match v/,
+  );
+});

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 #[derive(Parser)]
 #[command(name = "psf-guard")]
+#[command(version)]
 #[command(about = "PSF Guard: Astronomical image analysis and quality assessment tool", long_about = None)]
 pub struct Cli {
     #[arg(short, long, default_value = "schedulerdb.sqlite")]
@@ -1053,6 +1054,17 @@ impl PregenerationConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn version_flag_reports_package_version() {
+        let error = match Cli::try_parse_from(["psf-guard", "--version"]) {
+            Ok(_) => panic!("--version should exit after printing the package version"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayVersion);
+        assert!(error.to_string().contains(env!("CARGO_PKG_VERSION")));
+    }
 
     #[test]
     fn test_statistical_options_to_grading_config_disabled() {

--- a/static/package-lock.json
+++ b/static/package-lock.json
@@ -19,7 +19,7 @@
         "react-dom": "^19.1.1",
         "react-hotkeys-hook": "^5.1.0",
         "react-intersection-observer": "^9.16.0",
-        "react-router-dom": "^7.12.0",
+        "react-router-dom": "^7.18.1",
         "react-window": "^1.8.10"
       },
       "devDependencies": {
@@ -4733,9 +4733,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4755,12 +4755,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/static/package.json
+++ b/static/package.json
@@ -9,7 +9,7 @@
     "build:prod": "npm run build && cp -r dist/* ../dist/static/",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:release": "node --test ../scripts/release-feeds.test.mjs",
+    "test:release": "node --test ../scripts/check-release-version.test.mjs ../scripts/release-feeds.test.mjs",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
@@ -29,7 +29,7 @@
     "react-dom": "^19.1.1",
     "react-hotkeys-hook": "^5.1.0",
     "react-intersection-observer": "^9.16.0",
-    "react-router-dom": "^7.12.0",
+    "react-router-dom": "^7.18.1",
     "react-window": "^1.8.10"
   },
   "devDependencies": {

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -53,7 +53,7 @@ export default function ImageCard({
         { imageId: image.id, kind: 'preview', size: 'large', color }
       );
     }
-  }, [isSelected, image.id, dbId, selectionEffects]);
+  }, [isSelected, image.id, dbId, selectionEffects, color]);
 
   const getStatusClass = () => {
     switch (image.grading_status) {

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -265,7 +265,7 @@ export default function ImageComparisonView({
       setUseLeftOriginal(true);
     }
     // Never switch back from original to large
-  }, [leftZoom, leftImageId, showStars, leftImage, leftOriginalLoaded, dbId, maxStars]);
+  }, [leftZoom, leftImageId, showStars, leftImage, leftOriginalLoaded, dbId, maxStars, color]);
   
   // Load original dimensions from metadata if available
   useEffect(() => {
@@ -336,6 +336,7 @@ export default function ImageComparisonView({
     useLeftOriginal,
     dbId,
     maxStars,
+    color,
   ]);
   
   // Effect to make right image follow left image's resolution choice
@@ -354,7 +355,7 @@ export default function ImageComparisonView({
     setLoadedLeftSrc(null);
     leftDimensionsRef.current = { width: 0, height: 0 };
     leftImageStateRef.current = 'large';
-  }, [leftImageId, showStars]);
+  }, [leftImageId, showStars, color]);
   
   useLayoutEffect(() => {
     setRightOriginalLoaded(false);
@@ -363,7 +364,7 @@ export default function ImageComparisonView({
     setLoadedRightSrc(null);
     rightDimensionsRef.current = { width: 0, height: 0 };
     rightImageStateRef.current = 'large';
-  }, [rightImageId, showStars]);
+  }, [rightImageId, showStars, color]);
 
   // Sync zoom states when syncZoom is enabled
   useEffect(() => {

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -348,7 +348,18 @@ export default function ImageDetailView({
       setUseOriginalImage(true);
     }
     // Never switch back from original to large
-  }, [zoom, imageId, showStars, showPsf, image, isOriginalLoaded, dbId, maxStars, mainImageKey]);
+  }, [
+    zoom,
+    imageId,
+    showStars,
+    showPsf,
+    image,
+    isOriginalLoaded,
+    dbId,
+    maxStars,
+    mainImageKey,
+    colorPreview,
+  ]);
   
   // Reset preload state when image changes. Deliberately does NOT touch the
   // zoom state: in 'user' view mode the zoom/pan carries over to the next

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
## Summary

- bump the Rust package, Tauri app, lockfile, and RPM to 0.6.0
- add v0.6.0 notes and an operator release guide
- require matching versions, tag, and notes before release builds; publish the versioned notes as the release body
- fix the duplicate `reqwest` entry on main, add CLI `--version`, update React Router, and fix stale color-preview effect dependencies

## Local checks

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked` (439 passed, 5 ignored, plus all integration suites)
- `cargo build --release --locked --bin psf-guard-cli`; packaged CLI reports `psf-guard 0.6.0`
- `cargo tauri build --debug --no-bundle`
- Node 24: ESLint, 35 Vitest files / 162 tests, TypeScript and Vite production build
- release metadata and feed tests (5 passed)
- Playwright (65 passed)
- workflow YAML parse and `git diff --check`

## Audit note

`npm audit --omit=dev` still reports GHSA-qwww-vcr4-c8h2 in React Router RSC server-action handling. React Router 7.18.1 has no compatible fix and this app uses `createHashRouter`, not RSC or server actions.

This PR prepares the release only. Tag `v0.6.0` after this exact change passes review, merges, and the guarded release steps are complete.