### PR TITLE
Release v0.6.2 with correct Apple Silicon asset name

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -93,7 +93,7 @@ All releases now include both CLI binaries and desktop applications:
 ### CLI Binaries
 - `psf-guard-linux-x64` - Standalone Linux binary
 - `psf-guard-windows-x64.exe` - Standalone Windows binary
-- `psf-guard-macos-x64` - Standalone macOS binary
+- `psf-guard-macos-arm64` - Standalone Apple Silicon macOS binary
 
 ### Desktop Applications
 - **Linux**: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       uses: actions/upload-artifact@v7
       with:
-        name: psf-guard-macos-x64
+        name: psf-guard-macos-arm64
         path: target/release/psf-guard
 
   e2e:
@@ -348,7 +348,7 @@ jobs:
       if: matrix.os == 'macos-latest' && github.event_name != 'pull_request'
       uses: actions/upload-artifact@v7
       with:
-        name: psf-guard-tauri-macos-x64
+        name: psf-guard-tauri-macos-arm64
         path: |
           target/release/bundle/dmg/*.dmg
           target/release/bundle/macos/*.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
             asset_name: psf-guard-windows-x64.exe
           - os: macos-latest
             artifact_name: psf-guard-cli
-            asset_name: psf-guard-macos-x64
+            asset_name: psf-guard-macos-arm64
 
     steps:
     - uses: actions/checkout@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ These version-independent links point at the latest release:
 | Platform | Download | Notes |
 |----------|----------|-------|
 | Linux x64 | [`psf-guard-linux-x64`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-linux-x64) | Self-contained binary |
-| macOS | [`psf-guard-macos-x64`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-macos-x64) | Self-contained binary |
+| macOS (Apple Silicon) | [`psf-guard-macos-arm64`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-macos-arm64) | Self-contained binary |
 | Windows x64 | [`psf-guard-windows-x64.exe`](https://github.com/theatrus/psf-guard/releases/latest/download/psf-guard-windows-x64.exe) | Static binary, no dependencies |
 
 PSF Guard checks for newer releases without sending catalog or image data. The

--- a/docs/releases/v0.6.2.md
+++ b/docs/releases/v0.6.2.md
@@ -1,0 +1,16 @@
+# PSF Guard 0.6.2
+
+This patch release corrects the name of the stand-alone macOS CLI download.
+GitHub's `macos-latest` runner builds an Apple Silicon binary, so the public
+asset is now named `psf-guard-macos-arm64` instead of `psf-guard-macos-x64`.
+
+The desktop updater was already correct: its Apple Silicon package and
+`darwin-aarch64` manifest entry keep the same names. Windows, Linux, RPM,
+Docker, and server builds are unchanged from 0.6.1.
+
+## Download choices
+
+- Windows: NSIS setup or MSI, plus a stand-alone CLI.
+- macOS: DMG or zipped Apple Silicon app, plus a stand-alone Apple Silicon CLI.
+- Linux: Debian package, AppImage, Fedora RPM, or a stand-alone CLI.
+- Server: Docker image or the same CLI binary in `server` mode.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -7,7 +7,7 @@
 %global debug_package %{nil}
 
 Name:           psf-guard
-Version:        0.6.1
+Version:        0.6.2
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -90,6 +90,9 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.2-1
+- Label the Apple Silicon standalone CLI with its correct architecture
+
 * Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.1-1
 - Fix Windows release packaging and publish the 0.6 feature set
 

--- a/scripts/release-feeds.test.mjs
+++ b/scripts/release-feeds.test.mjs
@@ -11,6 +11,22 @@ import { writeUpdaterConfig } from './write-updater-config.mjs';
 
 const execFileAsync = promisify(execFile);
 
+test('labels macOS artifacts as Apple Silicon', async () => {
+  const releaseWorkflow = await readFile(
+    new URL('../.github/workflows/release.yml', import.meta.url),
+    'utf8',
+  );
+  const ciWorkflow = await readFile(
+    new URL('../.github/workflows/ci.yml', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(releaseWorkflow, /asset_name: psf-guard-macos-arm64/);
+  assert.doesNotMatch(releaseWorkflow, /asset_name: psf-guard-macos-x64/);
+  assert.match(ciWorkflow, /name: psf-guard-macos-arm64/);
+  assert.match(ciWorkflow, /name: psf-guard-tauri-macos-arm64/);
+});
+
 test('normal and signed builds use website-first updater endpoints', async () => {
   const mainConfig = JSON.parse(await readFile(
     new URL('../tauri.conf.json', import.meta.url),

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
## Summary
- label the standalone macOS CLI as `psf-guard-macos-arm64`
- update CI artifact names and download docs for the Apple Silicon-only build
- add a regression test that rejects the old `macos-x64` release label
- bump release metadata and add v0.6.2 notes

## Why
Public verification of v0.6.1 showed that `psf-guard-macos-x64` is a Mach-O arm64 binary. The desktop updater already uses the correct `darwin-aarch64` label. This patch fixes the standalone CLI name without adding an Intel build.

## Validation
- `node --test scripts/check-release-version.test.mjs scripts/release-feeds.test.mjs`
- `node scripts/check-release-version.mjs v0.6.2`
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- workflow YAML parse
- `git diff --check`