### PR TITLE
fix: repair Windows release packaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/v0.6.1.md
+++ b/docs/releases/v0.6.1.md
@@ -1,0 +1,45 @@
+# PSF Guard 0.6.1
+
+This is the first public build of the 0.6 series. It replaces the v0.6.0 tag,
+whose Windows package job stopped before GitHub published a release.
+
+## Highlights
+
+- Import FITS folders into new or existing catalogs. PSF Guard derives targets,
+  projects, exposure plans, and templates from headers, then fills in slower
+  quality data in the background.
+- Export accepted light frames for other processing tools, with dry-run review
+  and optional calibration-frame selection.
+- Build per-filter stack previews, inspect the full-resolution result, and make
+  LRGB, RGB, OSC, or narrowband color previews. Stretch stages, background
+  removal, palette choice, and optional deconvolution remain editable.
+- Manage dark, flat, and bias frames by camera, telescope, filter, binning,
+  exposure, temperature, and date.
+- Predict satellite crossings on solved images and compare bright trail paths
+  with the pixels.
+- Pull projects and captures from another catalog, push grades and plans back,
+  or sync two running PSF Guard servers. Preview remains the default before any
+  write.
+- Install and manage Seiza star and astrometry catalogs from Settings.
+- Find active projects faster with recent-frame highlights, target and project
+  search, keyboard navigation, multi-select, and image-centered pinch zoom.
+
+## Performance and packaging
+
+- Star detection now uses the pure-Rust `seiza-imgproc` path instead of OpenCV,
+  with faster N.I.N.A. and HocusFocus processing and no OpenCV runtime package.
+- The app has refreshed icons and branding on every desktop platform.
+- Desktop releases include signed Tauri updater payloads. The app and server
+  check a cached release notice; only the desktop app can install an update.
+- Windows release packaging now writes its signed updater build configuration
+  correctly when GitHub supplies a drive-letter path.
+
+## Download choices
+
+- Windows: NSIS setup or MSI, plus a stand-alone CLI.
+- macOS: DMG or zipped app, plus a stand-alone CLI.
+- Linux: Debian package, AppImage, Fedora RPM, or a stand-alone CLI.
+- Server: Docker image or the same CLI binary in `server` mode.
+
+Back up a Target Scheduler database before the first write. Import, export, and
+sync show a preview before wider changes.

--- a/docs/releases/v0.6.1.md
+++ b/docs/releases/v0.6.1.md
@@ -1,7 +1,7 @@
 # PSF Guard 0.6.1
 
 This is the first public build of the 0.6 series. It replaces the v0.6.0 tag,
-whose Windows package job stopped before GitHub published a release.
+whose Windows package job failed after GitHub published a partial release.
 
 ## Highlights
 

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -7,7 +7,7 @@
 %global debug_package %{nil}
 
 Name:           psf-guard
-Version:        0.6.0
+Version:        0.6.1
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -90,6 +90,9 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.1-1
+- Fix Windows release packaging and publish the 0.6 feature set
+
 * Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.0-1
 - Add FITS catalog import and export, stack and color previews, calibration
   libraries, satellite trail checks, remote sync, and signed desktop updates

--- a/scripts/release-feeds.test.mjs
+++ b/scripts/release-feeds.test.mjs
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 import { buildReleaseFeeds } from './release-feeds.mjs';
 import { writeUpdaterConfig } from './write-updater-config.mjs';
+
+const execFileAsync = promisify(execFile);
 
 test('normal and signed builds use website-first updater endpoints', async () => {
   const mainConfig = JSON.parse(await readFile(
@@ -23,6 +28,18 @@ test('normal and signed builds use website-first updater endpoints', async () =>
   const buildConfig = JSON.parse(await readFile(outputPath, 'utf8'));
   assert.equal(buildConfig.bundle.createUpdaterArtifacts, true);
   assert.deepEqual(buildConfig.plugins.updater, mainConfig.plugins.updater);
+});
+
+test('updater config command writes its output', async (t) => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'psf-guard-updater-cli-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const outputPath = path.join(directory, 'updater-config.json');
+  const scriptPath = fileURLToPath(new URL('./write-updater-config.mjs', import.meta.url));
+
+  await execFileAsync(process.execPath, [scriptPath, outputPath]);
+
+  const config = JSON.parse(await readFile(outputPath, 'utf8'));
+  assert.equal(config.bundle.createUpdaterArtifacts, true);
 });
 
 test('builds signed updater and server notice feeds', async () => {

--- a/scripts/write-updater-config.mjs
+++ b/scripts/write-updater-config.mjs
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -29,7 +29,7 @@ export async function writeUpdaterConfig(outputPath, overlayPath) {
   await writeFile(outputPath, `${JSON.stringify(config, null, 2)}\n`);
 }
 
-if (import.meta.url === new URL(process.argv[1], 'file:').href) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   const [outputPath, overlayPath] = process.argv.slice(2);
   if (!outputPath) {
     throw new Error('Usage: node scripts/write-updater-config.mjs OUTPUT [OVERLAY]');

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
## Summary

- use `pathToFileURL` for the updater-config CLI entry point so Windows drive-letter paths execute the script
- add a spawned-process regression test that requires the CLI to write its output
- prepare v0.6.1 as the complete 0.6 release because v0.6.0 published without Windows packages

## Failure evidence

The v0.6.0 Windows release job passed signing, metadata checks, and the release CLI build, then failed because `psf-guard-updater.json` did not exist. The old ESM entry-point comparison returned false on Windows, so the writer exited successfully without writing a file. GitHub had already published a partial v0.6.0 release from the other platform jobs.

## Local checks

- release metadata and feed tests: 6 passed
- `node scripts/check-release-version.mjs v0.6.1`
- `cargo check --locked --all-targets --all-features`
- `cargo fmt --all -- --check`
- workflow YAML parse
- `git diff --check`