### PR TITLE
Prepare PSF Guard 0.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/v0.6.5.md
+++ b/docs/releases/v0.6.5.md
@@ -1,0 +1,27 @@
+# PSF Guard 0.6.5
+
+This patch release fixes plate solving for binned NINA FITS files, adds star
+names to Seiza catalog packages, and shows full release summaries in update
+notices.
+
+N.I.N.A. records `XPIXSZ` as the effective pixel width after binning. PSF Guard
+no longer multiplies that value by the binning factor a second time. This gives
+the solver the right image scale. If a full hint still fails, blind solving now
+searches the full scale range instead of reusing the bad scale.
+
+Cached solve results now record both the Seiza and seiza-fits versions. PSF
+Guard retries old results when either part of the solver changes.
+
+Every Seiza catalog package now includes the bright-star identifier data used
+for star labels. Reinstall or update a catalog package in Settings to add the
+file to an existing setup.
+
+Update notices now use the opening sentence from these release notes instead
+of the generic fallback text.
+
+## Download choices
+
+- Windows: NSIS setup or MSI, plus a stand-alone CLI.
+- macOS: DMG or zipped Apple Silicon app, plus a stand-alone Apple Silicon CLI.
+- Linux: Debian package, AppImage, Fedora RPM, or a stand-alone CLI.
+- Server: Docker image or the same CLI binary in `server` mode.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -7,7 +7,7 @@
 %global debug_package %{nil}
 
 Name:           psf-guard
-Version:        0.6.4
+Version:        0.6.5
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -90,6 +90,10 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Tue Jul 28 2026 Yann Ramin <github@theatr.us> - 0.6.5-1
+- Fix N.I.N.A. pixel-scale hints and install star identifier catalogs
+- Show the release summary in update notices
+
 * Sun Jul 26 2026 Yann Ramin <github@theatr.us> - 0.6.4-1
 - Split Settings into Databases, Catalogs, and Sync tabs
 

--- a/scripts/release-feeds.test.mjs
+++ b/scripts/release-feeds.test.mjs
@@ -164,6 +164,10 @@ test('reads the summary shipped for a real tag', async () => {
   // Against the checked-in notes, so the extraction cannot drift from what
   // releases actually publish.
   assert.equal(
+    await readReleaseSummary('v0.6.5'),
+    'This patch release fixes plate solving for binned NINA FITS files, adds star names to Seiza catalog packages, and shows full release summaries in update notices.',
+  );
+  assert.equal(
     await readReleaseSummary('v0.6.4'),
     'This patch release reorganizes Settings.',
   );

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
## Release

Prepare PSF Guard 0.6.5 from current `main`.

Highlights:

- fix N.I.N.A. pixel-scale hints for binned FITS files
- broaden blind fallback after a rejected full hint
- invalidate cached solves when Seiza or seiza-fits changes
- include star identifiers in every Seiza catalog package
- publish the release-note summary in update notices

## Release files

- bump Cargo, Tauri, and RPM versions to `0.6.5`
- add the RPM changelog entry
- add `docs/releases/v0.6.5.md`
- lock the public update-banner summary in the release-feed test

## Local gates

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked` — 444 passed, 5 ignored; all integration tests passed
- `cargo build --release --locked --bin psf-guard-cli`
- `node scripts/check-release-version.mjs v0.6.5`
- Node 24: `npm ci`, lint, 174 Vitest tests, production build, and 14 release tests
- pinned `actionlint` on all GitHub workflows
- signed local macOS app bundle; deep code-signature check passed and bundle version is `0.6.5`

The first release-feed run caught the dotted `N.I.N.A.` name truncating the update banner. The notes now use `NINA` in that one summary sentence, and the corrected full sentence has a regression check.
