### PR TITLE
Add Sequence thumbnail zoom control

### DIFF
--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -369,6 +369,41 @@ test('sequence mode uses arrows and Space for the same keyboard selection flow',
   await expect(cards.nth(0)).toHaveClass(/current-selection/);
 });
 
+test('sequence thumbnail size can be changed and survives reload', async ({ page }) => {
+  await page.goto(
+    `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1`
+  );
+
+  const cards = page.locator('.sequence-image-card');
+  await expect(cards).toHaveCount(3, { timeout: 15_000 });
+  const size = page.getByLabel('Size:');
+  await expect(size).toHaveValue('150');
+
+  await size.fill('500');
+
+  await expect(page).toHaveURL(/size=500/);
+  const strip = page.locator('.sequence-strip');
+  await expect(strip).toHaveAttribute(
+    'style',
+    /grid-template-columns: repeat\(auto-fill, minmax\(500px, 1fr\)\)/
+  );
+  await expect(page.getByText('500px')).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByLabel('Size:')).toHaveValue('500');
+  await expect(page.locator('.sequence-strip')).toHaveAttribute(
+    'style',
+    /grid-template-columns: repeat\(auto-fill, minmax\(500px, 1fr\)\)/
+  );
+
+  await page.setViewportSize({ width: 760, height: 720 });
+  const controlsWidth = await page.locator('.sequence-controls').evaluate((element) => ({
+    client: element.clientWidth,
+    scroll: element.scrollWidth,
+  }));
+  expect(controlsWidth.scroll).toBeLessThanOrEqual(controlsWidth.client);
+});
+
 test('detail closes back to the Sequence session that opened it', async ({ page }) => {
   const secondSessionStart = Math.floor(Date.UTC(2026, 3, 17, 0, 25, 0) / 1000);
   await page.route(`**/api/db/${dbId}/analysis/sequence*`, async (route) => {

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -385,7 +385,7 @@ test('sequence thumbnail size can be changed and survives reload', async ({ page
   const strip = page.locator('.sequence-strip');
   await expect(strip).toHaveAttribute(
     'style',
-    /grid-template-columns: repeat\(auto-fill, minmax\(500px, 1fr\)\)/
+    /grid-template-columns: repeat\(auto-fill, minmax\(min\(500px, 100%\), 1fr\)\)/
   );
   await expect(page.getByText('500px')).toBeVisible();
 
@@ -393,15 +393,72 @@ test('sequence thumbnail size can be changed and survives reload', async ({ page
   await expect(page.getByLabel('Size:')).toHaveValue('500');
   await expect(page.locator('.sequence-strip')).toHaveAttribute(
     'style',
-    /grid-template-columns: repeat\(auto-fill, minmax\(500px, 1fr\)\)/
+    /grid-template-columns: repeat\(auto-fill, minmax\(min\(500px, 100%\), 1fr\)\)/
   );
 
+  await page.getByRole('button', { name: 'Images', exact: true }).click();
+  await expect(page.locator('.image-card')).toHaveCount(3);
+  const gridSize = page.getByLabel('Size:');
+  await expect(gridSize).toHaveValue('500');
+  await gridSize.fill('300');
+  await expect(page).toHaveURL(/size=300/);
+
+  await page.getByRole('button', { name: 'Sequence', exact: true }).click();
+  await expect(page.getByLabel('Size:')).toHaveValue('300');
+
   await page.setViewportSize({ width: 760, height: 720 });
-  const controlsWidth = await page.locator('.sequence-controls').evaluate((element) => ({
-    client: element.clientWidth,
-    scroll: element.scrollWidth,
-  }));
-  expect(controlsWidth.scroll).toBeLessThanOrEqual(controlsWidth.client);
+  await page.getByLabel('Size:').fill('1200');
+  await expect(page).toHaveURL(/size=1200/);
+  await expect(page.locator('.sequence-strip')).toHaveAttribute(
+    'style',
+    /grid-template-columns: repeat\(auto-fill, minmax\(min\(1200px, 100%\), 1fr\)\)/
+  );
+  const widths = await page.evaluate(() => {
+    const controls = document.querySelector<HTMLElement>('.sequence-controls')!;
+    const strip = document.querySelector<HTMLElement>('.sequence-strip')!;
+    return {
+      controls: { client: controls.clientWidth, scroll: controls.scrollWidth },
+      strip: { client: strip.clientWidth, scroll: strip.scrollWidth },
+    };
+  });
+  expect(widths.controls.scroll).toBeLessThanOrEqual(widths.controls.client);
+  expect(widths.strip.scroll).toBeLessThanOrEqual(widths.strip.client);
+});
+
+test('sequence thumbnail resizing keeps the active image visible', async ({ page }) => {
+  await page.route(`**/api/db/${dbId}/analysis/sequence*`, async (route) => {
+    const response = await route.fetch();
+    const body = await response.json() as {
+      data: {
+        sequences: Array<{
+          image_count: number;
+          images: Array<Record<string, unknown> & { image_id: number }>;
+        }>;
+      };
+    };
+    const sequence = body.data.sequences[0];
+    const template = sequence.images[0];
+    sequence.images = Array.from({ length: 30 }, (_, index) => ({
+      ...template,
+      image_id: 101 + index,
+    }));
+    sequence.image_count = sequence.images.length;
+    await route.fulfill({ response, json: body });
+  });
+
+  await page.goto(
+    `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1&current=125`
+  );
+
+  const cards = page.locator('.sequence-image-card');
+  await expect(cards).toHaveCount(30, { timeout: 15_000 });
+  const current = page.locator('.sequence-image-card.current-selection');
+  await expect(current).toBeInViewport();
+
+  await page.getByLabel('Size:').fill('500');
+
+  await expect(page).toHaveURL(/size=500/);
+  await expect(current).toBeInViewport();
 });
 
 test('detail closes back to the Sequence session that opened it', async ({ page }) => {

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -4433,7 +4433,7 @@
   border: none;
 }
 
-.size-control span {
+.size-control .size-value {
   color: var(--color-primary);
   font-weight: 500;
   min-width: 50px;
@@ -5038,7 +5038,7 @@
 
 .sequence-review-row {
   display: grid;
-  grid-template-columns: auto auto minmax(12rem, 1fr);
+  grid-template-columns: auto auto auto minmax(12rem, 1fr);
   align-items: center;
   gap: 0.5rem 0.9rem;
   min-width: 0;
@@ -5146,6 +5146,14 @@
   .sequence-primary-actions { grid-area: actions; }
   .sequence-job-status { grid-area: status; }
   .sequence-history-actions { grid-area: history; }
+
+  .sequence-review-row {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .sequence-selection-slot {
+    grid-column: 1 / -1;
+  }
 }
 
 @media (max-width: 620px) {
@@ -5188,14 +5196,6 @@
 
   .sequence-primary-actions {
     flex-wrap: wrap;
-  }
-
-  .sequence-review-row {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  }
-
-  .sequence-selection-slot {
-    grid-column: 1 / -1;
   }
 
   .sequence-selection-bar {
@@ -5460,7 +5460,6 @@
 /* Time-ordered image gallery */
 .sequence-strip {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(160px, 100%), 1fr));
   gap: 0.5rem;
   padding: 0.75rem 1rem;
   align-items: flex-start;

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -32,6 +32,7 @@ import {
   resolveExpandedGroups,
 } from '../utils/imageGrouping';
 import { imageDetailPath } from '../utils/imageDetailRoutes';
+import { thumbnailGridColumns } from '../utils/thumbnailSizing';
 
 interface GroupedImageGridProps {
   useLazyImages?: boolean;
@@ -861,7 +862,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                   <div 
                     className="filter-images"
                     style={{
-                      gridTemplateColumns: `repeat(auto-fill, minmax(${imageSize}px, 1fr))`,
+                      gridTemplateColumns: thumbnailGridColumns(imageSize),
                     }}
                   >
                     {group.images.map((image) => {

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -14,6 +14,7 @@ import FilterControls, { type FilterOptions } from './FilterControls';
 import StatsDashboard from './StatsDashboard';
 import UndoRedoToolbar from './UndoRedoToolbar';
 import StackPreviewPanel from './StackPreviewPanel';
+import ThumbnailSizeControl from './ThumbnailSizeControl';
 import { 
   type GroupingMode, 
   SINGLE_PROJECT_MODES,
@@ -672,18 +673,11 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
             />
             
             <div className="controls-section">
-              <div className="size-control compact">
-                <label>Size:</label>
-                <input
-                  type="range"
-                  min="150"
-                  max="1200"
-                  step="50"
-                  value={imageSize}
-                  onChange={(e) => setImageSize(Number(e.target.value))}
-                />
-                <span className="size-value">{imageSize}px</span>
-              </div>
+              <ThumbnailSizeControl
+                id="grid-thumbnail-size"
+                value={imageSize}
+                onChange={setImageSize}
+              />
               
               <div className="grouping-control compact">
                 <label>Group:</label>

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -21,6 +21,7 @@ import Dialog from './Dialog';
 import ThumbnailSizeControl from './ThumbnailSizeControl';
 import type { Image, ScoredSequence, ImageQualityResult } from '../api/types';
 import { imageDetailPath } from '../utils/imageDetailRoutes';
+import { thumbnailGridColumns } from '../utils/thumbnailSizing';
 
 function formatCategory(category: string): string {
   return category
@@ -840,14 +841,14 @@ const SequenceStrip = memo(function SequenceStrip({
       );
       currentCard?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
     });
-  }, [currentImageId]);
+  }, [currentImageId, imageSize]);
 
   return (
     <div
       ref={stripRef}
       className="filter-images sequence-strip"
       style={{
-        gridTemplateColumns: `repeat(auto-fill, minmax(${imageSize}px, 1fr))`,
+        gridTemplateColumns: thumbnailGridColumns(imageSize),
       }}
     >
       {images.map(quality => {

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -18,6 +18,7 @@ import { useDbProjectTarget, useGridState } from '../hooks/useUrlState';
 import UndoRedoToolbar from './UndoRedoToolbar';
 import ImageCard from './ImageCard';
 import Dialog from './Dialog';
+import ThumbnailSizeControl from './ThumbnailSizeControl';
 import type { Image, ScoredSequence, ImageQualityResult } from '../api/types';
 import { imageDetailPath } from '../utils/imageDetailRoutes';
 
@@ -48,7 +49,12 @@ function qualityColor(score: number): string {
 
 export default function SequenceView() {
   const { dbId, projectId, targetId } = useDbProjectTarget();
-  const { currentImageId: urlCurrentImageId, setCurrentImageId } = useGridState();
+  const {
+    imageSize,
+    currentImageId: urlCurrentImageId,
+    setImageSize,
+    setCurrentImageId,
+  } = useGridState(150);
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const grading = useGrading(dbId!);
@@ -444,6 +450,11 @@ export default function SequenceView() {
         </div>
 
         <div className="sequence-review-row">
+          <ThumbnailSizeControl
+            id="sequence-thumbnail-size"
+            value={imageSize}
+            onChange={setImageSize}
+          />
           <div className="threshold-control">
             <label htmlFor="sequence-threshold">Threshold:</label>
             <input
@@ -472,8 +483,8 @@ export default function SequenceView() {
               <option value="recommended">Recommended</option>
             </select>
           </div>
-          <div className="sequence-selection-slot">
-            {selectedImages.size > 0 && (
+          {selectedImages.size > 0 && (
+            <div className="sequence-selection-slot">
               <div className="selection-action-bar sequence-selection-bar" aria-label="Selected image actions">
                 <span className="selection-count">{selectedImages.size} selected</span>
                 <button
@@ -491,8 +502,8 @@ export default function SequenceView() {
                   Clear
                 </button>
               </div>
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
 
@@ -581,6 +592,7 @@ export default function SequenceView() {
                 currentImageId={activeImageId}
                 selectedImages={selectedImages}
                 threshold={threshold}
+                imageSize={imageSize}
                 onToggle={toggleImage}
                 onOpen={openImage}
               />
@@ -800,6 +812,7 @@ const SequenceStrip = memo(function SequenceStrip({
   currentImageId,
   selectedImages,
   threshold,
+  imageSize,
   onToggle,
   onOpen,
 }: {
@@ -813,6 +826,7 @@ const SequenceStrip = memo(function SequenceStrip({
   currentImageId: number | null;
   selectedImages: Set<number>;
   threshold: number;
+  imageSize: number;
   onToggle: (id: number) => void;
   onOpen: (id: number) => void;
 }) {
@@ -829,7 +843,13 @@ const SequenceStrip = memo(function SequenceStrip({
   }, [currentImageId]);
 
   return (
-    <div ref={stripRef} className="filter-images sequence-strip">
+    <div
+      ref={stripRef}
+      className="filter-images sequence-strip"
+      style={{
+        gridTemplateColumns: `repeat(auto-fill, minmax(${imageSize}px, 1fr))`,
+      }}
+    >
       {images.map(quality => {
         const image = imageMap.get(quality.image_id) ?? {
           id: quality.image_id,

--- a/static/src/components/ThumbnailSizeControl.tsx
+++ b/static/src/components/ThumbnailSizeControl.tsx
@@ -1,0 +1,27 @@
+interface ThumbnailSizeControlProps {
+  id: string;
+  value: number;
+  onChange: (value: number) => void;
+}
+
+export default function ThumbnailSizeControl({
+  id,
+  value,
+  onChange,
+}: ThumbnailSizeControlProps) {
+  return (
+    <div className="size-control compact">
+      <label htmlFor={id}>Size:</label>
+      <input
+        id={id}
+        type="range"
+        min="150"
+        max="1200"
+        step="50"
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value))}
+      />
+      <output htmlFor={id} className="size-value">{value}px</output>
+    </div>
+  );
+}

--- a/static/src/components/ThumbnailSizeControl.tsx
+++ b/static/src/components/ThumbnailSizeControl.tsx
@@ -1,3 +1,9 @@
+import {
+  THUMBNAIL_SIZE_MAX,
+  THUMBNAIL_SIZE_MIN,
+  THUMBNAIL_SIZE_STEP,
+} from '../utils/thumbnailSizing';
+
 interface ThumbnailSizeControlProps {
   id: string;
   value: number;
@@ -15,9 +21,9 @@ export default function ThumbnailSizeControl({
       <input
         id={id}
         type="range"
-        min="150"
-        max="1200"
-        step="50"
+        min={THUMBNAIL_SIZE_MIN}
+        max={THUMBNAIL_SIZE_MAX}
+        step={THUMBNAIL_SIZE_STEP}
         value={value}
         onChange={(event) => onChange(Number(event.target.value))}
       />

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -427,7 +427,7 @@ describe('SequenceView: interactions', () => {
       expect(new URLSearchParams(search).get('size')).toBe('500');
     });
     expect(document.querySelector('.sequence-strip')).toHaveStyle({
-      gridTemplateColumns: 'repeat(auto-fill, minmax(500px, 1fr))',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(min(500px, 100%), 1fr))',
     });
     expect(screen.getByText('500px')).toBeInTheDocument();
   });

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -401,6 +401,37 @@ describe('SequenceView: interactions', () => {
     expect(cards[0].classList.contains('selected')).toBe(false);
   });
 
+  it('changes thumbnail size and keeps it in the URL', async () => {
+    setupDefaultHandlers();
+    let search = '';
+    function LocationProbe() {
+      search = useLocation().search;
+      return null;
+    }
+
+    const Wrapper = createWrapper('/sequence?db=test&project=1&target=1');
+    render(
+      <Wrapper>
+        <SequenceView />
+        <LocationProbe />
+      </Wrapper>
+    );
+
+    await screen.findByText('82');
+    const size = screen.getByLabelText('Size:');
+    expect(size).toHaveValue('150');
+
+    fireEvent.change(size, { target: { value: '500' } });
+
+    await waitFor(() => {
+      expect(new URLSearchParams(search).get('size')).toBe('500');
+    });
+    expect(document.querySelector('.sequence-strip')).toHaveStyle({
+      gridTemplateColumns: 'repeat(auto-fill, minmax(500px, 1fr))',
+    });
+    expect(screen.getByText('500px')).toBeInTheDocument();
+  });
+
   it('moves the cursor with arrows and toggles selection with Space', async () => {
     setupDefaultHandlers();
 
@@ -440,7 +471,7 @@ describe('SequenceView: interactions', () => {
     // Instead, test with the default threshold -- just click the button and verify behavior.
     // The default threshold of 0.50 won't select any normal fixture images (all are >= 0.70),
     // so let's use fireEvent to set the threshold to 0.80.
-    const slider = screen.getByRole('slider');
+    const slider = screen.getByLabelText('Threshold:');
     // fireEvent is more reliable for range inputs than userEvent
     const { fireEvent } = await import('@testing-library/react');
     fireEvent.change(slider, { target: { value: '0.80' } });

--- a/static/src/hooks/__tests__/useUrlState.test.tsx
+++ b/static/src/hooks/__tests__/useUrlState.test.tsx
@@ -9,6 +9,17 @@ function Router({ children }: PropsWithChildren) {
 }
 
 describe('useGridState', () => {
+  it('supports a view-specific default thumbnail size', async () => {
+    const { result } = renderHook(() => useGridState(150), { wrapper: Router });
+    expect(result.current.imageSize).toBe(150);
+
+    act(() => result.current.setImageSize(500));
+    await waitFor(() => expect(result.current.imageSize).toBe(500));
+
+    act(() => result.current.setImageSize(150));
+    await waitFor(() => expect(result.current.imageSize).toBe(150));
+  });
+
   it('keeps rapid functional multi-selection updates and a stable setter', async () => {
     const { result } = renderHook(() => useGridState(), { wrapper: Router });
     const initialSetter = result.current.setSelectedImages;

--- a/static/src/hooks/useUrlState.ts
+++ b/static/src/hooks/useUrlState.ts
@@ -181,11 +181,14 @@ export function useFilters() {
 /**
  * Hook for managing grid state in URL
  */
-export function useGridState() {
+export function useGridState(defaultImageSize = 300) {
   const { getParam, getNumberParam, getBooleanParam, getArrayParam, getNumberArrayParam, updateParams } = useUrlParams();
   
   const groupingMode = useMemo(() => (getParam('grouping') as GroupingMode) || DEFAULT_SINGLE_PROJECT_MODE, [getParam]);
-  const imageSize = useMemo(() => getNumberParam('size') || 300, [getNumberParam]);
+  const imageSize = useMemo(
+    () => getNumberParam('size') || defaultImageSize,
+    [defaultImageSize, getNumberParam],
+  );
   const showStats = useMemo(() => getBooleanParam('stats'), [getBooleanParam]);
   const expandedGroups = useMemo(() => new Set(getArrayParam('expanded')), [getArrayParam]);
   const currentImageId = useMemo(() => getNumberParam('current'), [getNumberParam]);
@@ -198,8 +201,8 @@ export function useGridState() {
   }, [updateParams]);
   
   const setImageSize = useCallback((size: number) => {
-    updateParams({ size: size === 300 ? null : size });
-  }, [updateParams]);
+    updateParams({ size: size === defaultImageSize ? null : size });
+  }, [defaultImageSize, updateParams]);
   
   const setShowStats = useCallback((show: boolean) => {
     updateParams({ stats: show ? true : null });

--- a/static/src/hooks/useUrlState.ts
+++ b/static/src/hooks/useUrlState.ts
@@ -201,8 +201,8 @@ export function useGridState(defaultImageSize = 300) {
   }, [updateParams]);
   
   const setImageSize = useCallback((size: number) => {
-    updateParams({ size: size === defaultImageSize ? null : size });
-  }, [defaultImageSize, updateParams]);
+    updateParams({ size });
+  }, [updateParams]);
   
   const setShowStats = useCallback((show: boolean) => {
     updateParams({ stats: show ? true : null });

--- a/static/src/utils/thumbnailSizing.ts
+++ b/static/src/utils/thumbnailSizing.ts
@@ -1,0 +1,7 @@
+export const THUMBNAIL_SIZE_MIN = 150;
+export const THUMBNAIL_SIZE_MAX = 1200;
+export const THUMBNAIL_SIZE_STEP = 50;
+
+export function thumbnailGridColumns(size: number): string {
+  return `repeat(auto-fill, minmax(min(${size}px, 100%), 1fr))`;
+}


### PR DESCRIPTION
## Summary

- add the Grid thumbnail-size slider to Sequence analysis
- keep Sequence compact at 150 px until the user changes it
- store explicit thumbnail sizes in the URL so reloads and view changes keep them
- share one accessible size control and responsive grid formula between Grid and Sequence
- wrap Sequence review controls before they overflow at narrower widths
- keep the active Sequence image visible while thumbnail size changes
- clamp maximum thumbnail sizes to the available width

## Checks

- `npm run lint` under Node 24
- `npx vitest run`: 37 files, 182 tests passed
- `npm run build` under Node 24
- `cargo build --release --bin psf-guard`
- `npx playwright test e2e/navigation.spec.ts`: 22 passed
- `git diff --check`
