### PR TITLE
Stop rebuilding the same tree in CI and repair the cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main, master ]
 
+# Supersede a PR's earlier run when it is pushed again. Pushes to main keep
+# running to completion — each one is a distinct commit whose result we want,
+# and main's runs are what populate the shared cargo cache.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -54,26 +61,21 @@ jobs:
       with:
         toolchain: ${{ steps.rust-toolchain.outputs.channel }}
         components: rustfmt, clippy
-    - name: Cache cargo registry
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
 
-    - name: Cache cargo index
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-
+    # Replaces three hand-rolled actions/cache steps. rust-cache prunes the
+    # workspace's own artifacts, stale objects, and incremental output before
+    # saving, so an entry is a few hundred MB rather than the 1.3-2.5 GB the
+    # raw `target` directory cost. That matters: the repo was sitting at
+    # 10.03 GB against GitHub's 10 GB limit, and macOS entries were evicted so
+    # fast that no macOS job ever started warm.
+    #
+    # Only main writes. PR runs read main's cache but never save, which stops
+    # every branch from keeping its own copy of the same 2 GB.
     - name: Cache cargo build
-      uses: actions/cache@v6
-      continue-on-error: true
+      uses: Swatinem/rust-cache@v2
       with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+        key: test
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install npm dependencies and build frontend
       run: |
@@ -90,38 +92,30 @@ jobs:
     - name: Check formatting
       run: cargo fmt -- --check
 
-    - name: Build
-      run: cargo build --verbose
-
+    # No separate `cargo build`. Clippy type-checks every target with every
+    # feature, and `cargo test` builds the binaries anyway — the integration
+    # tests reach for them through CARGO_BIN_EXE_psf-guard. The extra step
+    # cost 485s on Windows and proved nothing the other two miss.
     - name: Run clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: Run tests
       run: cargo test --verbose
 
-    - name: Build release binary
+    # Only Linux needs a release binary, because only the e2e job consumes
+    # one. Release builds its own assets from release.yml, and the Windows and
+    # macOS artifacts this job used to upload were downloaded by nothing. The
+    # release profile still gets exercised on all three platforms by
+    # `cargo tauri build` in test-tauri.
+    - name: Build release binary (Linux, for the e2e job)
+      if: matrix.os == 'ubuntu-22.04'
       run: cargo build --verbose --release
-
 
     - name: Upload artifact (Linux)
       if: matrix.os == 'ubuntu-22.04'
       uses: actions/upload-artifact@v7
       with:
         name: psf-guard-linux-x64
-        path: target/release/psf-guard
-
-    - name: Upload artifact (Windows)
-      if: matrix.os == 'windows-latest'
-      uses: actions/upload-artifact@v7
-      with:
-        name: psf-guard-windows-x64
-        path: target/release/psf-guard.exe
-
-    - name: Upload artifact (macOS)
-      if: matrix.os == 'macos-latest'
-      uses: actions/upload-artifact@v7
-      with:
-        name: psf-guard-macos-arm64
         path: target/release/psf-guard
 
   e2e:
@@ -257,33 +251,11 @@ jobs:
         toolchain: ${{ steps.rust-toolchain.outputs.channel }}
         components: rustfmt, clippy
 
-    - name: Cache cargo registry
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-tauri-${{ hashFiles('Cargo.lock') }}
-
-    - name: Cache cargo bin
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/bin
-        key: ${{ runner.os }}-cargo-bin-tauri-${{ hashFiles('Cargo.lock') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-tauri-${{ hashFiles('Cargo.lock') }}
-
     - name: Cache cargo build
-      uses: actions/cache@v6
-      continue-on-error: true
+      uses: Swatinem/rust-cache@v2
       with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-tauri-${{ hashFiles('Cargo.lock', 'tauri.conf.json') }}
+        key: tauri
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install npm dependencies and build frontend
       run: |
@@ -291,12 +263,23 @@ jobs:
         npm ci
         npm run build
 
+    # Downloads the prebuilt cargo-tauri binary (tauri-cli carries binstall
+    # metadata) rather than compiling the CLI from source, which took 603s on
+    # Windows, 356s on macOS and 331s on Linux — every run. The old
+    # `cargo install` step cached ~/.cargo/bin but not ~/.cargo/.crates.toml,
+    # where cargo records what it has installed, so cargo could never tell the
+    # binary was already there and rebuilt it every time. `continue-on-error`
+    # then hid the whole thing.
     - name: Install Tauri CLI
-      run: cargo install tauri-cli --version "^2.0" --locked
-      continue-on-error: true
+      uses: taiki-e/install-action@v2
+      with:
+        tool: tauri-cli@2
 
-    - name: Test Tauri compilation
-      run: cargo build --features tauri --verbose
+    # `cargo build --features tauri` used to run here first. It compiled the
+    # same crate with the same feature as the `cargo tauri build` below, only
+    # in the debug profile, so it shared no artifacts and proved nothing the
+    # bundle build does not. It cost 823s on Windows, 462s on Linux and 352s
+    # on macOS every run.
 
     - name: Build Tauri desktop app (Linux)
       if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,10 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,18 @@ jobs:
         toolchain: ${{ steps.rust-toolchain.outputs.channel }}
         components: rustfmt, clippy
 
+    # This workflow had no cargo cache at all, so every release compiled the
+    # whole dependency tree from cold on three platforms. Read main's cache
+    # and never write: a cache saved under a tag ref is scoped to that tag and
+    # could never be read again, so saving here would only consume the repo's
+    # 10 GB budget. Worst case this restores nothing and we are no slower than
+    # before.
+    - name: Cache cargo build
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: tauri
+        save-if: false
+
     - name: Install Node.js
       uses: actions/setup-node@v7
       with:
@@ -97,9 +109,12 @@ jobs:
         npm ci
         npm run build
 
+    # Prebuilt binary rather than a from-source build; this step alone was
+    # 594s of the 36-minute Windows release job.
     - name: Install Tauri CLI
-      run: cargo install tauri-cli --version "^2.0" --locked
-      continue-on-error: true
+      uses: taiki-e/install-action@v2
+      with:
+        tool: tauri-cli@2
 
     - name: Verify updater signing credentials
       shell: bash

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main, master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: write
 
@@ -19,7 +23,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fedora: [ '43', '44' ]
+        # One Fedora is enough. Both builds compiled the same tree from cold
+        # (no cargo cache is possible here — the spec builds from vendored
+        # sources), and 43 caught nothing 44 did not.
+        fedora: [ '44' ]
 
     steps:
       - name: Install build tooling

--- a/README.md
+++ b/README.md
@@ -329,8 +329,10 @@ Then open http://localhost:3000/.
 
 ### Fedora RPM
 
-Releases after v0.3.0 attach prebuilt RPMs for Fedora 43 and 44 to the
-[releases page](https://github.com/theatrus/psf-guard/releases/latest):
+Releases after v0.3.0 attach a prebuilt Fedora 44 RPM to the
+[releases page](https://github.com/theatrus/psf-guard/releases/latest). For
+other Fedora releases, build one with
+[`packaging/rpm/build-in-podman.sh`](packaging/rpm/README.md):
 
 ```bash
 sudo dnf install ./psf-guard-*.fc44.x86_64.rpm

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -110,5 +110,8 @@ mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/psf-guard-*.src.rpm
 2. Add a `%changelog` entry.
 3. Regenerate sources for the tag: `./scripts/make-rpm-sources.sh --ref vX.Y.Z`.
 
-CI (`.github/workflows/rpm.yml`) builds the RPMs in Fedora 43 and 44 containers
-on every push and pull request and uploads them as artifacts.
+CI (`.github/workflows/rpm.yml`) builds the RPMs in a Fedora 44 container on
+every push and pull request and uploads them as artifacts. The local
+`build-in-podman.sh` still covers other releases; CI builds one because each
+container compiles the whole tree from cold and 43 never caught anything 44
+missed.

--- a/scripts/release-feeds.test.mjs
+++ b/scripts/release-feeds.test.mjs
@@ -23,8 +23,13 @@ test('labels macOS artifacts as Apple Silicon', async () => {
 
   assert.match(releaseWorkflow, /asset_name: psf-guard-macos-arm64/);
   assert.doesNotMatch(releaseWorkflow, /asset_name: psf-guard-macos-x64/);
-  assert.match(ciWorkflow, /name: psf-guard-macos-arm64/);
+  // CI publishes one macOS artifact, from the Tauri job. It carries the
+  // bundle and target/release/psf-guard, so dropping the test job's separate
+  // macOS upload cost no binary. What matters here is the label: these
+  // runners are Apple Silicon, and calling the result x64 is the bug this
+  // test exists to catch.
   assert.match(ciWorkflow, /name: psf-guard-tauri-macos-arm64/);
+  assert.doesNotMatch(ciWorkflow, /name: psf-guard-.*macos-x64/);
 });
 
 test('normal and signed builds use website-first updater endpoints', async () => {


### PR DESCRIPTION
CI takes 45 minutes per push to main and a release 37. Measured from run 30221921955 (CI on main) and 30221940484 (the v0.6.2 release), most of that is compiling work another step already did, or work that could not be cached.

## The cache was full, so macOS never had one

```
TOTAL CACHE: 10.03 GB   ← GitHub's per-repo limit is 10 GB
macOS entries:       0
```

Four raw `target` directories accounted for 7.03 GB (Linux 2.48, Linux-tauri 1.61, Windows 1.60, Windows-tauri 1.34). Every macOS job wrote ~2 GB and LRU evicted it before the next run read it, so every macOS job in every workflow compiled from cold. Three keys appeared twice — once for main, once for a PR branch — competing for the same budget.

`Swatinem/rust-cache` replaces nine hand-rolled `actions/cache` steps. It prunes the workspace's own artifacts, stale objects and incremental output before saving, so an entry is a few hundred MB rather than 2.5 GB. `save-if` restricts writes to main; PR runs read main's cache and never save.

## Ten minutes a job compiling a tool that ships prebuilt

| Job | `Install Tauri CLI` |
|---|---|
| Release, Windows | 594 s |
| CI tauri, Windows | 603 s |
| CI tauri, macOS | 356 s |
| CI tauri, Linux | 331 s |

CI tried to cache this and the entry exists (`Windows-cargo-bin-tauri`, 0.08 GB), but the key covered `~/.cargo/bin` only. Cargo records installs in `~/.cargo/.crates.toml`, which was not cached, so cargo could not tell the binary was already there and rebuilt it every run. `continue-on-error: true` hid it.

`taiki-e/install-action` downloads the prebuilt `cargo-tauri` — `tauri-cli` carries `[package.metadata.binstall]` producing that exact binary name, so `cargo tauri build` is unchanged.

## Release had no cargo cache at all

Every release compiled the whole dependency tree cold on three platforms. It now reads main's cache and never writes: a cache saved under a tag ref is scoped to that tag and could never be read again, so writing would only consume the 10 GB budget. Worst case it restores nothing and we are no slower than today.

## Three builds that another step already covered

- `cargo build` before clippy and `cargo test` — 485 s on Windows. Clippy checks every target with every feature, and `cargo test` builds the binaries anyway (the integration tests reach them through `CARGO_BIN_EXE_psf-guard`).
- `cargo build --release` on Windows and macOS — 531 s and 435 s, producing artifacts **nothing downloaded**. Only `psf-guard-linux-x64` is consumed, by the e2e job; `release.yml` builds its own assets. The release profile is still exercised on all three platforms by `cargo tauri build`.
- `cargo build --features tauri` before `cargo tauri build` — 823 s on Windows, 462 s Linux, 352 s macOS. Same crate, same feature, debug profile, sharing no artifacts with the bundle build that runs immediately after.

## Also

- Concurrency groups supersede a PR's earlier run. Pushes to main and tags run to completion.
- RPM builds Fedora 44 only. Both containers compiled the whole tree cold and 43 caught nothing 44 did not. Docs updated.

## Left alone deliberately

`release.yml` builds `psf-guard-cli` (676 s on Windows) before `cargo tauri build`. Whether that is redundant depends on whether tauri-cli compiles only the `default-run` binary or every bin target — the comments in `Cargo.toml` and `ci.yml` point in opposite directions, and guessing wrong changes which binary ships. Worth settling separately; it is ~34 min per release.

## Verification

`actionlint` clean. These are workflow changes, so the real proof is this PR's own run — the CI, RPM and Docker jobs here exercise every path except the release workflow.

Note the old cache entries will linger until LRU evicts them. To reclaim the space immediately:

```
gh api "repos/theatrus/psf-guard/actions/caches?per_page=100" --jq '.actions_caches[].id' \
  | xargs -I{} gh api -X DELETE repos/theatrus/psf-guard/actions/caches/{}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)