### PR TITLE
Put the release notes in the update notice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,9 @@ jobs:
         published_at=$(gh api \
           "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
           --jq .published_at)
+        # No summary argument: release-feeds.mjs takes the first sentence of
+        # docs/releases/<tag>.md, which the checkout above provides. Passing
+        # one here would override it.
         node scripts/release-feeds.mjs \
           update-feeds \
           "$APP_VERSION" \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,6 +39,12 @@ them.
 The release workflow prepends the matching `docs/releases/vVERSION.md` file to
 GitHub's generated change list. A missing file makes the release job fail.
 
+Open the notes with a plain sentence that says what the release does. That
+first sentence becomes the summary in `notice.json`, which is the single line
+every installed copy sees in its update banner, so write it for someone who
+has not read the rest of the file. Lead with a list or a heading and the
+banner falls back to "A new PSF Guard release is ready."
+
 ## 3. Run local gates
 
 Run the same broad checks used by CI:

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -41,6 +41,10 @@ The notice schema is:
 }
 ```
 
+`summary` is the first sentence of `docs/releases/<tag>.md`, shown on one line
+in the update banner. It falls back to "A new PSF Guard release is ready."
+when those notes open with something other than prose.
+
 `urgency` may be `normal`, `recommended`, or `required`. The UI also treats the
 notice as required when the installed version is older than
 `minimum_supported_version`. This changes the notice style and text; it never

--- a/scripts/release-feeds.mjs
+++ b/scripts/release-feeds.mjs
@@ -4,6 +4,84 @@ import { pathToFileURL } from 'node:url';
 
 export const NOTICE_SCHEMA_VERSION = 1;
 
+export const DEFAULT_SUMMARY = 'A new PSF Guard release is ready.';
+
+/** Longest summary the in-app notice can show without crowding its one line. */
+const SUMMARY_LIMIT = 200;
+
+/**
+ * First sentence of a release-notes file, for the in-app update notice.
+ *
+ * The notice renders one line, so it wants a sentence rather than the whole
+ * opening paragraph. Every docs/releases/vX.Y.Z.md so far opens with prose
+ * that summarises the release in its first sentence — "This patch release
+ * fixes the first-run catalog setup." — which is exactly what an installed
+ * copy should be told.
+ *
+ * Returns null when there is no usable prose, so callers keep the default
+ * rather than showing something mangled.
+ */
+export function summaryFromNotes(markdown) {
+  const lines = markdown.split('\n');
+  const paragraph = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '') {
+      if (paragraph.length > 0) break;
+      continue;
+    }
+    // Skip the title and stop at anything that is not plain prose: a list,
+    // quote, table, or fence means the prose paragraph is over.
+    if (/^#/.test(trimmed)) {
+      if (paragraph.length > 0) break;
+      continue;
+    }
+    if (/^([-*+>|]|\d+\.|```)/.test(trimmed)) {
+      if (paragraph.length > 0) break;
+      continue;
+    }
+    paragraph.push(trimmed);
+  }
+  if (paragraph.length === 0) return null;
+
+  const prose = paragraph
+    .join(' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links keep their text
+    .replace(/[*_`]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (prose === '') return null;
+
+  // First sentence. Require a few characters before the period so an
+  // abbreviation does not end it early.
+  const sentence = /^(.{12,}?[.!?])(?:\s|$)/.exec(prose);
+  let summary = sentence ? sentence[1] : prose;
+
+  if (summary.length > SUMMARY_LIMIT) {
+    const clipped = summary.slice(0, SUMMARY_LIMIT);
+    const lastSpace = clipped.lastIndexOf(' ');
+    summary = `${(lastSpace > 0 ? clipped.slice(0, lastSpace) : clipped).replace(/[.,;:]$/, '')}…`;
+  }
+  return summary;
+}
+
+/**
+ * Read the summary for a tag from its notes file. Missing or unreadable notes
+ * are not fatal: the release itself already fails when the file is absent,
+ * and the notice is better with a generic line than not published at all.
+ */
+export async function readReleaseSummary(tag) {
+  try {
+    const notes = await readFile(
+      new URL(`../docs/releases/${tag}.md`, import.meta.url),
+      'utf8',
+    );
+    return summaryFromNotes(notes);
+  } catch {
+    return null;
+  }
+}
+
 const platformAssets = (version) => ({
   'windows-x86_64': `PSF-Guard-${version}-windows-x64-setup.exe`,
   'linux-x86_64': `PSF-Guard-${version}-linux-x86_64.AppImage`,
@@ -24,7 +102,7 @@ export async function buildReleaseFeeds({
   tag,
   repository = 'theatrus/psf-guard',
   publishedAt,
-  summary = 'A new PSF Guard release is ready.',
+  summary = DEFAULT_SUMMARY,
   minimumSupportedVersion = '0.5.0',
 }) {
   if (!validVersion(version)) throw new Error(`Invalid release version: ${version}`);
@@ -73,12 +151,17 @@ async function main() {
       'Usage: node scripts/release-feeds.mjs ARTIFACT_DIR VERSION TAG PUBLISHED_AT [SUMMARY]',
     );
   }
+  // Without this the notice always read "A new PSF Guard release is ready.",
+  // so the notes written for each release never reached anyone already
+  // running PSF Guard. An explicit argument still wins.
+  const resolvedSummary = summary || (await readReleaseSummary(tag)) || undefined;
+
   const feeds = await buildReleaseFeeds({
     artifactDirectory,
     version,
     tag,
     publishedAt,
-    summary: summary || undefined,
+    summary: resolvedSummary,
   });
   await Promise.all([
     writeFile(

--- a/scripts/release-feeds.test.mjs
+++ b/scripts/release-feeds.test.mjs
@@ -6,7 +6,12 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { buildReleaseFeeds } from './release-feeds.mjs';
+import {
+  DEFAULT_SUMMARY,
+  buildReleaseFeeds,
+  readReleaseSummary,
+  summaryFromNotes,
+} from './release-feeds.mjs';
 import { writeUpdaterConfig } from './write-updater-config.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -111,4 +116,101 @@ test('rejects a mismatched release tag', async () => {
     tag: 'v1.2.4',
     publishedAt: '2026-07-26T18:00:00Z',
   }), /does not match/);
+});
+
+test('summarises release notes with their first sentence', () => {
+  const summary = summaryFromNotes([
+    '# PSF Guard 0.6.4',
+    '',
+    'This patch release reorganizes Settings. It had grown into one long page',
+    'holding three separate jobs, so reaching any one of them meant scrolling',
+    'past the other two. They are now tabs:',
+    '',
+    '- **Databases** — the catalog list.',
+  ].join('\n'));
+
+  // One line in the banner, so one sentence — not the whole paragraph, and
+  // not the dangling "They are now tabs:" that introduces the list.
+  assert.equal(summary, 'This patch release reorganizes Settings.');
+});
+
+test('strips markup and joins wrapped prose', () => {
+  const summary = summaryFromNotes([
+    '# PSF Guard 1.0.0',
+    '',
+    'Adds **stacking** for [OSC frames](https://example.com/osc) and',
+    '`narrowband` palettes.',
+  ].join('\n'));
+
+  assert.equal(summary, 'Adds stacking for OSC frames and narrowband palettes.');
+});
+
+test('keeps the default when the notes carry no prose', () => {
+  assert.equal(summaryFromNotes('# PSF Guard 1.0.0\n\n- Only a list item.\n'), null);
+  assert.equal(summaryFromNotes(''), null);
+  assert.equal(summaryFromNotes('# Heading only\n'), null);
+});
+
+test('truncates a long opening sentence on a word boundary', () => {
+  const long = `This release ${'improves things '.repeat(30)}everywhere.`;
+  const summary = summaryFromNotes(`# PSF Guard 1.0.0\n\n${long}\n`);
+
+  assert.ok(summary.length <= 201, `summary was ${summary.length} characters`);
+  assert.ok(summary.endsWith('…'));
+  assert.ok(!summary.includes('  '));
+});
+
+test('reads the summary shipped for a real tag', async () => {
+  // Against the checked-in notes, so the extraction cannot drift from what
+  // releases actually publish.
+  assert.equal(
+    await readReleaseSummary('v0.6.4'),
+    'This patch release reorganizes Settings.',
+  );
+  assert.equal(
+    await readReleaseSummary('v0.6.3'),
+    'This patch release fixes the first-run catalog setup.',
+  );
+  assert.equal(
+    await readReleaseSummary('v0.6.2'),
+    'This patch release corrects the name of the stand-alone macOS CLI download.',
+  );
+});
+
+test('falls back for a tag with no notes file', async () => {
+  assert.equal(await readReleaseSummary('v99.99.99'), null);
+  assert.equal(DEFAULT_SUMMARY, 'A new PSF Guard release is ready.');
+});
+
+test('the four-argument workflow invocation publishes a real summary', async (t) => {
+  // This is the shape release.yml uses. It passes no summary, which is how
+  // every notice up to 0.6.4 shipped the generic default line.
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'psf-guard-feeds-cli-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  const version = '0.6.4';
+  for (const fileName of [
+    `PSF-Guard-${version}-windows-x64-setup.exe`,
+    `PSF-Guard-${version}-linux-x86_64.AppImage`,
+    `PSF-Guard-${version}-macos-aarch64.app.tar.gz`,
+  ]) {
+    await writeFile(path.join(directory, fileName), 'payload\n');
+    await writeFile(path.join(directory, `${fileName}.sig`), `sig-${fileName}\n`);
+  }
+
+  const scriptPath = fileURLToPath(new URL('./release-feeds.mjs', import.meta.url));
+  await execFileAsync(process.execPath, [
+    scriptPath,
+    directory,
+    version,
+    `v${version}`,
+    '2026-07-27T06:00:00Z',
+  ]);
+
+  const notice = JSON.parse(await readFile(path.join(directory, 'notice.json'), 'utf8'));
+  assert.equal(notice.summary, 'This patch release reorganizes Settings.');
+  assert.notEqual(notice.summary, DEFAULT_SUMMARY);
+
+  const updater = JSON.parse(await readFile(path.join(directory, 'updater.json'), 'utf8'));
+  assert.equal(updater.notes, notice.summary);
 });


### PR DESCRIPTION
Every release since the notice feed existed has told installed copies the same thing. From the published `v0.6.3` asset:

```json
{
  "version": "0.6.3",
  "summary": "A new PSF Guard release is ready.",
  ...
}
```

`release.yml` calls `release-feeds.mjs` with four arguments and stops before the optional fifth, so `summary` always fell back to its default. The notes written for each release reached the GitHub release page and nowhere else — the one line every running copy actually sees said nothing about the release. `v0.6.4` shipped the same way; this fixes it from the next release on.

## The fix

`release-feeds.mjs` reads `docs/releases/<tag>.md` and takes its first sentence.

A sentence rather than the opening paragraph, because `UpdateNotice.tsx` renders it on one line:

```tsx
<span>{available.summary ?? status}</span>
```

And a first sentence works because every notes file so far opens with one that summarises the release:

| Tag | Derived summary |
|---|---|
| v0.6.4 | This patch release reorganizes Settings. |
| v0.6.3 | This patch release fixes the first-run catalog setup. |
| v0.6.2 | This patch release corrects the name of the stand-alone macOS CLI download. |
| v0.6.0 | This release makes PSF Guard a full image catalog and review tool. |

The extraction skips the title, stops at the first list, quote, table or fence, joins wrapped lines, strips link and emphasis markup, and truncates on a word boundary past 200 characters. Notes that open with something other than prose keep the old default rather than showing something mangled, and an explicit fifth argument still overrides everything.

`release.yml` needs no command change — it already passes four arguments — so it gains only a comment saying where the summary comes from.

## Tests

Seven new cases in `scripts/release-feeds.test.mjs`: first-sentence extraction, markup stripping and line joining, the empty and list-only cases, word-boundary truncation, and the real checked-in notes for v0.6.2/3/4 so the rule cannot drift from what actually ships.

One drives the CLI through the exact four-argument form `release.yml` uses — the shape that carried the bug — and asserts the published `notice.json` and `updater.json` both carry the derived line:

```js
assert.equal(notice.summary, 'This patch release reorganizes Settings.');
assert.notEqual(notice.summary, DEFAULT_SUMMARY);
```

## Docs

`docs/RELEASING.md` now says to open the notes with a plain sentence written for someone who has not read the rest of the file, since it becomes the banner. `docs/UPDATES.md` documents where `summary` comes from and when it falls back.

## Checks run locally

- `npm run test:release` — 14 passed
- `npx vitest run` — 174 passed
- `actionlint` — clean
- `git diff --check` — clean

Verified end to end by running the script exactly as the workflow does; the resulting `notice.json` carries `'This patch release reorganizes Settings.'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)