### PR TITLE
chore: prepare v0.6.6 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,34 @@ jobs:
       run: |
         bash scripts/package-macos.sh --config "${{ runner.temp }}/psf-guard-updater.json"
 
+    # Tauri notarizes and staples the app before it creates the DMG. The disk
+    # image is signed afterward, so submit and staple that final artifact too.
+    # These checks keep an unnotarized installer out of the public release.
+    - name: Notarize and verify macOS disk image
+      if: matrix.os == 'macos-latest'
+      env:
+        APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        APPLE_API_KEY_PATH: AuthKey_${{ secrets.APPLE_API_KEY }}.p8
+      shell: bash
+      run: |
+        app=$(find target/release/bundle/macos -maxdepth 1 -name "*.app" -print -quit)
+        dmg=$(find target/release/bundle/dmg -maxdepth 1 -name "*.dmg" -print -quit)
+        test -n "$app" && test -d "$app"
+        test -n "$dmg" && test -s "$dmg"
+
+        codesign --verify --deep --strict --verbose=2 "$app"
+        xcrun stapler validate "$app"
+        xcrun notarytool submit "$dmg" \
+          --key "$APPLE_API_KEY_PATH" \
+          --key-id "$APPLE_API_KEY" \
+          --issuer "$APPLE_API_ISSUER" \
+          --wait
+        xcrun stapler staple "$dmg"
+        hdiutil verify "$dmg"
+        xcrun stapler validate "$dmg"
+        spctl --assess --type open --context context:primary-signature -v "$dmg"
+
     - name: Prepare release assets
       shell: bash
       run: |
@@ -221,8 +249,11 @@ jobs:
             cp "$updater.sig" "release-assets/PSF-Guard-${APP_VERSION}-windows-x64-setup.exe.sig"
             ;;
           macos-latest)
-            # Copy .dmg installers
-            find target/release/bundle/dmg -name "*.dmg" -exec cp {} release-assets/ \; 2>/dev/null || echo "No .dmg files found"
+            # Tauri's generated name has varied between x64 and aarch64 on
+            # Apple's arm64 runners. Publish one stable, accurate name.
+            dmg=$(find target/release/bundle/dmg -name "*.dmg" -print -quit)
+            test -n "$dmg" && test -s "$dmg"
+            cp "$dmg" "release-assets/PSF.Guard_${APP_VERSION}_aarch64.dmg"
             # Create zip of .app bundles
             if [ -d "target/release/bundle/macos" ]; then
               cd target/release/bundle/macos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async_zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/v0.6.6.md
+++ b/docs/releases/v0.6.6.md
@@ -1,0 +1,15 @@
+# PSF Guard 0.6.6
+
+This patch release fixes the macOS installer so Gatekeeper can verify it.
+
+## Fixed
+
+- Notarize and staple the final DMG after Tauri creates and signs it.
+- Fail the release job unless the app and DMG pass signature, notarization,
+  checksum, and Gatekeeper checks.
+- Name the macOS installer for its Apple Silicon architecture even if Tauri
+  gives the staging file an `x64` suffix.
+
+The v0.6.5 app itself was signed and notarized, but its outer DMG was created
+after that step and lacked its own notarization ticket. Other platforms are
+unchanged from v0.6.5.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -7,7 +7,7 @@
 %global debug_package %{nil}
 
 Name:           psf-guard
-Version:        0.6.5
+Version:        0.6.6
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -90,6 +90,9 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Tue Jul 28 2026 Yann Ramin <github@theatr.us> - 0.6.6-1
+- Notarize and staple the macOS disk image for Gatekeeper
+
 * Tue Jul 28 2026 Yann Ramin <github@theatr.us> - 0.6.5-1
 - Fix N.I.N.A. pixel-scale hints and install star identifier catalogs
 - Show the release summary in update notices

--- a/scripts/release-feeds.test.mjs
+++ b/scripts/release-feeds.test.mjs
@@ -28,6 +28,19 @@ test('labels macOS artifacts as Apple Silicon', async () => {
 
   assert.match(releaseWorkflow, /asset_name: psf-guard-macos-arm64/);
   assert.doesNotMatch(releaseWorkflow, /asset_name: psf-guard-macos-x64/);
+  assert.match(
+    releaseWorkflow,
+    /release-assets\/PSF\.Guard_\$\{APP_VERSION\}_aarch64\.dmg/,
+  );
+  assert.doesNotMatch(
+    releaseWorkflow,
+    /release-assets\/PSF\.Guard_\$\{APP_VERSION\}_x64\.dmg/,
+  );
+  assert.match(releaseWorkflow, /xcrun stapler validate "\$app"/);
+  assert.match(releaseWorkflow, /xcrun notarytool submit "\$dmg"/);
+  assert.match(releaseWorkflow, /xcrun stapler staple "\$dmg"/);
+  assert.match(releaseWorkflow, /xcrun stapler validate "\$dmg"/);
+  assert.match(releaseWorkflow, /spctl --assess .* "\$dmg"/);
   // CI publishes one macOS artifact, from the Tauri job. It carries the
   // bundle and target/release/psf-guard, so dropping the test job's separate
   // macOS upload cost no binary. What matters here is the label: these
@@ -163,6 +176,10 @@ test('truncates a long opening sentence on a word boundary', () => {
 test('reads the summary shipped for a real tag', async () => {
   // Against the checked-in notes, so the extraction cannot drift from what
   // releases actually publish.
+  assert.equal(
+    await readReleaseSummary('v0.6.6'),
+    'This patch release fixes the macOS installer so Gatekeeper can verify it.',
+  );
   assert.equal(
     await readReleaseSummary('v0.6.5'),
     'This patch release fixes plate solving for binned NINA FITS files, adds star names to Seiza catalog packages, and shows full release summaries in update notices.',

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
## Summary

- release PSF Guard 0.6.6
- notarize and staple the final macOS DMG as well as the inner app
- block release uploads unless both Apple tickets, the DMG checksum, and Gatekeeper pass
- publish the Apple Silicon DMG with a stable `aarch64` name

## Why

The v0.6.5 app was signed, notarized, and stapled, but Tauri created the DMG
after that step. The DMG was signed but had no notarization ticket, so
Gatekeeper rejected the downloaded installer. The release guide says to fix a
bad public release with a new version instead of moving its tag.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked` — 444 passed, 5 ignored, plus all integration suites
- `cargo build --release --locked --bin psf-guard-cli`
- `node scripts/check-release-version.mjs v0.6.6`
- release metadata tests — 14 passed
- frontend lint — passed
- frontend Vitest — 36 files, 174 tests passed
- frontend production build — passed
- actionlint 1.7.12 — passed
- local signed app notarization and staple validation — passed
- local DMG notarization and staple validation — passed
- local DMG checksum and Gatekeeper assessment — passed (`Notarized Developer ID`)
