### PR TITLE
Fix N.I.N.A. FITS pixel-scale hints

### DIFF
--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -432,6 +432,8 @@ pub struct AstrometrySolutionResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AstrometrySolverProvenance {
     pub seiza_version: String,
+    #[serde(default)]
+    pub seiza_fits_version: String,
     pub detection_backend: String,
     pub star_catalog: AstrometryCatalogFileSignature,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -963,7 +965,7 @@ impl AstrometryContext {
             && cached.image_id == fresh.image_id
             && cached.source_fingerprint == fresh.source_fingerprint
             && cached.catalog_signature == fresh.catalog_signature
-            && provenance.seiza_version == SEIZA_VERSION
+            && solver_versions_match(provenance)
             && provenance.star_catalog == current_stars
             && blind_matches;
         if !valid {
@@ -1012,7 +1014,7 @@ impl AstrometryContext {
         let cached =
             self.persisted_pixel_analysis_for_source(cache_dir, image_id, expected_target)?;
         let provenance = cached.solver_provenance.as_ref()?;
-        if provenance.seiza_version != SEIZA_VERSION {
+        if !solver_versions_match(provenance) {
             return None;
         }
         let current_stars = self.load_star_catalog().ok()?;
@@ -1202,6 +1204,7 @@ impl AstrometryContext {
                             .flatten();
                         let provenance = deterministic.then(|| AstrometrySolverProvenance {
                             seiza_version: SEIZA_VERSION.to_string(),
+                            seiza_fits_version: SEIZA_FITS_VERSION.to_string(),
                             detection_backend: "mtf_u8+linear_f32".to_string(),
                             star_catalog: catalog_file_signature(
                                 "stars",
@@ -1227,6 +1230,7 @@ impl AstrometryContext {
 
         let provenance = AstrometrySolverProvenance {
             seiza_version: SEIZA_VERSION.to_string(),
+            seiza_fits_version: SEIZA_FITS_VERSION.to_string(),
             detection_backend,
             star_catalog: catalog_file_signature("stars", &stars_catalog.fingerprint),
             blind_index: blind_index
@@ -1322,9 +1326,12 @@ impl AstrometryContext {
             max_pattern_deg: blind_index.value.max_pattern_deg(),
             ..Default::default()
         };
-        if let Some(scale) = scale {
-            params.min_scale_arcsec_px = (scale * 0.5).max(0.01);
-            params.max_scale_arcsec_px = scale * 1.5;
+        // Once a complete hint has failed, it is no longer safe to narrow the
+        // blind search around the same scale. FITS focal lengths and mount
+        // coordinates can be stale even when the image pixels are sound.
+        if let Some((minimum, maximum)) = blind_scale_constraint(scale, hinted_error.is_some()) {
+            params.min_scale_arcsec_px = minimum;
+            params.max_scale_arcsec_px = maximum;
         }
         seiza::blind::solve_blind(stars, catalog, &blind_index.value, &params, dimensions)
             .map(|solution| (AstrometrySolveMode::Blind, solution, Some(blind_index)))
@@ -1551,6 +1558,17 @@ impl AstrometryContext {
 enum DetectionPass {
     MtfU8,
     LinearF32,
+}
+
+fn blind_scale_constraint(scale: Option<f64>, hinted_solve_failed: bool) -> Option<(f64, f64)> {
+    if hinted_solve_failed {
+        return None;
+    }
+    scale.map(|scale| ((scale * 0.5).max(0.01), scale * 1.5))
+}
+
+fn solver_versions_match(provenance: &AstrometrySolverProvenance) -> bool {
+    provenance.seiza_version == SEIZA_VERSION && provenance.seiza_fits_version == SEIZA_FITS_VERSION
 }
 
 struct PixelSolutionMetadata {
@@ -2783,6 +2801,36 @@ mod tests {
     }
 
     #[test]
+    fn failed_hint_removes_the_scale_constraint_from_blind_fallback() {
+        assert_eq!(blind_scale_constraint(Some(2.0), false), Some((1.0, 3.0)));
+        assert_eq!(blind_scale_constraint(Some(2.0), true), None);
+        assert_eq!(blind_scale_constraint(None, false), None);
+    }
+
+    #[test]
+    fn fits_decoder_version_participates_in_cache_validation() {
+        let mut provenance = AstrometrySolverProvenance {
+            seiza_version: SEIZA_VERSION.to_string(),
+            seiza_fits_version: SEIZA_FITS_VERSION.to_string(),
+            detection_backend: "mtf_u8".to_string(),
+            star_catalog: AstrometryCatalogFileSignature {
+                name: "stars".to_string(),
+                path: "/data/stars.bin".to_string(),
+                format: "test".to_string(),
+                size_bytes: 1,
+                modified_unix_seconds: 1,
+                modified_subsec_nanos: 0,
+                sha256: None,
+            },
+            blind_index: None,
+        };
+        assert!(solver_versions_match(&provenance));
+
+        provenance.seiza_fits_version.clear();
+        assert!(!solver_versions_match(&provenance));
+    }
+
+    #[test]
     fn malformed_object_catalog_is_reported_as_invalid() {
         let directory = tempfile::tempdir().unwrap();
         let objects_path = directory.path().join("objects.bin");
@@ -2867,6 +2915,7 @@ mod tests {
             catalog_signature: None,
             solver_provenance: Some(AstrometrySolverProvenance {
                 seiza_version: SEIZA_VERSION.to_string(),
+                seiza_fits_version: SEIZA_FITS_VERSION.to_string(),
                 detection_backend: "mtf_u8+linear_f32".to_string(),
                 star_catalog: AstrometryCatalogFileSignature {
                     name: "stars".to_string(),

--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -10,8 +10,8 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-pub const SEIZA_VERSION: &str = "0.12.0";
-pub const SEIZA_FITS_VERSION: &str = "0.2.0";
+pub const SEIZA_VERSION: &str = "0.12.2";
+pub const SEIZA_FITS_VERSION: &str = "0.2.1";
 
 pub type AstrometryResourcePath = Result<Option<PathBuf>, seiza::data_paths::DataPathError>;
 

--- a/src/astrometry_headers.rs
+++ b/src/astrometry_headers.rs
@@ -588,7 +588,21 @@ fn camera_geometry_scale(
 ) -> Option<Provenanced<f64>> {
     let focal_length_mm = focal_length_mm?;
     let pixel_size_um = pixel_size_um?;
-    let binning = binning_x.map_or(1.0, |value| value.value);
+    // XPIXSZ is the image pixel width after binning. N.I.N.A. can therefore
+    // write both XPIXSZ=4.63 and XBINNING=2 for the native 4144x2822 mode of
+    // an ASI294MM. Multiplying the two again doubles the scale hint. Preserve
+    // the old binning behavior for the non-standard PIXSIZE aliases, whose
+    // writers may still report the physical sensor pixel width.
+    let pixel_size_is_effective = pixel_size_um
+        .sources
+        .first()
+        .is_some_and(|source| source.eq_ignore_ascii_case("XPIXSZ"));
+    let applied_binning = if pixel_size_is_effective {
+        None
+    } else {
+        binning_x
+    };
+    let binning = applied_binning.map_or(1.0, |value| value.value);
     let scale = 206.265 * pixel_size_um.value * binning / focal_length_mm.value;
     if !scale.is_finite() || scale <= 0.0 {
         return None;
@@ -596,13 +610,17 @@ fn camera_geometry_scale(
     let mut sources = Vec::new();
     sources.extend(focal_length_mm.sources.iter().cloned());
     sources.extend(pixel_size_um.sources.iter().cloned());
-    if let Some(binning_x) = binning_x {
+    if let Some(binning_x) = applied_binning {
         sources.extend(binning_x.sources.iter().cloned());
     }
     Some(Provenanced::derived(
         scale,
         sources,
-        "206.265 * pixel_size_um * binning_x / focal_length_mm",
+        if pixel_size_is_effective {
+            "206.265 * effective_pixel_size_um / focal_length_mm"
+        } else {
+            "206.265 * pixel_size_um * binning_x / focal_length_mm"
+        },
     ))
 }
 
@@ -721,7 +739,7 @@ mod tests {
     }
 
     #[test]
-    fn derives_camera_geometry_scale_with_binning() {
+    fn treats_xpixsz_as_the_effective_binned_pixel_size() {
         let parsed = FitsAstrometryHeaders::from_headers(&headers(&[
             ("XPIXSZ", HeaderValue::Float(3.76)),
             ("XBINNING", HeaderValue::Integer(2)),
@@ -729,9 +747,47 @@ mod tests {
         ]));
 
         let scale = parsed.pixel_scale_arcsec_per_pixel.unwrap();
+        let expected = 206.265 * 3.76 / 550.0;
+        assert!((scale.value - expected).abs() < 1e-10);
+        assert_eq!(scale.sources, ["FOCALLEN", "XPIXSZ"]);
+    }
+
+    #[test]
+    fn derives_nina_asi294_scale_without_double_counting_binning() {
+        let parsed = FitsAstrometryHeaders::from_headers(&headers(&[
+            ("NAXIS1", HeaderValue::Integer(4144)),
+            ("NAXIS2", HeaderValue::Integer(2822)),
+            ("RA", HeaderValue::Float(315.147297524169)),
+            ("DEC", HeaderValue::Float(45.1289918743763)),
+            ("XPIXSZ", HeaderValue::Float(4.63)),
+            ("YPIXSZ", HeaderValue::Float(4.63)),
+            ("XBINNING", HeaderValue::Integer(2)),
+            ("YBINNING", HeaderValue::Integer(2)),
+            ("FOCALLEN", HeaderValue::Float(1000.0)),
+            ("INSTRUME", HeaderValue::String("ZWO ASI294MM Pro".into())),
+            (
+                "SWCREATE",
+                HeaderValue::String("N.I.N.A. 3.2.0.9001 (x64)".into()),
+            ),
+        ]));
+
+        let scale = parsed.pixel_scale_arcsec_per_pixel.unwrap();
+        assert!((scale.value - 0.955_006_95).abs() < 1e-10);
+        assert_eq!(scale.sources, ["FOCALLEN", "XPIXSZ"]);
+    }
+
+    #[test]
+    fn preserves_binning_for_non_standard_physical_pixel_size_aliases() {
+        let parsed = FitsAstrometryHeaders::from_headers(&headers(&[
+            ("PIXSIZE", HeaderValue::Float(3.76)),
+            ("XBINNING", HeaderValue::Integer(2)),
+            ("FOCALLEN", HeaderValue::Float(550.0)),
+        ]));
+
+        let scale = parsed.pixel_scale_arcsec_per_pixel.unwrap();
         let expected = 206.265 * 3.76 * 2.0 / 550.0;
         assert!((scale.value - expected).abs() < 1e-10);
-        assert_eq!(scale.sources, ["FOCALLEN", "XPIXSZ", "XBINNING"]);
+        assert_eq!(scale.sources, ["FOCALLEN", "PIXSIZE", "XBINNING"]);
     }
 
     #[test]

--- a/static/e2e/astrometry-capabilities.spec.ts
+++ b/static/e2e/astrometry-capabilities.spec.ts
@@ -9,8 +9,8 @@ test('partial data directory reports usable and missing Seiza resources', async 
   const body = await response.json();
   expect(body.success).toBe(true);
   expect(body.data).toMatchObject({
-    seiza_version: '0.12.0',
-    seiza_fits_version: '0.2.0',
+    seiza_version: '0.12.2',
+    seiza_fits_version: '0.2.1',
     features: {
       object_association: true,
       object_name_search: false,

--- a/static/e2e/image-astrometry.spec.ts
+++ b/static/e2e/image-astrometry.spec.ts
@@ -129,7 +129,7 @@ test('keeps catalog-only association distinct when a real FITS file has no WCS',
     mode: 'hinted',
     catalog_scope: 'solved_footprint',
     solver_provenance: {
-      seiza_version: '0.12.0',
+      seiza_version: '0.12.2',
       detection_backend: 'mtf_u8',
       star_catalog: { format: 'SEIZAST2' },
     },

--- a/tests/integration_astrometry_capabilities.rs
+++ b/tests/integration_astrometry_capabilities.rs
@@ -100,8 +100,8 @@ async fn capabilities_and_validation_report_a_partial_data_directory() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["data"]["seiza_version"], "0.12.0");
-    assert_eq!(body["data"]["seiza_fits_version"], "0.2.0");
+    assert_eq!(body["data"]["seiza_version"], "0.12.2");
+    assert_eq!(body["data"]["seiza_fits_version"], "0.2.1");
     assert_eq!(
         body["data"]["resources"]["objects"]["status"],
         serde_json::to_value(AstrometryResourceStatus::Available).unwrap()

--- a/tests/integration_spatial_scan.rs
+++ b/tests/integration_spatial_scan.rs
@@ -425,7 +425,7 @@ async fn cached_astrometry_reduces_score_and_marks_regrade_reason() {
             "modified_subsec_nanos": source_modified.subsec_nanos()
         },
         "solver_provenance": {
-            "seiza_version": "0.12.0", "detection_backend": "mtf_u8",
+            "seiza_version": "0.12.2", "detection_backend": "mtf_u8",
             "star_catalog": {
                 "name": "stars", "path": "/data/stars.bin", "format": "test",
                 "size_bytes": 1, "modified_unix_seconds": 1

--- a/tests/integration_spatial_scan.rs
+++ b/tests/integration_spatial_scan.rs
@@ -425,7 +425,8 @@ async fn cached_astrometry_reduces_score_and_marks_regrade_reason() {
             "modified_subsec_nanos": source_modified.subsec_nanos()
         },
         "solver_provenance": {
-            "seiza_version": "0.12.2", "detection_backend": "mtf_u8",
+            "seiza_version": "0.12.2", "seiza_fits_version": "0.2.1",
+            "detection_backend": "mtf_u8",
             "star_catalog": {
                 "name": "stars", "path": "/data/stars.bin", "format": "test",
                 "size_bytes": 1, "modified_unix_seconds": 1


### PR DESCRIPTION
## Summary

- treat the standard FITS `XPIXSZ` value as the effective pixel width after binning
- retain the prior binning behavior for the non-standard `PIXSIZE` and `PIXELSIZE` aliases
- retry failed hinted solves with a broad blind search instead of constraining the fallback around the rejected scale
- include both Seiza and seiza-fits versions in persisted solve provenance so stale cache entries retry
- add a regression test based on the reported N.I.N.A. ASI294 header

## Cause

N.I.N.A. writes `XPIXSZ` as the effective pixel width. Multiplying it by `XBINNING` doubled the inferred width and produced a 1.91 arcsec/pixel hint for a field whose scale is about 0.945 arcsec/pixel. That bad hint yielded only five catalog matches. It also set the lower bound of the constrained blind fallback just above the true scale.

## Validation

- the reported FITS frame now solves in hinted mode with 94 matches, 1.34 arcsec RMS, and a 96 ms solve time
- all seven distinct local camera/header classes solve through the exact PSF Guard build
- the same field passes a broad pure blind solve with 114 matches
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet` (444 passed, 5 ignored)
