### PR TITLE
Offer building a catalog from images on first run

### DIFF
--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -15,7 +15,10 @@ a trusted interface and opt in:
 psf-guard server --host 127.0.0.1 --allow-database-management
 ```
 
-Then open **Settings** and choose **New Database from Images**.
+Then open **Settings** and choose **New Database from Images**. On a first run
+PSF Guard has no catalogs yet, so it opens Settings for you and the welcome
+banner offers this alongside **Add Existing Database**. The overview's empty
+state offers the same two starting points.
 
 ![New Database from Images form](import-from-images.png)
 

--- a/static/e2e/add-database.spec.ts
+++ b/static/e2e/add-database.spec.ts
@@ -11,6 +11,12 @@ test('add a database via settings → see it in the Overview', async ({ page }) 
   // Wait for settings to auto-open (gated on a couple of async API calls).
   await page.getByRole('heading', { name: /Welcome to PSF Guard/i }).waitFor();
 
+  // First run offers two starting points and picks neither for you.
+  await page
+    .locator('.tauri-settings')
+    .getByRole('button', { name: /Add Existing Database/i })
+    .click();
+
   // The form is now visible. Fill the inputs.
   await page
     .getByPlaceholder('e.g. Imaging Rig (defaults to filename)')
@@ -55,6 +61,10 @@ test('add a database via settings → see it in the Overview', async ({ page }) 
 test('add then remove a database', async ({ page }) => {
   await page.goto('/');
   await page.getByRole('heading', { name: /Welcome to PSF Guard/i }).waitFor();
+  await page
+    .locator('.tauri-settings')
+    .getByRole('button', { name: /Add Existing Database/i })
+    .click();
 
   await page.getByPlaceholder('Select or enter database path').fill(fixtureDbPath());
   // The backend rejects a DB without image dirs, so populate one.
@@ -73,9 +83,14 @@ test('add then remove a database', async ({ page }) => {
   await row.getByRole('button', { name: 'Remove' }).click();
 
   // After removing the only DB, the registry is empty again and the welcome
-  // banner + add form reappear.
+  // banner returns with both starting points on offer.
   await expect(page.getByText(/Removed/i)).toBeVisible();
   await expect(
     page.getByRole('heading', { name: /Welcome to PSF Guard/i })
+  ).toBeVisible();
+  await expect(
+    page
+      .locator('.tauri-settings')
+      .getByRole('button', { name: /New Database from Images/i })
   ).toBeVisible();
 });

--- a/static/e2e/empty-state.spec.ts
+++ b/static/e2e/empty-state.spec.ts
@@ -19,19 +19,77 @@ test('overview shows the empty-state when no databases are configured', async ({
   await expect(
     page.getByRole('heading', { name: 'No databases configured' })
   ).toBeVisible();
+  // Both starting points are offered here, not just "open an existing
+  // N.I.N.A. database".
+  await expect(
+    page.getByRole('button', { name: /New Database from Images/i })
+  ).toBeVisible();
   // The empty state offers an action that re-opens settings — confirm it
   // actually triggers the modal again.
-  await page.getByRole('button', { name: /Open Settings/i }).click();
+  await page.getByRole('button', { name: /Add Existing Database/i }).click();
   await expect(
     page.getByRole('heading', { name: /Welcome to PSF Guard/i })
+  ).toBeVisible();
+});
+
+test('first run offers importing images as well as opening a N.I.N.A. database', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await expect(
+    page.getByRole('heading', { name: /Welcome to PSF Guard/i })
+  ).toBeVisible();
+
+  // Both choices sit in the welcome banner, above the fold. This is the whole
+  // point: the import path used to live below a catalog-install panel and two
+  // "add a catalog first" dead ends, so a first-time user never saw it.
+  // Scope to the modal: the overview's own empty state sits behind it and
+  // offers the same two choices.
+  const modal = page.locator('.tauri-settings');
+  const create = modal.getByRole('button', { name: /New Database from Images/i });
+  const add = modal.getByRole('button', { name: /Add Existing Database/i });
+  await expect(create).toBeVisible();
+  await expect(add).toBeVisible();
+
+  // Nothing that needs a database to be useful should be in the way.
+  await expect(
+    modal.getByText('Add a catalog before syncing with a remote PSF Guard.')
+  ).toBeHidden();
+  await expect(
+    modal.getByText('Add a second catalog to merge data or send planning and grades.')
+  ).toBeHidden();
+
+  // The import choice opens the create form, which asks for image folders
+  // rather than an existing database file.
+  await create.click();
+  await expect(
+    modal.getByRole('heading', { name: 'New Database from Images' })
+  ).toBeVisible();
+  await expect(modal.getByText('N.I.N.A. Database File:')).toBeHidden();
+  await expect(modal.getByText('Image Directories:')).toBeVisible();
+});
+
+test('the overview import action opens settings on the create form', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await page.getByRole('heading', { name: /Welcome to PSF Guard/i }).waitFor();
+  await page.getByRole('button', { name: 'Done' }).click();
+  await page.getByRole('heading', { name: 'No databases configured' }).waitFor();
+
+  // The intent rides along with the open-settings event, so the user lands on
+  // the form they asked for instead of hunting for it again.
+  await page.getByRole('button', { name: /New Database from Images/i }).click();
+  await expect(
+    page.getByRole('heading', { name: 'New Database from Images' })
   ).toBeVisible();
 });
 
 test('header Settings button is present in browser mode', async ({ page }) => {
   await page.goto('/');
   // Wait for the auto-popup to appear, then close it so we can find the
-  // header button beneath. Use `exact: true` because the overview's empty
-  // state also has an "Open Settings" button.
+  // header button beneath. `exact: true` keeps this off any other control
+  // whose name merely contains "Settings".
   await page.getByRole('heading', { name: /Welcome to PSF Guard/i }).waitFor();
   await page.getByRole('button', { name: 'Done' }).click();
   await expect(

--- a/static/src/App.tsx
+++ b/static/src/App.tsx
@@ -12,6 +12,11 @@ import AggregatedCacheStatus from './components/AggregatedCacheStatus';
 import TauriSettings from './components/TauriSettings';
 import { useGridState } from './hooks/useUrlState';
 import { isTauriApp, tauriConfig } from './utils/tauri';
+import {
+  OPEN_SETTINGS_EVENT,
+  settingsIntentOf,
+  type SettingsIntent,
+} from './utils/settingsIntent';
 import { apiClient } from './api/client';
 import './App.css';
 
@@ -32,6 +37,11 @@ function App() {
     location.search ? `${path}${location.search}` : path;
   const [showHelp, setShowHelp] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  // Which form the settings modal should land on. Set by whoever asked for
+  // the modal; read once when it mounts.
+  const [settingsIntent, setSettingsIntent] = useState<SettingsIntent | null>(
+    null
+  );
   // We track this only to short-circuit checks against Tauri-only commands;
   // the modal itself is shown regardless of mode.
   const [, setIsTauri] = useState(false);
@@ -81,13 +91,16 @@ function App() {
 
     // Let any component request opening settings via a window event (e.g.
     // the Overview empty-state button).
-    const openHandler = () => setShowSettings(true);
-    window.addEventListener('psf-guard:open-settings', openHandler);
+    const openHandler = (event: Event) => {
+      setSettingsIntent(settingsIntentOf(event));
+      setShowSettings(true);
+    };
+    window.addEventListener(OPEN_SETTINGS_EVENT, openHandler);
 
     return () => {
       cancelled = true;
       clearTimeout(handle);
-      window.removeEventListener('psf-guard:open-settings', openHandler);
+      window.removeEventListener(OPEN_SETTINGS_EVENT, openHandler);
     };
   }, []);
 
@@ -207,7 +220,11 @@ function App() {
       {showSettings && (
         <TauriSettings
           isOpen={showSettings}
-          onClose={() => setShowSettings(false)}
+          initialIntent={settingsIntent}
+          onClose={() => {
+            setShowSettings(false);
+            setSettingsIntent(null);
+          }}
         />
       )}
     </div>

--- a/static/src/components/Overview.css
+++ b/static/src/components/Overview.css
@@ -20,6 +20,13 @@
   color: var(--color-text-muted);
 }
 
+.overview-empty-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
 /* Compact catalog summary */
 .overview-summary {
   display: grid;

--- a/static/src/components/Overview.tsx
+++ b/static/src/components/Overview.tsx
@@ -16,6 +16,7 @@ import {
   type WithDb,
 } from '../hooks/useDatabases';
 import { isTauriApp, tauriFileSystem } from '../utils/tauri';
+import { openSettings } from '../utils/settingsIntent';
 import {
   loadProjectSeenState,
   markerForProject,
@@ -359,13 +360,24 @@ export default function Overview() {
         <h2>No databases configured</h2>
         {managementAllowed ? (
           <>
-            <p>Add a N.I.N.A. scheduler database to get started.</p>
-            <button
-              className="action-button primary"
-              onClick={() => window.dispatchEvent(new CustomEvent('psf-guard:open-settings'))}
-            >
-              Open Settings
-            </button>
+            <p>
+              Build a catalog from folders of FITS images, or open a N.I.N.A.
+              scheduler database you already have.
+            </p>
+            <div className="overview-empty-actions">
+              <button
+                className="action-button primary"
+                onClick={() => openSettings('create')}
+              >
+                New Database from Images
+              </button>
+              <button
+                className="action-button"
+                onClick={() => openSettings('add')}
+              >
+                Add Existing Database
+              </button>
+            </div>
           </>
         ) : (
           <>

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -95,6 +95,36 @@
   line-height: 1.5;
 }
 
+.tauri-settings .welcome-choices {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tauri-settings .welcome-choices .add-directory-button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  text-align: left;
+  width: auto;
+  flex: 1;
+  min-width: 240px;
+  padding: 12px 14px;
+  white-space: normal;
+}
+
+.tauri-settings .welcome-choice-title {
+  font-weight: 600;
+}
+
+.tauri-settings .welcome-choice-detail {
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.4;
+  opacity: 0.85;
+}
+
 .tauri-settings .welcome-message ul {
   margin: 0;
   padding-left: 20px;

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { isTauriApp, tauriConfig, tauriFileSystem } from '../utils/tauri';
 import type { DbEntry, DbRegistry } from '../utils/tauri';
 import { apiClient } from '../api/client';
+import type { SettingsIntent } from '../utils/settingsIntent';
 import type { DatabaseSummary } from '../api/types';
 import { describeImportProgress, useImportJob } from '../hooks/useImportJob';
 import QualityBackfillControls from './QualityBackfillControls';
@@ -15,6 +16,12 @@ import './TauriSettings.css';
 interface TauriSettingsProps {
   isOpen: boolean;
   onClose: () => void;
+  /**
+   * Form to land on when the modal opens. Lets the overview's empty state
+   * send the user straight to "add an existing database" or "build one from
+   * image folders" instead of dropping them at the top of the modal.
+   */
+  initialIntent?: SettingsIntent | null;
 }
 
 /**
@@ -32,7 +39,11 @@ interface TauriSettingsProps {
  *   same UI is usable when the server was launched via `psf-guard server`.
  *   The file pickers degrade to plain text inputs.
  */
-export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
+export default function TauriSettings({
+  isOpen,
+  onClose,
+  initialIntent = null,
+}: TauriSettingsProps) {
   const isTauri = isTauriApp();
   const queryClient = useQueryClient();
   const { data: serverInfo } = useQuery({
@@ -157,15 +168,17 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
         setConfirmImport(runningImport);
       }
 
-      // If empty AND we're allowed to mutate, default to showing the add
-      // form so the welcome flow lands somewhere usable.
-      setShowAddForm((!reg || reg.databases.length === 0) && managementAllowed);
+      // Deliberately no form is forced open on an empty registry. Doing that
+      // picked "add an existing N.I.N.A. database" for the user and, because
+      // the choice buttons hide behind an open form, removed "build one from
+      // image folders" from the first run altogether. The welcome banner
+      // offers both instead.
     } catch (err) {
       console.error('Failed to load registry:', err);
     } finally {
       setIsLoading(false);
     }
-  }, [isTauri, managementAllowed]);
+  }, [isTauri]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -250,6 +263,15 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
       }
     }
   };
+
+  // Land on the form the caller asked for. This runs once, at mount: App
+  // unmounts the modal when it closes, so re-opening with a fresh intent
+  // mounts a fresh component and the effect fires again.
+  useEffect(() => {
+    if (initialIntent === 'create') startCreate();
+    if (initialIntent === 'add') void startAdd();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handlePickDbPath = async () => {
     if (!isTauri) {
@@ -558,7 +580,40 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
           {!hasDatabases && managementAllowed && (
             <div className="welcome-message">
               <h3>🚀 Welcome to PSF Guard!</h3>
-              <p>Configure one or more N.I.N.A. scheduler databases to get started.</p>
+              <p>
+                Start from folders of FITS images, or from a N.I.N.A. scheduler
+                database you already have. You can add more catalogs later.
+              </p>
+              {!showAddForm && (
+                <div className="welcome-choices">
+                  <button
+                    className="add-directory-button"
+                    onClick={startCreate}
+                    disabled={isApplying}
+                  >
+                    <span className="welcome-choice-title">
+                      ✨ New Database from Images
+                    </span>
+                    <span className="welcome-choice-detail">
+                      Pick folders of FITS files. PSF Guard builds a Target
+                      Scheduler database and imports them.
+                    </span>
+                  </button>
+                  <button
+                    className="add-directory-button"
+                    onClick={startAdd}
+                    disabled={isApplying}
+                  >
+                    <span className="welcome-choice-title">
+                      + Add Existing Database
+                    </span>
+                    <span className="welcome-choice-detail">
+                      Open a N.I.N.A. Target Scheduler database and point it at
+                      your image folders.
+                    </span>
+                  </button>
+                </div>
+              )}
             </div>
           )}
 
@@ -581,7 +636,10 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
 
           {managementAllowed && <SeizaCatalogControls />}
 
-          {managementAllowed && (
+          {/* Both panels can only say "add a catalog first" until one exists.
+              On a first run that is two dead ends between the welcome banner
+              and the buttons that actually do something. */}
+          {managementAllowed && hasDatabases && (
             <>
               <SchedulerSyncControls databases={databases} disabled={isApplying} />
               <RemotePeerSync databases={databases} disabled={isApplying} />
@@ -655,7 +713,9 @@ export default function TauriSettings({ isOpen, onClose }: TauriSettingsProps) {
               </div>
             ))}
 
-            {managementAllowed && !showAddForm && (
+            {/* With no databases yet the welcome banner carries these same two
+                actions, so rendering them here too would just duplicate them. */}
+            {managementAllowed && hasDatabases && !showAddForm && (
               <div className="db-add-buttons">
                 <button
                   className="add-directory-button"

--- a/static/src/components/__tests__/TauriSettings.test.tsx
+++ b/static/src/components/__tests__/TauriSettings.test.tsx
@@ -253,3 +253,85 @@ describe('TauriSettings import state', () => {
     expect(screen.getByRole('button', { name: 'Copy' })).toBeEnabled();
   });
 });
+
+describe('TauriSettings first run', () => {
+  function serveEmptyRegistry() {
+    server.use(
+      http.get('/api/info', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            version: 'test',
+            cache_directory: '/tmp/cache',
+            allow_database_management: true,
+          },
+          error: null,
+          status: 'ready',
+        })
+      ),
+      http.get('/api/databases', () =>
+        HttpResponse.json({
+          success: true,
+          data: [],
+          error: null,
+          status: 'ready',
+        })
+      )
+    );
+  }
+
+  it('offers importing images as well as opening an existing database', async () => {
+    serveEmptyRegistry();
+
+    render(<TauriSettings isOpen onClose={() => undefined} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(
+      await screen.findByRole('button', { name: /New Database from Images/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Add Existing Database/ })
+    ).toBeInTheDocument();
+
+    // Nothing that needs an existing catalog should sit between the welcome
+    // banner and those two buttons.
+    expect(
+      screen.queryByText('Add a catalog before syncing with a remote PSF Guard.')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Add a second catalog to merge data or send planning and grades.'
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens straight onto the create form when the caller asks for it', async () => {
+    serveEmptyRegistry();
+
+    render(
+      <TauriSettings isOpen initialIntent="create" onClose={() => undefined} />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'New Database from Images' })
+    ).toBeInTheDocument();
+    // The create flow bootstraps its own database, so it never asks for one.
+    expect(screen.queryByText('N.I.N.A. Database File:')).not.toBeInTheDocument();
+  });
+
+  it('opens straight onto the add form when the caller asks for it', async () => {
+    serveEmptyRegistry();
+
+    render(
+      <TauriSettings isOpen initialIntent="add" onClose={() => undefined} />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Add Database' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('N.I.N.A. Database File:')).toBeInTheDocument();
+  });
+});

--- a/static/src/utils/settingsIntent.ts
+++ b/static/src/utils/settingsIntent.ts
@@ -1,0 +1,32 @@
+/**
+ * Opening the settings modal from elsewhere in the app.
+ *
+ * The modal lives in `App`, so any component that wants it open asks by
+ * window event rather than by prop drilling. The intent rides along so a
+ * caller can land the user directly on the form they asked for instead of
+ * making them find it again inside the modal.
+ */
+
+/** Which form the settings modal should open on, if any. */
+export type SettingsIntent = 'add' | 'create';
+
+export const OPEN_SETTINGS_EVENT = 'psf-guard:open-settings';
+
+export interface OpenSettingsDetail {
+  intent?: SettingsIntent;
+}
+
+/** Ask `App` to open settings, optionally on a specific form. */
+export function openSettings(intent?: SettingsIntent): void {
+  window.dispatchEvent(
+    new CustomEvent<OpenSettingsDetail>(OPEN_SETTINGS_EVENT, {
+      detail: intent ? { intent } : {},
+    })
+  );
+}
+
+/** Read the intent back off an event, tolerating a bare `dispatchEvent`. */
+export function settingsIntentOf(event: Event): SettingsIntent | null {
+  const detail = (event as CustomEvent<OpenSettingsDetail>).detail;
+  return detail?.intent ?? null;
+}


### PR DESCRIPTION
## The problem

A fresh desktop start only offered opening an existing N.I.N.A. Target Scheduler database. The "build a catalog from FITS folders" path was implemented and working, but a first-time user could not reach it.

The cause is one line in `TauriSettings`. Loading an empty registry forced the *add an existing database* form open:

```ts
setShowAddForm((!reg || reg.databases.length === 0) && managementAllowed);
```

Both choice buttons — including **✨ New Database from Images** — render only when no form is open. So the state meant to make the welcome flow "land somewhere usable" landed it on one of two choices and hid the other.

## The fix

- Stop opening a form for the user. The welcome banner names both starting points and says what each does.
- The overview's empty state offers the same two actions instead of a bare "Open Settings". An intent rides along with the `psf-guard:open-settings` event (`static/src/utils/settingsIntent.ts`), so each button lands on its own form rather than dropping the user at the top of the modal.
- Drop the scheduler-sync and remote-peer panels while no catalog exists. Both can only render "add a catalog first", and on a first run they sat between the welcome banner and the buttons that do something.
- With no databases, the buttons at the foot of the database list would duplicate the banner's, so they render only once a catalog exists.

`docs/IMPORTING.md` gains a line on where the choice appears on a first run.

## Tests

Three unit tests in `TauriSettings.test.tsx`: the first-run banner offers both paths with no dead-end sync panels, and each intent opens its own form. Three Playwright tests in `empty-state.spec.ts` cover the banner, the overview actions, and what each opens.

The two `add-database.spec.ts` tests now click **Add Existing Database** first — they had been relying on the auto-opened form, which is the behavior this PR removes.

## Checks run locally

- `npm run lint` — clean
- `npx vitest run` — 165 passed (35 files)
- `npm run build` — clean
- `npx playwright test` — 67 passed
- `cargo fmt -- --check` — clean (no Rust changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)