### PR TITLE
Keep the tauri feature out of the shipped CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main, master ]
 
+# Supersede a PR's earlier run when it is pushed again. Pushes to main keep
+# running to completion — each one is a distinct commit whose result we want,
+# and main's runs are what populate the shared cargo cache.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -54,26 +61,21 @@ jobs:
       with:
         toolchain: ${{ steps.rust-toolchain.outputs.channel }}
         components: rustfmt, clippy
-    - name: Cache cargo registry
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
 
-    - name: Cache cargo index
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-
+    # Replaces three hand-rolled actions/cache steps. rust-cache prunes the
+    # workspace's own artifacts, stale objects, and incremental output before
+    # saving, so an entry is a few hundred MB rather than the 1.3-2.5 GB the
+    # raw `target` directory cost. That matters: the repo was sitting at
+    # 10.03 GB against GitHub's 10 GB limit, and macOS entries were evicted so
+    # fast that no macOS job ever started warm.
+    #
+    # Only main writes. PR runs read main's cache but never save, which stops
+    # every branch from keeping its own copy of the same 2 GB.
     - name: Cache cargo build
-      uses: actions/cache@v6
-      continue-on-error: true
+      uses: Swatinem/rust-cache@v2
       with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
+        key: test
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install npm dependencies and build frontend
       run: |
@@ -90,38 +92,30 @@ jobs:
     - name: Check formatting
       run: cargo fmt -- --check
 
-    - name: Build
-      run: cargo build --verbose
-
+    # No separate `cargo build`. Clippy type-checks every target with every
+    # feature, and `cargo test` builds the binaries anyway — the integration
+    # tests reach for them through CARGO_BIN_EXE_psf-guard. The extra step
+    # cost 485s on Windows and proved nothing the other two miss.
     - name: Run clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: Run tests
       run: cargo test --verbose
 
-    - name: Build release binary
+    # Only Linux needs a release binary, because only the e2e job consumes
+    # one. Release builds its own assets from release.yml, and the Windows and
+    # macOS artifacts this job used to upload were downloaded by nothing. The
+    # release profile still gets exercised on all three platforms by
+    # `cargo tauri build` in test-tauri.
+    - name: Build release binary (Linux, for the e2e job)
+      if: matrix.os == 'ubuntu-22.04'
       run: cargo build --verbose --release
-
 
     - name: Upload artifact (Linux)
       if: matrix.os == 'ubuntu-22.04'
       uses: actions/upload-artifact@v7
       with:
         name: psf-guard-linux-x64
-        path: target/release/psf-guard
-
-    - name: Upload artifact (Windows)
-      if: matrix.os == 'windows-latest'
-      uses: actions/upload-artifact@v7
-      with:
-        name: psf-guard-windows-x64
-        path: target/release/psf-guard.exe
-
-    - name: Upload artifact (macOS)
-      if: matrix.os == 'macos-latest'
-      uses: actions/upload-artifact@v7
-      with:
-        name: psf-guard-macos-arm64
         path: target/release/psf-guard
 
   e2e:
@@ -257,33 +251,11 @@ jobs:
         toolchain: ${{ steps.rust-toolchain.outputs.channel }}
         components: rustfmt, clippy
 
-    - name: Cache cargo registry
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-tauri-${{ hashFiles('Cargo.lock') }}
-
-    - name: Cache cargo bin
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/bin
-        key: ${{ runner.os }}-cargo-bin-tauri-${{ hashFiles('Cargo.lock') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@v6
-      continue-on-error: true
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-tauri-${{ hashFiles('Cargo.lock') }}
-
     - name: Cache cargo build
-      uses: actions/cache@v6
-      continue-on-error: true
+      uses: Swatinem/rust-cache@v2
       with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-tauri-${{ hashFiles('Cargo.lock', 'tauri.conf.json') }}
+        key: tauri
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install npm dependencies and build frontend
       run: |
@@ -291,12 +263,23 @@ jobs:
         npm ci
         npm run build
 
+    # Downloads the prebuilt cargo-tauri binary (tauri-cli carries binstall
+    # metadata) rather than compiling the CLI from source, which took 603s on
+    # Windows, 356s on macOS and 331s on Linux — every run. The old
+    # `cargo install` step cached ~/.cargo/bin but not ~/.cargo/.crates.toml,
+    # where cargo records what it has installed, so cargo could never tell the
+    # binary was already there and rebuilt it every time. `continue-on-error`
+    # then hid the whole thing.
     - name: Install Tauri CLI
-      run: cargo install tauri-cli --version "^2.0" --locked
-      continue-on-error: true
+      uses: taiki-e/install-action@v2
+      with:
+        tool: tauri-cli@2
 
-    - name: Test Tauri compilation
-      run: cargo build --features tauri --verbose
+    # `cargo build --features tauri` used to run here first. It compiled the
+    # same crate with the same feature as the `cargo tauri build` below, only
+    # in the debug profile, so it shared no artifacts and proved nothing the
+    # bundle build does not. It cost 823s on Windows, 462s on Linux and 352s
+    # on macOS every run.
 
     - name: Build Tauri desktop app (Linux)
       if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,10 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,9 +169,11 @@ jobs:
       run: cargo tauri build --verbose --config "${{ runner.temp }}/psf-guard-updater.json" -- --bin psf-guard
 
     - name: Build Tauri desktop app (Windows, with bundled CLI)
-      # externalBin (the CLI sidecar staged above) + the NSIS PATH hook live in
-      # tauri.bundle-windows.json, applied only here via --config so other
-      # tauri-feature compiles don't require the sidecar.
+      # tauri.bundle-windows.json carries the NSIS PATH hook, and nothing else
+      # — there is no externalBin sidecar. `externalBin` is [] in
+      # tauri.conf.json; psf-guard-cli.exe reaches the installer because the
+      # bundler picks up every cargo bin target from target/release, where the
+      # tauri-free build above already put it.
       if: matrix.os == 'windows-latest'
       env:
         TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,18 @@ jobs:
         toolchain: ${{ steps.rust-toolchain.outputs.channel }}
         components: rustfmt, clippy
 
+    # This workflow had no cargo cache at all, so every release compiled the
+    # whole dependency tree from cold on three platforms. Read main's cache
+    # and never write: a cache saved under a tag ref is scoped to that tag and
+    # could never be read again, so saving here would only consume the repo's
+    # 10 GB budget. Worst case this restores nothing and we are no slower than
+    # before.
+    - name: Cache cargo build
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: tauri
+        save-if: false
+
     - name: Install Node.js
       uses: actions/setup-node@v7
       with:
@@ -97,9 +109,12 @@ jobs:
         npm ci
         npm run build
 
+    # Prebuilt binary rather than a from-source build; this step alone was
+    # 594s of the 36-minute Windows release job.
     - name: Install Tauri CLI
-      run: cargo install tauri-cli --version "^2.0" --locked
-      continue-on-error: true
+      uses: taiki-e/install-action@v2
+      with:
+        tool: tauri-cli@2
 
     - name: Verify updater signing credentials
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,14 @@ jobs:
       # Dedicated console-subsystem CLI (no tauri) — the standalone release
       # asset. The installer's bundled copy comes from Tauri auto-bundling the
       # psf-guard-cli bin target, so no sidecar staging is needed here.
+      #
+      # The `-- --bin psf-guard` on every tauri build below exists to protect
+      # this artifact. `cargo tauri build` takes its features from
+      # tauri.conf.json ("features": ["tauri"]) and, left alone, compiles
+      # EVERY bin target with them — psf-guard-cli included. It would land on
+      # top of this one, and "Prepare release assets" would then ship a
+      # tauri-linked binary as the standalone CLI: GUI subsystem behaviour on
+      # Windows, and a link against GTK/WebKit on Linux.
       run: cargo build --release --locked --bin psf-guard-cli
 
     - name: Build Tauri desktop app (Linux)
@@ -158,7 +166,7 @@ jobs:
       env:
         TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-      run: cargo tauri build --verbose --config "${{ runner.temp }}/psf-guard-updater.json"
+      run: cargo tauri build --verbose --config "${{ runner.temp }}/psf-guard-updater.json" -- --bin psf-guard
 
     - name: Build Tauri desktop app (Windows, with bundled CLI)
       # externalBin (the CLI sidecar staged above) + the NSIS PATH hook live in
@@ -168,7 +176,7 @@ jobs:
       env:
         TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-      run: cargo tauri build --verbose --config "${{ runner.temp }}/psf-guard-updater.json"
+      run: cargo tauri build --verbose --config "${{ runner.temp }}/psf-guard-updater.json" -- --bin psf-guard
 
     - name: Build Tauri desktop app (macOS)
       if: matrix.os == 'macos-latest'
@@ -179,7 +187,7 @@ jobs:
         TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
       run: |
-        bash scripts/package-macos.sh --config "${{ runner.temp }}/psf-guard-updater.json"
+        bash scripts/package-macos.sh --config "${{ runner.temp }}/psf-guard-updater.json" -- --bin psf-guard
 
     - name: Prepare release assets
       shell: bash

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main, master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: write
 
@@ -19,7 +23,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fedora: [ '43', '44' ]
+        # One Fedora is enough. Both builds compiled the same tree from cold
+        # (no cargo cache is possible here — the spec builds from vendored
+        # sources), and 43 caught nothing 44 did not.
+        fedora: [ '44' ]
 
     steps:
       - name: Install build tooling

--- a/README.md
+++ b/README.md
@@ -329,8 +329,10 @@ Then open http://localhost:3000/.
 
 ### Fedora RPM
 
-Releases after v0.3.0 attach prebuilt RPMs for Fedora 43 and 44 to the
-[releases page](https://github.com/theatrus/psf-guard/releases/latest):
+Releases after v0.3.0 attach a prebuilt Fedora 44 RPM to the
+[releases page](https://github.com/theatrus/psf-guard/releases/latest). For
+other Fedora releases, build one with
+[`packaging/rpm/build-in-podman.sh`](packaging/rpm/README.md):
 
 ```bash
 sudo dnf install ./psf-guard-*.fc44.x86_64.rpm

--- a/packaging/rpm/README.md
+++ b/packaging/rpm/README.md
@@ -110,5 +110,8 @@ mock -r fedora-44-x86_64 ~/rpmbuild/SRPMS/psf-guard-*.src.rpm
 2. Add a `%changelog` entry.
 3. Regenerate sources for the tag: `./scripts/make-rpm-sources.sh --ref vX.Y.Z`.
 
-CI (`.github/workflows/rpm.yml`) builds the RPMs in Fedora 43 and 44 containers
-on every push and pull request and uploads them as artifacts.
+CI (`.github/workflows/rpm.yml`) builds the RPMs in a Fedora 44 container on
+every push and pull request and uploads them as artifacts. The local
+`build-in-podman.sh` still covers other releases; CI builds one because each
+container compiles the whole tree from cold and 43 never caught anything 44
+missed.

--- a/scripts/release-feeds.test.mjs
+++ b/scripts/release-feeds.test.mjs
@@ -32,6 +32,43 @@ test('labels macOS artifacts as Apple Silicon', async () => {
   assert.doesNotMatch(ciWorkflow, /name: psf-guard-.*macos-x64/);
 });
 
+test('the shipped CLI is never built with the tauri feature', async () => {
+  const releaseWorkflow = await readFile(
+    new URL('../.github/workflows/release.yml', import.meta.url),
+    'utf8',
+  );
+
+  // psf-guard-cli must stay free of tauri: the feature flips the Windows
+  // binary to the GUI subsystem, where a console process has no stdout to
+  // write to, and drags GTK/WebKit into what is meant to be a plain CLI.
+  //
+  // The trap is that `cargo tauri build` reads its features from
+  // tauri.conf.json and compiles EVERY bin target with them. Without an
+  // explicit `--bin psf-guard` it rebuilds psf-guard-cli on top of the
+  // tauri-free one built earlier in the job, and "Prepare release assets"
+  // ships that. Every tauri build in the release must therefore name the
+  // binary it is allowed to touch.
+  const tauriBuilds = releaseWorkflow
+    .split('\n')
+    .filter((line) => /cargo tauri build|package-macos\.sh/.test(line))
+    .filter((line) => !line.trimStart().startsWith('#'));
+
+  assert.ok(
+    tauriBuilds.length >= 3,
+    `expected a tauri build per platform, found ${tauriBuilds.length}`,
+  );
+  for (const line of tauriBuilds) {
+    assert.match(
+      line,
+      /-- --bin psf-guard$/,
+      `tauri build must not be allowed to rebuild psf-guard-cli: ${line.trim()}`,
+    );
+  }
+
+  // And the tauri-free build it protects has to actually run.
+  assert.match(releaseWorkflow, /cargo build --release --locked --bin psf-guard-cli/);
+});
+
 test('normal and signed builds use website-first updater endpoints', async () => {
   const mainConfig = JSON.parse(await readFile(
     new URL('../tauri.conf.json', import.meta.url),

--- a/scripts/release-feeds.test.mjs
+++ b/scripts/release-feeds.test.mjs
@@ -23,8 +23,13 @@ test('labels macOS artifacts as Apple Silicon', async () => {
 
   assert.match(releaseWorkflow, /asset_name: psf-guard-macos-arm64/);
   assert.doesNotMatch(releaseWorkflow, /asset_name: psf-guard-macos-x64/);
-  assert.match(ciWorkflow, /name: psf-guard-macos-arm64/);
+  // CI publishes one macOS artifact, from the Tauri job. It carries the
+  // bundle and target/release/psf-guard, so dropping the test job's separate
+  // macOS upload cost no binary. What matters here is the label: these
+  // runners are Apple Silicon, and calling the result x64 is the bug this
+  // test exists to catch.
   assert.match(ciWorkflow, /name: psf-guard-tauri-macos-arm64/);
+  assert.doesNotMatch(ciWorkflow, /name: psf-guard-.*macos-x64/);
 });
 
 test('normal and signed builds use website-first updater endpoints', async () => {


### PR DESCRIPTION
Stacked on #253 — review that first.

`psf-guard-cli` must be free of tauri. Checking that turned up a live bug: **the release workflow builds it correctly and then overwrites it before shipping.**

## What happens today

```
1. cargo build --release --bin psf-guard-cli   ← tauri-free, correct
2. cargo tauri build                            ← overwrites it
3. Prepare release assets → cp target/release/psf-guard-cli
```

`cargo tauri build` takes its features from `tauri.conf.json`, which sets `"features": ["tauri"]`, and cargo builds **every** bin target by default. So step 2 recompiles `psf-guard-cli` with the tauri feature on top of step 1's output, and step 3 ships that.

Measured locally:

```
$ md5sum target/debug/psf-guard-cli
bec532eaf07f46d2b45a663213486afa      520,983,728 bytes
$ cargo build --features tauri
$ md5sum target/debug/psf-guard-cli
e72b642a30ba7b5ce78fea89d493b0a4      709,164,200 bytes
```

This predates #253. Every standalone CLI asset released so far is the tauri-linked build, on all three platforms, and so is the `psf-guard-cli.exe` the Windows installer puts on PATH.

## What is actually broken, and what is not

The Windows **subsystem** was never wrong. It is set only by the crate attribute in `src/main.rs`:

```rust
#![cfg_attr(all(not(debug_assertions), target_os = "windows", feature = "tauri"),
            windows_subsystem = "windows")]
```

`src/bin/psf-guard-cli.rs` carries no such attribute, `tauri-build` emits no `/SUBSYSTEM` link arg (only `/NODEFAULTLIB` and `/DEFAULTLIB` for the static CRT), and `[profile.release]` does not re-enable `debug-assertions`. So in Windows releases `psf-guard.exe` is GUI subsystem and `psf-guard-cli.exe` is console subsystem, whatever features it is built with.

What the overwrite does cost:

- the CLI links the whole tauri stack and roughly doubles in size;
- on Linux it links GTK/WebKit, a real runtime dependency for a tool meant to run headless;
- it picks up `tauri-build`'s static-CRT link args and Windows manifest.

Worth fixing, but it is a linkage bug, not a subsystem one.

## The fix

Name the binary each tauri build may touch:

```yaml
run: cargo tauri build --verbose --config "..." -- --bin psf-guard
```

Step 1 always writes a tauri-free `psf-guard-cli` into `target/release` **before** any tauri build runs, so nothing that used to be bundled can go missing — the file is on disk either way. The only change is that tauri no longer rebuilds it with the feature on.

Platform by platform:

- **Windows** — the installer bundles `psf-guard-cli.exe` and puts it on PATH. It now gets the tauri-free one. (`externalBin` is `[]`; the bundler picks up cargo bin targets from `target/release`. A stale comment claiming a sidecar is corrected here.)
- **Linux and macOS** — no installer bundles the CLI; the binaries ship as distinct release artifacts. The standalone asset comes straight from step 1, so these are unaffected either way.

## Guard

A test asserts every tauri build in `release.yml` carries the flag and that the tauri-free build still runs. Verified it fails when the flag is dropped from any one of the three:

```
not ok 4 - the shipped CLI is never built with the tauri feature
  error: 'tauri build must not be allowed to rebuild psf-guard-cli: run: cargo tauri build --verbose --config "..."'
```

## Verified / not verified

- Verified: `--features tauri` rebuilds `psf-guard-cli`; the subsystem analysis above, read from `tauri-build` 2.6.3 and the profile settings; guard test passes and fails correctly; `actionlint` clean; `test:release` 8/8.
- **Not verified:** that `tauri build` accepts `-- --bin psf-guard` as a cargo passthrough. The v2 CLI documents trailing `[ARGS]... Command line arguments passed to the runner`, and `package-macos.sh` / `build-macos.sh` already forward `"$@"`, but no local tauri-cli was available to exercise it. This is the one thing a tag build would prove.

## Deliberately not changed

`ci.yml`'s Tauri jobs still let tauri build every target. Mirroring the fix there needs a separate tauri-free CLI build per platform — a full extra compile — which cuts into what #253 recovered. It would, however, prove the passthrough before a tag. Say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)