### PR TITLE
Clean up the e2e tmp directories

### DIFF
--- a/static/e2e/global-setup.ts
+++ b/static/e2e/global-setup.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { installAstrometryFixture } from './fixtures/astrometry';
 import { ensureAllFixtures } from './fixtures/loader';
+import { sweepAbandonedRunDirectories } from './tmp-dirs';
 
 const FITS_CARD_BYTES = 80;
 const FITS_BLOCK_BYTES = 2880;
@@ -86,6 +87,18 @@ export default async function globalSetup() {
   const tmpBase =
     process.env.PSF_GUARD_E2E_TMP ??
     path.join(os.tmpdir(), `psf-guard-e2e-${process.pid}`);
+
+  // Reclaim directories left by runs that were interrupted before teardown
+  // could run. Each holds ~1.8 GB of FITS fixtures, and on a tmpfs /tmp a few
+  // of them fill the disk and the next run dies mid-copy on ENOSPC/EDQUOT.
+  const reclaimed = sweepAbandonedRunDirectories(tmpBase);
+  if (reclaimed.length > 0) {
+    console.log(
+      `Removed ${reclaimed.length} abandoned e2e tmp director${
+        reclaimed.length === 1 ? 'y' : 'ies'
+      }`
+    );
+  }
 
   fs.rmSync(tmpBase, { recursive: true, force: true });
   fs.mkdirSync(tmpBase, { recursive: true });

--- a/static/e2e/global-teardown.ts
+++ b/static/e2e/global-teardown.ts
@@ -1,0 +1,26 @@
+import * as os from 'os';
+import * as path from 'path';
+import { removeRunDirectories } from './tmp-dirs';
+
+/**
+ * Remove this run's tmp directories.
+ *
+ * There was no teardown at all, so each run left roughly 1.8 GB of copied
+ * FITS fixtures behind under a PID-named directory that nothing ever
+ * revisited. Global setup only ever wiped the directory it was about to use.
+ *
+ * Keep the directories when PSF_GUARD_E2E_KEEP_TMP is set — a failing run is
+ * much easier to diagnose with its catalogs and caches still on disk. The
+ * sweep in global setup collects them on a later run either way.
+ */
+export default async function globalTeardown() {
+  if (process.env.PSF_GUARD_E2E_KEEP_TMP) {
+    return;
+  }
+
+  const tmpBase =
+    process.env.PSF_GUARD_E2E_TMP ??
+    path.join(os.tmpdir(), `psf-guard-e2e-${process.pid}`);
+
+  removeRunDirectories(tmpBase);
+}

--- a/static/e2e/tmp-dirs.ts
+++ b/static/e2e/tmp-dirs.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Lifecycle for the per-run tmp directories.
+ *
+ * A run works in `<tmpdir>/psf-guard-e2e-<pid>` plus a `-sync` sibling, and
+ * they are not small: the FITS fixtures copied into each one come to roughly
+ * 1.8 GB. Nothing removed them. Global setup wipes only the directory the
+ * current run is about to use, and the name carries a PID, so every previous
+ * run's directory survived. On a developer machine with a tmpfs `/tmp` that
+ * ends in a full disk, and the failure is confusing:
+ *
+ *   Error: Unknown system error -122 ... copyfile '.../0030.fits'
+ *
+ * Teardown handles a run that finishes. The sweep handles one that does not —
+ * interrupt Playwright and teardown never runs, which is how the directories
+ * accumulated in the first place.
+ */
+
+const PREFIX = 'psf-guard-e2e-';
+/** `psf-guard-e2e-1234` and its `psf-guard-e2e-1234-sync` sibling. */
+const RUN_DIR = /^psf-guard-e2e-(\d+)(-sync)?$/;
+
+/** Both directories a run owns, given its base. */
+export function runDirectories(tmpBase: string): string[] {
+  return [tmpBase, `${tmpBase}-sync`];
+}
+
+/** Remove this run's directories. Safe to call when they do not exist. */
+export function removeRunDirectories(tmpBase: string): void {
+  for (const directory of runDirectories(tmpBase)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    // Signal 0 performs the permission and existence checks without
+    // delivering anything.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but belongs to somebody else — alive as
+    // far as we are concerned. Only ESRCH proves it is gone.
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Delete run directories whose owning process has exited.
+ *
+ * A PID can be reused, in which case a dead run's directory looks live and is
+ * left alone. That is the harmless direction: the next sweep gets it. Deleting
+ * a directory out from under a running Playwright process is the one thing
+ * this must never do, which is why liveness decides rather than age.
+ *
+ * Returns the paths removed, so setup can say what it reclaimed.
+ */
+export function sweepAbandonedRunDirectories(currentTmpBase: string): string[] {
+  const root = os.tmpdir();
+  const keep = new Set(runDirectories(path.resolve(currentTmpBase)));
+  const removed: string[] = [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return removed;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith(PREFIX)) continue;
+    const match = RUN_DIR.exec(entry.name);
+    if (!match) continue;
+
+    const directory = path.join(root, entry.name);
+    if (keep.has(path.resolve(directory))) continue;
+    if (processIsAlive(Number(match[1]))) continue;
+
+    try {
+      fs.rmSync(directory, { recursive: true, force: true });
+      removed.push(directory);
+    } catch {
+      // Another run may have removed it, or it may belong to a different
+      // user. Neither is worth failing the suite over.
+    }
+  }
+
+  return removed;
+}

--- a/static/playwright.config.ts
+++ b/static/playwright.config.ts
@@ -61,6 +61,9 @@ export default defineConfig({
   reporter: process.env.CI ? [['list'], ['github']] : 'list',
 
   globalSetup: './e2e/global-setup.ts',
+  // Removes this run's tmp directories, ~1.8 GB of copied FITS fixtures.
+  // Set PSF_GUARD_E2E_KEEP_TMP to keep them while debugging a failure.
+  globalTeardown: './e2e/global-teardown.ts',
 
   use: {
     baseURL: `http://127.0.0.1:${PORT}`,

--- a/static/src/__tests__/e2eTmpDirs.test.ts
+++ b/static/src/__tests__/e2eTmpDirs.test.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  removeRunDirectories,
+  runDirectories,
+  sweepAbandonedRunDirectories,
+} from '../../e2e/tmp-dirs';
+
+/**
+ * The e2e run directories hold ~1.8 GB of FITS fixtures each. Nothing removed
+ * them, so a tmpfs /tmp filled up and runs began dying mid-copy. These cover
+ * the rule that matters: a directory is reclaimed only once its owning
+ * process is gone.
+ */
+
+const created: string[] = [];
+
+function makeRunDir(pid: number, suffix = ''): string {
+  const directory = path.join(os.tmpdir(), `psf-guard-e2e-${pid}${suffix}`);
+  fs.mkdirSync(path.join(directory, 'images'), { recursive: true });
+  fs.writeFileSync(path.join(directory, 'images', 'frame.fits'), 'x');
+  created.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (created.length > 0) {
+    fs.rmSync(created.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe('e2e tmp directories', () => {
+  it('reclaims a directory whose process has exited', () => {
+    // A PID that cannot be running: process.kill reports ESRCH for it.
+    const dead = makeRunDir(999_000_001);
+    const deadSync = makeRunDir(999_000_001, '-sync');
+
+    const removed = sweepAbandonedRunDirectories(
+      path.join(os.tmpdir(), 'psf-guard-e2e-999000002')
+    );
+
+    expect(fs.existsSync(dead)).toBe(false);
+    expect(fs.existsSync(deadSync)).toBe(false);
+    expect(removed).toEqual(expect.arrayContaining([dead, deadSync]));
+  });
+
+  it('leaves a running suite alone', () => {
+    // This test process is unquestionably alive.
+    const live = makeRunDir(process.pid);
+
+    sweepAbandonedRunDirectories(
+      path.join(os.tmpdir(), 'psf-guard-e2e-999000003')
+    );
+
+    expect(fs.existsSync(live)).toBe(true);
+  });
+
+  it('never removes the directory the current run is about to use', () => {
+    // Belt and braces: even if the PID looks dead, the run that is starting
+    // owns these two and global setup is about to populate them.
+    const current = makeRunDir(999_000_004);
+    const currentSync = makeRunDir(999_000_004, '-sync');
+
+    const removed = sweepAbandonedRunDirectories(current);
+
+    expect(fs.existsSync(current)).toBe(true);
+    expect(fs.existsSync(currentSync)).toBe(true);
+    expect(removed).not.toContain(current);
+  });
+
+  it('ignores directories that are not run directories', () => {
+    const stray = path.join(os.tmpdir(), 'psf-guard-e2e-fixtures');
+    fs.mkdirSync(stray, { recursive: true });
+    created.push(stray);
+
+    sweepAbandonedRunDirectories(
+      path.join(os.tmpdir(), 'psf-guard-e2e-999000005')
+    );
+
+    // The shared fixture cache has no PID and must survive; re-downloading
+    // it costs ~470 MB.
+    expect(fs.existsSync(stray)).toBe(true);
+  });
+
+  it('treats a process it cannot signal as alive', () => {
+    const foreign = makeRunDir(999_000_006);
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const error = new Error('operation not permitted') as NodeJS.ErrnoException;
+      error.code = 'EPERM';
+      throw error;
+    });
+
+    sweepAbandonedRunDirectories(
+      path.join(os.tmpdir(), 'psf-guard-e2e-999000007')
+    );
+
+    expect(fs.existsSync(foreign)).toBe(true);
+  });
+
+  it('removes both directories a run owns', () => {
+    const base = makeRunDir(999_000_008);
+    const sync = makeRunDir(999_000_008, '-sync');
+
+    expect(runDirectories(base)).toEqual([base, sync]);
+    removeRunDirectories(base);
+
+    expect(fs.existsSync(base)).toBe(false);
+    expect(fs.existsSync(sync)).toBe(false);
+  });
+});


### PR DESCRIPTION
An e2e run works in `<tmpdir>/psf-guard-e2e-<pid>` plus a `-sync` sibling and copies ~1.8 GB of FITS fixtures into them. **Nothing ever removed them.**

There was no `globalTeardown` at all, and global setup wiped only the directory the current run was about to use — which, being PID-named, was never a previous run's. So every run leaked ~1.8 GB until `/tmp` filled and the next one died mid-copy:

```
Error: Unknown system error -122: Unknown system error -122,
copyfile '.../2026-04-16_22-27-23_B_-10.00_60.00s_0030.fits'
   at global-setup.ts:110
```

This bit twice while working on the settings tabs — once taking down 12 specs and a disk-quota test with failures that looked unrelated to anything being changed.

## The fix

- **`globalTeardown`** removes the directories a finished run owns.
- **A sweep in global setup** removes directories whose owning process has exited. This is the half that matters: interrupt Playwright and teardown never runs, which is exactly how they accumulated.

### What decides a reclaim

Liveness, not age:

- `process.kill(pid, 0)` — existence and permission checks with no signal delivered.
- `ESRCH` proves the process is gone; the directory goes.
- `EPERM` means somebody else's process holds that PID, so it counts as alive.
- A reused PID makes a dead run's directory look live. It is left for a later sweep — the harmless direction. Deleting a directory out from under a running suite is the one outcome this must never produce.
- The directory the current run is about to use is excluded outright.
- Only `psf-guard-e2e-<digits>` and its `-sync` sibling match. The shared `psf-guard-e2e-fixtures` cache has no PID and survives; re-downloading it costs ~470 MB.

`PSF_GUARD_E2E_KEEP_TMP` keeps a run's directories for debugging a failure; the sweep collects them on a later run.

## Tests

Six unit tests in `src/__tests__/e2eTmpDirs.test.ts` cover the reclaim rule, a live suite being left alone, the current run's directories being excluded, non-run directories being ignored, and EPERM counting as alive.

Verified end to end rather than only in unit tests. Planting an abandoned pair and running the suite:

```
Removed 2 abandoned e2e tmp directories
  7 passed (4.8s)
=== after the run:
(none — sweep + teardown both worked)
```

And `PSF_GUARD_E2E_KEEP_TMP=1` leaves `psf-guard-e2e-231027` and its `-sync` sibling in place, as documented.

## Checks run locally

- `npm run lint` — clean
- `tsc --noEmit` — clean
- `npx vitest run` — 174 passed
- `npx playwright test` — 68 passed, no directories left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)