### PR TITLE
Restore Sequence position after image details

### DIFF
--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -510,15 +510,47 @@ test('detail closes back to the Sequence session that opened it', async ({ page 
   await expect(page).toHaveURL(/#\/detail\/2/);
   await expect(page).toHaveURL(/returnTo=sequence/);
   await expect(page.locator('.image-card-wrapper')).toHaveCount(0);
+  await page.keyboard.press('ArrowRight');
+  await expect(page).toHaveURL(/#\/detail\/3/);
+  await expect(page).toHaveURL(/current=3/);
   await page.reload();
 
   await page.locator('.image-detail-overlay .close-button').click();
 
   await expect(page).toHaveURL(/#\/sequence\?/);
   await expect(page).not.toHaveURL(/returnTo=/);
-  await expect(page).toHaveURL(/current=2/);
+  await expect(page).toHaveURL(/current=3/);
   await expect(tabs.nth(1)).toHaveClass(/active/);
-  await expect(cards.nth(0)).toHaveClass(/current-selection/);
+  await expect(cards.nth(1)).toHaveClass(/current-selection/);
+});
+
+test('detail restores the exact Sequence scroll position', async ({ page }) => {
+  await page.goto(
+    `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1&current=2&size=1200`
+  );
+
+  const cards = page.locator('.sequence-image-card');
+  await expect(cards).toHaveCount(3, { timeout: 15_000 });
+  const current = cards.nth(1);
+  await expect(current).toHaveClass(/current-selection/);
+  await current.evaluate((element) => element.scrollIntoView({ block: 'center' }));
+  await expect(current).toBeInViewport();
+  const scroller = page.locator('.app-main');
+  const before = await scroller.evaluate((element) => element.scrollTop);
+  expect(before).toBeGreaterThan(0);
+
+  // Dispatch directly so Playwright does not reposition this oversized card
+  // while making it actionable; a real user can double-click its visible area.
+  await current.dispatchEvent('dblclick');
+  await expect(page).toHaveURL(/#\/detail\/2/);
+  expect(await page.evaluate(() => window.history.state.usr?.sequenceReturn.scrollTop)).toBe(before);
+  await page.locator('.image-detail-overlay .close-button').click();
+
+  await expect(page).toHaveURL(/#\/sequence\?/);
+  await expect(cards.nth(1)).toHaveClass(/current-selection/);
+  await expect.poll(
+    () => scroller.evaluate((element) => element.scrollTop)
+  ).toBeCloseTo(before, 0);
 });
 
 test('detail opened from Images still closes back to Images', async ({ page }) => {

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -369,6 +369,47 @@ test('sequence mode uses arrows and Space for the same keyboard selection flow',
   await expect(cards.nth(0)).toHaveClass(/current-selection/);
 });
 
+test('sequence arrows reveal a normal card that is only partly visible', async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 800 });
+  await page.goto(
+    `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1&size=300`
+  );
+
+  const cards = page.locator('.sequence-image-card');
+  await expect(cards).toHaveCount(3, { timeout: 15_000 });
+  await expect(cards.nth(0)).toHaveClass(/current-selection/);
+  const nextCard = cards.nth(1);
+
+  await nextCard.evaluate((card) => {
+    const container = document.querySelector<HTMLElement>('.app-main')!;
+    const cardRect = card.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    container.scrollTop += cardRect.top - containerRect.bottom + 20;
+  });
+  const visibleBefore = await nextCard.evaluate((card) => {
+    const container = document.querySelector<HTMLElement>('.app-main')!;
+    const cardRect = card.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    return {
+      partlyVisible: cardRect.top < containerRect.bottom && cardRect.bottom > containerRect.bottom,
+      fitsViewport: cardRect.height <= containerRect.height,
+    };
+  });
+  expect(visibleBefore).toEqual({ partlyVisible: true, fitsViewport: true });
+
+  await page.keyboard.press('ArrowRight');
+  await expect(nextCard).toHaveClass(/current-selection/);
+  await expect.poll(async () => {
+    return nextCard.evaluate((card) => {
+      const container = document.querySelector<HTMLElement>('.app-main')!;
+      const cardRect = card.getBoundingClientRect();
+      const containerRect = container.getBoundingClientRect();
+      return cardRect.top >= containerRect.top - 1
+        && cardRect.bottom <= containerRect.bottom + 1;
+    });
+  }).toBe(true);
+});
+
 test('sequence thumbnail size can be changed and survives reload', async ({ page }) => {
   await page.goto(
     `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1`

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -98,6 +98,7 @@ export default function ImageCard({
   return (
     <div
       ref={setCardRef}
+      data-card-image-id={image.id}
       className={`image-card ${getStatusClass()} ${isSelected ? 'selected' : ''} ${className}`.trim()}
       onClick={onClick}
       onDoubleClick={onDoubleClick}

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -7,7 +7,7 @@ import {
   useLayoutEffect,
   useRef,
 } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useLocation, useSearchParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { apiClient } from '../api/client';
@@ -20,7 +20,11 @@ import ImageCard from './ImageCard';
 import Dialog from './Dialog';
 import ThumbnailSizeControl from './ThumbnailSizeControl';
 import type { Image, ScoredSequence, ImageQualityResult } from '../api/types';
-import { imageDetailPath } from '../utils/imageDetailRoutes';
+import {
+  imageDetailNavigationState,
+  imageDetailPath,
+  sequenceReturnPositionFromState,
+} from '../utils/imageDetailRoutes';
 import { thumbnailGridColumns } from '../utils/thumbnailSizing';
 
 function formatCategory(category: string): string {
@@ -34,6 +38,7 @@ function formatSequenceLabel(sequence: ScoredSequence): string {
   if (!sequence.session_start) return `${sequence.filter_name} (${sequence.image_count})`;
   const start = new Date(sequence.session_start * 1000);
   const when = start.toLocaleString([], {
+    year: 'numeric',
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
@@ -56,6 +61,7 @@ export default function SequenceView() {
     setImageSize,
     setCurrentImageId,
   } = useGridState(150);
+  const location = useLocation();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const grading = useGrading(dbId!);
@@ -122,6 +128,42 @@ export default function SequenceView() {
   }, [activeSequence, urlCurrentImageId]);
   const activeImageIdRef = useRef(activeImageId);
   activeImageIdRef.current = activeImageId;
+  const restoredScrollRef = useRef(false);
+
+  useLayoutEffect(() => {
+    const position = sequenceReturnPositionFromState(location.state);
+    if (restoredScrollRef.current || !position || isAnalyzing || !activeSequence) {
+      return;
+    }
+
+    const scroller = document.querySelector<HTMLElement>('.app-main');
+    if (!scroller) return;
+    restoredScrollRef.current = true;
+
+    const restorePosition = () => {
+      const anchor = document.querySelector<HTMLElement>(
+        `.sequence-image-card[data-card-image-id="${position.imageId}"]`,
+      );
+      if (!anchor) {
+        scroller.scrollTop = position.scrollTop;
+        return;
+      }
+      const currentOffset =
+        anchor.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+      scroller.scrollTop += currentOffset - position.offsetTop;
+    };
+
+    restorePosition();
+    let secondFrame = 0;
+    const firstFrame = requestAnimationFrame(() => {
+      restorePosition();
+      secondFrame = requestAnimationFrame(restorePosition);
+    });
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      if (secondFrame) cancelAnimationFrame(secondFrame);
+    };
+  }, [activeSequence, isAnalyzing, location.state]);
 
   useEffect(() => {
     if (activeImageId !== null && activeImageId !== urlCurrentImageId) {
@@ -303,12 +345,19 @@ export default function SequenceView() {
     if (currentImageId !== null) toggleImage(currentImageId);
   }, sequenceHotkeyOptions, [toggleImage]);
 
-  const routeQuery = searchParams.toString();
   const openImage = useCallback((imageId: number) => {
-    const params = new URLSearchParams(routeQuery);
-    params.set('current', String(imageId));
-    navigate(imageDetailPath(imageId, params, 'sequence'));
-  }, [navigate, routeQuery]);
+    const scroller = document.querySelector<HTMLElement>('.app-main');
+    const anchor = document.querySelector<HTMLElement>(
+      `.sequence-image-card[data-card-image-id="${imageId}"]`,
+    );
+    const scrollTop = scroller?.scrollTop ?? 0;
+    const offsetTop = scroller && anchor
+      ? anchor.getBoundingClientRect().top - scroller.getBoundingClientRect().top
+      : 0;
+    navigate(imageDetailPath(imageId, searchParams, 'sequence'), {
+      state: imageDetailNavigationState({ scrollTop, imageId, offsetTop }),
+    });
+  }, [navigate, searchParams]);
 
   const selectSequence = useCallback((sequence: ScoredSequence) => {
     const firstImageId = sequence.images[0]?.image_id;
@@ -839,7 +888,15 @@ const SequenceStrip = memo(function SequenceStrip({
       const currentCard = stripRef.current?.querySelector<HTMLElement>(
         '.sequence-image-card.current-selection',
       );
-      currentCard?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+      const scroller = stripRef.current?.closest<HTMLElement>('.app-main');
+      if (!currentCard || !scroller) return;
+      const cardRect = currentCard.getBoundingClientRect();
+      const scrollerRect = scroller.getBoundingClientRect();
+      const isOutsideViewport =
+        cardRect.bottom <= scrollerRect.top || cardRect.top >= scrollerRect.bottom;
+      if (isOutsideViewport) {
+        currentCard.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      }
     });
   }, [currentImageId, imageSize]);
 

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -892,9 +892,12 @@ const SequenceStrip = memo(function SequenceStrip({
       if (!currentCard || !scroller) return;
       const cardRect = currentCard.getBoundingClientRect();
       const scrollerRect = scroller.getBoundingClientRect();
+      const isClipped =
+        cardRect.top < scrollerRect.top || cardRect.bottom > scrollerRect.bottom;
       const isOutsideViewport =
         cardRect.bottom <= scrollerRect.top || cardRect.top >= scrollerRect.bottom;
-      if (isOutsideViewport) {
+      const fitsViewport = cardRect.height <= scrollerRect.height;
+      if (isOutsideViewport || (fitsViewport && isClipped)) {
         currentCard.scrollIntoView({ block: 'nearest', inline: 'nearest' });
       }
     });

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -609,6 +609,10 @@ describe('SequenceView: multi-session', () => {
       // Each tab shows the filter, session time, and image count.
       const tabs = screen.getAllByText(/L · .* \(5\)/);
       expect(tabs).toHaveLength(2);
+      const year = new Date(
+        multiSessionFixture.data.sequences[0].session_start * 1000,
+      ).getFullYear();
+      expect(tabs[0]).toHaveTextContent(String(year));
     });
   });
 

--- a/static/src/hooks/useImageNavigation.ts
+++ b/static/src/hooks/useImageNavigation.ts
@@ -1,6 +1,6 @@
 import { useMemo, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { apiClient } from '../api/client';
 import { useDbProjectTarget, useFilters, useGridState } from './useUrlState';
 import type { Image } from '../api/types';
@@ -19,6 +19,7 @@ import {
  * Hook for navigating between images in the current context
  */
 export function useImageNavigation(currentImageId?: number) {
+  const location = useLocation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { dbId, projectId, targetId } = useDbProjectTarget();
@@ -170,7 +171,7 @@ export function useImageNavigation(currentImageId?: number) {
     if (view === 'detail') {
       navigate(
         imageDetailPath(imageId, searchParams, imageDetailReturnView(searchParams)),
-        { replace: true },
+        { replace: true, state: location.state },
       );
     } else {
       // For comparison, we need both left and right image IDs
@@ -178,7 +179,7 @@ export function useImageNavigation(currentImageId?: number) {
         (canGoNext ? flatImages[currentIndex + 1]?.id : imageId) : imageId;
       navigate(`/compare/${imageId}/${rightImageId}?${params}`, { replace: true });
     }
-  }, [navigate, searchParams, currentImageId, canGoNext, flatImages, currentIndex]);
+  }, [navigate, searchParams, currentImageId, canGoNext, flatImages, currentIndex, location.state]);
 
   const goToNext = useCallback(() => {
     if (canGoNext && currentIndex >= 0) {
@@ -200,8 +201,11 @@ export function useImageNavigation(currentImageId?: number) {
   }, [navigate, searchParams]);
 
   const closeDetail = useCallback(() => {
-    navigate(imageDetailClosePath(searchParams), { replace: true });
-  }, [navigate, searchParams]);
+    navigate(imageDetailClosePath(searchParams), {
+      replace: true,
+      state: location.state,
+    });
+  }, [location.state, navigate, searchParams]);
 
   return {
     canGoPrevious,

--- a/static/src/utils/__tests__/imageDetailRoutes.test.ts
+++ b/static/src/utils/__tests__/imageDetailRoutes.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  imageDetailNavigationState,
   imageDetailClosePath,
   imageDetailPath,
   imageDetailReturnView,
+  sequenceReturnPositionFromState,
 } from '../imageDetailRoutes';
 
 describe('image detail routes', () => {
@@ -11,6 +13,16 @@ describe('image detail routes', () => {
 
     expect(imageDetailPath(12, params, 'sequence')).toBe(
       '/detail/12?db=test&project=1&target=2&current=12&returnTo=sequence'
+    );
+  });
+
+  it('updates the Sequence cursor while navigating between Detail images', () => {
+    const params = new URLSearchParams(
+      'db=test&project=1&target=2&current=12&returnTo=sequence'
+    );
+
+    expect(imageDetailPath(13, params, 'sequence')).toBe(
+      '/detail/13?db=test&project=1&target=2&current=13&returnTo=sequence'
     );
   });
 
@@ -38,5 +50,18 @@ describe('image detail routes', () => {
 
     expect(imageDetailReturnView(params)).toBe('grid');
     expect(imageDetailClosePath(params)).toBe('/grid?db=test&project=1');
+  });
+
+  it('validates Sequence scroll state', () => {
+    const position = { scrollTop: 432, imageId: 12, offsetTop: 180 };
+    expect(imageDetailNavigationState(position)).toEqual({ sequenceReturn: position });
+    expect(imageDetailNavigationState({ ...position, scrollTop: -10 })).toEqual({
+      sequenceReturn: { ...position, scrollTop: 0 },
+    });
+    expect(sequenceReturnPositionFromState({ sequenceReturn: position })).toEqual(position);
+    expect(sequenceReturnPositionFromState({
+      sequenceReturn: { ...position, offsetTop: Number.NaN },
+    })).toBeNull();
+    expect(sequenceReturnPositionFromState(null)).toBeNull();
   });
 });

--- a/static/src/utils/imageDetailRoutes.ts
+++ b/static/src/utils/imageDetailRoutes.ts
@@ -2,6 +2,54 @@ export type ImageDetailReturnView = 'grid' | 'sequence';
 
 const RETURN_TO_PARAM = 'returnTo';
 
+export interface SequenceReturnPosition {
+  scrollTop: number;
+  imageId: number;
+  offsetTop: number;
+}
+
+export interface ImageDetailNavigationState {
+  sequenceReturn: SequenceReturnPosition;
+}
+
+export function imageDetailNavigationState(
+  sequenceReturn: SequenceReturnPosition,
+): ImageDetailNavigationState {
+  return {
+    sequenceReturn: {
+      scrollTop: Math.max(0, sequenceReturn.scrollTop),
+      imageId: sequenceReturn.imageId,
+      offsetTop: sequenceReturn.offsetTop,
+    },
+  };
+}
+
+export function sequenceReturnPositionFromState(
+  state: unknown,
+): SequenceReturnPosition | null {
+  if (!state || typeof state !== 'object' || !('sequenceReturn' in state)) {
+    return null;
+  }
+  const value = state.sequenceReturn;
+  if (!value || typeof value !== 'object') return null;
+  if (!('scrollTop' in value) || !('imageId' in value) || !('offsetTop' in value)) {
+    return null;
+  }
+  return typeof value.scrollTop === 'number'
+    && Number.isFinite(value.scrollTop)
+    && value.scrollTop >= 0
+    && typeof value.imageId === 'number'
+    && Number.isInteger(value.imageId)
+    && typeof value.offsetTop === 'number'
+    && Number.isFinite(value.offsetTop)
+    ? {
+        scrollTop: value.scrollTop,
+        imageId: value.imageId,
+        offsetTop: value.offsetTop,
+      }
+    : null;
+}
+
 export function imageDetailReturnView(
   searchParams: URLSearchParams,
 ): ImageDetailReturnView {
@@ -16,6 +64,7 @@ export function imageDetailPath(
   const params = new URLSearchParams(searchParams);
   if (returnView === 'sequence') {
     params.set(RETURN_TO_PARAM, 'sequence');
+    params.set('current', String(imageId));
   } else {
     params.delete(RETURN_TO_PARAM);
   }


### PR DESCRIPTION
## Summary

- restore the Sequence image anchor and exact scroll offset after closing Detail
- keep the Sequence `current` image in sync while moving through images in Detail
- preserve the return state through Detail reloads and previous/next navigation
- show the year in sequence session labels; the server still owns full-timestamp ordering

## Checks

- `npm run lint` (Node 24)
- `npx vitest run` (37 files, 184 tests)
- `npm run build` (Node 24)
- `cargo build --release --bin psf-guard`
- `npx playwright test e2e/navigation.spec.ts` (23 passed)
- `git diff --check`
