### PR TITLE
Wrap Sequence tabs without horizontal scrolling

### DIFF
--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -227,6 +227,23 @@ test('multi-select stays active without changing the toolbar height', async ({ p
   await expect(page.locator('.image-card-wrapper.multi-selected')).toHaveCount(3);
 });
 
+test('Grid Shift-click selects a range from a plain-click anchor', async ({ page }) => {
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+
+  const cards = page.locator('.image-card');
+  const wrappers = page.locator('.image-card-wrapper');
+  await expect(cards).toHaveCount(3, { timeout: 15_000 });
+  await cards.nth(0).click();
+  await cards.nth(2).click({ modifiers: ['Shift'] });
+
+  await expect(page.locator('.image-card-wrapper.multi-selected')).toHaveCount(3);
+  await expect(page.locator('.selection-action-bar')).toContainText('3 selected');
+
+  await cards.nth(1).click({ modifiers: ['Shift'] });
+  await expect(page.locator('.image-card-wrapper.multi-selected')).toHaveCount(2);
+  await expect(wrappers.nth(2)).not.toHaveClass(/multi-selected/);
+});
+
 test('arrow keys move through the image grid', async ({ page }) => {
   await page.setViewportSize({ width: 760, height: 720 });
   await page.goto(
@@ -470,6 +487,24 @@ test('Sequence Shift-click selects a visible range', async ({ page }) => {
 
   await expect(page.locator('.sequence-image-card.selected')).toHaveCount(3);
   await expect(page.locator('.sequence-selection-bar')).toContainText('3 selected');
+
+  await cards.nth(1).click({ modifiers: ['Shift'] });
+  await expect(page.locator('.sequence-image-card.selected')).toHaveCount(2);
+  await expect(cards.nth(2)).not.toHaveClass(/selected/);
+});
+
+test('Sequence chart Shift-click selects a visible range', async ({ page }) => {
+  await page.goto(
+    `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1`
+  );
+
+  const bars = page.locator('.sequence-timeline rect[data-image-id]');
+  await expect(bars).toHaveCount(3, { timeout: 15_000 });
+  await bars.nth(0).click();
+  await bars.nth(2).click({ modifiers: ['Shift'] });
+
+  await expect(page.locator('.sequence-image-card.selected')).toHaveCount(3);
+  await expect(page.locator('.sequence-selection-bar')).toContainText('3 selected');
 });
 
 test('many Sequence tabs wrap into a stable grid without horizontal scrolling', async ({ page }) => {
@@ -514,8 +549,8 @@ test('many Sequence tabs wrap into a stable grid without horizontal scrolling', 
     top: element.getBoundingClientRect().top,
     width: element.getBoundingClientRect().width,
   })));
-  expect(after.map(tab => Math.round(tab.top))).toEqual(
-    before.map(tab => Math.round(tab.top))
+  expect(after.map(tab => Math.round(tab.top - after[0].top))).toEqual(
+    before.map(tab => Math.round(tab.top - before[0].top))
   );
   expect(after.map(tab => Math.round(tab.width))).toEqual(
     before.map(tab => Math.round(tab.width))

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -472,7 +472,7 @@ test('Sequence Shift-click selects a visible range', async ({ page }) => {
   await expect(page.locator('.sequence-selection-bar')).toContainText('3 selected');
 });
 
-test('many Sequence tabs stay on one stable scrolling row', async ({ page }) => {
+test('many Sequence tabs wrap into a stable grid without horizontal scrolling', async ({ page }) => {
   await page.route(`**/api/db/${dbId}/analysis/sequence*`, async (route) => {
     const response = await route.fetch();
     const body = await response.json() as {
@@ -506,7 +506,7 @@ test('many Sequence tabs stay on one stable scrolling row', async ({ page }) => 
     top: element.getBoundingClientRect().top,
     width: element.getBoundingClientRect().width,
   })));
-  expect(new Set(before.map(tab => Math.round(tab.top))).size).toBe(1);
+  expect(new Set(before.map(tab => Math.round(tab.top))).size).toBeGreaterThan(1);
 
   await tabs.last().click();
   await expect(tabs.last()).toHaveClass(/active/);
@@ -514,13 +514,17 @@ test('many Sequence tabs stay on one stable scrolling row', async ({ page }) => 
     top: element.getBoundingClientRect().top,
     width: element.getBoundingClientRect().width,
   })));
-  expect(new Set(after.map(tab => Math.round(tab.top))).size).toBe(1);
+  expect(after.map(tab => Math.round(tab.top))).toEqual(
+    before.map(tab => Math.round(tab.top))
+  );
   expect(after.map(tab => Math.round(tab.width))).toEqual(
     before.map(tab => Math.round(tab.width))
   );
-  await expect.poll(
-    () => page.locator('.sequence-tabs').evaluate(element => element.scrollLeft)
-  ).toBeGreaterThan(0);
+  const overflow = await page.locator('.sequence-tabs').evaluate(element => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+  expect(overflow.scrollWidth).toBe(overflow.clientWidth);
 });
 
 test('sequence arrows reveal a normal card that is only partly visible', async ({ page }) => {

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -244,6 +244,27 @@ test('Grid Shift-click selects a range from a plain-click anchor', async ({ page
   await expect(wrappers.nth(2)).not.toHaveClass(/multi-selected/);
 });
 
+test('Grid Shift-click resets an anchor from another project', async ({ page }) => {
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+
+  const cards = page.locator('.image-card');
+  await expect(cards).toHaveCount(3, { timeout: 15_000 });
+  await cards.first().click();
+
+  await page.locator('#scope-select').click();
+  const picker = page.getByRole('dialog', { name: 'Choose a project or target' });
+  const betaProject = picker.locator('.selector-project-tree').filter({ hasText: 'Project Beta' });
+  const betaToggle = betaProject.getByRole('button', { name: /^Project Beta/ });
+  if (await betaToggle.getAttribute('aria-expanded') === 'false') await betaToggle.click();
+  await betaProject.getByRole('button', { name: /^All images/ }).click();
+
+  await expect(page).toHaveURL(new RegExp(`db=${dbId}.*project=2`));
+  await expect(cards).toHaveCount(1);
+  await cards.first().click({ modifiers: ['Shift'] });
+  await expect(page.locator('.image-card-wrapper.multi-selected')).toHaveCount(1);
+  await expect(page.locator('.selection-action-bar')).toContainText('1 selected');
+});
+
 test('arrow keys move through the image grid', async ({ page }) => {
   await page.setViewportSize({ width: 760, height: 720 });
   await page.goto(

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -5355,28 +5355,36 @@
 
 /* Sequence tabs */
 .sequence-tabs {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 0.25rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+  gap: 0.35rem;
   padding: 0.75rem 1rem 0;
-  overflow-x: auto;
-  overscroll-behavior-inline: contain;
 }
 
 .sequence-tab {
-  display: inline-flex;
-  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 0.4rem;
+  width: 100%;
+  min-width: 0;
+  min-height: 2.5rem;
   background: var(--color-bg-tertiary);
   border: 1px solid var(--color-bg-quaternary);
   border-radius: 6px;
-  padding: 0.5rem 1rem;
+  padding: 0.45rem 0.7rem;
   cursor: pointer;
   color: var(--color-text-secondary);
   font-size: 0.9rem;
-  white-space: nowrap;
+  text-align: left;
   transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.sequence-tab > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sequence-tab.active {

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -78,6 +78,8 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
   // Initialize grading system with undo/redo
   const grading = useGrading(dbId!);
   const [lastSelectedImageId, setLastSelectedImageId] = useState<number | null>(null);
+  const selectionAnchorIdRef = useRef<number | null>(null);
+  const selectionBaseIdsRef = useRef<Set<number>>(new Set());
 
   // Navigation helpers
   const [searchParams] = useSearchParams();
@@ -286,13 +288,25 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
   // Keep the cursor on an image ID. Group positions can move when new images
   // arrive or the grouping mode changes.
   useEffect(() => {
+    if (selectionAnchorIdRef.current === null && activeImageId !== null) {
+      selectionAnchorIdRef.current = activeImageId;
+      const base = new Set(selectedImages);
+      base.delete(activeImageId);
+      selectionBaseIdsRef.current = base;
+    }
     if (activeImageId !== lastSelectedImageId) {
       setLastSelectedImageId(activeImageId);
     }
     if (activeImageId !== null && activeImageId !== urlCurrentImageId) {
       setCurrentImageId(activeImageId);
     }
-  }, [activeImageId, lastSelectedImageId, setCurrentImageId, urlCurrentImageId]);
+  }, [
+    activeImageId,
+    lastSelectedImageId,
+    selectedImages,
+    setCurrentImageId,
+    urlCurrentImageId,
+  ]);
 
   // Grading is now handled by the useGrading hook
 
@@ -330,6 +344,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
   const toggleCurrentImageSelection = useCallback(() => {
     const currentImageId = activeImageIdRef.current;
     if (currentImageId === null) return;
+    selectionAnchorIdRef.current = currentImageId;
     setSelectedImages((selected) => {
       const next = new Set(selected);
       if (next.has(currentImageId)) {
@@ -337,6 +352,9 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
       } else {
         next.add(currentImageId);
       }
+      const base = new Set(next);
+      base.delete(currentImageId);
+      selectionBaseIdsRef.current = base;
       return next;
     });
   }, [setSelectedImages]);
@@ -368,9 +386,10 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
 
   // Handle image selection with shift+click support
   const handleImageSelection = useCallback((imageId: number, event: React.MouseEvent) => {
-    if (event.shiftKey && lastSelectedImageId) {
+    const selectionAnchorId = selectionAnchorIdRef.current ?? activeImageIdRef.current;
+    if (event.shiftKey && selectionAnchorId !== null) {
       // Shift+click: select range
-      const startIndex = flatImages.findIndex(image => image.id === lastSelectedImageId);
+      const startIndex = flatImages.findIndex(image => image.id === selectionAnchorId);
       const endIndex = flatImages.findIndex(image => image.id === imageId);
       
       if (startIndex !== -1 && endIndex !== -1) {
@@ -381,11 +400,9 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
           newSelections.add(flatImages[i].id);
         }
         
-        setSelectedImages((prev: Set<number>) => {
-          const next = new Set(prev);
-          newSelections.forEach(id => next.add(id));
-          return next;
-        });
+        const next = new Set(selectionBaseIdsRef.current);
+        newSelections.forEach(id => next.add(id));
+        setSelectedImages(next);
       }
       activeImageIdRef.current = imageId;
       setCurrentImageId(imageId);
@@ -398,20 +415,25 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
         } else {
           next.add(imageId);
         }
+        const base = new Set(next);
+        base.delete(imageId);
+        selectionBaseIdsRef.current = base;
         return next;
       });
       activeImageIdRef.current = imageId;
       setCurrentImageId(imageId);
       setLastSelectedImageId(imageId);
+      selectionAnchorIdRef.current = imageId;
     } else {
       // Regular click: single selection for navigation
       activeImageIdRef.current = imageId;
       setCurrentImageSelection(imageId);
       setLastSelectedImageId(imageId);
+      selectionAnchorIdRef.current = imageId;
+      selectionBaseIdsRef.current = new Set();
     }
   }, [
     flatImages,
-    lastSelectedImageId,
     setCurrentImageId,
     setCurrentImageSelection,
     setSelectedImages,
@@ -427,6 +449,8 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
       // Clear selection after batch operation
       setSelectedImages(new Set());
       setLastSelectedImageId(null);
+      selectionAnchorIdRef.current = null;
+      selectionBaseIdsRef.current = new Set();
     } catch (error) {
       console.error('Batch grading failed:', error);
     }
@@ -490,6 +514,8 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
     previousSelectionFilterKey.current = selectionFilterKey;
     setSelectedImages(new Set());
     setLastSelectedImageId(null);
+    selectionAnchorIdRef.current = null;
+    selectionBaseIdsRef.current = new Set();
   }, [selectionFilterKey, setSelectedImages]);
 
   // Keyboard shortcuts
@@ -587,6 +613,8 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
     // Just clear selection on escape (we're already in grid view)
     setSelectedImages(new Set());
     setLastSelectedImageId(null);
+    selectionAnchorIdRef.current = null;
+    selectionBaseIdsRef.current = new Set();
   }, gridHotkeyOptions, [setSelectedImages, isLiveGridRoute]);
   
   // Add comparison keyboard shortcut
@@ -777,6 +805,8 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                     onClick={() => {
                       setSelectedImages(new Set());
                       setLastSelectedImageId(null);
+                      selectionAnchorIdRef.current = null;
+                      selectionBaseIdsRef.current = new Set();
                     }}
                   >
                     Clear

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -386,7 +386,10 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
 
   // Handle image selection with shift+click support
   const handleImageSelection = useCallback((imageId: number, event: React.MouseEvent) => {
-    const selectionAnchorId = selectionAnchorIdRef.current ?? activeImageIdRef.current;
+    const storedAnchorId = selectionAnchorIdRef.current;
+    const selectionAnchorId = storedAnchorId !== null && flatImages.some(
+      image => image.id === storedAnchorId,
+    ) ? storedAnchorId : activeImageIdRef.current;
     if (event.shiftKey && selectionAnchorId !== null) {
       // Shift+click: select range
       const startIndex = flatImages.findIndex(image => image.id === selectionAnchorId);

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -201,20 +201,7 @@ export default function SequenceView() {
   const activeImageIdRef = useRef(activeImageId);
   activeImageIdRef.current = activeImageId;
   const sequenceStripRef = useRef<HTMLDivElement>(null);
-  const sequenceTabsRef = useRef<HTMLDivElement>(null);
   const restoredScrollRef = useRef(false);
-
-  useEffect(() => {
-    const tabs = sequenceTabsRef.current;
-    const activeTab = tabs?.querySelector<HTMLElement>('.sequence-tab.active');
-    if (!tabs || !activeTab) return;
-    const left = activeTab.offsetLeft;
-    const right = left + activeTab.offsetWidth;
-    if (left < tabs.scrollLeft) tabs.scrollLeft = left;
-    else if (right > tabs.scrollLeft + tabs.clientWidth) {
-      tabs.scrollLeft = right - tabs.clientWidth;
-    }
-  }, [activeSequenceIndex, selectedImages, sequences]);
 
   useLayoutEffect(() => {
     const position = sequenceReturnPositionFromState(location.state);
@@ -694,7 +681,7 @@ export default function SequenceView() {
         <>
           {/* Sequence tabs (if multiple) */}
           {sequences.length > 1 && (
-            <div className="sequence-tabs" ref={sequenceTabsRef}>
+            <div className="sequence-tabs">
               {sequences.map((seq, i) => {
                 const selectedCount = seq.images.filter(image =>
                   selectedImages.has(image.image_id)

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -260,6 +260,15 @@ export default function SequenceView() {
     }
   }, [activeImageId, setCurrentImageId, urlCurrentImageId]);
 
+  const replaceSelectedImages = useCallback((ids: Set<number>) => {
+    const anchorId = activeImageIdRef.current;
+    const base = new Set(ids);
+    if (anchorId !== null) base.delete(anchorId);
+    selectionAnchorIdRef.current = anchorId;
+    selectionBaseIdsRef.current = base;
+    setSelectedImages(ids);
+  }, [setSelectedImages]);
+
   // Get unique filter names from available targets
   const availableFilters = useMemo(() => {
     const filters = new Set<string>();
@@ -278,8 +287,8 @@ export default function SequenceView() {
         ids.add(img.image_id);
       }
     });
-    setSelectedImages(ids);
-  }, [activeSequence, setSelectedImages, threshold]);
+    replaceSelectedImages(ids);
+  }, [activeSequence, replaceSelectedImages, threshold]);
 
   // Select contiguous runs of clouded/occluded/bad images
   const selectCloudedSequence = useCallback(() => {
@@ -308,36 +317,36 @@ export default function SequenceView() {
     if (inRun && runBuffer.length >= 2) {
       runBuffer.forEach(id => ids.add(id));
     }
-    setSelectedImages(ids);
-  }, [activeSequence, setSelectedImages]);
+    replaceSelectedImages(ids);
+  }, [activeSequence, replaceSelectedImages]);
 
   const selectAstrometryIssues = useCallback(() => {
     if (!activeSequence) return;
-    setSelectedImages(new Set(
+    replaceSelectedImages(new Set(
       activeSequence.images
         .filter(img => (img.flags ?? []).some(flag =>
           flag === 'off_target' || flag === 'pointing_jump' || flag === 'pointing_drift'))
         .map(img => img.image_id)
     ));
-  }, [activeSequence, setSelectedImages]);
+  }, [activeSequence, replaceSelectedImages]);
 
   const selectUnsolved = useCallback(() => {
     if (!activeSequence) return;
-    setSelectedImages(new Set(
+    replaceSelectedImages(new Set(
       activeSequence.images
         .filter(img => img.pointing?.solve_failed && img.pointing.image_quality_evidence)
         .map(img => img.image_id)
     ));
-  }, [activeSequence, setSelectedImages]);
+  }, [activeSequence, replaceSelectedImages]);
 
   const selectRecommended = useCallback(() => {
     if (!activeSequence) return;
-    setSelectedImages(new Set(
+    replaceSelectedImages(new Set(
       activeSequence.images
         .filter(img => !!img.regrade_reason)
         .map(img => img.image_id)
     ));
-  }, [activeSequence, setSelectedImages]);
+  }, [activeSequence, replaceSelectedImages]);
 
   const applySelectionPreset = useCallback((preset: string) => {
     switch (preset) {

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -77,6 +77,8 @@ export default function SequenceView() {
   const filterName = searchParams.get('filterName') || undefined;
   const [threshold, setThreshold] = useState(0.5);
   const [showRejectReview, setShowRejectReview] = useState(false);
+  const selectionAnchorIdRef = useRef<number | null>(null);
+  const selectionBaseIdsRef = useRef<Set<number>>(new Set());
   const spatialScan = useSpatialScan(dbId, targetId ?? undefined, filterName);
 
   // Fetch targets for the project to allow selection
@@ -148,6 +150,8 @@ export default function SequenceView() {
       const inferredSelection = inferredSelectionRef.current;
       inferredSelectionRef.current = null;
       if (inferredSelection === null) entrySelectionRef.current = null;
+      selectionAnchorIdRef.current = null;
+      selectionBaseIdsRef.current = new Set();
       setSelectedImages(inferredSelection ?? new Set());
     }
   }, [selectionScope, setSelectedImages]);
@@ -202,6 +206,18 @@ export default function SequenceView() {
   activeImageIdRef.current = activeImageId;
   const sequenceStripRef = useRef<HTMLDivElement>(null);
   const restoredScrollRef = useRef(false);
+
+  useEffect(() => {
+    if (selectionAnchorIdRef.current === null && activeImageId !== null) {
+      selectionAnchorIdRef.current = activeImageId;
+      const activeImageIds = new Set(
+        activeSequence?.images.map(image => image.image_id) ?? [],
+      );
+      selectionBaseIdsRef.current = new Set(
+        Array.from(selectedImages).filter(imageId => !activeImageIds.has(imageId)),
+      );
+    }
+  }, [activeImageId, activeSequence, selectedImages]);
 
   useLayoutEffect(() => {
     const position = sequenceReturnPositionFromState(location.state);
@@ -376,12 +392,15 @@ export default function SequenceView() {
       await grading.gradeBatch(ids, 'rejected', reason);
     }
     setSelectedImages(new Set());
+    selectionAnchorIdRef.current = null;
+    selectionBaseIdsRef.current = new Set();
     setShowRejectReview(false);
   }, [grading, selectedForReview, setSelectedImages]);
 
   // Toggle individual image selection
   const toggleImage = useCallback((imageId: number) => {
     activeImageIdRef.current = imageId;
+    selectionAnchorIdRef.current = imageId;
     setCurrentImageId(imageId);
     setSelectedImages(prev => {
       const next = new Set(prev);
@@ -390,20 +409,26 @@ export default function SequenceView() {
       } else {
         next.add(imageId);
       }
+      const base = new Set(next);
+      base.delete(imageId);
+      selectionBaseIdsRef.current = base;
       return next;
     });
   }, [setCurrentImageId, setSelectedImages]);
 
   const selectImage = useCallback((imageId: number, event: React.MouseEvent) => {
-    const anchorId = activeImageIdRef.current;
+    const storedAnchorId = selectionAnchorIdRef.current;
+    const anchorId = storedAnchorId !== null && activeSequence?.images.some(
+      image => image.image_id === storedAnchorId,
+    ) ? storedAnchorId : activeImageIdRef.current;
     if (event.shiftKey && activeSequence && anchorId !== null) {
       const anchorIndex = activeSequence.images.findIndex(image => image.image_id === anchorId);
       const imageIndex = activeSequence.images.findIndex(image => image.image_id === imageId);
       if (anchorIndex >= 0 && imageIndex >= 0) {
         const start = Math.min(anchorIndex, imageIndex);
         const end = Math.max(anchorIndex, imageIndex);
-        setSelectedImages(previous => {
-          const next = new Set(previous);
+        setSelectedImages(() => {
+          const next = new Set(selectionBaseIdsRef.current);
           activeSequence.images.slice(start, end + 1).forEach(image => {
             next.add(image.image_id);
           });
@@ -469,9 +494,14 @@ export default function SequenceView() {
   const selectSequence = useCallback((sequence: ScoredSequence) => {
     const firstImageId = sequence.images[0]?.image_id;
     if (firstImageId !== undefined) {
+      selectionAnchorIdRef.current = firstImageId;
+      const sequenceImageIds = new Set(sequence.images.map(image => image.image_id));
+      selectionBaseIdsRef.current = new Set(
+        Array.from(selectedImages).filter(imageId => !sequenceImageIds.has(imageId)),
+      );
       setCurrentImageId(firstImageId);
     }
-  }, [setCurrentImageId]);
+  }, [selectedImages, setCurrentImageId]);
 
   if (!projectId) {
     return (
@@ -654,7 +684,11 @@ export default function SequenceView() {
                 <button
                   type="button"
                   className="header-button"
-                  onClick={() => setSelectedImages(new Set())}
+                  onClick={() => {
+                    setSelectedImages(new Set());
+                    selectionAnchorIdRef.current = null;
+                    selectionBaseIdsRef.current = new Set();
+                  }}
                 >
                   Clear
                 </button>
@@ -745,7 +779,7 @@ export default function SequenceView() {
                 threshold={threshold}
                 currentImageId={activeImageId}
                 selectedImages={selectedImages}
-                onToggle={toggleImage}
+                onSelect={selectImage}
               />
 
               <PointingScatter images={activeSequence.images} />
@@ -874,13 +908,13 @@ const SequenceTimeline = memo(function SequenceTimeline({
   threshold,
   currentImageId,
   selectedImages,
-  onToggle,
+  onSelect,
 }: {
   images: ImageQualityResult[];
   threshold: number;
   currentImageId: number | null;
   selectedImages: Set<number>;
-  onToggle: (id: number) => void;
+  onSelect: (id: number, event: React.MouseEvent) => void;
 }) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const [viewportWidth, setViewportWidth] = useState(0);
@@ -950,6 +984,7 @@ const SequenceTimeline = memo(function SequenceTimeline({
           return (
             <rect
               key={img.image_id}
+              data-image-id={img.image_id}
               x={x}
               y={y}
               width={barWidth}
@@ -961,7 +996,7 @@ const SequenceTimeline = memo(function SequenceTimeline({
                 : isSelected ? 'var(--color-warning)' : 'none'}
               strokeWidth={isCurrent ? 2 : isSelected ? 1 : 0}
               style={{ cursor: 'pointer' }}
-              onClick={() => onToggle(img.image_id)}
+              onClick={(event) => onSelect(img.image_id, event)}
             >
               <title>Score: {img.quality_score.toFixed(2)}{img.category ? ` (${formatCategory(img.category)})` : ''}</title>
             </rect>

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -624,6 +624,34 @@ describe('SequenceView: interactions', () => {
     });
   });
 
+  it('uses a selection preset as the base for the next Shift-click range', async () => {
+    setupDefaultHandlers();
+    const user = userEvent.setup();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?db=test&project=1&target=1') });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.sequence-image-card')).toHaveLength(10);
+    });
+    const cards = document.querySelectorAll('.sequence-image-card');
+    fireEvent.click(cards[0]);
+    fireEvent.click(cards[8]);
+
+    fireEvent.change(screen.getByLabelText('Threshold:'), { target: { value: '0.80' } });
+    await user.selectOptions(screen.getByLabelText('Select:'), 'threshold');
+    await waitFor(() => expect(screen.getByText('4 selected')).toBeInTheDocument());
+
+    fireEvent.click(cards[9], { shiftKey: true });
+
+    await waitFor(() => expect(screen.getByText('5 selected')).toBeInTheDocument());
+    expect(cards[0]).not.toHaveClass('selected');
+    expect(cards[2]).toHaveClass('selected');
+    expect(cards[4]).toHaveClass('selected');
+    expect(cards[6]).toHaveClass('selected');
+    expect(cards[8]).toHaveClass('selected');
+    expect(cards[9]).toHaveClass('selected');
+  });
+
   it('shows "Select Clouded" button and selects cloud runs', async () => {
     server.use(
       http.get('/api/db/:dbId/analysis/sequence', () => {

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -570,6 +570,29 @@ describe('SequenceView: interactions', () => {
     expect(cards[0]).toHaveClass('selected');
     expect(cards[1]).toHaveClass('selected');
     expect(cards[2]).toHaveClass('selected');
+
+    fireEvent.click(cards[1], { shiftKey: true });
+    await waitFor(() => {
+      expect(document.querySelectorAll('.sequence-image-card.selected')).toHaveLength(2);
+    });
+    expect(cards[2]).not.toHaveClass('selected');
+  });
+
+  it('selects a range with Shift-click in the quality chart', async () => {
+    setupDefaultHandlers();
+
+    render(<SequenceView />, { wrapper: createWrapper('/sequence?db=test&project=1&target=1') });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.sequence-timeline rect[data-image-id]')).toHaveLength(10);
+    });
+    const bars = document.querySelectorAll('.sequence-timeline rect[data-image-id]');
+    fireEvent.click(bars[0]);
+    fireEvent.click(bars[2], { shiftKey: true });
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('.sequence-image-card.selected')).toHaveLength(3);
+    });
   });
 
   it('selects images below threshold', async () => {


### PR DESCRIPTION
## Summary

- replace the horizontal Sequence tab strip with a responsive wrapped grid
- keep every tab's size and position stable when the active session changes
- truncate long labels inside their fixed grid cell instead of widening the page
- remove the scroll-follow effect that moved the tab strip after selection
- keep a stable Shift-click anchor in Grid and Sequence while the cursor moves
- use the same range-selection path for Sequence thumbnails and quality-chart bars

## Checks

- `npm run lint`
- `npx vitest run` (193 tests)
- `npm run build`
- `npx playwright test e2e/navigation.spec.ts` (32 tests)
