### PR TITLE
Clarify Sequence history and score reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ bright trail, not catalog presence alone.
 PSF Guard screens for occlusion, clouds, veils, stray light, off-target
 pointing, and tracking loss. These faults can pass star-count and HFR grading.
 
-**In the app:** open a target's Sequence view and choose **Scan Quality**. Use
+**In the app:** open a target's Sequence view and choose **Analyze Quality**. Use
 the selectors to focus Clouded, Off Target, Unsolved, or all Recommended
 frames.
 

--- a/docs/ASTROMETRY_QUALITY.md
+++ b/docs/ASTROMETRY_QUALITY.md
@@ -1,6 +1,6 @@
 # Astrometry quality grading
 
-PSF Guard's **Scan Quality** workflow combines fresh Seiza plate solutions
+PSF Guard's **Analyze Quality** workflow combines fresh Seiza plate solutions
 with the existing sequence, occlusion, photometry, guiding, and grading
 signals. It identifies images that were captured away from the intended
 catalog target, sequences that lost tracking, and frames whose pixels could not
@@ -10,8 +10,9 @@ be matched to the sky.
 
 ## Run a quality scan
 
-Open a catalog target in the **Sequence Analysis** view and press **Scan
-Quality**. The background job runs two stages:
+Open a catalog target in the **Sequence Analysis** view and press **Analyze
+Quality**. The background job runs two stages, then refreshes the sequence
+scores:
 
 1. spatial and photometric screening for clouds, occlusion, transparency, and
    errant light; and

--- a/docs/SATELLITES.md
+++ b/docs/SATELLITES.md
@@ -64,7 +64,7 @@ abstain; it does not turn missing evidence into a clean-frame claim.
 
 ## Orbital-element cache
 
-The explicit **Show tracks** action and server **Scan Quality** action choose
+The explicit **Show tracks** action and server **Analyze Quality** action choose
 the orbital source from the exposure time through
 `seiza-satellites::OrbitalCatalogSource`; PSF Guard does not own a parallel age
 cutoff or provider list. Recent images use CelesTrak's active-satellite
@@ -102,7 +102,7 @@ Per-image results are written atomically to
 `<cache>/<db-slug>/satellites/<image-id>.json`. They carry the exact orbital
 payload SHA-256 and are accepted only when the FITS fingerprint, exact WCS,
 Seiza version, seiza-satellites version, and pixel-alignment version still
-match. A normal quality scan reuses that evidence. Shift-click **Scan Quality**
+match. A normal quality scan reuses that evidence. Shift-click **Analyze Quality**
 to recompute all cached quality evidence, including every satellite prediction,
 against the orbital snapshot the current cache now prefers. This forced scan is
 allowed to refresh or download orbital data when the Seiza resolver needs it.
@@ -168,7 +168,7 @@ associations rather than asserted identities.
 
 ## Background and CLI behavior
 
-The server's user-triggered **Scan Quality** action seeds missing current or
+The server's user-triggered **Analyze Quality** action seeds missing current or
 historical orbital snapshots, then computes and persists exposure predictions
 alongside each plate solution. Merely opening Sequence Analysis remains
 read-only and never causes a download.

--- a/docs/SCREENING.md
+++ b/docs/SCREENING.md
@@ -108,8 +108,12 @@ sequence analysis shows coverage badges, classifications, solved-center
 scatter, a session view, and an all-session stack comparison for each filter.
 When analysis names a cause, the same reason and supporting evidence appear on
 the Sequence card, the matching Grid card, and the image detail panel.
-Grid reuses one project or target analysis; **All Projects** stays unscored and
-says so instead of starting a database-wide analysis.
+Grid reuses one target, project, or database-wide scoring request. **All
+Projects** scores each target/filter group on its own; it never compares frames
+from unrelated targets. This request reads stored metadata and cached evidence
+but does not start the full FITS quality scan. Grid states how many visible
+images remain unscored because they lack a comparable sequence or enough
+evidence.
 The stack comparison scores only capture profiles with at least three matching
 frames across two sessions. It reports profiles without enough matches instead
 of assigning them a perfect score. Stack previews use the same cross-session

--- a/docs/SCREENING.md
+++ b/docs/SCREENING.md
@@ -14,7 +14,7 @@ jumps, tracking drift, and deterministic solve failures. See
 failure semantics, score caps, and the guarded regrade workflow.
 
 All pixel detections are classical statistics — no machine learning or
-training data. An explicit server **Scan Quality** may download and retain
+training data. An explicit server **Analyze Quality** run may download and retain
 orbital elements needed for satellite checks. Merely opening Sequence Analysis
 and CLI regrading remain cache-only. Thresholds were calibrated against real
 sessions (measured clean-frame envelopes across multiple nights and filters),
@@ -100,9 +100,10 @@ psf-guard screen-fits "/path/to/LIGHT" --regrade-db my-db-slug
 psf-guard move-rejects --db my-db-slug
 ```
 
-From the **web UI**: open a target's Sequence view and press **Scan Quality**.
+From the **web UI**: open a target's Sequence view and press **Analyze Quality**.
 The scan runs spatial/photometric screening and fresh plate solves in the
-background (progress shown live), and results persist across restarts. The
+background (progress shown live), then refreshes the sequence scores. Results
+persist across restarts. The
 sequence analysis shows coverage badges, classifications, solved-center
 scatter, a session view, and an all-session stack comparison for each filter.
 The stack comparison scores only capture profiles with at least three matching

--- a/docs/SCREENING.md
+++ b/docs/SCREENING.md
@@ -106,6 +106,8 @@ background (progress shown live), then refreshes the sequence scores. Results
 persist across restarts. The
 sequence analysis shows coverage badges, classifications, solved-center
 scatter, a session view, and an all-session stack comparison for each filter.
+When analysis names a cause, the same reason and supporting evidence appear on
+the Sequence card, the matching Grid card, and the image detail panel.
 The stack comparison scores only capture profiles with at least three matching
 frames across two sessions. It reports profiles without enough matches instead
 of assigning them a perfect score. Stack previews use the same cross-session

--- a/docs/SCREENING.md
+++ b/docs/SCREENING.md
@@ -108,6 +108,8 @@ sequence analysis shows coverage badges, classifications, solved-center
 scatter, a session view, and an all-session stack comparison for each filter.
 When analysis names a cause, the same reason and supporting evidence appear on
 the Sequence card, the matching Grid card, and the image detail panel.
+Grid reuses one project or target analysis; **All Projects** stays unscored and
+says so instead of starting a database-wide analysis.
 The stack comparison scores only capture profiles with at least three matching
 frames across two sessions. It reports profiles without enough matches instead
 of assigning them a perfect score. Stack previews use the same cross-session

--- a/docs/STATISTICAL_GRADING.md
+++ b/docs/STATISTICAL_GRADING.md
@@ -24,7 +24,7 @@ images.
   median absolute deviation (MAD).
 
 These checks use catalog measurements. They do not replace a fresh
-**Scan Quality** run.
+**Analyze Quality** run.
 
 ### Sequence cloud check
 

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -704,12 +704,16 @@ pub struct FileStatusResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct SequenceAnalysisQuery {
-    /// Analyze one target. Exactly one of `target_id` and `project_id` must be
-    /// supplied.
+    /// Analyze one target. Exactly one scope must be supplied.
     pub target_id: Option<i32>,
     /// Analyze every target with images in one project. This lets grid views
     /// load quality results in one request instead of one request per card.
     pub project_id: Option<i32>,
+    /// Analyze every target/filter group in this database. Scores remain
+    /// relative to their own target/filter sequence; this does not start a
+    /// FITS quality scan.
+    #[serde(default)]
+    pub all_projects: bool,
     pub filter_name: Option<String>,
     pub session_gap_minutes: Option<u64>,
     pub weight_star_count: Option<f64>,

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -704,7 +704,12 @@ pub struct FileStatusResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct SequenceAnalysisQuery {
-    pub target_id: i32,
+    /// Analyze one target. Exactly one of `target_id` and `project_id` must be
+    /// supplied.
+    pub target_id: Option<i32>,
+    /// Analyze every target with images in one project. This lets grid views
+    /// load quality results in one request instead of one request per card.
+    pub project_id: Option<i32>,
     pub filter_name: Option<String>,
     pub session_gap_minutes: Option<u64>,
     pub weight_star_count: Option<f64>,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -3617,15 +3617,16 @@ pub async fn analyze_sequence(
     let weight_spatial = params.weight_spatial;
     let weight_pointing = params.weight_pointing;
 
-    // Fetch images from the requested target or project. Project scope keeps
-    // Grid at one analysis request regardless of its thumbnail count.
+    // Fetch images from the requested target, project, or database. Wider
+    // scopes still score each target/filter group independently and only read
+    // evidence already stored in metadata or caches.
     let (images_data, expected_by_image) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
-        let targets = match (params.target_id, params.project_id) {
-            (Some(target_id), None) => {
+        let target_ids = match (params.target_id, params.project_id, params.all_projects) {
+            (Some(target_id), None, false) => {
                 let targets = db.get_targets_by_ids(&[target_id]).map_err(AppError::db)?;
                 if targets.is_empty() {
                     return Err(AppError::BadRequest(format!(
@@ -3633,17 +3634,20 @@ pub async fn analyze_sequence(
                         target_id
                     )));
                 }
-                targets
+                Some(std::collections::HashSet::from([target_id]))
             }
-            (None, Some(project_id)) => db
-                .get_targets_with_images(project_id)
-                .map_err(AppError::db)?
-                .into_iter()
-                .map(|(target, _, _, _)| target)
-                .collect(),
+            (None, Some(project_id), false) => Some(
+                db.get_targets_with_images(project_id)
+                    .map_err(AppError::db)?
+                    .into_iter()
+                    .map(|(target, _, _, _)| target.id)
+                    .collect(),
+            ),
+            (None, None, true) => None,
             _ => {
                 return Err(AppError::BadRequest(
-                    "Specify exactly one of target_id or project_id".to_string(),
+                    "Specify exactly one of target_id, project_id, or all_projects=true"
+                        .to_string(),
                 ));
             }
         };
@@ -3651,16 +3655,14 @@ pub async fn analyze_sequence(
         let mut resolver =
             crate::acquisition_context::FramingResolver::new(&conn).map_err(AppError::db)?;
         let mut images_data = Vec::new();
-        let target_ids = targets
-            .iter()
-            .map(|target| target.id)
-            .collect::<std::collections::HashSet<_>>();
         let mut expected_by_image = std::collections::HashMap::new();
         let all_images = db
             .query_images_scoped(None, params.project_id, params.target_id, None, 0)
             .map_err(AppError::db)?;
         for image in all_images.into_iter().filter(|(image, _, _)| {
-            target_ids.contains(&image.target_id)
+            target_ids
+                .as_ref()
+                .is_none_or(|target_ids| target_ids.contains(&image.target_id))
                 && filter_name
                     .as_ref()
                     .is_none_or(|filter| image.filter_name == *filter)

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -3757,10 +3757,13 @@ pub async fn analyze_sequence(
         result.0.into_iter().map(Into::into).collect();
     let mut target_filter_rollups: Vec<crate::server::api::TargetFilterRollupResponse> =
         result.1.into_iter().map(Into::into).collect();
-    sequences.sort_by(|a, b| {
-        b.session_start
-            .cmp(&a.session_start)
-            .then_with(|| a.filter_name.cmp(&b.filter_name))
+    sequences.sort_by(|a, b| match (a.session_start, b.session_start) {
+        (Some(left), Some(right)) => left
+            .cmp(&right)
+            .then_with(|| a.filter_name.cmp(&b.filter_name)),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.filter_name.cmp(&b.filter_name),
     });
     target_filter_rollups.sort_by(|a, b| a.filter_name.cmp(&b.filter_name));
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -3607,7 +3607,6 @@ pub async fn analyze_sequence(
         extract_metrics_from_metadata, QualityWeights, SequenceAnalyzer, SequenceAnalyzerConfig,
     };
 
-    let target_id = params.target_id;
     let filter_name = params.filter_name.clone();
     let session_gap = params.session_gap_minutes;
     let weight_star_count = params.weight_star_count;
@@ -3618,45 +3617,64 @@ pub async fn analyze_sequence(
     let weight_spatial = params.weight_spatial;
     let weight_pointing = params.weight_pointing;
 
-    // Fetch images from database
-    let (images_data, target_name, expected_by_image) = {
+    // Fetch images from the requested target or project. Project scope keeps
+    // Grid at one analysis request regardless of its thumbnail count.
+    let (images_data, expected_by_image) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
-        // Get target name
-        let targets = db.get_targets_by_ids(&[target_id]).map_err(AppError::db)?;
-        let target = targets
-            .into_iter()
-            .next()
-            .ok_or_else(|| AppError::BadRequest(format!("Target {} not found", target_id)))?;
-        let target_name = target.name.clone();
+        let targets = match (params.target_id, params.project_id) {
+            (Some(target_id), None) => {
+                let targets = db.get_targets_by_ids(&[target_id]).map_err(AppError::db)?;
+                if targets.is_empty() {
+                    return Err(AppError::BadRequest(format!(
+                        "Target {} not found",
+                        target_id
+                    )));
+                }
+                targets
+            }
+            (None, Some(project_id)) => db
+                .get_targets_with_images(project_id)
+                .map_err(AppError::db)?
+                .into_iter()
+                .map(|(target, _, _, _)| target)
+                .collect(),
+            _ => {
+                return Err(AppError::BadRequest(
+                    "Specify exactly one of target_id or project_id".to_string(),
+                ));
+            }
+        };
 
-        // Query images for this target
-        let all_images = db
-            .query_images_scoped(None, None, Some(target_id), None, 0)
-            .map_err(AppError::db)?;
-
-        let filtered: Vec<_> = all_images
-            .into_iter()
-            .filter(|(img, _, _)| {
-                img.target_id == target_id
-                    && filter_name.as_ref().is_none_or(|f| img.filter_name == *f)
-            })
-            .collect();
         let mut resolver =
             crate::acquisition_context::FramingResolver::new(&conn).map_err(AppError::db)?;
-        let expected_by_image = filtered
+        let mut images_data = Vec::new();
+        let target_ids = targets
             .iter()
-            .map(|(image, _, _)| {
-                resolver
-                    .expected_for_grading(&conn, image)
-                    .map(|expected| (image.id, expected))
-            })
-            .collect::<Result<std::collections::HashMap<_, _>, _>>()
+            .map(|target| target.id)
+            .collect::<std::collections::HashSet<_>>();
+        let mut expected_by_image = std::collections::HashMap::new();
+        let all_images = db
+            .query_images_scoped(None, params.project_id, params.target_id, None, 0)
             .map_err(AppError::db)?;
+        for image in all_images.into_iter().filter(|(image, _, _)| {
+            target_ids.contains(&image.target_id)
+                && filter_name
+                    .as_ref()
+                    .is_none_or(|filter| image.filter_name == *filter)
+        }) {
+            expected_by_image.insert(
+                image.0.id,
+                resolver
+                    .expected_for_grading(&conn, &image.0)
+                    .map_err(AppError::db)?,
+            );
+            images_data.push(image);
+        }
 
-        (filtered, target_name, expected_by_image)
+        (images_data, expected_by_image)
     };
 
     if images_data.is_empty() {
@@ -3674,7 +3692,6 @@ pub async fn analyze_sequence(
     let spatial_store = ctx.spatial_metrics.clone();
     let astrometry_cache_dir = ctx.cache_dir_path.clone();
     let astrometry_evidence = ctx.astrometry_evidence.clone();
-    let target_name_clone = target_name.clone();
     let result = tokio::task::spawn_blocking(move || {
         let mut config = SequenceAnalyzerConfig::default();
         if let Some(gap) = session_gap {
@@ -3704,12 +3721,13 @@ pub async fn analyze_sequence(
         let session_gap_minutes = config.session_gap_minutes;
         let analyzer = SequenceAnalyzer::new(config);
 
-        // Group by filter_name and analyze each group
-        let mut by_filter: std::collections::HashMap<String, Vec<_>> =
+        // Group by target and filter so project analysis preserves the same
+        // comparison boundaries as one-target Sequence analysis.
+        let mut by_group: std::collections::HashMap<(i32, String, String), Vec<_>> =
             std::collections::HashMap::new();
-        let mut entries_by_filter: std::collections::HashMap<String, Vec<_>> =
+        let mut entries_by_group: std::collections::HashMap<(i32, String, String), Vec<_>> =
             std::collections::HashMap::new();
-        for (img, _proj, _target) in &images_data {
+        for (img, _project_name, target_name) in &images_data {
             let mut metrics =
                 extract_metrics_from_metadata(img.id, &img.metadata, img.acquired_date);
             merge_spatial_metrics(&mut metrics, &spatial_store, &img.metadata);
@@ -3720,26 +3738,26 @@ pub async fn analyze_sequence(
                 &astrometry_evidence,
                 expected_by_image.get(&img.id).copied().flatten(),
             );
-            entries_by_filter
-                .entry(img.filter_name.clone())
+            let group = (img.target_id, target_name.clone(), img.filter_name.clone());
+            entries_by_group
+                .entry(group.clone())
                 .or_default()
                 .push(stored_entry_for(&spatial_store, img.id, &img.metadata));
-            by_filter
-                .entry(img.filter_name.clone())
-                .or_default()
-                .push(metrics);
+            by_group.entry(group).or_default().push(metrics);
         }
 
         let mut all_sequences = Vec::new();
         let mut target_filter_rollups = Vec::new();
-        for (filter, mut metrics) in by_filter {
-            if let Some(entries) = entries_by_filter.get(&filter) {
+        for ((target_id, target_name, filter), mut metrics) in by_group {
+            if let Some(entries) =
+                entries_by_group.get(&(target_id, target_name.clone(), filter.clone()))
+            {
                 merge_photometric_signals(&mut metrics, entries, session_gap_minutes);
             }
             let (scored, rollup) = analyzer.analyze_with_target_filter_rollup(
                 &metrics,
                 target_id,
-                &target_name_clone,
+                &target_name,
                 &filter,
             );
             all_sequences.extend(scored);
@@ -3760,12 +3778,20 @@ pub async fn analyze_sequence(
     sequences.sort_by(|a, b| match (a.session_start, b.session_start) {
         (Some(left), Some(right)) => left
             .cmp(&right)
+            .then_with(|| a.target_id.cmp(&b.target_id))
             .then_with(|| a.filter_name.cmp(&b.filter_name)),
         (Some(_), None) => std::cmp::Ordering::Less,
         (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => a.filter_name.cmp(&b.filter_name),
+        (None, None) => a
+            .target_id
+            .cmp(&b.target_id)
+            .then_with(|| a.filter_name.cmp(&b.filter_name)),
     });
-    target_filter_rollups.sort_by(|a, b| a.filter_name.cmp(&b.filter_name));
+    target_filter_rollups.sort_by(|a, b| {
+        a.target_id
+            .cmp(&b.target_id)
+            .then_with(|| a.filter_name.cmp(&b.filter_name))
+    });
 
     Ok(Json(ApiResponse::success(
         crate::server::api::SequenceAnalysisResponse {

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -584,18 +584,15 @@ test('Sequence shows long score reasons in a popover without resizing the card',
 test('quality reasons remain available in Grid and image details', async ({ page }) => {
   const reviewReason = 'Tracking error: elongated stars';
   const evidence = 'HFR and eccentricity are poor compared with this capture sequence.';
+  let perImageQualityRequests = 0;
+  page.on('request', (request) => {
+    if (request.url().includes('/analysis/image/')) perImageQualityRequests += 1;
+  });
   await page.route(`**/api/db/${dbId}/analysis/sequence*`, async (route) => {
     const response = await route.fetch();
     const body = await response.json();
     body.data.sequences[0].images[0].regrade_reason = reviewReason;
     body.data.sequences[0].images[0].details = evidence;
-    await route.fulfill({ response, json: body });
-  });
-  await page.route(`**/api/db/${dbId}/analysis/image/1`, async (route) => {
-    const response = await route.fetch();
-    const body = await response.json();
-    body.data.quality.regrade_reason = reviewReason;
-    body.data.quality.details = evidence;
     await route.fulfill({ response, json: body });
   });
 
@@ -613,6 +610,23 @@ test('quality reasons remain available in Grid and image details', async ({ page
   await expect(detail.getByRole('heading', { name: 'Quality analysis' })).toBeVisible();
   await expect(detail).toContainText(reviewReason);
   await expect(detail).toContainText(evidence);
+  expect(perImageQualityRequests).toBe(0);
+});
+
+test('All Projects explains that quality remains unscored without a project scope', async ({
+  page,
+}) => {
+  let sequenceRequests = 0;
+  page.on('request', (request) => {
+    if (request.url().includes('/analysis/sequence')) sequenceRequests += 1;
+  });
+
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}`);
+  await expect(page.locator('.image-card')).toHaveCount(4, { timeout: 15_000 });
+  const state = page.locator('.grid-quality-state');
+  await expect(state).toHaveText('Quality: unscored — choose a project');
+  await expect(state).toHaveAttribute('title', /does not run a database-wide sequence analysis/);
+  expect(sequenceRequests).toBe(0);
 });
 
 test('Sequence chart Shift-click selects a visible range', async ({ page }) => {

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -581,6 +581,40 @@ test('Sequence shows long score reasons in a popover without resizing the card',
   await expect(popover).not.toBeVisible();
 });
 
+test('quality reasons remain available in Grid and image details', async ({ page }) => {
+  const reviewReason = 'Tracking error: elongated stars';
+  const evidence = 'HFR and eccentricity are poor compared with this capture sequence.';
+  await page.route(`**/api/db/${dbId}/analysis/sequence*`, async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    body.data.sequences[0].images[0].regrade_reason = reviewReason;
+    body.data.sequences[0].images[0].details = evidence;
+    await route.fulfill({ response, json: body });
+  });
+  await page.route(`**/api/db/${dbId}/analysis/image/1`, async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    body.data.quality.regrade_reason = reviewReason;
+    body.data.quality.details = evidence;
+    await route.fulfill({ response, json: body });
+  });
+
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+  const card = page.locator('[data-card-image-id="1"]');
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await card.getByRole('button', { name: 'Show quality reason' }).click();
+  const popover = page.getByRole('dialog', { name: 'Quality reason' });
+  await expect(popover).toContainText(reviewReason);
+  await expect(popover).toContainText(evidence);
+  await popover.getByRole('button', { name: 'Close quality reason' }).click();
+
+  await card.dblclick();
+  const detail = page.locator('.detail-quality-analysis');
+  await expect(detail.getByRole('heading', { name: 'Quality analysis' })).toBeVisible();
+  await expect(detail).toContainText(reviewReason);
+  await expect(detail).toContainText(evidence);
+});
+
 test('Sequence chart Shift-click selects a visible range', async ({ page }) => {
   await page.goto(
     `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1`

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -555,6 +555,32 @@ test('Sequence keeps flagged image thumbnails at full opacity', async ({ page })
   await expect(flaggedCard).toHaveCSS('opacity', '1');
 });
 
+test('Sequence shows long score reasons in a popover without resizing the card', async ({ page }) => {
+  const reason = 'Star count and background are outside the normal range for matching capture settings across all available sessions.';
+  await page.route(`**/api/db/${dbId}/analysis/sequence*`, async (route) => {
+    const response = await route.fetch();
+    const body = await response.json();
+    body.data.sequences[0].images[0].details = reason;
+    await route.fulfill({ response, json: body });
+  });
+  await page.goto(
+    `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1`
+  );
+
+  const card = page.locator('.sequence-image-card').first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  const before = await card.boundingBox();
+  await card.getByRole('button', { name: 'Show quality reason' }).click();
+
+  const popover = page.getByRole('dialog', { name: 'Quality reason' });
+  await expect(popover).toContainText(reason);
+  const after = await card.boundingBox();
+  expect(after?.height).toBeCloseTo(before?.height ?? 0, 2);
+
+  await popover.getByRole('button', { name: 'Close quality reason' }).click();
+  await expect(popover).not.toBeVisible();
+});
+
 test('Sequence chart Shift-click selects a visible range', async ({ page }) => {
   await page.goto(
     `/#/sequence?db=${encodeURIComponent(dbId)}&project=1&target=1`

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -613,20 +613,28 @@ test('quality reasons remain available in Grid and image details', async ({ page
   expect(perImageQualityRequests).toBe(0);
 });
 
-test('All Projects explains that quality remains unscored without a project scope', async ({
+test('All Projects loads scores without starting a quality scan', async ({
   page,
 }) => {
   let sequenceRequests = 0;
+  let qualityScanRequests = 0;
+  let databaseScope = false;
   page.on('request', (request) => {
-    if (request.url().includes('/analysis/sequence')) sequenceRequests += 1;
+    if (request.url().includes('/analysis/sequence')) {
+      sequenceRequests += 1;
+      databaseScope = new URL(request.url()).searchParams.get('all_projects') === 'true';
+    }
+    if (request.url().includes('/analysis/quality-scan')) qualityScanRequests += 1;
   });
 
   await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}`);
   await expect(page.locator('.image-card')).toHaveCount(4, { timeout: 15_000 });
   const state = page.locator('.grid-quality-state');
-  await expect(state).toHaveText('Quality: unscored — choose a project');
-  await expect(state).toHaveAttribute('title', /does not run a database-wide sequence analysis/);
-  expect(sequenceRequests).toBe(0);
+  await expect(state).toHaveText('Quality: 4 scored');
+  await expect(page.locator('.image-card .quality-badge')).toHaveCount(4);
+  expect(sequenceRequests).toBe(1);
+  expect(databaseScope).toBe(true);
+  expect(qualityScanRequests).toBe(0);
 });
 
 test('Sequence chart Shift-click selects a visible range', async ({ page }) => {

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -1314,6 +1314,12 @@
   color: var(--color-text-lighter);
 }
 
+.grid-quality-state {
+  display: inline-block;
+  min-width: 10rem;
+  color: var(--color-text-muted);
+}
+
 .reject-reason-inline {
   font-size: 0.85rem;
   color: var(--color-error-light);
@@ -1888,6 +1894,13 @@
 
 .detail-quality-reason .quality-reason-text {
   font-size: 0.82rem;
+}
+
+.detail-quality-status {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+  line-height: 1.45;
 }
 
 .info-section dl {
@@ -5644,6 +5657,18 @@
 .sequence-reason-trigger:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
+}
+
+.card-quality-reason-overlay {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  z-index: 6;
+}
+
+.card-quality-reason-overlay .sequence-reason-trigger {
+  margin-top: 0;
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, transparent);
 }
 
 .sequence-reason-popover {

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -1857,6 +1857,39 @@
   color: var(--color-error-light);
 }
 
+.detail-quality-analysis {
+  padding: 0.8rem;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: 6px;
+  background: var(--color-bg-secondary);
+}
+
+.detail-quality-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.7rem;
+}
+
+.detail-quality-summary strong {
+  color: var(--color-primary);
+  font-size: 1rem;
+}
+
+.detail-quality-summary span {
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.detail-quality-reason > strong {
+  color: var(--color-text-secondary);
+  font-size: 0.78rem;
+}
+
+.detail-quality-reason .quality-reason-text {
+  font-size: 0.82rem;
+}
+
 .info-section dl {
   margin: 0;
   display: grid;
@@ -5654,13 +5687,13 @@
   color: var(--color-text-primary);
 }
 
-.sequence-reason-popover p {
+.quality-reason-text p {
   margin: 0.55rem 0 0;
   overflow-wrap: anywhere;
   line-height: 1.4;
 }
 
-.sequence-reason-evidence-label {
+.quality-reason-evidence-label {
   display: block;
   margin-top: 0.7rem;
   color: var(--color-text-muted);

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -5570,8 +5570,7 @@
 
 .analysis-signal,
 .sequence-image-coverage,
-.sequence-score-basis,
-.sequence-image-details {
+.sequence-score-basis {
   font-size: 0.7rem;
   color: var(--color-text-hint);
 }
@@ -5589,10 +5588,86 @@
   color: var(--color-error);
 }
 
-.sequence-image-details {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.sequence-reason-trigger {
+  display: block;
+  width: fit-content;
+  margin-top: 0.25rem;
+  padding: 0.12rem 0.45rem;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: 999px;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: 0.7rem;
+  cursor: pointer;
+}
+
+.sequence-reason-trigger:hover,
+.sequence-reason-trigger[aria-expanded='true'] {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.sequence-reason-trigger:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.sequence-reason-popover {
+  position: fixed;
+  z-index: 1200;
+  box-sizing: border-box;
+  max-height: min(18rem, calc(100vh - 24px));
+  overflow: auto;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: 8px;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 45%);
+  font-size: 0.82rem;
+}
+
+.sequence-reason-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--color-primary);
+}
+
+.sequence-reason-popover-header button {
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.sequence-reason-popover-header button:hover {
+  background: var(--color-bg-quaternary);
+  color: var(--color-text-primary);
+}
+
+.sequence-reason-popover p {
+  margin: 0.55rem 0 0;
+  overflow-wrap: anywhere;
+  line-height: 1.4;
+}
+
+.sequence-reason-evidence-label {
+  display: block;
+  margin-top: 0.7rem;
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 /* Async preview-generation placeholder (PreviewImage / poll-on-error). Fills a

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -33,6 +33,7 @@ import type {
   OverallStats,
   CacheRefreshProgress,
   SequenceAnalysisRequest,
+  ProjectSequenceAnalysisRequest,
   SequenceAnalysisResponse,
   ImageQualityResponse,
   SpatialScanRequest,
@@ -985,7 +986,7 @@ export const apiClient = {
 
   analyzeSequence: async (
     dbId: string,
-    request: SequenceAnalysisRequest
+    request: SequenceAnalysisRequest | ProjectSequenceAnalysisRequest
   ): Promise<SequenceAnalysisResponse> => {
     const apiInstance = await getApi();
     const { data } = await apiInstance.get<ApiResponse<SequenceAnalysisResponse>>(

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -34,6 +34,7 @@ import type {
   CacheRefreshProgress,
   SequenceAnalysisRequest,
   ProjectSequenceAnalysisRequest,
+  DatabaseSequenceAnalysisRequest,
   SequenceAnalysisResponse,
   ImageQualityResponse,
   SpatialScanRequest,
@@ -986,7 +987,7 @@ export const apiClient = {
 
   analyzeSequence: async (
     dbId: string,
-    request: SequenceAnalysisRequest | ProjectSequenceAnalysisRequest
+    request: SequenceAnalysisRequest | ProjectSequenceAnalysisRequest | DatabaseSequenceAnalysisRequest
   ): Promise<SequenceAnalysisResponse> => {
     const apiInstance = await getApi();
     const { data } = await apiInstance.get<ApiResponse<SequenceAnalysisResponse>>(

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1231,6 +1231,11 @@ export interface SequenceAnalysisRequest {
   weight_pointing?: number;
 }
 
+export interface ProjectSequenceAnalysisRequest {
+  project_id: number;
+  filter_name?: string;
+}
+
 export interface SequenceAnalysisResponse {
   sequences: ScoredSequence[];
   /** Scores across all stack candidates for each target/filter. Each score is

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1236,6 +1236,11 @@ export interface ProjectSequenceAnalysisRequest {
   filter_name?: string;
 }
 
+export interface DatabaseSequenceAnalysisRequest {
+  all_projects: true;
+  filter_name?: string;
+}
+
 export interface SequenceAnalysisResponse {
   sequences: ScoredSequence[];
   /** Scores across all stack candidates for each target/filter. Each score is

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -37,7 +37,7 @@ import {
   type GridNavigationDirection,
 } from '../utils/gridNavigation';
 import { thumbnailGridColumns } from '../utils/thumbnailSizing';
-import { useGridQuality } from '../hooks/useSequenceAnalysis';
+import { useScopedQuality } from '../hooks/useSequenceAnalysis';
 
 interface GroupedImageGridProps {
   useLazyImages?: boolean;
@@ -158,12 +158,37 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
     return Array.from(filterSet).sort();
   }, [allImages]);
 
-  const { qualityByImage } = useGridQuality(
+  const quality = useScopedQuality(
     dbId,
     projectId,
     targetId,
     filters.filterName === 'all' ? undefined : filters.filterName,
   );
+  let qualityStatus = {
+    label: 'Quality: unscored',
+    title: 'No sequence score is available for this scope. Analyze Quality from a target Sequence view to add pixel evidence.',
+  };
+  if (!quality.isScoped) {
+    qualityStatus = {
+      label: 'Quality: unscored — choose a project',
+      title: 'All Projects does not run a database-wide sequence analysis. Choose a project or target to load quality scores and reasons.',
+    };
+  } else if (quality.isLoading) {
+    qualityStatus = {
+      label: 'Quality: loading',
+      title: 'Loading cached sequence scores and reasons for this scope.',
+    };
+  } else if (quality.error) {
+    qualityStatus = {
+      label: 'Quality: unavailable',
+      title: 'Sequence quality could not be loaded for this scope.',
+    };
+  } else if (quality.qualityByImage.size > 0) {
+    qualityStatus = {
+      label: `Quality: ${quality.qualityByImage.size} scored`,
+      title: 'Sequence scores and reasons are available for these images.',
+    };
+  }
 
   // Determine if we're in multi-project mode
   const isMultiProjectMode = projectId === null;
@@ -779,6 +804,10 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                 {filters.status !== 'all' && ` • ${filters.status}`}
                 {filters.filterName !== 'all' && ` • ${filters.filterName}`}
                 {filters.searchTerm && ` • "${filters.searchTerm}"`}
+                {' • '}
+                <span className="grid-quality-state" title={qualityStatus.title}>
+                  {qualityStatus.label}
+                </span>
               </div>
               <div
                 className={`selection-action-bar ${selectedImages.size > 1 ? 'active' : ''}`}
@@ -892,7 +921,8 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                           <CardComponent
                             dbId={dbId!}
                             image={image}
-                            quality={qualityByImage.get(image.id)}
+                            quality={quality.qualityByImage.get(image.id)}
+                            qualityPresentation="compact"
                             isSelected={
                               selectedImages.has(image.id) ||
                               image.id === activeImageId

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -37,6 +37,7 @@ import {
   type GridNavigationDirection,
 } from '../utils/gridNavigation';
 import { thumbnailGridColumns } from '../utils/thumbnailSizing';
+import { useGridQuality } from '../hooks/useSequenceAnalysis';
 
 interface GroupedImageGridProps {
   useLazyImages?: boolean;
@@ -156,6 +157,13 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
     });
     return Array.from(filterSet).sort();
   }, [allImages]);
+
+  const { qualityByImage } = useGridQuality(
+    dbId,
+    projectId,
+    targetId,
+    filters.filterName === 'all' ? undefined : filters.filterName,
+  );
 
   // Determine if we're in multi-project mode
   const isMultiProjectMode = projectId === null;
@@ -884,6 +892,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                           <CardComponent
                             dbId={dbId!}
                             image={image}
+                            quality={qualityByImage.get(image.id)}
                             isSelected={
                               selectedImages.has(image.id) ||
                               image.id === activeImageId

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -166,27 +166,37 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
   );
   let qualityStatus = {
     label: 'Quality: unscored',
-    title: 'No sequence score is available for this scope. Analyze Quality from a target Sequence view to add pixel evidence.',
+    title: 'No sequence score is available for these images. Open a target Sequence view to inspect the evidence or run Analyze Quality.',
   };
-  if (!quality.isScoped) {
-    qualityStatus = {
-      label: 'Quality: unscored — choose a project',
-      title: 'All Projects does not run a database-wide sequence analysis. Choose a project or target to load quality scores and reasons.',
-    };
-  } else if (quality.isLoading) {
+  const scoredImageCount = filteredImages.reduce(
+    (count, image) => count + Number(quality.qualityByImage.has(image.id)),
+    0,
+  );
+  const unscoredImageCount = filteredImages.length - scoredImageCount;
+  if (quality.isLoading) {
     qualityStatus = {
       label: 'Quality: loading',
-      title: 'Loading cached sequence scores and reasons for this scope.',
+      title: 'Loading sequence scores and reasons from stored metadata and cached evidence.',
     };
   } else if (quality.error) {
     qualityStatus = {
       label: 'Quality: unavailable',
       title: 'Sequence quality could not be loaded for this scope.',
     };
-  } else if (quality.qualityByImage.size > 0) {
+  } else if (scoredImageCount > 0 && unscoredImageCount > 0) {
     qualityStatus = {
-      label: `Quality: ${quality.qualityByImage.size} scored`,
-      title: 'Sequence scores and reasons are available for these images.',
+      label: `Quality: ${scoredImageCount} scored · ${unscoredImageCount} unscored`,
+      title: 'Unscored images lack a comparable sequence or enough evidence. Open their target Sequence view to inspect them or run Analyze Quality.',
+    };
+  } else if (scoredImageCount > 0) {
+    qualityStatus = {
+      label: `Quality: ${scoredImageCount} scored`,
+      title: 'Sequence scores and reasons are available for all visible images.',
+    };
+  } else if (unscoredImageCount > 0) {
+    qualityStatus = {
+      label: `Quality: ${unscoredImageCount} unscored`,
+      title: 'These images lack a comparable sequence or enough evidence. Open a target Sequence view to inspect them or run Analyze Quality.',
     };
   }
 

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -21,6 +21,7 @@ export interface ImageCardProps {
   onDoubleClick: () => void;
   quality?: ImageQualityResult;
   qualityScoreScope?: QualityScoreScope;
+  qualityPresentation?: 'full' | 'compact';
   lazyPreview?: boolean;
   selectionEffects?: boolean;
   className?: string;
@@ -34,6 +35,7 @@ export default function ImageCard({
   onDoubleClick,
   quality,
   qualityScoreScope = 'capture_sequence',
+  qualityPresentation = 'full',
   lazyPreview = false,
   selectionEffects = true,
   className = '',
@@ -139,6 +141,15 @@ export default function ImageCard({
             {formatCategory(quality.category)}
           </div>
         )}
+        {qualityPresentation === 'compact'
+          && (quality?.regrade_reason || quality?.details) && (
+          <div className="card-quality-reason-overlay">
+            <QualityReasonPopover
+              reason={quality.regrade_reason}
+              details={quality.details}
+            />
+          </div>
+        )}
       </div>
       <div className="image-info">
         <h3>{image.target_name}</h3>
@@ -150,7 +161,7 @@ export default function ImageCard({
             {stats.starCount && <span className="stat-stars">★ {stats.starCount}</span>}
           </div>
         )}
-        {quality && (
+        {qualityPresentation === 'full' && quality && (
           <span
             className="sequence-score-basis"
             title={qualityScoreDescription(quality, qualityScoreScope)}
@@ -164,13 +175,15 @@ export default function ImageCard({
             <span className="reject-reason-inline"> - {image.reject_reason}</span>
           )}
         </div>
-        {quality?.normalized_metrics.spatial_coverage != null
+        {qualityPresentation === 'full'
+          && quality?.normalized_metrics.spatial_coverage != null
           && quality.normalized_metrics.spatial_coverage < 0.9 && (
           <span className="sequence-image-coverage" title="Spatial star coverage (1.0 = stars across the whole frame)">
             coverage {quality.normalized_metrics.spatial_coverage.toFixed(2)}
           </span>
         )}
-        {quality?.pointing?.field_fraction_offset != null && (
+        {qualityPresentation === 'full'
+          && quality?.pointing?.field_fraction_offset != null && (
           <span
             className={quality.regrade_reason ? 'analysis-signal danger' : 'analysis-signal'}
             title={`Solved target offset: ${quality.pointing.separation_arcsec?.toFixed(0) ?? '?'} arcsec`}
@@ -178,7 +191,7 @@ export default function ImageCard({
             offset {(quality.pointing.field_fraction_offset * 100).toFixed(0)}% field
           </span>
         )}
-        {quality?.pointing?.solve_failed && (
+        {qualityPresentation === 'full' && quality?.pointing?.solve_failed && (
           <span
             className="analysis-signal warning"
             title={quality.pointing.error || (quality.pointing.image_quality_evidence
@@ -188,7 +201,8 @@ export default function ImageCard({
             {quality.pointing.image_quality_evidence ? 'unsolved' : 'solve unavailable'}
           </span>
         )}
-        {quality?.satellite && (quality.satellite.potentially_bright_count > 0
+        {qualityPresentation === 'full' && quality?.satellite
+          && (quality.satellite.potentially_bright_count > 0
           || quality.satellite.pixel_aligned_count > 0) && (
           <span
             className={quality.satellite.pixel_aligned_high_risk_count > 0
@@ -207,7 +221,8 @@ export default function ImageCard({
                   : 'possible'}
           </span>
         )}
-        {(quality?.regrade_reason || quality?.details) && (
+        {qualityPresentation === 'full'
+          && (quality?.regrade_reason || quality?.details) && (
           <QualityReasonPopover
             reason={quality.regrade_reason}
             details={quality.details}

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -11,6 +11,7 @@ import {
   qualityScoreDescription,
   type QualityScoreScope,
 } from '../utils/qualityScore';
+import QualityReasonPopover from './QualityReasonPopover';
 
 export interface ImageCardProps {
   dbId: string;
@@ -206,10 +207,11 @@ export default function ImageCard({
                   : 'possible'}
           </span>
         )}
-        {quality?.details && (
-          <span className="sequence-image-details" title={quality.details}>
-            {quality.details}
-          </span>
+        {(quality?.regrade_reason || quality?.details) && (
+          <QualityReasonPopover
+            reason={quality.regrade_reason}
+            details={quality.details}
+          />
         )}
       </div>
     </div>

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -14,7 +14,7 @@ import AstrometryOverlay from './AstrometryOverlay';
 import SatellitePanel from './SatellitePanel';
 import SatelliteTrackOverlay from './SatelliteTrackOverlay';
 import ImageFileLocation from './ImageFileLocation';
-import { useImageQuality } from '../hooks/useSequenceAnalysis';
+import { useScopedQuality } from '../hooks/useSequenceAnalysis';
 import QualityAnalysisSummary from './QualityAnalysisSummary';
 import {
   colorPreviewEnabled,
@@ -25,6 +25,9 @@ import {
 interface ImageDetailViewProps {
   dbId: string;
   imageId: number;
+  projectId?: number | null;
+  targetId?: number | null;
+  qualityFilterName?: string;
   onClose: () => void;
   onNext: () => void;
   onPrevious: () => void;
@@ -47,6 +50,9 @@ interface ImageDetailViewProps {
 export default function ImageDetailView({
   dbId,
   imageId,
+  projectId,
+  targetId,
+  qualityFilterName,
   onClose,
   onNext,
   onPrevious,
@@ -169,8 +175,17 @@ export default function ImageDetailView({
     placeholderData: (previousData) => previousData, // Keep showing previous image while loading new one
   });
 
-  const { data: qualityContext } = useImageQuality(dbId, imageId);
-  const quality = qualityContext?.quality;
+  const qualityScope = useScopedQuality(dbId, projectId, targetId, qualityFilterName);
+  const quality = qualityScope.qualityByImage.get(imageId);
+  const qualityStatus = !qualityScope.isScoped
+    ? 'Quality scores and reasons are not calculated in All Projects. Choose a project or target to load them.'
+    : qualityScope.isLoading
+      ? 'Loading the sequence quality score and reason…'
+      : qualityScope.error
+        ? 'Sequence quality is unavailable for this scope.'
+        : quality
+          ? undefined
+          : 'No sequence score is available for this image.';
 
   const {
     data: astrometry,
@@ -752,7 +767,7 @@ export default function ImageDetailView({
               )}
             </div>
 
-            <QualityAnalysisSummary quality={quality} />
+            <QualityAnalysisSummary quality={quality} statusMessage={qualityStatus} />
 
             <AstrometryPanel
               analysis={astrometry}

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -14,6 +14,8 @@ import AstrometryOverlay from './AstrometryOverlay';
 import SatellitePanel from './SatellitePanel';
 import SatelliteTrackOverlay from './SatelliteTrackOverlay';
 import ImageFileLocation from './ImageFileLocation';
+import { useImageQuality } from '../hooks/useSequenceAnalysis';
+import QualityAnalysisSummary from './QualityAnalysisSummary';
 import {
   colorPreviewEnabled,
   setColorPreview,
@@ -166,6 +168,9 @@ export default function ImageDetailView({
     queryFn: () => apiClient.getImage(dbId, imageId),
     placeholderData: (previousData) => previousData, // Keep showing previous image while loading new one
   });
+
+  const { data: qualityContext } = useImageQuality(dbId, imageId);
+  const quality = qualityContext?.quality;
 
   const {
     data: astrometry,
@@ -746,6 +751,8 @@ export default function ImageDetailView({
                 </div>
               )}
             </div>
+
+            <QualityAnalysisSummary quality={quality} />
 
             <AstrometryPanel
               analysis={astrometry}

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -177,9 +177,7 @@ export default function ImageDetailView({
 
   const qualityScope = useScopedQuality(dbId, projectId, targetId, qualityFilterName);
   const quality = qualityScope.qualityByImage.get(imageId);
-  const qualityStatus = !qualityScope.isScoped
-    ? 'Quality scores and reasons are not calculated in All Projects. Choose a project or target to load them.'
-    : qualityScope.isLoading
+  const qualityStatus = qualityScope.isLoading
       ? 'Loading the sequence quality score and reason…'
       : qualityScope.error
         ? 'Sequence quality is unavailable for this scope.'

--- a/static/src/components/MainView.tsx
+++ b/static/src/components/MainView.tsx
@@ -12,12 +12,18 @@ export default function MainView() {
   const params = useParams();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { dbId } = useDbProjectTarget();
+  const { dbId, projectId, targetId } = useDbProjectTarget();
 
   // Determine current view mode from URL
   const isDetailView = location.pathname.startsWith('/detail/');
   const isComparisonView = location.pathname.startsWith('/compare/');
   const detailReturnView = imageDetailReturnView(searchParams);
+  const requestedQualityFilter = searchParams.get(
+    detailReturnView === 'sequence' ? 'filterName' : 'filter',
+  );
+  const qualityFilterName = requestedQualityFilter && requestedQualityFilter !== 'all'
+    ? requestedQualityFilter
+    : undefined;
 
   const imageId = params.imageId ? parseInt(params.imageId, 10) : undefined;
   const leftImageId = params.leftImageId ? parseInt(params.leftImageId, 10) : undefined;
@@ -160,6 +166,9 @@ export default function MainView() {
           <ImageDetailView
             dbId={dbId}
             imageId={imageId}
+            projectId={projectId}
+            targetId={targetId}
+            qualityFilterName={qualityFilterName}
             onClose={navigation.closeDetail}
             onNext={navigation.goToNext}
             onPrevious={navigation.goToPrevious}

--- a/static/src/components/QualityAnalysisSummary.tsx
+++ b/static/src/components/QualityAnalysisSummary.tsx
@@ -4,10 +4,22 @@ import { QualityReasonText } from './QualityReasonPopover';
 
 interface QualityAnalysisSummaryProps {
   quality?: ImageQualityResult | null;
+  statusMessage?: string;
 }
 
-export default function QualityAnalysisSummary({ quality }: QualityAnalysisSummaryProps) {
-  if (!quality || (!quality.regrade_reason && !quality.details)) return null;
+export default function QualityAnalysisSummary({
+  quality,
+  statusMessage,
+}: QualityAnalysisSummaryProps) {
+  if (!quality) {
+    if (!statusMessage) return null;
+    return (
+      <div className="info-section detail-quality-analysis">
+        <h3>Quality analysis</h3>
+        <p className="detail-quality-status">{statusMessage}</p>
+      </div>
+    );
+  }
 
   return (
     <div className="info-section detail-quality-analysis">
@@ -19,10 +31,14 @@ export default function QualityAnalysisSummary({ quality }: QualityAnalysisSumma
         <strong>{Math.round(quality.quality_score * 100)}%</strong>
         <span>{qualityScoreBasis(quality)}</span>
       </div>
-      <div className="detail-quality-reason">
-        <strong>{quality.regrade_reason ? 'Review reason' : 'Score reason'}</strong>
-        <QualityReasonText reason={quality.regrade_reason} details={quality.details} />
-      </div>
+      {quality.regrade_reason || quality.details ? (
+        <div className="detail-quality-reason">
+          <strong>{quality.regrade_reason ? 'Review reason' : 'Score reason'}</strong>
+          <QualityReasonText reason={quality.regrade_reason} details={quality.details} />
+        </div>
+      ) : (
+        <p className="detail-quality-status">No specific quality issue was identified.</p>
+      )}
     </div>
   );
 }

--- a/static/src/components/QualityAnalysisSummary.tsx
+++ b/static/src/components/QualityAnalysisSummary.tsx
@@ -1,0 +1,28 @@
+import type { ImageQualityResult } from '../api/types';
+import { qualityScoreBasis, qualityScoreDescription } from '../utils/qualityScore';
+import { QualityReasonText } from './QualityReasonPopover';
+
+interface QualityAnalysisSummaryProps {
+  quality?: ImageQualityResult | null;
+}
+
+export default function QualityAnalysisSummary({ quality }: QualityAnalysisSummaryProps) {
+  if (!quality || (!quality.regrade_reason && !quality.details)) return null;
+
+  return (
+    <div className="info-section detail-quality-analysis">
+      <h3>Quality analysis</h3>
+      <div
+        className="detail-quality-summary"
+        title={qualityScoreDescription(quality, 'capture_sequence')}
+      >
+        <strong>{Math.round(quality.quality_score * 100)}%</strong>
+        <span>{qualityScoreBasis(quality)}</span>
+      </div>
+      <div className="detail-quality-reason">
+        <strong>{quality.regrade_reason ? 'Review reason' : 'Score reason'}</strong>
+        <QualityReasonText reason={quality.regrade_reason} details={quality.details} />
+      </div>
+    </div>
+  );
+}

--- a/static/src/components/QualityReasonPopover.tsx
+++ b/static/src/components/QualityReasonPopover.tsx
@@ -7,6 +7,20 @@ interface QualityReasonPopoverProps {
   details?: string | null;
 }
 
+export function QualityReasonText({ reason, details }: QualityReasonPopoverProps) {
+  return (
+    <div className="quality-reason-text">
+      {reason && <p>{reason}</p>}
+      {details && details !== reason && (
+        <>
+          {reason && <span className="quality-reason-evidence-label">Evidence</span>}
+          <p>{details}</p>
+        </>
+      )}
+    </div>
+  );
+}
+
 export default function QualityReasonPopover({ reason, details }: QualityReasonPopoverProps) {
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState<CSSProperties>({});
@@ -99,13 +113,7 @@ export default function QualityReasonPopover({ reason, details }: QualityReasonP
               ×
             </button>
           </div>
-          {reason && <p>{reason}</p>}
-          {details && details !== reason && (
-            <>
-              {reason && <span className="sequence-reason-evidence-label">Evidence</span>}
-              <p>{details}</p>
-            </>
-          )}
+          <QualityReasonText reason={reason} details={details} />
         </div>,
         document.body,
       )}

--- a/static/src/components/QualityReasonPopover.tsx
+++ b/static/src/components/QualityReasonPopover.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react';
+import { createPortal } from 'react-dom';
+
+interface QualityReasonPopoverProps {
+  reason?: string | null;
+  details?: string | null;
+}
+
+export default function QualityReasonPopover({ reason, details }: QualityReasonPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<CSSProperties>({});
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const popoverId = useId();
+
+  const updatePosition = useCallback(() => {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const gutter = 12;
+    const width = Math.min(360, window.innerWidth - gutter * 2);
+    const left = Math.max(gutter, Math.min(rect.left, window.innerWidth - width - gutter));
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    setPosition(spaceBelow >= 180 || spaceBelow >= spaceAbove
+      ? { top: rect.bottom + 8, left, width }
+      : { bottom: window.innerHeight - rect.top + 8, left, width });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnOutsideClick = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (buttonRef.current?.contains(target) || popoverRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+      buttonRef.current?.focus();
+    };
+    const reposition = () => updatePosition();
+    document.addEventListener('pointerdown', closeOnOutsideClick);
+    document.addEventListener('keydown', closeOnEscape, true);
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsideClick);
+      document.removeEventListener('keydown', closeOnEscape, true);
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [open, updatePosition]);
+
+  const toggle = (event: ReactMouseEvent) => {
+    event.stopPropagation();
+    if (!open) updatePosition();
+    setOpen(value => !value);
+  };
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        className="sequence-reason-trigger"
+        aria-expanded={open}
+        aria-controls={popoverId}
+        aria-haspopup="dialog"
+        aria-label={`${open ? 'Hide' : 'Show'} quality reason`}
+        onClick={toggle}
+        onDoubleClick={event => event.stopPropagation()}
+      >
+        Reason
+      </button>
+      {open && createPortal(
+        <div
+          ref={popoverRef}
+          id={popoverId}
+          className="sequence-reason-popover"
+          role="dialog"
+          aria-label="Quality reason"
+          style={position}
+          onClick={event => event.stopPropagation()}
+          onDoubleClick={event => event.stopPropagation()}
+        >
+          <div className="sequence-reason-popover-header">
+            <strong>{reason ? 'Review reason' : 'Score reason'}</strong>
+            <button
+              type="button"
+              aria-label="Close quality reason"
+              onClick={() => {
+                setOpen(false);
+                buttonRef.current?.focus();
+              }}
+            >
+              ×
+            </button>
+          </div>
+          {reason && <p>{reason}</p>}
+          {details && details !== reason && (
+            <>
+              {reason && <span className="sequence-reason-evidence-label">Evidence</span>}
+              <p>{details}</p>
+            </>
+          )}
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -205,8 +205,8 @@ export default function SequenceView() {
       sequences.flatMap(sequence => sequence.images).map(image => [image.image_id, image]),
     );
 
-    // Keep the server's newest-session-first filter order. This preserves the
-    // prior default when the target has more than one filter.
+    // Keep the server's chronological session order so the tabs read left to
+    // right in capture order. Each filter's all-session view stays first.
     sessionsByFilter.forEach((sessions, filter) => {
       const rollup = rollupsByFilter.get(filter);
       if (rollup && sessions.length > 1) {

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -706,21 +706,13 @@ export default function SequenceView() {
             <button
               type="button"
               className="header-button"
-              onClick={() => analyze({ target_id: targetId, filter_name: filterName })}
-              disabled={isAnalyzing}
-            >
-              {isAnalyzing ? 'Analyzing...' : 'Re-analyze'}
-            </button>
-            <button
-              type="button"
-              className="header-button"
               onClick={(event) => spatialScan.start(event.shiftKey || undefined)}
               disabled={spatialScan.isStarting || spatialScan.isRunning}
-              title="Analyze FITS pixels for occlusion, photometry, plate solutions, target offset, tracking loss, and satellite trails. Shift-click to recompute all cached evidence from the current catalogs."
+              title="Analyze FITS pixels, then refresh sequence scores. Shift-click to recompute all cached evidence from the current catalogs."
             >
               {spatialScan.isRunning
                 ? `${spatialScan.status?.progress.stage === 'astrometry' ? 'Solving' : 'Scanning'} ${spatialScan.status?.progress.processed ?? 0}/${spatialScan.status?.progress.total ?? 0}...`
-                : 'Scan Quality'}
+                : 'Analyze Quality'}
             </button>
           </div>
           <div className="sequence-job-status" aria-live="polite">

--- a/static/src/components/__tests__/ImageCard.reason.test.tsx
+++ b/static/src/components/__tests__/ImageCard.reason.test.tsx
@@ -83,4 +83,24 @@ describe('ImageCard quality reason', () => {
     expect(screen.queryByRole('dialog', { name: 'Quality reason' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Show quality reason' })).toHaveFocus();
   });
+
+  it('keeps compact Grid quality controls out of the card body', () => {
+    const { container } = render(
+      <ImageCard
+        dbId="db"
+        image={image}
+        isSelected={false}
+        onClick={() => {}}
+        onDoubleClick={() => {}}
+        quality={quality}
+        qualityPresentation="compact"
+        selectionEffects={false}
+      />
+    );
+
+    expect(container.querySelector('.quality-badge')).toHaveTextContent('42');
+    expect(container.querySelector('.sequence-score-basis')).not.toBeInTheDocument();
+    expect(container.querySelector('.image-info .sequence-reason-trigger')).not.toBeInTheDocument();
+    expect(container.querySelector('.image-preview .sequence-reason-trigger')).toBeInTheDocument();
+  });
 });

--- a/static/src/components/__tests__/ImageCard.reason.test.tsx
+++ b/static/src/components/__tests__/ImageCard.reason.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { Image, ImageQualityResult } from '../../api/types';
+import ImageCard from '../ImageCard';
+
+const image = {
+  id: 42,
+  project_id: 1,
+  project_name: 'Project',
+  project_display_name: 'Project',
+  target_id: 1,
+  target_name: 'Target',
+  acquired_date: 1_750_000_000,
+  filter_name: 'Ha',
+  grading_status: 0,
+  reject_reason: null,
+  metadata: {},
+  filesystem_path: null,
+} as unknown as Image;
+
+const quality = {
+  image_id: 42,
+  quality_score: 0.42,
+  temporal_anomaly_score: 0,
+  category: null,
+  flags: [],
+  normalized_metrics: {
+    star_count: 0.4,
+    hfr: null,
+    eccentricity: null,
+    snr: null,
+    background: null,
+    spatial_coverage: null,
+    transparency: null,
+    pointing: null,
+  },
+  details: 'Star count is below the normal range for matching capture settings.',
+} satisfies ImageQualityResult;
+
+describe('ImageCard quality reason', () => {
+  it('keeps the score visible without adding an empty reason trigger', () => {
+    const { container } = render(
+      <ImageCard
+        dbId="db"
+        image={image}
+        isSelected={false}
+        onClick={() => {}}
+        onDoubleClick={() => {}}
+        quality={{ ...quality, details: null }}
+        selectionEffects={false}
+      />
+    );
+
+    expect(container.querySelector('.quality-badge')).toHaveTextContent('42');
+    expect(container.querySelector('.sequence-score-basis')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Show quality reason' })).not.toBeInTheDocument();
+  });
+
+  it('opens long evidence in a popover without selecting the card', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <ImageCard
+        dbId="db"
+        image={image}
+        isSelected={false}
+        onClick={onClick}
+        onDoubleClick={() => {}}
+        quality={quality}
+        selectionEffects={false}
+      />
+    );
+
+    expect(screen.queryByText(quality.details!)).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Show quality reason' }));
+
+    const popover = screen.getByRole('dialog', { name: 'Quality reason' });
+    expect(popover).toHaveTextContent(quality.details!);
+    expect(onClick).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog', { name: 'Quality reason' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show quality reason' })).toHaveFocus();
+  });
+});

--- a/static/src/components/__tests__/QualityAnalysisSummary.test.tsx
+++ b/static/src/components/__tests__/QualityAnalysisSummary.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ImageQualityResult } from '../../api/types';
+import QualityAnalysisSummary from '../QualityAnalysisSummary';
+
+const quality: ImageQualityResult = {
+  image_id: 42,
+  quality_score: 0.36,
+  temporal_anomaly_score: 0.8,
+  category: 'tracking_issue',
+  normalized_metrics: {
+    star_count: 0.4,
+    hfr: 0.3,
+    eccentricity: 0.2,
+    snr: null,
+    background: null,
+  },
+  regrade_reason: 'Tracking error: elongated stars',
+  details: 'HFR and eccentricity are poor compared with this capture sequence.',
+};
+
+describe('QualityAnalysisSummary', () => {
+  it('shows the sequence score, review reason, and evidence', () => {
+    render(<QualityAnalysisSummary quality={quality} />);
+
+    expect(screen.getByRole('heading', { name: 'Quality analysis' })).toBeInTheDocument();
+    expect(screen.getByText('36%')).toBeInTheDocument();
+    expect(screen.getByText('Review reason')).toBeInTheDocument();
+    expect(screen.getByText(quality.regrade_reason!)).toBeInTheDocument();
+    expect(screen.getByText('Evidence')).toBeInTheDocument();
+    expect(screen.getByText(quality.details!)).toBeInTheDocument();
+  });
+
+  it('renders nothing when analysis has no reason', () => {
+    const { container } = render(
+      <QualityAnalysisSummary quality={{ ...quality, regrade_reason: undefined, details: null }} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/static/src/components/__tests__/QualityAnalysisSummary.test.tsx
+++ b/static/src/components/__tests__/QualityAnalysisSummary.test.tsx
@@ -31,11 +31,17 @@ describe('QualityAnalysisSummary', () => {
     expect(screen.getByText(quality.details!)).toBeInTheDocument();
   });
 
-  it('renders nothing when analysis has no reason', () => {
-    const { container } = render(
+  it('says when a scored image has no specific issue', () => {
+    render(
       <QualityAnalysisSummary quality={{ ...quality, regrade_reason: undefined, details: null }} />,
     );
 
-    expect(container).toBeEmptyDOMElement();
+    expect(screen.getByText('No specific quality issue was identified.')).toBeInTheDocument();
+  });
+
+  it('explains why an image has no score', () => {
+    render(<QualityAnalysisSummary statusMessage="Choose a project to load quality." />);
+
+    expect(screen.getByText('Choose a project to load quality.')).toBeInTheDocument();
   });
 });

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -1080,13 +1080,43 @@ describe('SequenceView: batch operations', () => {
     });
   });
 
-  it('shows Re-analyze button', async () => {
+  it('offers one action that scans pixels and refreshes sequence scores', async () => {
     setupDefaultHandlers();
+    let scanRequests = 0;
+    server.use(
+      http.post('/api/db/:dbId/analysis/quality-scan', () => {
+        scanRequests += 1;
+        return HttpResponse.json({
+          success: true,
+          data: {
+            started: false,
+            progress: {
+              running: false,
+              target_id: null,
+              filter_name: null,
+              total: 0,
+              processed: 0,
+              skipped_cached: 0,
+              errors: 0,
+              current_file: null,
+              last_error: null,
+              stage: 'idle',
+            },
+            cached_count: 0,
+          },
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+    const user = userEvent.setup();
 
     render(<SequenceView />, { wrapper: createWrapper('/sequence?db=test&project=1&target=1') });
 
-    await waitFor(() => {
-      expect(screen.getByText('Re-analyze')).toBeInTheDocument();
-    });
+    const analyzeQuality = await screen.findByRole('button', { name: 'Analyze Quality' });
+    expect(screen.queryByRole('button', { name: 'Re-analyze' })).not.toBeInTheDocument();
+
+    await user.click(analyzeQuality);
+    await waitFor(() => expect(scanRequests).toBe(1));
   });
 });

--- a/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
+++ b/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
@@ -175,11 +175,13 @@ describe('useScopedQuality', () => {
     );
   });
 
-  it('keeps All Projects unscored without starting a database-wide analysis', () => {
+  it('loads All Projects scores in one database-wide request', async () => {
     let requests = 0;
+    let allProjects: string | null = null;
     server.use(
-      http.get('/api/db/:dbId/analysis/sequence', () => {
+      http.get('/api/db/:dbId/analysis/sequence', ({ request }) => {
         requests += 1;
+        allProjects = new URL(request.url).searchParams.get('all_projects');
         return HttpResponse.json(normalFixture);
       }),
     );
@@ -188,8 +190,8 @@ describe('useScopedQuality', () => {
       wrapper: createWrapper(),
     });
 
-    expect(result.current.isScoped).toBe(false);
-    expect(result.current.qualityByImage.size).toBe(0);
-    expect(requests).toBe(0);
+    await waitFor(() => expect(result.current.qualityByImage.size).toBeGreaterThan(0));
+    expect(allProjects).toBe('true');
+    expect(requests).toBe(1);
   });
 });

--- a/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
+++ b/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../test/msw-server';
-import { useSequenceAnalysis, useImageQuality } from '../useSequenceAnalysis';
+import { useGridQuality, useSequenceAnalysis, useImageQuality } from '../useSequenceAnalysis';
 import normalFixture from '../../__fixtures__/sequence-analysis-normal.json';
 import imageQualityFixture from '../../__fixtures__/image-quality-context.json';
 
@@ -145,5 +145,33 @@ describe('useImageQuality', () => {
     expect(result.current.data!.quality).toBeDefined();
     expect(result.current.data!.quality!.quality_score).toBe(0.70);
     expect(result.current.data!.sequence_filter_name).toBe('L');
+  });
+});
+
+describe('useGridQuality', () => {
+  it('loads one project analysis and indexes results by image', async () => {
+    let requests = 0;
+    let projectId: string | null = null;
+    server.use(
+      http.get('/api/db/:dbId/analysis/sequence', ({ request }) => {
+        requests += 1;
+        projectId = new URL(request.url).searchParams.get('project_id');
+        return HttpResponse.json(normalFixture);
+      }),
+    );
+
+    const { result } = renderHook(() => useGridQuality('test', 7, undefined), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.qualityByImage.size).toBe(10);
+    });
+
+    expect(requests).toBe(1);
+    expect(projectId).toBe('7');
+    expect(result.current.qualityByImage.get(1)?.details).toBe(
+      normalFixture.data.sequences[0].images[0].details,
+    );
   });
 });

--- a/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
+++ b/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../test/msw-server';
-import { useGridQuality, useSequenceAnalysis, useImageQuality } from '../useSequenceAnalysis';
+import { useScopedQuality, useSequenceAnalysis, useImageQuality } from '../useSequenceAnalysis';
 import normalFixture from '../../__fixtures__/sequence-analysis-normal.json';
 import imageQualityFixture from '../../__fixtures__/image-quality-context.json';
 
@@ -148,7 +148,7 @@ describe('useImageQuality', () => {
   });
 });
 
-describe('useGridQuality', () => {
+describe('useScopedQuality', () => {
   it('loads one project analysis and indexes results by image', async () => {
     let requests = 0;
     let projectId: string | null = null;
@@ -160,7 +160,7 @@ describe('useGridQuality', () => {
       }),
     );
 
-    const { result } = renderHook(() => useGridQuality('test', 7, undefined), {
+    const { result } = renderHook(() => useScopedQuality('test', 7, undefined), {
       wrapper: createWrapper(),
     });
 
@@ -173,5 +173,23 @@ describe('useGridQuality', () => {
     expect(result.current.qualityByImage.get(1)?.details).toBe(
       normalFixture.data.sequences[0].images[0].details,
     );
+  });
+
+  it('keeps All Projects unscored without starting a database-wide analysis', () => {
+    let requests = 0;
+    server.use(
+      http.get('/api/db/:dbId/analysis/sequence', () => {
+        requests += 1;
+        return HttpResponse.json(normalFixture);
+      }),
+    );
+
+    const { result } = renderHook(() => useScopedQuality('test', null, null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isScoped).toBe(false);
+    expect(result.current.qualityByImage.size).toBe(0);
+    expect(requests).toBe(0);
   });
 });

--- a/static/src/hooks/useSequenceAnalysis.ts
+++ b/static/src/hooks/useSequenceAnalysis.ts
@@ -1,6 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
-import type { SequenceAnalysisRequest } from '../api/types';
+import type {
+  ImageQualityResult,
+  ProjectSequenceAnalysisRequest,
+  SequenceAnalysisRequest,
+} from '../api/types';
 import { useState, useCallback } from 'react';
 
 export function useSequenceAnalysis(dbId: string | null | undefined) {
@@ -33,4 +37,39 @@ export function useImageQuality(dbId: string | null | undefined, imageId: number
     enabled: !!dbId && !!imageId,
     staleTime: 60000,
   });
+}
+
+/**
+ * Load Sequence quality for a Grid scope in one request. Project scope is
+ * handled on the server so a page never issues one analysis request per card.
+ */
+export function useGridQuality(
+  dbId: string | null | undefined,
+  projectId: number | null | undefined,
+  targetId: number | null | undefined,
+  filterName?: string,
+) {
+  const request: SequenceAnalysisRequest | ProjectSequenceAnalysisRequest | null = targetId != null
+    ? { target_id: targetId, filter_name: filterName }
+    : projectId != null
+      ? { project_id: projectId, filter_name: filterName }
+      : null;
+  const queryKey = targetId != null
+    ? ['db', dbId, 'sequence-analysis', targetId, filterName]
+    : ['db', dbId, 'sequence-analysis', 'project', projectId, filterName];
+  const query = useQuery({
+    queryKey,
+    queryFn: () => apiClient.analyzeSequence(dbId!, request!),
+    enabled: !!dbId && request !== null,
+    staleTime: 60000,
+  });
+
+  const qualityByImage = new Map<number, ImageQualityResult>();
+  for (const sequence of query.data?.sequences ?? []) {
+    for (const quality of sequence.images) {
+      qualityByImage.set(quality.image_id, quality);
+    }
+  }
+
+  return { qualityByImage, isLoading: query.isLoading, error: query.error };
 }

--- a/static/src/hooks/useSequenceAnalysis.ts
+++ b/static/src/hooks/useSequenceAnalysis.ts
@@ -43,7 +43,7 @@ export function useImageQuality(dbId: string | null | undefined, imageId: number
  * Load Sequence quality for a Grid scope in one request. Project scope is
  * handled on the server so a page never issues one analysis request per card.
  */
-export function useGridQuality(
+export function useScopedQuality(
   dbId: string | null | undefined,
   projectId: number | null | undefined,
   targetId: number | null | undefined,
@@ -71,5 +71,10 @@ export function useGridQuality(
     }
   }
 
-  return { qualityByImage, isLoading: query.isLoading, error: query.error };
+  return {
+    qualityByImage,
+    isLoading: query.isLoading,
+    error: query.error,
+    isScoped: request !== null,
+  };
 }

--- a/static/src/hooks/useSequenceAnalysis.ts
+++ b/static/src/hooks/useSequenceAnalysis.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import type {
   ImageQualityResult,
+  DatabaseSequenceAnalysisRequest,
   ProjectSequenceAnalysisRequest,
   SequenceAnalysisRequest,
 } from '../api/types';
@@ -40,8 +41,9 @@ export function useImageQuality(dbId: string | null | undefined, imageId: number
 }
 
 /**
- * Load Sequence quality for a Grid scope in one request. Project scope is
- * handled on the server so a page never issues one analysis request per card.
+ * Load Sequence quality for a Grid scope in one request. The server keeps
+ * target/filter comparison groups separate even for project and database
+ * scopes, so the page never issues one analysis request per card.
  */
 export function useScopedQuality(
   dbId: string | null | undefined,
@@ -49,18 +51,23 @@ export function useScopedQuality(
   targetId: number | null | undefined,
   filterName?: string,
 ) {
-  const request: SequenceAnalysisRequest | ProjectSequenceAnalysisRequest | null = targetId != null
-    ? { target_id: targetId, filter_name: filterName }
-    : projectId != null
-      ? { project_id: projectId, filter_name: filterName }
-      : null;
+  const request:
+    | SequenceAnalysisRequest
+    | ProjectSequenceAnalysisRequest
+    | DatabaseSequenceAnalysisRequest = targetId != null
+      ? { target_id: targetId, filter_name: filterName }
+      : projectId != null
+        ? { project_id: projectId, filter_name: filterName }
+        : { all_projects: true, filter_name: filterName };
   const queryKey = targetId != null
     ? ['db', dbId, 'sequence-analysis', targetId, filterName]
-    : ['db', dbId, 'sequence-analysis', 'project', projectId, filterName];
+    : projectId != null
+      ? ['db', dbId, 'sequence-analysis', 'project', projectId, filterName]
+      : ['db', dbId, 'sequence-analysis', 'all-projects', filterName];
   const query = useQuery({
     queryKey,
-    queryFn: () => apiClient.analyzeSequence(dbId!, request!),
-    enabled: !!dbId && request !== null,
+    queryFn: () => apiClient.analyzeSequence(dbId!, request),
+    enabled: !!dbId,
     staleTime: 60000,
   });
 
@@ -75,6 +82,5 @@ export function useScopedQuality(
     qualityByImage,
     isLoading: query.isLoading,
     error: query.error,
-    isScoped: request !== null,
   };
 }

--- a/tests/integration_sequence_analysis.rs
+++ b/tests/integration_sequence_analysis.rs
@@ -441,9 +441,9 @@ async fn test_analyze_sequence_session_split() {
     assert_eq!(sequences[0]["image_count"], 5);
     assert_eq!(sequences[1]["image_count"], 5);
 
-    // The API presents newest sessions first for navigation. Sort the bounds
-    // chronologically here because this test checks splitting, not UI order.
-    let mut bounds = sequences
+    // The API presents sessions in capture order so the tab row reads from
+    // the start of the project to its latest session.
+    let bounds = sequences
         .iter()
         .map(|sequence| {
             (
@@ -452,7 +452,6 @@ async fn test_analyze_sequence_session_split() {
             )
         })
         .collect::<Vec<_>>();
-    bounds.sort_by_key(|(start, _)| *start);
     let (_, seq0_end) = bounds[0];
     let (seq1_start, _) = bounds[1];
 

--- a/tests/integration_sequence_analysis.rs
+++ b/tests/integration_sequence_analysis.rs
@@ -407,14 +407,63 @@ async fn test_analyze_sequence_requires_one_scope() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(
         json["error"],
-        "Specify exactly one of target_id or project_id"
+        "Specify exactly one of target_id, project_id, or all_projects=true"
+    );
+
+    let (status, json) = get_json(
+        app.clone(),
+        "/api/db/test/analysis/sequence?target_id=1&all_projects=true",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        json["error"],
+        "Specify exactly one of target_id, project_id, or all_projects=true"
     );
 
     let (status, json) = get_json(app, "/api/db/test/analysis/sequence").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(
         json["error"],
-        "Specify exactly one of target_id or project_id"
+        "Specify exactly one of target_id, project_id, or all_projects=true"
+    );
+}
+
+#[tokio::test]
+async fn test_analyze_sequence_all_projects_keeps_target_groups_separate() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_normal_sequence(&conn);
+    insert_project(&conn, 2, "Other project");
+    insert_target(&conn, 2, 2, "M43");
+    for i in 0i32..3 {
+        insert_image(
+            &conn,
+            1000 + i,
+            2,
+            2,
+            1705352400 + i as i64 * 300,
+            "R",
+            &build_metadata(200.0 + i as f64 * 5.0, 2.8, None, None, None),
+        );
+    }
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/db/test/analysis/sequence?all_projects=true").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    let target_ids = sequences
+        .iter()
+        .map(|sequence| sequence["target_id"].as_i64().unwrap())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(target_ids, std::collections::BTreeSet::from([1, 2]));
+    assert_eq!(
+        sequences
+            .iter()
+            .map(|sequence| sequence["image_count"].as_u64().unwrap())
+            .sum::<u64>(),
+        13
     );
 }
 

--- a/tests/integration_sequence_analysis.rs
+++ b/tests/integration_sequence_analysis.rs
@@ -354,6 +354,70 @@ async fn test_analyze_sequence_normal() {
     );
 }
 
+#[tokio::test]
+async fn test_analyze_project_returns_each_targets_sequences() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_normal_sequence(&conn);
+    insert_target(&conn, 2, 1, "M43");
+    for i in 0i32..3 {
+        insert_image(
+            &conn,
+            1000 + i,
+            1,
+            2,
+            1705352400 + i as i64 * 300,
+            "R",
+            &build_metadata(200.0 + i as f64 * 5.0, 2.8, None, None, None),
+        );
+    }
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(app, "/api/db/test/analysis/sequence?project_id=1").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let sequences = json["data"]["sequences"].as_array().unwrap();
+    let target_ids = sequences
+        .iter()
+        .map(|sequence| sequence["target_id"].as_i64().unwrap())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(target_ids, std::collections::BTreeSet::from([1, 2]));
+    assert_eq!(
+        sequences
+            .iter()
+            .map(|sequence| sequence["image_count"].as_u64().unwrap())
+            .sum::<u64>(),
+        13
+    );
+}
+
+#[tokio::test]
+async fn test_analyze_sequence_requires_one_scope() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    load_normal_sequence(&conn);
+    let app = create_test_app(conn);
+
+    let (status, json) = get_json(
+        app.clone(),
+        "/api/db/test/analysis/sequence?target_id=1&project_id=1",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        json["error"],
+        "Specify exactly one of target_id or project_id"
+    );
+
+    let (status, json) = get_json(app, "/api/db/test/analysis/sequence").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        json["error"],
+        "Specify exactly one of target_id or project_id"
+    );
+}
+
 /// Test 2: Cloud detection through the full API path
 #[tokio::test]
 async fn test_analyze_sequence_cloud_detection() {


### PR DESCRIPTION
## Summary

- list Sequence capture sessions from oldest to newest, with unknown dates last
- replace long inline score and review reasons with an accessible popover
- keep image card dimensions stable and preserve score badges when a frame has no reason
- replace the separate Re-analyze and Scan Quality controls with one Analyze Quality workflow
- show the same quality reason on Sequence cards, Grid cards, and image details
- reuse one scoped quality result across Grid and image details instead of rescoring on each image
- load All Projects scores in one database-wide request while keeping each target/filter comparison separate
- state how many visible images remain unscored without starting the full FITS quality scan
- place Grid reason controls over the preview so late results do not change card height or scroll position

## Interaction

- **Reason** opens the explanation without selecting or opening the image card
- the popover separates the review reason from supporting score evidence
- outside click, the close button, and Escape dismiss it
- Escape closes the popover without reaching Sequence keyboard shortcuts
- Analyze Quality scans missing pixel evidence and refreshes sequence scores when it finishes; Shift-click forces a full evidence rebuild

## Tests

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (454 unit tests and 82 integration tests passed; 5 ignored)
- `mise exec node@24 -- npm run lint -- --max-warnings=0`
- `mise exec node@24 -- npx vitest run` (206 passed)
- `mise exec node@24 -- npm run build`
- focused Sequence reason, Grid-to-Detail quality, and All Projects scoring Playwright tests (3 passed in Chromium)
