### PR TITLE
Install Seiza star identifier catalogs

### DIFF
--- a/src/server/catalog_install.rs
+++ b/src/server/catalog_install.rs
@@ -30,12 +30,14 @@ impl CatalogInstallPreset {
                 Dataset::MinorBodies,
                 Dataset::Transients,
                 Dataset::StarsLiteTycho2,
+                Dataset::StarsLiteTycho2Identifiers,
             ],
             Self::SolverGaia => &[
                 Dataset::Objects,
                 Dataset::MinorBodies,
                 Dataset::Transients,
                 Dataset::StarsGaia,
+                Dataset::StarsLiteTycho2Identifiers,
             ],
             Self::BlindDeep => &[
                 Dataset::Objects,
@@ -43,6 +45,7 @@ impl CatalogInstallPreset {
                 Dataset::Transients,
                 Dataset::StarsDeepGaia17,
                 Dataset::BlindGaia16,
+                Dataset::StarsLiteTycho2Identifiers,
             ],
             Self::BlindDeepGaia20 => &[
                 Dataset::Objects,
@@ -50,6 +53,7 @@ impl CatalogInstallPreset {
                 Dataset::Transients,
                 Dataset::StarsDeepGaia20,
                 Dataset::BlindGaia16,
+                Dataset::StarsLiteTycho2Identifiers,
             ],
         }
     }
@@ -375,11 +379,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn presets_request_the_expected_number_of_files() {
-        assert_eq!(CatalogInstallPreset::SolverLite.file_count(), 4);
-        assert_eq!(CatalogInstallPreset::SolverGaia.file_count(), 4);
-        assert_eq!(CatalogInstallPreset::BlindDeep.file_count(), 5);
-        assert_eq!(CatalogInstallPreset::BlindDeepGaia20.file_count(), 5);
+    fn presets_request_the_expected_files() {
+        let presets = [
+            (CatalogInstallPreset::SolverLite, 5),
+            (CatalogInstallPreset::SolverGaia, 5),
+            (CatalogInstallPreset::BlindDeep, 6),
+            (CatalogInstallPreset::BlindDeepGaia20, 6),
+        ];
+
+        for (preset, file_count) in presets {
+            assert_eq!(preset.file_count(), file_count);
+            assert!(
+                preset
+                    .datasets()
+                    .contains(&Dataset::StarsLiteTycho2Identifiers),
+                "{preset:?} must install the star identifier catalog"
+            );
+        }
     }
 
     #[test]

--- a/static/src/components/SeizaCatalogControls.tsx
+++ b/static/src/components/SeizaCatalogControls.tsx
@@ -107,8 +107,8 @@ export default function SeizaCatalogControls() {
         <div>
           <h3 id="seiza-catalog-title">Seiza Catalogs</h3>
           <p>
-            Install the sky data used for object overlays and plate solving. Downloads are
-            verified, cached, and safe to retry.
+            Install the sky data used for object and star labels, overlays, and plate solving.
+            Downloads are verified, cached, and safe to retry.
           </p>
         </div>
         {capabilities.data && (

--- a/static/src/components/__tests__/SeizaCatalogControls.test.tsx
+++ b/static/src/components/__tests__/SeizaCatalogControls.test.tsx
@@ -72,7 +72,7 @@ describe('SeizaCatalogControls', () => {
               output_dir: '/catalogs',
               file_name: 'stars-deep-gaia17.bin',
               files_completed: 2,
-              files_total: 5,
+              files_total: 6,
               bytes_completed: 50,
               bytes_total: 100,
             },
@@ -94,7 +94,7 @@ describe('SeizaCatalogControls', () => {
     expect(
       await screen.findByText('Downloading stars-deep-gaia17.bin…')
     ).toBeInTheDocument();
-    expect(screen.getByText('2/5 files')).toBeInTheDocument();
+    expect(screen.getByText('2/6 files')).toBeInTheDocument();
     expect(screen.getByRole('progressbar')).toHaveAttribute('value', '50');
   });
 });


### PR DESCRIPTION
## What changed

- request `StarsLiteTycho2Identifiers` in every catalog install preset
- report the new file in package progress totals
- state in Settings that catalog installs include star labels
- test both the package size and the required identifier dataset

## Root cause

PSF Guard showed the star identifier catalog as unavailable because none of its four install presets selected the identifier dataset exposed by `seiza-download`.

## Checks

- `cargo fmt --check`
- `cargo test server::catalog_install::tests`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm run lint`
- `npm test -- --run src/components/__tests__/SeizaCatalogControls.test.tsx`

Closes #260.
