### PR TITLE
Move the buildkit cache to the registry and layer Docker dependencies

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,6 +67,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The build cache lives in the registry beside the image, not in the
+      # Actions cache. type=gha shares the repo's 10 GB cache limit with the
+      # cargo caches, and buildkit was holding about 2.6 GB of it — enough to
+      # push the repo to the cap and start evicting the caches CI actually
+      # waits on. GHCR has no such budget.
+      #
+      # The package is public, so PR builds read this cache anonymously even
+      # though they never log in and never write to it.
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v7
@@ -74,11 +83,11 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Per-platform cache scope so amd64 and arm64 don't overwrite each
-          # other. Only write cache on push events — PRs writing cache would
-          # evict the shared repo cache and break other PRs' reads.
-          cache-from: type=gha,scope=docker-${{ env.PLATFORM_PAIR }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=gha,mode=max,scope=docker-{0}', env.PLATFORM_PAIR) || '' }}
+          # Per-platform cache tag so amd64 and arm64 don't overwrite each
+          # other. Only write on push events — a PR cannot log in, and letting
+          # PRs write would let any branch replace what main published.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ env.PLATFORM_PAIR }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true,oci-mediatypes=true', env.REGISTRY, env.IMAGE_NAME, env.PLATFORM_PAIR) || '' }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
       - name: Export digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,45 @@ RUN apt-get update && apt-get install -y \
 # Create app directory
 WORKDIR /app
 
-# Copy manifests first for better caching
+# Compile the dependency tree against a stub crate.
+#
+# "Copy manifests first for better caching" only pays off if something builds
+# between the manifest copy and the source copy. Nothing did, so every source
+# edit invalidated the single `cargo build --release` layer and recompiled
+# every dependency from scratch: 614s on amd64 and 555s on arm64 for the
+# v0.6.3 merge, and a fresh multi-hundred-MB layer written to the build cache
+# each time.
+#
+# The stubs keep this layer keyed on Cargo.toml and Cargo.lock alone. build.rs
+# is stubbed too — the real one shells out to npm, and lib.rs is empty here so
+# nothing yet references static/dist.
 COPY Cargo.toml Cargo.lock ./
+RUN mkdir -p src/bin && \
+    echo 'fn main() {}' > src/main.rs && \
+    : > src/lib.rs && \
+    echo 'fn main() {}' > src/bin/psf-guard-cli.rs && \
+    echo 'fn main() {}' > build.rs && \
+    cargo build --release --locked && \
+    rm -rf src build.rs
 
-# Copy source code
+# Copy source code. Only these layers move on an ordinary commit; the compiled
+# dependencies above are reused.
+COPY build.rs ./
 COPY src ./src
 COPY static ./static
-COPY build.rs ./
 
-RUN cargo build --release
+# Drop the stub crate's fingerprints before building for real.
+#
+# COPY preserves the host's mtimes, and cargo decides freshness by mtime. The
+# stub above was written inside the container, so it is *newer* than the real
+# sources that land on top of it: cargo concludes psf-guard is already built,
+# skips build.rs, never runs the frontend build, and the compile dies on
+# include_dir!("static/dist") with "is not a directory". Clearing only this
+# crate's fingerprints forces it and its build script to run again; every
+# compiled dependency in target/ is left alone, which is the point of the
+# layer above.
+RUN rm -rf target/release/.fingerprint/psf-guard-* && \
+    cargo build --release --locked
 
 # Runtime stage - use trixie to match the build stage
 FROM debian:trixie-slim


### PR DESCRIPTION
Two changes, both about how much the Docker build writes into the shared Actions cache.

## The buildx cache was a co-tenant of the 10 GB budget

`cache-to: type=gha` shares the repository's 10 GB Actions cache limit with the cargo caches. Buildkit held ~2.6 GB of it — enough, alongside the cargo entries, to sit the repo at the cap and start evicting the caches CI actually waits on.

It now writes to GHCR beside the image (`buildcache-linux-amd64` / `buildcache-linux-arm64`), which has no such budget. The package is public — anonymous `tags/list` returns 200 — so PR builds still read the cache; they never log in and never write, so a branch cannot replace what main published.

`mode=min` was the other option and is the wrong one here: for a multi-stage build it caches only the final runtime image, discarding the builder stage. The measured value of that stage is real — on a workflow-only PR the Docker builds took **20s and 15s** against 9–11 min when source changes.

## The Dockerfile recompiled every dependency on any source edit

```dockerfile
COPY Cargo.toml Cargo.lock ./   # "Copy manifests first for better caching"
COPY src ./src                  # ...but nothing built in between,
COPY static ./static            #    so this invalidated everything
RUN cargo build --release
```

The comment never paid off: with no build step between the manifest copy and the source copy, every commit recompiled the whole dependency tree — **614s on amd64 and 555s on arm64** for the v0.6.3 merge — and pushed a fresh multi-hundred-MB layer into the cache each time.

A stub crate now compiles dependencies in a layer keyed on `Cargo.toml` and `Cargo.lock` alone.

### The stub needs one guard, and it is not obvious

`COPY` preserves the host's mtimes and cargo decides freshness by mtime. The stub is written *inside* the container, so it is newer than the real sources copied on top of it. Cargo concludes `psf-guard` is already built, skips `build.rs`, never runs the frontend build, and the compile dies:

```
error: proc macro panicked
10 | static STATIC_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/static/dist");
   = help: message: "/app/static/dist" is not a directory
```

Clearing this crate's fingerprints before the real build fixes it and leaves every compiled dependency in place:

```dockerfile
RUN rm -rf target/release/.fingerprint/psf-guard-* && cargo build --release --locked
```

## Verification

Built locally with podman. On a source-only edit the dependency layer is reused:

```
STEP 4/9: COPY Cargo.toml Cargo.lock ./
--> Using cache dbb288e6e7f9...
STEP 5/9: RUN ... cargo build --release --locked && rm -rf src build.rs
--> Using cache 7ddd72a23f28...          ← dependencies not recompiled
STEP 7/9: COPY src ./src                 ← re-runs, as it should
STEP 9/9: RUN rm -rf target/release/.fingerprint/psf-guard-* && cargo build ...
```

`PODMAN EXIT=0  ELAPSED=271s`, against the ~614s a source change costs today. The image carries `/app/static/dist/assets/app-*.js`, so the frontend really built, and both `psf-guard` and `psf-guard-cli` are present.

`actionlint` clean. The Docker jobs on this PR exercise the real buildkit path — note the first run writes no cache (PRs never do), so the registry cache only starts paying off after this lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)