### PR TITLE
Prepare PSF Guard 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/v0.6.3.md
+++ b/docs/releases/v0.6.3.md
@@ -1,0 +1,20 @@
+# PSF Guard 0.6.3
+
+This patch release fixes the first-run catalog setup. A new desktop install now
+offers both ways to start:
+
+- Build a new catalog from folders of FITS images.
+- Open an existing N.I.N.A. Target Scheduler database.
+
+The overview shows the same choices when no catalog exists, and each action
+opens the right Settings form. Sync controls that need an existing catalog no
+longer crowd the first-run view.
+
+This release keeps the corrected Apple Silicon CLI name from 0.6.2.
+
+## Download choices
+
+- Windows: NSIS setup or MSI, plus a stand-alone CLI.
+- macOS: DMG or zipped Apple Silicon app, plus a stand-alone Apple Silicon CLI.
+- Linux: Debian package, AppImage, Fedora RPM, or a stand-alone CLI.
+- Server: Docker image or the same CLI binary in `server` mode.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -7,7 +7,7 @@
 %global debug_package %{nil}
 
 Name:           psf-guard
-Version:        0.6.2
+Version:        0.6.3
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -90,6 +90,9 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.3-1
+- Offer both catalog import paths on first run
+
 * Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.2-1
 - Label the Apple Silicon standalone CLI with its correct architecture
 

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
## Summary

- bump the Rust, Tauri, lockfile, and RPM versions to 0.6.3
- add release notes for the first-run catalog choices from #251
- keep the corrected Apple Silicon download names from 0.6.2

## Local checks

- `node --test scripts/release-feeds.test.mjs`
- `node scripts/check-release-version.mjs v0.6.3`
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets --all-features`
- parsed every GitHub Actions workflow as YAML
- `git diff --check`