### PR TITLE
Release v0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/v0.6.4.md
+++ b/docs/releases/v0.6.4.md
@@ -1,0 +1,25 @@
+# PSF Guard 0.6.4
+
+This patch release reorganizes Settings. It had grown into one long page
+holding three separate jobs, so reaching any one of them meant scrolling past
+the other two. They are now tabs:
+
+- **Databases** — the catalog list, the add and import forms, and import
+  progress.
+- **Catalogs** — Seiza data package readiness, installation, and validation.
+- **Sync** — Data Transfer between catalogs, and Remote PSF Guard.
+
+Sync appears once you have a catalog to move records between. Choosing a
+starting point on a first run now opens its form directly, instead of below
+the catalog installer where it could fall off the bottom of the window.
+
+Arrow keys move along the tab strip.
+
+Nothing else changes for existing catalogs, and no settings need updating.
+
+## Download choices
+
+- Windows: NSIS setup or MSI, plus a stand-alone CLI.
+- macOS: DMG or zipped Apple Silicon app, plus a stand-alone Apple Silicon CLI.
+- Linux: Debian package, AppImage, Fedora RPM, or a stand-alone CLI.
+- Server: Docker image or the same CLI binary in `server` mode.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -7,7 +7,7 @@
 %global debug_package %{nil}
 
 Name:           psf-guard
-Version:        0.6.3
+Version:        0.6.4
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -90,6 +90,9 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.4-1
+- Split Settings into Databases, Catalogs, and Sync tabs
+
 * Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.3-1
 - Offer both catalog import paths on first run
 

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
Prepares the 0.6.4 release. Per `docs/RELEASING.md`, do not tag until this exact PR has merged and all required checks pass on the merge commit.

## Release boundary

Four commits since `v0.6.3`, of which **one is user-facing**:

| Commit | User-facing? |
|---|---|
| `f810b89` Split settings into tabs (#255) | **yes** |
| `76cd8cb` Stop rebuilding the same tree in CI (#253) | no — CI only |
| `7369e6d` Move the buildkit cache to the registry (#256) | no — build only |
| `e92aa92` Clean up the e2e tmp directories (#257) | no — test harness |

A UI reorganization with no new capability and no data-format change, so a patch. This matches the precedent set by 0.6.3, which shipped a comparable first-run UX change as a patch.

No open PR needs to ship with this release. All Apple and updater secrets are present (`APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_KEY_PRIVATE`, `APPLE_BUILD_CERTIFICATE`, `APPLE_BUILD_CERTIFICATE_PASSWORD`, `TAURI_SIGNING_PRIVATE_KEY`, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`) — names checked only.

## Version bump

`Cargo.toml`, `Cargo.lock`, `tauri.conf.json`, and `packaging/rpm/psf-guard.spec`, plus an RPM changelog entry and `docs/releases/v0.6.4.md`.

The remaining `0.6.3` matches were inspected rather than replaced, as the guide warns:

- `Cargo.lock` — the `jsonptr` dependency, genuinely at 0.6.3;
- `static/package-lock.json` — `dom-accessibility-api`, likewise;
- `packaging/rpm/psf-guard.spec` — the historical 0.6.3 changelog entry.

## Local checks

| Check | Result |
|---|---|
| `node scripts/check-release-version.mjs v0.6.4` | `0.6.4` |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --locked --all-targets --all-features -- -D warnings` | clean |
| `cargo test --locked` | 0 failed suites (440 passed, 5 ignored, plus 12 integration suites) |
| `cargo build --release --locked --bin psf-guard-cli` | built 0.6.4 |
| `npm ci && npm run lint` | clean |
| `npx vitest run` | 174 passed (36 files) |
| `npm run build` | clean |
| `npm run test:release` | 7/7 |
| `npx playwright test` | 68 passed |
| `actionlint` (parses ci.yml and release.yml) | clean |
| `git diff --check` | clean |

No local Tauri bundle was built. The guide asks for one when app, updater, packaging, or signing code changed; the only matching paths touched since `v0.6.3` are `packaging/rpm/README.md` and `scripts/release-feeds.test.mjs`, and the latter is covered by `npm run test:release`.

## After merge

Tag the merge commit, not this branch head:

```bash
git fetch origin
git tag -a v0.6.4 MERGE_SHA -m "PSF Guard 0.6.4"
git push origin v0.6.4
```

Then watch `release.yml` through to a public, non-draft release with all assets — green CI alone is not the finish line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)