### PR TITLE
Align Sequence navigation with the image grid

### DIFF
--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -365,8 +365,112 @@ test('sequence mode uses arrows and Space for the same keyboard selection flow',
   await page.keyboard.press('Space');
   await expect(page.locator('.sequence-image-card.selected')).toHaveCount(2);
 
+  await page.keyboard.press('ArrowLeft');
+  await expect(cards.nth(0)).toHaveClass(/current-selection/);
+});
+
+test('Sequence opens the only target in a project', async ({ page }) => {
+  await page.goto(`/#/sequence?db=${encodeURIComponent(dbId)}&project=1`);
+
+  await expect(page).toHaveURL(/target=1/);
+  await expect(page.locator('.sequence-image-card')).toHaveCount(3, { timeout: 15_000 });
+});
+
+test('Sequence keeps the current Grid image and opens its session', async ({ page }) => {
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1&size=300`);
+  const gridCards = page.locator('.image-card-wrapper');
+  await expect(gridCards).toHaveCount(3, { timeout: 15_000 });
+  const chosenId = await gridCards.nth(1).getAttribute('data-image-id');
+  expect(chosenId).not.toBeNull();
+  await gridCards.nth(1).click();
+
+  await page.getByRole('button', { name: 'Sequence', exact: true }).click();
+
+  await expect(page).toHaveURL(/target=1/);
+  await expect(page).toHaveURL(new RegExp(`current=${chosenId}`));
+  await expect(
+    page.locator(`.sequence-image-card[data-card-image-id="${chosenId}"]`)
+  ).toHaveClass(/current-selection/);
+});
+
+test('Sequence vertical arrows follow the rendered thumbnail grid', async ({ page }) => {
+  await page.setViewportSize({ width: 760, height: 720 });
+  await page.goto(
+    `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1&size=300`
+  );
+
+  const cards = page.locator('.sequence-image-card');
+  await expect(cards).toHaveCount(3, { timeout: 15_000 });
+  await expect(cards.nth(0)).toHaveClass(/current-selection/);
+
+  await page.keyboard.press('ArrowDown');
+  await expect(cards.nth(2)).toHaveClass(/current-selection/);
   await page.keyboard.press('ArrowUp');
   await expect(cards.nth(0)).toHaveClass(/current-selection/);
+});
+
+test('Sequence Shift-click selects a visible range', async ({ page }) => {
+  await page.goto(
+    `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1`
+  );
+
+  const cards = page.locator('.sequence-image-card');
+  await expect(cards).toHaveCount(3, { timeout: 15_000 });
+  await cards.nth(2).click({ modifiers: ['Shift'] });
+
+  await expect(page.locator('.sequence-image-card.selected')).toHaveCount(3);
+  await expect(page.locator('.sequence-selection-bar')).toContainText('3 selected');
+});
+
+test('many Sequence tabs stay on one stable scrolling row', async ({ page }) => {
+  await page.route(`**/api/db/${dbId}/analysis/sequence*`, async (route) => {
+    const response = await route.fetch();
+    const body = await response.json() as {
+      data: {
+        sequences: Array<{
+          session_start: number;
+          session_end: number;
+          image_count: number;
+          images: Array<Record<string, unknown> & { image_id: number }>;
+        }>;
+      };
+    };
+    const template = body.data.sequences[0];
+    body.data.sequences = Array.from({ length: 12 }, (_, sequenceIndex) => ({
+      ...template,
+      session_start: template.session_start - sequenceIndex * 86_400,
+      session_end: template.session_end - sequenceIndex * 86_400,
+      images: template.images.map((image, imageIndex) => ({
+        ...image,
+        image_id: 1_000 + sequenceIndex * 10 + imageIndex,
+      })),
+    }));
+    await route.fulfill({ response, json: body });
+  });
+  await page.setViewportSize({ width: 760, height: 720 });
+  await page.goto(`/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1`);
+
+  const tabs = page.locator('.sequence-tab');
+  await expect(tabs).toHaveCount(12, { timeout: 15_000 });
+  const before = await tabs.evaluateAll(elements => elements.map(element => ({
+    top: element.getBoundingClientRect().top,
+    width: element.getBoundingClientRect().width,
+  })));
+  expect(new Set(before.map(tab => Math.round(tab.top))).size).toBe(1);
+
+  await tabs.last().click();
+  await expect(tabs.last()).toHaveClass(/active/);
+  const after = await tabs.evaluateAll(elements => elements.map(element => ({
+    top: element.getBoundingClientRect().top,
+    width: element.getBoundingClientRect().width,
+  })));
+  expect(new Set(after.map(tab => Math.round(tab.top))).size).toBe(1);
+  expect(after.map(tab => Math.round(tab.width))).toEqual(
+    before.map(tab => Math.round(tab.width))
+  );
+  await expect.poll(
+    () => page.locator('.sequence-tabs').evaluate(element => element.scrollLeft)
+  ).toBeGreaterThan(0);
 });
 
 test('sequence arrows reveal a normal card that is only partly visible', async ({ page }) => {

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -393,6 +393,56 @@ test('Sequence keeps the current Grid image and opens its session', async ({ pag
   ).toHaveClass(/current-selection/);
 });
 
+test('Sequence keeps a Grid selection that spans session tabs', async ({ page }) => {
+  const secondSessionStart = Math.floor(Date.UTC(2026, 3, 17, 0, 25, 0) / 1000);
+  await page.route(`**/api/db/${dbId}/analysis/sequence*`, async (route) => {
+    const response = await route.fetch();
+    const body = await response.json() as {
+      data: {
+        sequences: Array<{
+          session_start?: number;
+          session_end?: number;
+          image_count: number;
+          images: Array<{ image_id: number }>;
+        }>;
+      };
+    };
+    const original = body.data.sequences[0];
+    const [firstImage, ...laterImages] = original.images;
+    body.data.sequences = [
+      {
+        ...original,
+        image_count: 1,
+        images: [firstImage],
+      },
+      {
+        ...original,
+        session_start: secondSessionStart,
+        session_end: secondSessionStart + 132,
+        image_count: laterImages.length,
+        images: laterImages,
+      },
+    ];
+    await route.fulfill({ response, json: body });
+  });
+
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+  const gridCards = page.locator('.image-card-wrapper');
+  await expect(gridCards).toHaveCount(3, { timeout: 15_000 });
+  await gridCards.nth(0).click();
+  const additiveModifier: 'Meta' | 'Control' = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await gridCards.nth(2).click({ modifiers: [additiveModifier] });
+  await expect(page.locator('.image-card-wrapper.multi-selected')).toHaveCount(2);
+
+  await page.getByRole('button', { name: 'Sequence', exact: true }).click();
+
+  await expect(page.locator('.sequence-tab')).toHaveCount(2, { timeout: 15_000 });
+  await expect(page.locator('.sequence-tab-selection-count')).toHaveCount(2);
+  await expect(page.locator('.sequence-selection-bar')).toContainText('2 selected');
+  await expect(page.locator('.sequence-image-card.selected')).toHaveCount(1);
+  await expect(page.locator('.sequence-tab').nth(1)).toHaveClass(/active/);
+});
+
 test('Sequence vertical arrows follow the rendered thumbnail grid', async ({ page }) => {
   await page.setViewportSize({ width: 760, height: 720 });
   await page.goto(

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -5356,21 +5356,27 @@
 /* Sequence tabs */
 .sequence-tabs {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.25rem;
   padding: 0.75rem 1rem 0;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
 }
 
 .sequence-tab {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.4rem;
   background: var(--color-bg-tertiary);
   border: 1px solid var(--color-bg-quaternary);
-  border-bottom: none;
-  border-radius: 6px 6px 0 0;
+  border-radius: 6px;
   padding: 0.5rem 1rem;
   cursor: pointer;
   color: var(--color-text-secondary);
   font-size: 0.9rem;
-  transition: all 0.2s;
+  white-space: nowrap;
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s;
 }
 
 .sequence-tab.active {
@@ -5381,6 +5387,19 @@
 
 .sequence-tab:hover:not(.active) {
   background: var(--color-bg-quaternary);
+}
+
+.sequence-tab-selection-count {
+  display: inline-grid;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.3rem;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--color-bg-primary);
+  background: var(--color-warning);
+  font-size: 0.72rem;
+  font-weight: 700;
 }
 
 /* Summary bar */

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -32,13 +32,15 @@ import {
   resolveExpandedGroups,
 } from '../utils/imageGrouping';
 import { imageDetailPath } from '../utils/imageDetailRoutes';
+import {
+  findGridNavigationIndex,
+  type GridNavigationDirection,
+} from '../utils/gridNavigation';
 import { thumbnailGridColumns } from '../utils/thumbnailSizing';
 
 interface GroupedImageGridProps {
   useLazyImages?: boolean;
 }
-
-type GridNavigationDirection = 'next' | 'prev' | 'up' | 'down';
 
 export default function GroupedImageGrid({ useLazyImages = false }: GroupedImageGridProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -302,46 +304,14 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
 
     if (currentIndex === -1) return;
 
-    let newIndex = currentIndex;
-    if (direction === 'next') {
-      newIndex = Math.min(currentIndex + 1, flatImages.length - 1);
-    } else if (direction === 'prev') {
-      newIndex = Math.max(currentIndex - 1, 0);
-    } else {
-      const currentId = flatImages[currentIndex].id;
-      const currentNode = containerRef.current?.querySelector<HTMLElement>(
-        `[data-image-id="${currentId}"]`,
-      );
-      if (!currentNode) return;
-
-      const currentRect = currentNode.getBoundingClientRect();
-      const currentCenter = currentRect.left + currentRect.width / 2;
-      const sign = direction === 'down' ? 1 : -1;
-      let bestVerticalDistance = Number.POSITIVE_INFINITY;
-      let bestHorizontalDistance = Number.POSITIVE_INFINITY;
-
-      flatImages.forEach((image, index) => {
-        if (index === currentIndex) return;
-        const node = containerRef.current?.querySelector<HTMLElement>(
-          `[data-image-id="${image.id}"]`,
-        );
-        if (!node) return;
-
-        const rect = node.getBoundingClientRect();
-        const verticalDistance = (rect.top - currentRect.top) * sign;
-        if (verticalDistance <= 4) return;
-        const horizontalDistance = Math.abs((rect.left + rect.width / 2) - currentCenter);
-
-        const isCloserRow = verticalDistance < bestVerticalDistance - 4;
-        const isCloserColumn = Math.abs(verticalDistance - bestVerticalDistance) <= 4
-          && horizontalDistance < bestHorizontalDistance;
-        if (isCloserRow || isCloserColumn) {
-          newIndex = index;
-          bestVerticalDistance = verticalDistance;
-          bestHorizontalDistance = horizontalDistance;
-        }
-      });
-    }
+    const newIndex = findGridNavigationIndex(
+      flatImages,
+      currentIndex,
+      direction,
+      image => containerRef.current
+        ?.querySelector<HTMLElement>(`[data-image-id="${image.id}"]`)
+        ?.getBoundingClientRect() ?? null,
+    );
 
     if (newIndex === currentIndex) return;
 

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -63,8 +63,10 @@ export default function SequenceView() {
   const {
     imageSize,
     currentImageId: urlCurrentImageId,
+    selectedImages,
     setImageSize,
     setCurrentImageId,
+    setSelectedImages,
   } = useGridState(150);
   const location = useLocation();
   const [searchParams] = useSearchParams();
@@ -74,7 +76,6 @@ export default function SequenceView() {
 
   const filterName = searchParams.get('filterName') || undefined;
   const [threshold, setThreshold] = useState(0.5);
-  const [selectedImages, setSelectedImages] = useState<Set<number>>(new Set());
   const [showRejectReview, setShowRejectReview] = useState(false);
   const spatialScan = useSpatialScan(dbId, targetId ?? undefined, filterName);
 
@@ -106,14 +107,36 @@ export default function SequenceView() {
 
   // Preserve the Grid cursor when it identifies a target. With no cursor,
   // skip the target picker when the project has only one choice.
+  const entrySelectionRef = useRef<Set<number> | null>(new Set(selectedImages));
+  const inferredSelectionRef = useRef<Set<number> | null>(null);
   useEffect(() => {
     if (!projectId || targetId) return;
     const currentTargetId = urlCurrentImageId === null
       ? null
       : imageMap.get(urlCurrentImageId)?.target_id ?? null;
-    const inferredTargetId = currentTargetId ?? (targets.length === 1 ? targets[0].id : null);
-    if (inferredTargetId !== null) setTargetId(inferredTargetId);
-  }, [imageMap, projectId, setTargetId, targetId, targets, urlCurrentImageId]);
+    const onlyTargetId = targets.length === 1 ? targets[0].id : null;
+    const inferredTargetId = currentTargetId ?? onlyTargetId;
+    if (inferredTargetId !== null) {
+      const inferredSelection = new Set(
+        Array.from(entrySelectionRef.current ?? []).filter(imageId => {
+          const image = imageMap.get(imageId);
+          return image?.target_id === inferredTargetId || (
+            image === undefined && onlyTargetId === inferredTargetId
+          );
+        }),
+      );
+      entrySelectionRef.current = inferredSelection;
+      inferredSelectionRef.current = inferredSelection;
+      setTargetId(inferredTargetId);
+    }
+  }, [
+    imageMap,
+    projectId,
+    setTargetId,
+    targetId,
+    targets,
+    urlCurrentImageId,
+  ]);
 
   // A selection may span sessions for one target, but never survives a scope
   // change where its quality evidence is no longer loaded.
@@ -122,9 +145,12 @@ export default function SequenceView() {
   useEffect(() => {
     if (selectionScopeRef.current !== selectionScope) {
       selectionScopeRef.current = selectionScope;
-      setSelectedImages(new Set());
+      const inferredSelection = inferredSelectionRef.current;
+      inferredSelectionRef.current = null;
+      if (inferredSelection === null) entrySelectionRef.current = null;
+      setSelectedImages(inferredSelection ?? new Set());
     }
-  }, [selectionScope]);
+  }, [selectionScope, setSelectedImages]);
 
   // Auto-analyze when target is selected
   useEffect(() => {
@@ -134,6 +160,25 @@ export default function SequenceView() {
   }, [targetId, filterName, analyze]);
 
   const sequences = useMemo(() => analysisData?.sequences ?? [], [analysisData?.sequences]);
+
+  // Grid selection shares URL state with Sequence. Normalize that initial
+  // selection once the active target's analysis has loaded. Later Sequence
+  // selections must remain untouched.
+  useEffect(() => {
+    const entrySelection = entrySelectionRef.current;
+    if (!targetId || !analysisData || isAnalyzing || entrySelection === null) return;
+
+    entrySelectionRef.current = null;
+    const sequenceImageIds = new Set(
+      sequences.flatMap(sequence => sequence.images.map(image => image.image_id)),
+    );
+    const normalizedSelection = new Set(
+      Array.from(entrySelection).filter(imageId => sequenceImageIds.has(imageId)),
+    );
+    const unchanged = normalizedSelection.size === selectedImages.size
+      && Array.from(normalizedSelection).every(imageId => selectedImages.has(imageId));
+    if (!unchanged) setSelectedImages(normalizedSelection);
+  }, [analysisData, isAnalyzing, selectedImages, sequences, setSelectedImages, targetId]);
   const activeSequenceIndex = useMemo(() => {
     if (urlCurrentImageId !== null) {
       const currentIndex = sequences.findIndex(sequence =>
@@ -231,7 +276,7 @@ export default function SequenceView() {
       }
     });
     setSelectedImages(ids);
-  }, [activeSequence, threshold]);
+  }, [activeSequence, setSelectedImages, threshold]);
 
   // Select contiguous runs of clouded/occluded/bad images
   const selectCloudedSequence = useCallback(() => {
@@ -261,7 +306,7 @@ export default function SequenceView() {
       runBuffer.forEach(id => ids.add(id));
     }
     setSelectedImages(ids);
-  }, [activeSequence]);
+  }, [activeSequence, setSelectedImages]);
 
   const selectAstrometryIssues = useCallback(() => {
     if (!activeSequence) return;
@@ -271,7 +316,7 @@ export default function SequenceView() {
           flag === 'off_target' || flag === 'pointing_jump' || flag === 'pointing_drift'))
         .map(img => img.image_id)
     ));
-  }, [activeSequence]);
+  }, [activeSequence, setSelectedImages]);
 
   const selectUnsolved = useCallback(() => {
     if (!activeSequence) return;
@@ -280,7 +325,7 @@ export default function SequenceView() {
         .filter(img => img.pointing?.solve_failed && img.pointing.image_quality_evidence)
         .map(img => img.image_id)
     ));
-  }, [activeSequence]);
+  }, [activeSequence, setSelectedImages]);
 
   const selectRecommended = useCallback(() => {
     if (!activeSequence) return;
@@ -289,7 +334,7 @@ export default function SequenceView() {
         .filter(img => !!img.regrade_reason)
         .map(img => img.image_id)
     ));
-  }, [activeSequence]);
+  }, [activeSequence, setSelectedImages]);
 
   const applySelectionPreset = useCallback((preset: string) => {
     switch (preset) {
@@ -345,7 +390,7 @@ export default function SequenceView() {
     }
     setSelectedImages(new Set());
     setShowRejectReview(false);
-  }, [grading, selectedForReview]);
+  }, [grading, selectedForReview, setSelectedImages]);
 
   // Toggle individual image selection
   const toggleImage = useCallback((imageId: number) => {
@@ -360,7 +405,7 @@ export default function SequenceView() {
       }
       return next;
     });
-  }, [setCurrentImageId]);
+  }, [setCurrentImageId, setSelectedImages]);
 
   const selectImage = useCallback((imageId: number, event: React.MouseEvent) => {
     const anchorId = activeImageIdRef.current;
@@ -383,7 +428,7 @@ export default function SequenceView() {
       }
     }
     toggleImage(imageId);
-  }, [activeSequence, setCurrentImageId, toggleImage]);
+  }, [activeSequence, setCurrentImageId, setSelectedImages, toggleImage]);
 
   const moveImageCursor = useCallback((direction: GridNavigationDirection) => {
     const currentImageId = activeImageIdRef.current;

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -7,6 +7,7 @@ import {
   useLayoutEffect,
   useRef,
 } from 'react';
+import type { RefObject } from 'react';
 import { useLocation, useSearchParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useHotkeys } from 'react-hotkeys-hook';
@@ -25,6 +26,10 @@ import {
   imageDetailPath,
   sequenceReturnPositionFromState,
 } from '../utils/imageDetailRoutes';
+import {
+  findGridNavigationIndex,
+  type GridNavigationDirection,
+} from '../utils/gridNavigation';
 import { thumbnailGridColumns } from '../utils/thumbnailSizing';
 
 function formatCategory(category: string): string {
@@ -54,7 +59,7 @@ function qualityColor(score: number): string {
 }
 
 export default function SequenceView() {
-  const { dbId, projectId, targetId } = useDbProjectTarget();
+  const { dbId, projectId, targetId, setTargetId } = useDbProjectTarget();
   const {
     imageSize,
     currentImageId: urlCurrentImageId,
@@ -99,6 +104,28 @@ export default function SequenceView() {
     return map;
   }, [images]);
 
+  // Preserve the Grid cursor when it identifies a target. With no cursor,
+  // skip the target picker when the project has only one choice.
+  useEffect(() => {
+    if (!projectId || targetId) return;
+    const currentTargetId = urlCurrentImageId === null
+      ? null
+      : imageMap.get(urlCurrentImageId)?.target_id ?? null;
+    const inferredTargetId = currentTargetId ?? (targets.length === 1 ? targets[0].id : null);
+    if (inferredTargetId !== null) setTargetId(inferredTargetId);
+  }, [imageMap, projectId, setTargetId, targetId, targets, urlCurrentImageId]);
+
+  // A selection may span sessions for one target, but never survives a scope
+  // change where its quality evidence is no longer loaded.
+  const selectionScope = `${dbId ?? ''}:${projectId ?? ''}:${targetId ?? ''}:${filterName ?? ''}`;
+  const selectionScopeRef = useRef(selectionScope);
+  useEffect(() => {
+    if (selectionScopeRef.current !== selectionScope) {
+      selectionScopeRef.current = selectionScope;
+      setSelectedImages(new Set());
+    }
+  }, [selectionScope]);
+
   // Auto-analyze when target is selected
   useEffect(() => {
     if (targetId) {
@@ -128,7 +155,21 @@ export default function SequenceView() {
   }, [activeSequence, urlCurrentImageId]);
   const activeImageIdRef = useRef(activeImageId);
   activeImageIdRef.current = activeImageId;
+  const sequenceStripRef = useRef<HTMLDivElement>(null);
+  const sequenceTabsRef = useRef<HTMLDivElement>(null);
   const restoredScrollRef = useRef(false);
+
+  useEffect(() => {
+    const tabs = sequenceTabsRef.current;
+    const activeTab = tabs?.querySelector<HTMLElement>('.sequence-tab.active');
+    if (!tabs || !activeTab) return;
+    const left = activeTab.offsetLeft;
+    const right = left + activeTab.offsetWidth;
+    if (left < tabs.scrollLeft) tabs.scrollLeft = left;
+    else if (right > tabs.scrollLeft + tabs.clientWidth) {
+      tabs.scrollLeft = right - tabs.clientWidth;
+    }
+  }, [activeSequenceIndex, selectedImages, sequences]);
 
   useLayoutEffect(() => {
     const position = sequenceReturnPositionFromState(location.state);
@@ -276,19 +317,24 @@ export default function SequenceView() {
     selectUnsolved,
   ]);
 
-  const selectedForReview = useMemo(() =>
-    activeSequence?.images.filter(img => selectedImages.has(img.image_id)) ?? [],
-  [activeSequence, selectedImages]);
+  const selectedForReview = useMemo(() => {
+    const selected = new Map<number, ImageQualityResult>();
+    sequences.forEach(sequence => {
+      sequence.images.forEach(image => {
+        if (selectedImages.has(image.image_id)) selected.set(image.image_id, image);
+      });
+    });
+    return Array.from(selected.values());
+  }, [selectedImages, sequences]);
 
   // Batch rejection is deliberately two-step: show the exact per-image
   // evidence/reason before changing scheduler grades. Each image's own reason
   // is written — the scheduler keeps rejectreason per image, so a mixed batch
   // must not collapse to one shared string.
   const confirmRejectSelected = useCallback(async () => {
-    if (selectedImages.size === 0) return;
-    const selected = activeSequence?.images.filter(img => selectedImages.has(img.image_id)) ?? [];
+    if (selectedForReview.length === 0) return;
     const byReason = new Map<string, number[]>();
-    for (const img of selected) {
+    for (const img of selectedForReview) {
       const reason = img.regrade_reason ?? 'Quality analysis';
       const ids = byReason.get(reason);
       if (ids) ids.push(img.image_id);
@@ -299,7 +345,7 @@ export default function SequenceView() {
     }
     setSelectedImages(new Set());
     setShowRejectReview(false);
-  }, [selectedImages, activeSequence, grading]);
+  }, [grading, selectedForReview]);
 
   // Toggle individual image selection
   const toggleImage = useCallback((imageId: number) => {
@@ -316,16 +362,43 @@ export default function SequenceView() {
     });
   }, [setCurrentImageId]);
 
-  const moveImageCursor = useCallback((offset: -1 | 1) => {
+  const selectImage = useCallback((imageId: number, event: React.MouseEvent) => {
+    const anchorId = activeImageIdRef.current;
+    if (event.shiftKey && activeSequence && anchorId !== null) {
+      const anchorIndex = activeSequence.images.findIndex(image => image.image_id === anchorId);
+      const imageIndex = activeSequence.images.findIndex(image => image.image_id === imageId);
+      if (anchorIndex >= 0 && imageIndex >= 0) {
+        const start = Math.min(anchorIndex, imageIndex);
+        const end = Math.max(anchorIndex, imageIndex);
+        setSelectedImages(previous => {
+          const next = new Set(previous);
+          activeSequence.images.slice(start, end + 1).forEach(image => {
+            next.add(image.image_id);
+          });
+          return next;
+        });
+        activeImageIdRef.current = imageId;
+        setCurrentImageId(imageId);
+        return;
+      }
+    }
+    toggleImage(imageId);
+  }, [activeSequence, setCurrentImageId, toggleImage]);
+
+  const moveImageCursor = useCallback((direction: GridNavigationDirection) => {
     const currentImageId = activeImageIdRef.current;
     if (!activeSequence || currentImageId === null) return;
     const currentIndex = activeSequence.images.findIndex(
       image => image.image_id === currentImageId,
     );
     if (currentIndex < 0) return;
-    const nextIndex = Math.max(
-      0,
-      Math.min(activeSequence.images.length - 1, currentIndex + offset),
+    const nextIndex = findGridNavigationIndex(
+      activeSequence.images,
+      currentIndex,
+      direction,
+      image => sequenceStripRef.current
+        ?.querySelector<HTMLElement>(`[data-card-image-id="${image.image_id}"]`)
+        ?.getBoundingClientRect() ?? null,
     );
     if (nextIndex === currentIndex) return;
     const nextImageId = activeSequence.images[nextIndex].image_id;
@@ -338,8 +411,10 @@ export default function SequenceView() {
     preventDefault: true,
   }), [activeSequence, isAnalyzing, showRejectReview]);
 
-  useHotkeys('left,up', () => moveImageCursor(-1), sequenceHotkeyOptions, [moveImageCursor]);
-  useHotkeys('right,down', () => moveImageCursor(1), sequenceHotkeyOptions, [moveImageCursor]);
+  useHotkeys('left', () => moveImageCursor('prev'), sequenceHotkeyOptions, [moveImageCursor]);
+  useHotkeys('right', () => moveImageCursor('next'), sequenceHotkeyOptions, [moveImageCursor]);
+  useHotkeys('up', () => moveImageCursor('up'), sequenceHotkeyOptions, [moveImageCursor]);
+  useHotkeys('down', () => moveImageCursor('down'), sequenceHotkeyOptions, [moveImageCursor]);
   useHotkeys('space', () => {
     const currentImageId = activeImageIdRef.current;
     if (currentImageId !== null) toggleImage(currentImageId);
@@ -533,10 +608,10 @@ export default function SequenceView() {
               <option value="recommended">Recommended</option>
             </select>
           </div>
-          {selectedImages.size > 0 && (
+          {selectedForReview.length > 0 && (
             <div className="sequence-selection-slot">
               <div className="selection-action-bar sequence-selection-bar" aria-label="Selected image actions">
-                <span className="selection-count">{selectedImages.size} selected</span>
+                <span className="selection-count">{selectedForReview.length} selected</span>
                 <button
                   type="button"
                   className="action-button reject"
@@ -574,16 +649,30 @@ export default function SequenceView() {
         <>
           {/* Sequence tabs (if multiple) */}
           {sequences.length > 1 && (
-            <div className="sequence-tabs">
-              {sequences.map((seq, i) => (
-                <button
-                  key={i}
-                  className={`sequence-tab ${i === activeSequenceIndex ? 'active' : ''}`}
-                  onClick={() => selectSequence(seq)}
-                >
-                  {formatSequenceLabel(seq)}
-                </button>
-              ))}
+            <div className="sequence-tabs" ref={sequenceTabsRef}>
+              {sequences.map((seq, i) => {
+                const selectedCount = seq.images.filter(image =>
+                  selectedImages.has(image.image_id)
+                ).length;
+                const sequenceKey = [
+                  seq.target_id,
+                  seq.filter_name,
+                  seq.session_start ?? 'unknown',
+                  seq.images[0]?.image_id ?? 'empty',
+                ].join('-');
+                return (
+                  <button
+                    key={sequenceKey}
+                    className={`sequence-tab ${i === activeSequenceIndex ? 'active' : ''}`}
+                    onClick={() => selectSequence(seq)}
+                  >
+                    <span>{formatSequenceLabel(seq)}</span>
+                    {selectedCount > 0 && (
+                      <span className="sequence-tab-selection-count">{selectedCount}</span>
+                    )}
+                  </button>
+                );
+              })}
             </div>
           )}
 
@@ -643,7 +732,8 @@ export default function SequenceView() {
                 selectedImages={selectedImages}
                 threshold={threshold}
                 imageSize={imageSize}
-                onToggle={toggleImage}
+                stripRef={sequenceStripRef}
+                onSelect={selectImage}
                 onOpen={openImage}
               />
             </>
@@ -863,7 +953,8 @@ const SequenceStrip = memo(function SequenceStrip({
   selectedImages,
   threshold,
   imageSize,
-  onToggle,
+  stripRef,
+  onSelect,
   onOpen,
 }: {
   dbId: string;
@@ -877,11 +968,10 @@ const SequenceStrip = memo(function SequenceStrip({
   selectedImages: Set<number>;
   threshold: number;
   imageSize: number;
-  onToggle: (id: number) => void;
+  stripRef: RefObject<HTMLDivElement | null>;
+  onSelect: (id: number, event: React.MouseEvent) => void;
   onOpen: (id: number) => void;
 }) {
-  const stripRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
     if (currentImageId === null) return;
     requestAnimationFrame(() => {
@@ -901,7 +991,7 @@ const SequenceStrip = memo(function SequenceStrip({
         currentCard.scrollIntoView({ block: 'nearest', inline: 'nearest' });
       }
     });
-  }, [currentImageId, imageSize]);
+  }, [currentImageId, imageSize, stripRef]);
 
   return (
     <div
@@ -934,7 +1024,7 @@ const SequenceStrip = memo(function SequenceStrip({
             image={image}
             quality={quality}
             isSelected={selectedImages.has(quality.image_id)}
-            onClick={() => onToggle(quality.image_id)}
+            onClick={(event) => onSelect(quality.image_id, event)}
             onDoubleClick={() => onOpen(quality.image_id)}
             lazyPreview
             selectionEffects={false}

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -794,6 +794,27 @@ describe('SequenceView: multi-session', () => {
     ]));
   });
 
+  it('restores a URL selection across session tabs', async () => {
+    setupMultiSessionHandlers();
+    const firstImageId = multiSessionFixture.data.sequences[0].images[0].image_id;
+    const secondImageId = multiSessionFixture.data.sequences[1].images[0].image_id;
+
+    render(<SequenceView />, {
+      wrapper: createWrapper(
+        `/sequence?db=test&project=1&target=2&current=${secondImageId}`
+        + `&selected=${firstImageId},${secondImageId}`
+      ),
+    });
+
+    await screen.findAllByRole('button', { name: /L · .* \(5\)/ });
+    expect(document.querySelectorAll('.sequence-tab-selection-count')).toHaveLength(2);
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+    expect(document.querySelector('.sequence-image-card.selected')).toHaveAttribute(
+      'data-card-image-id',
+      String(secondImageId),
+    );
+  });
+
   it('stores the active image and return view when opening Detail', async () => {
     setupMultiSessionHandlers();
     const user = userEvent.setup();

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -152,6 +152,102 @@ describe('SequenceView: rendering states', () => {
     expect(screen.getByText('NGC7000')).toBeInTheDocument();
   });
 
+  it('opens the only target in a project', async () => {
+    server.use(
+      http.get('/api/db/:dbId/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: [mockTargets[0]],
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/db/:dbId/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockImages,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/db/:dbId/analysis/sequence', () => {
+        return HttpResponse.json(normalFixture);
+      }),
+    );
+    let search = '';
+    function LocationProbe() {
+      search = useLocation().search;
+      return null;
+    }
+
+    const Wrapper = createWrapper('/sequence?db=test&project=1');
+    render(
+      <Wrapper>
+        <SequenceView />
+        <LocationProbe />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(new URLSearchParams(search).get('target')).toBe('1');
+    });
+    expect(await screen.findByText('82')).toBeInTheDocument();
+  });
+
+  it('uses the current Grid image to choose a target', async () => {
+    const selectedImageId = multiSessionFixture.data.sequences[1].images[1].image_id;
+    const selectedImage = {
+      ...mockImages[0],
+      id: selectedImageId,
+      target_id: 2,
+      target_name: 'NGC7000',
+    };
+    server.use(
+      http.get('/api/db/:dbId/projects/:projectId/targets', () => {
+        return HttpResponse.json({
+          success: true,
+          data: mockTargets,
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/db/:dbId/images', () => {
+        return HttpResponse.json({
+          success: true,
+          data: [...mockImages, selectedImage],
+          error: null,
+          status: 'ready',
+        });
+      }),
+      http.get('/api/db/:dbId/analysis/sequence', () => {
+        return HttpResponse.json(multiSessionFixture);
+      }),
+    );
+    let search = '';
+    function LocationProbe() {
+      search = useLocation().search;
+      return null;
+    }
+
+    const Wrapper = createWrapper(`/sequence?db=test&project=1&current=${selectedImageId}`);
+    render(
+      <Wrapper>
+        <SequenceView />
+        <LocationProbe />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(new URLSearchParams(search).get('target')).toBe('2');
+    });
+    expect(new URLSearchParams(search).get('current')).toBe(String(selectedImageId));
+    const tabs = await screen.findAllByRole('button', { name: /L · .* \(5\)/ });
+    expect(tabs[1]).toHaveClass('active');
+    expect(document.querySelector(`[data-card-image-id="${selectedImageId}"]`)).toHaveClass(
+      'current-selection'
+    );
+  });
+
   it('clicking a target card keeps the db/project context (no blank analysis)', async () => {
     setupDefaultHandlers();
 
@@ -453,8 +549,27 @@ describe('SequenceView: interactions', () => {
     fireEvent.keyDown(document, { key: ' ', code: 'Space' });
     expect(cards[1]).toHaveClass('selected');
 
-    fireEvent.keyDown(document, { key: 'ArrowUp', code: 'ArrowUp' });
+    fireEvent.keyDown(document, { key: 'ArrowLeft', code: 'ArrowLeft' });
     await waitFor(() => expect(cards[0]).toHaveClass('current-selection'));
+  });
+
+  it('selects a range with Shift-click', async () => {
+    setupDefaultHandlers();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?db=test&project=1&target=1') });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.sequence-image-card')).toHaveLength(10);
+    });
+    const cards = document.querySelectorAll('.sequence-image-card');
+    fireEvent.click(cards[2], { shiftKey: true });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.sequence-image-card.selected')).toHaveLength(3);
+    });
+    expect(cards[0]).toHaveClass('selected');
+    expect(cards[1]).toHaveClass('selected');
+    expect(cards[2]).toHaveClass('selected');
   });
 
   it('selects images below threshold', async () => {
@@ -607,7 +722,7 @@ describe('SequenceView: multi-session', () => {
 
     await waitFor(() => {
       // Each tab shows the filter, session time, and image count.
-      const tabs = screen.getAllByText(/L · .* \(5\)/);
+      const tabs = screen.getAllByRole('button', { name: /L · .* \(5\)/ });
       expect(tabs).toHaveLength(2);
       const year = new Date(
         multiSessionFixture.data.sequences[0].session_start * 1000,
@@ -624,11 +739,11 @@ describe('SequenceView: multi-session', () => {
     render(<SequenceView />, { wrapper: createWrapper('/sequence?db=test&project=1&target=2') });
 
     await waitFor(() => {
-      const tabs = screen.getAllByText(/L · .* \(5\)/);
+      const tabs = screen.getAllByRole('button', { name: /L · .* \(5\)/ });
       expect(tabs).toHaveLength(2);
     });
 
-    const tabs = screen.getAllByText(/L · .* \(5\)/);
+    const tabs = screen.getAllByRole('button', { name: /L · .* \(5\)/ });
 
     // First tab should be active by default
     expect(tabs[0].classList.contains('active')).toBe(true);
@@ -639,6 +754,44 @@ describe('SequenceView: multi-session', () => {
     // Second tab should now be active
     expect(tabs[1].classList.contains('active')).toBe(true);
     expect(tabs[0].classList.contains('active')).toBe(false);
+  });
+
+  it('keeps cross-session selections visible and reviews all of them', async () => {
+    setupMultiSessionHandlers();
+    const gradedImageIds: string[] = [];
+    server.use(
+      http.put('/api/db/:dbId/images/:imageId/grade', ({ params }) => {
+        gradedImageIds.push(params.imageId as string);
+        return HttpResponse.json({
+          success: true,
+          data: null,
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+    const user = userEvent.setup();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?db=test&project=1&target=2') });
+
+    const tabs = await screen.findAllByRole('button', { name: /L · .* \(5\)/ });
+    let cards = document.querySelectorAll('.sequence-image-card');
+    await user.click(cards[0]);
+    expect(tabs[0].querySelector('.sequence-tab-selection-count')).toHaveTextContent('1');
+
+    await user.click(tabs[1]);
+    cards = document.querySelectorAll('.sequence-image-card');
+    await user.click(cards[0]);
+
+    expect(document.querySelectorAll('.sequence-tab-selection-count')).toHaveLength(2);
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Review rejection' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm rejection (2)' }));
+    await waitFor(() => expect(gradedImageIds).toHaveLength(2));
+    expect(gradedImageIds).toEqual(expect.arrayContaining([
+      String(multiSessionFixture.data.sequences[0].images[0].image_id),
+      String(multiSessionFixture.data.sequences[1].images[0].image_id),
+    ]));
   });
 
   it('stores the active image and return view when opening Detail', async () => {
@@ -661,7 +814,7 @@ describe('SequenceView: multi-session', () => {
       </Wrapper>
     );
 
-    const tabs = await screen.findAllByText(/L · .* \(5\)/);
+    const tabs = await screen.findAllByRole('button', { name: /L · .* \(5\)/ });
     await user.click(tabs[1]);
 
     await waitFor(() => {
@@ -690,7 +843,7 @@ describe('SequenceView: multi-session', () => {
       ),
     });
 
-    const tabs = await screen.findAllByText(/L · .* \(5\)/);
+    const tabs = await screen.findAllByRole('button', { name: /L · .* \(5\)/ });
     expect(tabs[1]).toHaveClass('active');
     expect(document.querySelectorAll('.sequence-image-card')[1]).toHaveClass(
       'current-selection'

--- a/static/src/utils/__tests__/gridNavigation.test.ts
+++ b/static/src/utils/__tests__/gridNavigation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { findGridNavigationIndex, type GridNavigationRect } from '../gridNavigation';
+
+const items = [1, 2, 3, 4, 5];
+const rects = new Map<number, GridNavigationRect>([
+  [1, { top: 0, left: 0, width: 100 }],
+  [2, { top: 0, left: 110, width: 100 }],
+  [3, { top: 120, left: 0, width: 100 }],
+  [4, { top: 120, left: 110, width: 100 }],
+  [5, { top: 240, left: 0, width: 100 }],
+]);
+
+const navigate = (currentIndex: number, direction: 'next' | 'prev' | 'up' | 'down') =>
+  findGridNavigationIndex(items, currentIndex, direction, item => rects.get(item) ?? null);
+
+describe('findGridNavigationIndex', () => {
+  it('moves left and right through item order', () => {
+    expect(navigate(1, 'prev')).toBe(0);
+    expect(navigate(1, 'next')).toBe(2);
+  });
+
+  it('uses the nearest column in the next or previous row', () => {
+    expect(navigate(0, 'down')).toBe(2);
+    expect(navigate(1, 'down')).toBe(3);
+    expect(navigate(4, 'up')).toBe(2);
+  });
+
+  it('stays put when no item exists in that direction', () => {
+    expect(navigate(0, 'up')).toBe(0);
+    expect(navigate(4, 'down')).toBe(4);
+  });
+});

--- a/static/src/utils/gridNavigation.ts
+++ b/static/src/utils/gridNavigation.ts
@@ -1,0 +1,47 @@
+export type GridNavigationDirection = 'next' | 'prev' | 'up' | 'down';
+
+export interface GridNavigationRect {
+  top: number;
+  left: number;
+  width: number;
+}
+
+export function findGridNavigationIndex<T>(
+  items: readonly T[],
+  currentIndex: number,
+  direction: GridNavigationDirection,
+  getRect: (item: T) => GridNavigationRect | null,
+): number {
+  if (currentIndex < 0 || currentIndex >= items.length) return currentIndex;
+  if (direction === 'next') return Math.min(currentIndex + 1, items.length - 1);
+  if (direction === 'prev') return Math.max(currentIndex - 1, 0);
+
+  const currentRect = getRect(items[currentIndex]);
+  if (!currentRect) return currentIndex;
+
+  const currentCenter = currentRect.left + currentRect.width / 2;
+  const sign = direction === 'down' ? 1 : -1;
+  let result = currentIndex;
+  let bestVerticalDistance = Number.POSITIVE_INFINITY;
+  let bestHorizontalDistance = Number.POSITIVE_INFINITY;
+
+  items.forEach((item, index) => {
+    if (index === currentIndex) return;
+    const rect = getRect(item);
+    if (!rect) return;
+
+    const verticalDistance = (rect.top - currentRect.top) * sign;
+    if (verticalDistance <= 4) return;
+    const horizontalDistance = Math.abs((rect.left + rect.width / 2) - currentCenter);
+    const isCloserRow = verticalDistance < bestVerticalDistance - 4;
+    const isCloserColumn = Math.abs(verticalDistance - bestVerticalDistance) <= 4
+      && horizontalDistance < bestHorizontalDistance;
+    if (isCloserRow || isCloserColumn) {
+      result = index;
+      bestVerticalDistance = verticalDistance;
+      bestHorizontalDistance = horizontalDistance;
+    }
+  });
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- make Sequence arrow navigation follow the rendered thumbnail grid using the same helper as Images
- carry the current Images cursor into Sequence and infer its target, or open the only target in a project
- add Shift-click range selection within a sequence
- preserve selections across session tabs for one target, show per-tab counts, and review every selected frame
- clear Sequence selections when the target or filter changes
- keep large session lists on one stable horizontal tab row

## Selection boundary

Shift-click never selects through a hidden session. A user can select frames in more than one session tab for the same target; each tab shows its count, and rejection review includes the full set. Moving to another target or filter clears the set because that quality evidence is no longer loaded.

## Checks

- `npm run lint` (Node 24)
- `npx vitest run` (38 files, 191 tests)
- `npm run build` (Node 24)
- `npx playwright test e2e/navigation.spec.ts` (29 passed)
- `git diff --check`
