### PR TITLE
Require a login on a network server

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,8 +882,11 @@ Viewer accounts can browse images and cached results, but cannot change
 grades, plans, files, or server settings. Set
 `allow_read_only_compute = true` only when viewers should also start stacks,
 plate solves, and satellite predictions. Editor accounts keep normal write
-and compute access. With no users, the server stays open as before. Tauri
-always stays unauthenticated on its localhost-only server. See
+and compute access. With no users, a loopback server stays open as before; a
+server bound to any other address answers 401 until you add one, unless you
+pass `--allow-anonymous-access` to keep it open to everyone. Remote sync and
+image upload keep working either way on their own bearer keys. Tauri always
+stays unauthenticated on its localhost-only server. See
 [Server authentication](docs/AUTHENTICATION.md).
 
 Signed-in editors can manage every account from the separate **Users** tab in

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -6,6 +6,40 @@ localhost and remains trusted by the desktop UI.
 
 ![PSF Guard server login](server-login.png)
 
+## What a server with no accounts serves
+
+The bind address decides what an account-less server hands out. Reaching a
+loopback server already means reaching the machine, so it stays open:
+
+| Bind address | No accounts configured |
+|---|---|
+| `127.0.0.1`, `::1`, `localhost` | Full access, as before. The desktop app and local development use this. |
+| Anything else, including the `0.0.0.0` default | Every API request answers 401, including reads. |
+
+A network server therefore needs at least one account before it serves
+anything. `psf-guard server --allow-database-management` goes further and
+refuses to start on a network address until an account exists, because those
+routes name paths the server then reads and writes. Only an editor can use
+them once it does.
+
+Remote sync and image upload are the exception. They carry their own
+`Authorization: Bearer` keys, so those routes keep working on a server with no
+browser accounts — that is how a headless intake box runs.
+
+### Keeping a network server open
+
+`--allow-anonymous-access` gives every caller on a network address what a
+localhost server gives them, with no accounts and no login:
+
+```bash
+psf-guard server --host 0.0.0.0 --allow-anonymous-access
+```
+
+It exists for a server on a network you trust as much as the machine itself,
+and for upgrading an older deployment without an outage. It hands full editor
+access — grading, imports, and, with `--allow-database-management`, the
+registry — to anyone who can reach the port. Add accounts and drop the flag.
+
 ## Manage users from the CLI
 
 Add a viewer or editor. If `--password-file` is absent, the CLI prompts twice
@@ -129,6 +163,10 @@ continue to work when browser authentication is enabled.
   `psf-guard users add editor --role read-write --password-file PATH`. PSF Guard
   stores only the resulting hash in `auth.json`.
 - Keep `--allow-database-management` off unless browser-side database
-  management is needed. An editor login does not override that gate.
+  management is needed. An editor login does not override that gate, and the
+  gate does not override the login: on a network address the server needs
+  both.
+- Treat `--allow-anonymous-access` as a temporary measure. A public server
+  running it has no access control at all.
 - Signing out revokes the current in-memory session. Restarting the server
   revokes every browser session.

--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -15,6 +15,11 @@ a trusted interface and opt in:
 psf-guard server --host 127.0.0.1 --allow-database-management
 ```
 
+On any other bind address the server refuses to start until a user account
+exists, because database management names paths the server then reads and
+writes. Only an editor can use those routes. `--allow-anonymous-access` opens
+them to everyone instead. See [server authentication](AUTHENTICATION.md).
+
 Settings has three tabs: **Databases** for catalogs and imports, **Catalogs**
 for the Seiza data packages, and **Sync** for moving records between catalogs.
 Sync appears once you have a catalog to move records between.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -727,6 +727,15 @@ pub enum Commands {
         /// trusted interface (e.g. localhost). Tauri mode always enables it.
         #[arg(long)]
         allow_database_management: bool,
+
+        /// Serve a network address with no user accounts, granting every
+        /// caller the access a localhost server grants. Off by default: a
+        /// server bound anywhere but loopback answers 401 until an operator
+        /// adds a user. Use this only on a network you trust as much as the
+        /// machine itself. Adding accounts is the better fix — see
+        /// `psf-guard users add`.
+        #[arg(long)]
+        allow_anonymous_access: bool,
     },
 }
 

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -1025,6 +1025,7 @@ pub fn main() -> Result<()> {
             pregenerate_all,
             cache_expiry,
             allow_database_management,
+            allow_anonymous_access,
         } => {
             use crate::config::Config;
             use crate::db_registry::DbRegistry;
@@ -1137,6 +1138,7 @@ pub fn main() -> Result<()> {
                     pregeneration_config,
                     Some(registry_path),
                     allow_database_management,
+                    allow_anonymous_access,
                     site_banner,
                     server_auth,
                     worker_policy,

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -386,13 +386,24 @@ pub async fn status(State(state): State<Arc<AppState>>, headers: HeaderMap) -> R
                 .is_some_and(|session| auth.can_compute(session.role)),
             username: session.map(|session| session.username),
         }
-    } else {
+    } else if state.anonymous_access_trusted() {
         AuthStatus {
             authentication_required: false,
             authenticated: true,
             role: Some(AccessRole::ReadWrite),
             username: None,
             can_compute: true,
+        }
+    } else {
+        // A routable bind with no accounts. Report the truth: a login is
+        // required and this caller does not have one. The browser shows the
+        // sign-in page and the operator sees the startup warning.
+        AuthStatus {
+            authentication_required: true,
+            authenticated: false,
+            role: None,
+            username: None,
+            can_compute: false,
         }
     };
     (
@@ -407,6 +418,9 @@ pub async fn login(
     Json(request): Json<LoginRequest>,
 ) -> Response {
     let Some(auth) = state.server_auth() else {
+        if !state.anonymous_access_trusted() {
+            return no_accounts_response();
+        }
         return Json(ApiResponse::success(AuthStatus {
             authentication_required: false,
             authenticated: true,
@@ -494,14 +508,6 @@ pub async fn authorize_api(
     mut request: Request,
     next: Next,
 ) -> Response {
-    let Some(auth) = state.server_auth() else {
-        request.extensions_mut().insert(RequestAccess {
-            role: AccessRole::ReadWrite,
-            username: None,
-        });
-        return next.run(request).await;
-    };
-
     let path = api_path(request.uri().path());
     if request.method() == Method::OPTIONS
         || is_public_auth_path(path)
@@ -509,6 +515,21 @@ pub async fn authorize_api(
     {
         return next.run(request).await;
     }
+
+    let Some(auth) = state.server_auth() else {
+        // No user accounts. A loopback server — the desktop app, or a
+        // developer's own machine — keeps full access. A routable bind does
+        // not: the port is open to the network, so it answers 401 until an
+        // operator adds a user.
+        if !state.anonymous_access_trusted() {
+            return no_accounts_response();
+        }
+        request.extensions_mut().insert(RequestAccess {
+            role: AccessRole::ReadWrite,
+            username: None,
+        });
+        return next.run(request).await;
+    };
 
     let Some(session) = session_from_headers(&auth, request.headers()) else {
         return (
@@ -537,6 +558,37 @@ pub async fn authorize_api(
     let mut response = next.run(request).await;
     mark_response_private(&mut response);
     response
+}
+
+/// Answer for a network caller on a server that has no user accounts. The
+/// wording names the fix because only an operator can apply it.
+pub(crate) const NO_ACCOUNTS_MESSAGE: &str =
+    "This server has no user accounts. Add one with `psf-guard users add <name> \
+     --role read-write`, then restart the server.";
+
+fn no_accounts_response() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [(CACHE_CONTROL, "no-store")],
+        Json(ApiResponse::<()>::error(NO_ACCOUNTS_MESSAGE.to_string())),
+    )
+        .into_response()
+}
+
+/// Whether a bind host keeps the server on the machine that runs it.
+/// `0.0.0.0` and `::` are not loopback: they accept traffic from the network.
+/// An unresolvable name counts as routable, which is the safe answer.
+pub(crate) fn host_is_loopback(host: &str) -> bool {
+    let host = host.trim();
+    let host = host
+        .strip_prefix('[')
+        .and_then(|rest| rest.strip_suffix(']'))
+        .unwrap_or(host);
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<std::net::IpAddr>()
+        .is_ok_and(|address| address.is_loopback())
 }
 
 fn session_from_headers(auth: &ServerAuth, headers: &HeaderMap) -> Option<Session> {
@@ -731,6 +783,24 @@ mod tests {
             assert!(auth.claim_login_slot());
         }
         assert!(!auth.claim_login_slot());
+    }
+
+    #[test]
+    fn only_a_bind_that_stays_on_this_machine_counts_as_loopback() {
+        assert!(host_is_loopback("127.0.0.1"));
+        assert!(host_is_loopback("127.5.5.5"));
+        assert!(host_is_loopback("localhost"));
+        assert!(host_is_loopback("LocalHost"));
+        assert!(host_is_loopback("::1"));
+        assert!(host_is_loopback("[::1]"));
+        assert!(host_is_loopback(" 127.0.0.1 "));
+
+        assert!(!host_is_loopback("0.0.0.0"));
+        assert!(!host_is_loopback("::"));
+        assert!(!host_is_loopback("192.168.1.10"));
+        assert!(!host_is_loopback("guard.example"));
+        assert!(!host_is_loopback("localhost.example.com"));
+        assert!(!host_is_loopback(""));
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -58,6 +58,10 @@ pub struct ServerConfig {
     /// Allow HTTP clients to mutate the configured database list. Off by
     /// default for CLI servers; Tauri always enables it.
     pub allow_database_management: bool,
+    /// Trust every session-less caller even on a routable bind address, so a
+    /// server with no user accounts stays open the way a localhost server is.
+    /// Off by default. Loopback binds are trusted without it.
+    pub allow_anonymous_access: bool,
     /// Optional notice shown below the application header.
     pub site_banner: Option<crate::config::SiteBannerConfig>,
     /// Optional browser/server authentication. Tauri always leaves this off.
@@ -84,6 +88,7 @@ pub async fn run_server(
     pregeneration_config: PregenerationConfig,
     registry_path: Option<PathBuf>,
     allow_database_management: bool,
+    allow_anonymous_access: bool,
     site_banner: Option<crate::config::SiteBannerConfig>,
     auth: Option<auth::ServerAuth>,
     worker_policy: crate::concurrency::WorkerPolicy,
@@ -113,6 +118,7 @@ pub async fn run_server(
         pregeneration_config,
         registry_path,
         allow_database_management,
+        allow_anonymous_access,
         site_banner,
         auth,
         worker_policy,
@@ -141,10 +147,46 @@ pub async fn run_server_with_config(config: ServerConfig) -> anyhow::Result<()> 
     run_server_internal(config, None).await
 }
 
+/// Whether a caller with no session is trusted while the server has no user
+/// accounts. Reaching a loopback server already means reaching the machine,
+/// so it stays open. Any other address needs the operator to say so.
+fn anonymous_access_is_trusted(host: &str, allow_anonymous_access: bool) -> bool {
+    auth::host_is_loopback(host) || allow_anonymous_access
+}
+
+/// Refuse a network server that would hand out database management with no
+/// login. Loopback servers — the desktop app, and local development — keep
+/// working, as does a server whose operator asked for anonymous access.
+fn check_management_needs_a_login(
+    host: &str,
+    allow_database_management: bool,
+    anonymous_access_trusted: bool,
+    has_users: bool,
+) -> anyhow::Result<()> {
+    if allow_database_management && !has_users && !anonymous_access_trusted {
+        anyhow::bail!(
+            "Database management on {host} needs a login. Add an editor with \
+             `psf-guard users add <name> --role read-write` (pass the same \
+             --registry you give the server), or bind the server to 127.0.0.1. \
+             --allow-anonymous-access serves it to everyone instead."
+        );
+    }
+    Ok(())
+}
+
 async fn run_server_internal(
     config: ServerConfig,
     shutdown_rx: Option<oneshot::Receiver<()>>,
 ) -> anyhow::Result<()> {
+    let anonymous_access_trusted =
+        anonymous_access_is_trusted(&config.host, config.allow_anonymous_access);
+    check_management_needs_a_login(
+        &config.host,
+        config.allow_database_management,
+        anonymous_access_trusted,
+        config.auth.is_some(),
+    )?;
+
     tracing::info!("🚀 Starting PSF Guard server");
     tracing::info!(
         "📊 Databases ({}):{}",
@@ -185,6 +227,7 @@ async fn run_server_internal(
             state.set_allow_database_management(config.allow_database_management);
             state.set_site_banner(config.site_banner.clone());
             state.set_server_auth(config.auth.clone());
+            state.set_anonymous_access_trusted(anonymous_access_trusted);
             state.set_worker_policy(config.worker_policy);
             state.set_preview_encoding(config.preview_encoding);
             state.set_preview_color_default(config.preview_color_default);
@@ -193,6 +236,26 @@ async fn run_server_internal(
             }
             if config.auth.is_some() {
                 tracing::info!("🔐 Browser authentication enabled");
+            } else if !anonymous_access_trusted {
+                tracing::warn!(
+                    "🔐 No user accounts, so {} answers 401 to every API request. Add one \
+                     with `psf-guard users add <name> --role read-write` and restart, or \
+                     bind the server to 127.0.0.1 to keep it on this machine. Remote sync \
+                     and image upload keys keep working either way.",
+                    config.host
+                );
+            } else if config.allow_anonymous_access && !auth::host_is_loopback(&config.host) {
+                tracing::warn!(
+                    "⚠️ --allow-anonymous-access is ON with no user accounts. Everyone who \
+                     can reach {} gets full editor access to every catalog. Add users and \
+                     drop the flag as soon as you can.",
+                    config.host
+                );
+            } else {
+                tracing::info!(
+                    "🔓 No user accounts; {} is a loopback server and stays open to this machine",
+                    config.host
+                );
             }
             tracing::info!(
                 "📐 Worker ratios — interactive {:.2}, background {:.2} (of {} logical cores)",
@@ -208,8 +271,9 @@ async fn run_server_internal(
                     );
                 } else {
                     tracing::warn!(
-                        "⚠️ Database management via HTTP is ENABLED. Anyone who can reach \
-                         this server can add/edit/remove configured databases."
+                        "⚠️ Database management via HTTP is ENABLED with no login. Anyone \
+                         who can reach {} can add/edit/remove configured databases.",
+                        config.host
                     );
                 }
             } else {
@@ -1051,4 +1115,39 @@ async fn pregenerate_annotated(
 
     tracing::trace!("✅ Generated annotated image for image {}", image_id);
     Ok(true) // Successfully generated
+}
+
+#[cfg(test)]
+mod startup_tests {
+    use super::{anonymous_access_is_trusted, check_management_needs_a_login};
+
+    /// The startup pair, as `run_server_internal` computes it: work out who a
+    /// session-less caller is, then decide whether the server may start.
+    fn start(host: &str, manage: bool, anonymous: bool, has_users: bool) -> anyhow::Result<bool> {
+        let trusted = anonymous_access_is_trusted(host, anonymous);
+        check_management_needs_a_login(host, manage, trusted, has_users)?;
+        Ok(trusted)
+    }
+
+    #[test]
+    fn a_network_server_cannot_offer_database_management_without_a_login() {
+        let refusal = start("0.0.0.0", true, false, false).unwrap_err();
+        assert!(refusal.to_string().contains("psf-guard users add"));
+
+        // A login exists, so the editor gate applies as usual.
+        assert!(start("0.0.0.0", true, false, true).is_ok());
+        // No management asked for, so nothing to hand out.
+        assert!(start("0.0.0.0", false, false, false).is_ok());
+    }
+
+    #[test]
+    fn only_loopback_or_the_explicit_flag_trusts_a_caller_with_no_account() {
+        // The desktop app and local development.
+        assert!(start("127.0.0.1", true, false, false).unwrap());
+        assert!(start("localhost", true, false, false).unwrap());
+        // A network server stays closed until an operator says otherwise.
+        assert!(!start("0.0.0.0", false, false, false).unwrap());
+        // The operator said otherwise, so management may start too.
+        assert!(start("0.0.0.0", true, true, false).unwrap());
+    }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -48,6 +48,11 @@ pub struct AppState {
     pub site_banner: RwLock<Option<crate::config::SiteBannerConfig>>,
     /// Optional browser/server authentication. Tauri leaves this unset.
     pub server_auth: RwLock<Option<crate::server::auth::ServerAuth>>,
+    /// Whether a caller without a session is trusted while no user accounts
+    /// exist. True for a loopback bind — the desktop app and local
+    /// development. False once the server listens on a routable address, so
+    /// an open port cannot read or change a catalog without a login.
+    pub anonymous_access_trusted: RwLock<bool>,
     /// Process-global 24-hour cache for the public release notice feeds.
     pub update_notices: crate::server::update_notice::UpdateNoticeManager,
     /// Tuning policy for the parallel scans and background pre-generation (see
@@ -385,6 +390,7 @@ impl AppState {
             allow_database_management: RwLock::new(false),
             site_banner: RwLock::new(None),
             server_auth: RwLock::new(None),
+            anonymous_access_trusted: RwLock::new(true),
             update_notices: crate::server::update_notice::UpdateNoticeManager::default(),
             worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
             preview_encoding: RwLock::new(crate::preview_format::PreviewEncoding::default()),
@@ -415,6 +421,17 @@ impl AppState {
 
     pub fn server_auth(&self) -> Option<crate::server::auth::ServerAuth> {
         self.server_auth.read().unwrap().clone()
+    }
+
+    /// Say whether a session-less caller is trusted while the server has no
+    /// user accounts. Loopback servers set this true; a routable bind sets it
+    /// false so the API answers 401 until an operator adds a user.
+    pub fn set_anonymous_access_trusted(&self, trusted: bool) {
+        *self.anonymous_access_trusted.write().unwrap() = trusted;
+    }
+
+    pub fn anonymous_access_trusted(&self) -> bool {
+        *self.anonymous_access_trusted.read().unwrap()
     }
 
     /// Toggle the database CRUD endpoints. When false, mutating routes on
@@ -538,6 +555,7 @@ impl AppState {
             allow_database_management: RwLock::new(false),
             site_banner: RwLock::new(None),
             server_auth: RwLock::new(None),
+            anonymous_access_trusted: RwLock::new(true),
             update_notices: crate::server::update_notice::UpdateNoticeManager::default(),
             worker_policy: RwLock::new(crate::concurrency::WorkerPolicy::default()),
             preview_encoding: RwLock::new(crate::preview_format::PreviewEncoding::default()),

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -272,6 +272,7 @@ async fn start_server_for_tauri(
         // The Tauri app is local-only and trusted; always enable CRUD so the
         // settings panel can add/remove databases without an extra flag.
         allow_database_management: true,
+        allow_anonymous_access: false,
         // The desktop app does not read the server TOML.
         site_banner: None,
         // Tauri binds localhost and does not use browser authentication.

--- a/static/playwright.config.ts
+++ b/static/playwright.config.ts
@@ -93,6 +93,9 @@ export default defineConfig({
       command:
         `${serverCommand} server ` +
         `--port ${PORT} ` +
+        // Loopback, because database management with no user account is a
+        // localhost-only grant. The specs reach the server here anyway.
+        `--host 127.0.0.1 ` +
         `--registry ${path.join(TMP_BASE, 'registry.json')} ` +
         `--cache-dir ${path.join(TMP_BASE, 'cache')} ` +
         `--allow-database-management`,
@@ -120,6 +123,7 @@ export default defineConfig({
       command:
         `${serverCommand} server ` +
         `--port ${port} ` +
+        `--host 127.0.0.1 ` +
         `--registry ${instance.registryPath} ` +
         `--cache-dir ${instance.cacheDir} ` +
         `--config ${instance.configPath}` +

--- a/tests/integration_server_auth.rs
+++ b/tests/integration_server_auth.rs
@@ -90,6 +90,37 @@ fn app_with_auth(config: ServerAuthConfig) -> Router {
     Router::new().nest("/api", api)
 }
 
+/// A server with no user accounts. `anonymous_access_trusted` is what a
+/// loopback bind sets at startup; a routable bind sets it false.
+fn app_without_users(anonymous_access_trusted: bool) -> Router {
+    let state = Arc::new(AppState::new_for_test(
+        Connection::open_in_memory().unwrap(),
+    ));
+    state.set_anonymous_access_trusted(anonymous_access_trusted);
+    state.set_allow_database_management(true);
+
+    let api = Router::new()
+        .route("/auth/status", get(auth::status))
+        .route("/auth/login", post(auth::login))
+        .route("/info", get(handlers::get_server_info))
+        .route(
+            "/databases/create",
+            post(|| async { "registered a database" }),
+        )
+        .route("/images", get(|| async { "catalog" }))
+        .route(
+            "/sync/v1/capabilities",
+            post(|| async { "remote bearer route" }),
+        )
+        .layer(middleware::from_fn_with_state(
+            Arc::clone(&state),
+            auth::authorize_api,
+        ))
+        .with_state(state);
+
+    Router::new().nest("/api", api)
+}
+
 fn user_management_app(directory: &tempfile::TempDir) -> Router {
     let database_registry_path = directory.path().join("config.json");
     let auth_registry_path = AuthRegistry::path_for_database_registry(&database_registry_path);
@@ -309,6 +340,87 @@ async fn protected_api_challenges_but_remote_bearer_routes_stay_separate() {
         .body(Body::empty())
         .unwrap();
     assert_eq!(app.oneshot(remote).await.unwrap().status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn a_network_server_without_users_answers_nobody_but_its_api_keys() {
+    let app = app_without_users(false);
+
+    for (method, uri) in [
+        (Method::GET, "/api/images"),
+        (Method::GET, "/api/info"),
+        (Method::POST, "/api/databases/create"),
+    ] {
+        let request = Request::builder()
+            .method(method.clone())
+            .uri(uri)
+            .body(Body::empty())
+            .unwrap();
+        let (status, headers, body) = json(&app, request).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "{method} {uri}");
+        assert_eq!(headers[CACHE_CONTROL], "no-store");
+        assert!(body["error"]
+            .as_str()
+            .unwrap()
+            .contains("psf-guard users add"));
+    }
+
+    // The login page can still ask what this server wants, and hears that it
+    // wants a login it cannot give.
+    let status_request = Request::builder()
+        .uri("/api/auth/status")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _, body) = json(&app, status_request).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["data"]["authentication_required"], true);
+    assert_eq!(body["data"]["authenticated"], false);
+
+    // Signing in cannot invent an account.
+    assert_eq!(
+        login(&app, "editor", "editor-secret").await.0,
+        StatusCode::UNAUTHORIZED
+    );
+
+    // Keys carry their own proof, so remote sync and upload keep working.
+    let remote = Request::builder()
+        .method(Method::POST)
+        .uri("/api/sync/v1/capabilities")
+        .header("authorization", "Bearer remote-key")
+        .body(Body::empty())
+        .unwrap();
+    assert_eq!(app.oneshot(remote).await.unwrap().status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn a_loopback_server_without_users_stays_open_to_its_own_machine() {
+    let app = app_without_users(true);
+
+    let create = Request::builder()
+        .method(Method::POST)
+        .uri("/api/databases/create")
+        .body(Body::empty())
+        .unwrap();
+    assert_eq!(
+        app.clone().oneshot(create).await.unwrap().status(),
+        StatusCode::OK
+    );
+
+    let info = Request::builder()
+        .uri("/api/info")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _, info) = json(&app, info).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(info["data"]["allow_database_management"], true);
+
+    let auth_status = Request::builder()
+        .uri("/api/auth/status")
+        .body(Body::empty())
+        .unwrap();
+    let (_, _, auth_status) = json(&app, auth_status).await;
+    assert_eq!(auth_status["data"]["authentication_required"], false);
+    assert_eq!(auth_status["data"]["role"], "read_write");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## The gap

A server with no user accounts treated every caller as a full editor: `ServerAuth::from_sources` returns `None` when `auth.json` has no users, and the middleware then skipped straight past the session check. The default bind is `0.0.0.0`, so `--allow-database-management` was reachable by anyone on the network. Against a live server:

```
POST /api/databases/create  →  200, registry written with a caller-named server path
```

From there the normal API reads that path back.

With auth **on**, the API was already fully gated — every management route answered 401 without a session, and only the bearer-key routes were exempt. This PR closes the auth-*off* case.

## The change

The bind address decides. Reaching a loopback server already means reaching the machine, so it stays open — that is how the desktop app and local development work.

| Bind address | No accounts configured |
|---|---|
| `127.0.0.1`, `::1`, `localhost` | Full access, unchanged |
| Anything else, including the `0.0.0.0` default | 401 on every API request, reads included |

- `src/server/auth.rs` — the bypass check (OPTIONS, `/auth/*`, bearer routes) now runs *before* the auth-less branch, and that branch answers 401 unless the bind is trusted. `host_is_loopback` treats `0.0.0.0`, `::`, and unresolvable names as routable.
- `src/server/mod.rs` — `--allow-database-management` on an untrusted address with no users refuses to start, before binding, naming both fixes.
- `/api/auth/status` reports `authentication_required: true, authenticated: false` there, so the UI shows the sign-in page; a login attempt returns the "no user accounts" message the login screen already surfaces.
- Remote sync and image upload are untouched. Their bearer keys carry their own proof, which is how a headless intake box runs with no browser accounts.

## Escape hatch

`--allow-anonymous-access` (off by default) restores the old open behaviour on a network address, for a network trusted as much as the machine and for upgrading a deployment without an outage. It logs what it gives away, and composes with `--allow-database-management` for a LAN server that wants the desktop experience.

## Upgrade note for release notes

This is a breaking change. An existing LAN server with no accounts stops serving until an account is added or the flag is passed; one that also passes `--allow-database-management` refuses to start.

## Checks run locally

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — all pass, including 4 new tests: two middleware cases (network vs loopback, no accounts) and two startup cases
- `cd static && npm run lint` — clean
- `npx playwright test` — 89 passed against a release binary. The e2e servers ran `--allow-database-management` on the `0.0.0.0` default with no users, so they now pass `--host 127.0.0.1`.
- `npx vitest run` — 5 pre-existing failures in `useColorPreview`, untouched by this PR (no files under `static/src` changed)

Not verified live: binding `0.0.0.0` to exercise `--allow-anonymous-access` end to end would open a port on the LAN, so I left it to the tests. Both halves are covered — the trust decision by unit test, the middleware behaviour by integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)