### PR TITLE
feat: build opt-in dust-corrected stack previews

### DIFF
--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -142,6 +142,42 @@ This real three-frame M44 check finds no source that clearly separates from
 its peers. PSF Guard keeps the ranked crops visible and labels each result
 **low** instead of inventing a culprit.
 
+### Build an opt-in dust-corrected preview
+
+A **strong** or **possible** dark ring or broad-shadow result can offer
+**Build dust-corrected preview** on a mono channel stack. The result starts a
+separate derived job. It does not replace the saved stack or alter source
+files, grades, or calibration records.
+
+PSF Guard maps the selected output region back to the suspect frame's detector
+coordinates, adds a clean border, and takes the same detector crop from every
+integrated light. It first applies the ordinary bias, dark, and flat masters.
+Seiza then fits each crop's local background, smooths small moving sources,
+and keeps only dark response at least 0.5% deep and shared by at least 70% of
+the frames. It also requires one region of at least 64 connected detector
+pixels, which keeps scattered low-level noise from becoming a correction. The
+response blends back to one at the crop edge and divides into each light
+before registration. The default peak gain is capped at 1.2; the API refuses
+values above 1.3.
+
+This needs more proof than the shape label alone. The channel must have at
+least five compatible integrated frames, at least three distinct dither
+positions, and enough detector-to-sky motion for sky structure to move across
+the patch. Large stacks use at most 64 evenly spaced inputs for response
+estimation, then apply the accepted patch to every integrated light. The job
+stops and explains the missing evidence when these checks fail. A matching
+master flat may still leave a residual if dust moved after the flat was
+captured; when no flat matches, the job says so. In both cases, the generated
+patch remains a small supplemental correction, not a synthetic replacement
+for a full master flat.
+
+When the job finishes, the inspector shows the estimated response, source
+count, dither span, corrected area, largest connected region, applied peak
+gain, and corrected stack count. **Show corrected stack** and **Show original stack** switch the
+full-size view for comparison. **Download corrected FITS** saves the separate
+linear result. Build the correction from a mono channel first; color
+recomposition from corrected channels remains follow-up work.
+
 Stacks made before this feature lack the retained frame mappings and source
 fingerprints. Rebuild the mono stacks and color preview once before searching
 them. PSF Guard also asks for a rebuild if a source file, calibration choice,
@@ -350,6 +386,13 @@ Artifacts live below the database cache directory:
 <cache>/<database>/stack-previews/artifact-searches/<search-id>/
   manifest.json
   image-<image-id>.png
+<cache>/<database>/stack-previews/residual-flats/<correction-id>/
+  manifest.json
+  response.fits
+  response.png
+  corrected.fits
+  corrected.png
+  corrected-original.png
 ```
 
 The content-addressed job ID includes the database/project, exact ordered
@@ -383,6 +426,9 @@ immutable cached response for the rebuilt output.
 - Source-artifact search detects local differences between registered inputs.
   It does not label the cause, replace full-frame quality analysis, or change a
   catalog grade.
+- Residual-flat correction requires repeated detector-space evidence and user
+  action. It does not infer dust from one frame, replace a master flat, or run
+  automatically during ordinary stack builds.
 
 ## HTTP API
 
@@ -404,6 +450,11 @@ POST /api/db/{db}/stack-previews/{job}/{group}/artifact-searches
 POST /api/db/{db}/stack-previews/color/{job}/artifact-searches
 GET  /api/db/{db}/stack-previews/artifact-searches/{search}
 GET  /api/db/{db}/stack-previews/artifact-searches/{search}/crops/{image}
+POST /api/db/{db}/stack-previews/artifact-searches/{search}/residual-flats
+GET  /api/db/{db}/stack-previews/residual-flats/{correction}
+GET  /api/db/{db}/stack-previews/residual-flats/{correction}/response
+GET  /api/db/{db}/stack-previews/residual-flats/{correction}/preview[?size=screen|original]
+GET  /api/db/{db}/stack-previews/residual-flats/{correction}/fits
 GET  /api/db/{db}/stack-previews/stretch/{stretch}/preview[?size=screen|original]
 GET  /api/db/{db}/stack-previews/stretch/{stretch}/fits
 ```
@@ -447,3 +498,9 @@ in stack-image pixels:
 The response names an asynchronous search. Poll its GET endpoint until the
 state is `completed` or `failed`; completed results include immutable crop
 URLs and per-frame outlier evidence.
+
+The residual-flat POST body is `{ "image_id": 42, "maximum_gain": 1.2 }`.
+The selected result must belong to the completed mono search and carry
+possible or strong dark ring/broad-shadow evidence. Poll the correction GET
+endpoint until it completes, then read the response PNG or corrected preview
+and FITS endpoints.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -423,8 +423,28 @@ async fn run_server_internal(
             get(stack_preview::artifact::get_artifact_search),
         )
         .route(
+            "/stack-previews/artifact-searches/{search_id}/residual-flats",
+            post(stack_preview::artifact::residual_flat::start_residual_flat),
+        )
+        .route(
             "/stack-previews/artifact-searches/{search_id}/crops/{image_id}",
             get(stack_preview::artifact::get_artifact_crop),
+        )
+        .route(
+            "/stack-previews/residual-flats/{correction_id}",
+            get(stack_preview::artifact::residual_flat::get_residual_flat),
+        )
+        .route(
+            "/stack-previews/residual-flats/{correction_id}/response",
+            get(stack_preview::artifact::residual_flat::get_residual_flat_response),
+        )
+        .route(
+            "/stack-previews/residual-flats/{correction_id}/preview",
+            get(stack_preview::artifact::residual_flat::get_residual_flat_preview),
+        )
+        .route(
+            "/stack-previews/residual-flats/{correction_id}/fits",
+            get(stack_preview::artifact::residual_flat::download_residual_flat_fits),
         )
         .route(
             "/stack-previews/stretch/{stretch_id}/preview",

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -190,6 +190,7 @@ pub struct StackPreviewManager {
     jobs: Mutex<HashMap<String, StackPreviewJob>>,
     color_jobs: Mutex<HashMap<String, color::StackColorJob>>,
     artifact_jobs: Mutex<HashMap<String, artifact::ArtifactSearchJob>>,
+    residual_flat_jobs: Mutex<HashMap<String, artifact::residual_flat::ResidualFlatJob>>,
     latest_write: Mutex<()>,
     permit: Arc<Semaphore>,
 }
@@ -200,6 +201,7 @@ impl StackPreviewManager {
             jobs: Mutex::new(HashMap::new()),
             color_jobs: Mutex::new(HashMap::new()),
             artifact_jobs: Mutex::new(HashMap::new()),
+            residual_flat_jobs: Mutex::new(HashMap::new()),
             latest_write: Mutex::new(()),
             permit: Arc::new(Semaphore::new(1)),
         }
@@ -242,6 +244,55 @@ impl StackPreviewManager {
 
     fn update(&self, job_id: &str, update: impl FnOnce(&mut StackPreviewJob)) {
         if let Some(job) = self.jobs.lock().unwrap().get_mut(job_id) {
+            update(job);
+        }
+    }
+
+    fn get_residual_flat(
+        &self,
+        correction_id: &str,
+    ) -> Option<artifact::residual_flat::ResidualFlatJob> {
+        self.residual_flat_jobs
+            .lock()
+            .unwrap()
+            .get(correction_id)
+            .cloned()
+    }
+
+    fn insert_residual_flat(&self, job: artifact::residual_flat::ResidualFlatJob) -> bool {
+        let mut jobs = self.residual_flat_jobs.lock().unwrap();
+        if jobs.len() >= MAX_REMEMBERED_JOBS && !jobs.contains_key(&job.correction_id) {
+            let Some(oldest) = jobs
+                .values()
+                .filter(|entry| {
+                    matches!(
+                        entry.state,
+                        artifact::residual_flat::ResidualFlatState::Completed
+                            | artifact::residual_flat::ResidualFlatState::Failed
+                    )
+                })
+                .min_by_key(|entry| entry.created_unix_seconds)
+                .map(|entry| entry.correction_id.clone())
+            else {
+                return false;
+            };
+            jobs.remove(&oldest);
+        }
+        jobs.insert(job.correction_id.clone(), job);
+        true
+    }
+
+    fn update_residual_flat(
+        &self,
+        correction_id: &str,
+        update: impl FnOnce(&mut artifact::residual_flat::ResidualFlatJob),
+    ) {
+        if let Some(job) = self
+            .residual_flat_jobs
+            .lock()
+            .unwrap()
+            .get_mut(correction_id)
+        {
             update(job);
         }
     }

--- a/src/server/stack_preview/artifact.rs
+++ b/src/server/stack_preview/artifact.rs
@@ -1,5 +1,7 @@
 //! User-directed source-frame search for a suspicious stack region.
 
+pub mod residual_flat;
+
 use super::{
     color::{self, StackColorJob},
     source_fingerprint, StackGroupState, StackGroupStatus, StackJobState, StackPreviewJob,

--- a/src/server/stack_preview/artifact/residual_flat.rs
+++ b/src/server/stack_preview/artifact/residual_flat.rs
@@ -1,0 +1,1229 @@
+//! Opt-in dust-residual correction derived from repeated detector-space evidence.
+
+use super::{
+    hex_digest, load_artifact_job, load_stack_job, prepare_search, source_fingerprint,
+    validate_search_id, ArtifactMorphology, ArtifactSearchJob, ArtifactSearchRequest,
+    ArtifactSearchState, PreparedSearch, SearchSource,
+};
+use crate::{
+    calibration::AppliedCalibration,
+    server::{
+        api::ApiResponse,
+        extract::DbContext,
+        handlers::AppError,
+        stack_preview::{stretch, StackGroupState, StackPreviewImageQuery, StackPreviewImageSize},
+        state::AppState,
+    },
+};
+use axum::{
+    body::Body,
+    extract::{Path, Query, State},
+    http::{
+        header::{CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE},
+        StatusCode,
+    },
+    response::Response,
+    Json,
+};
+use rayon::ThreadPoolBuilder;
+use seiza_stacking::{
+    build_residual_flat_patch, FitsFrame, FrameDisposition, LinearImage, LiveStacker,
+    NormalizationMode, ReferenceRegion, ResidualFlatDiagnostics, ResidualFlatOptions,
+    SimilarityTransform, StackOptions, RESIDUAL_FLAT_ALGORITHM_VERSION,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashSet,
+    path::{Path as FsPath, PathBuf},
+    sync::Arc,
+};
+use tokio_util::io::ReaderStream;
+
+const RESIDUAL_FLAT_CACHE_VERSION: u32 = 1;
+const MAXIMUM_USER_GAIN: f32 = 1.3;
+const MAX_RESIDUAL_FLAT_SAMPLES: usize = 64;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResidualFlatRequest {
+    pub image_id: i32,
+    #[serde(default = "default_maximum_gain")]
+    pub maximum_gain: f32,
+}
+
+fn default_maximum_gain() -> f32 {
+    1.2
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResidualFlatState {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResidualFlatJob {
+    pub schema_version: u32,
+    pub correction_id: String,
+    pub database_id: String,
+    pub search_id: String,
+    pub source_job_id: String,
+    pub source_image_id: i32,
+    pub filter_name: String,
+    pub state: ResidualFlatState,
+    pub phase: String,
+    pub total_work_units: usize,
+    pub completed_work_units: usize,
+    pub created_unix_seconds: i64,
+    pub options: ResidualFlatOptions,
+    pub detector_region: Option<ReferenceRegion>,
+    pub sample_count: usize,
+    pub dither_span_pixels: Option<f64>,
+    pub required_dither_span_pixels: Option<f64>,
+    pub diagnostics: Option<ResidualFlatDiagnostics>,
+    pub accepted_frames: usize,
+    pub rejected_frames: usize,
+    pub calibration: Option<AppliedCalibration>,
+    #[serde(default)]
+    pub notes: Vec<String>,
+    pub error: Option<String>,
+}
+
+struct CompletedResidualFlat {
+    detector_region: ReferenceRegion,
+    sample_count: usize,
+    dither_span_pixels: f64,
+    required_dither_span_pixels: f64,
+    diagnostics: ResidualFlatDiagnostics,
+    accepted_frames: usize,
+    rejected_frames: usize,
+    calibration: AppliedCalibration,
+    notes: Vec<String>,
+}
+
+pub async fn start_residual_flat(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path((_db_id, search_id)): Path<(String, String)>,
+    Json(request): Json<ResidualFlatRequest>,
+) -> Result<Json<ApiResponse<ResidualFlatJob>>, AppError> {
+    validate_search_id(&search_id)?;
+    if !request.maximum_gain.is_finite()
+        || !(1.0..=MAXIMUM_USER_GAIN).contains(&request.maximum_gain)
+    {
+        return Err(AppError::BadRequest(format!(
+            "Maximum dust-correction gain must be between 1 and {MAXIMUM_USER_GAIN}"
+        )));
+    }
+    let search = load_artifact_job(&state, &ctx, &search_id)?;
+    if search.database_id != ctx.id || search.state != ArtifactSearchState::Completed {
+        return Err(AppError::NotFound);
+    }
+    if search.source_kind != "mono" {
+        return Err(AppError::BadRequest(
+            "Build a dust correction from one mono channel stack before recomposing color".into(),
+        ));
+    }
+    let result = search
+        .results
+        .iter()
+        .find(|result| result.image_id == request.image_id)
+        .ok_or(AppError::NotFound)?;
+    if !residual_flat_candidate(
+        result.evidence.as_str(),
+        result.direction.as_str(),
+        result.morphology,
+    ) {
+        return Err(AppError::BadRequest(
+            "This source result lacks repeated dark ring or broad-shadow evidence".into(),
+        ));
+    }
+
+    let options = ResidualFlatOptions {
+        maximum_gain: request.maximum_gain,
+        ..ResidualFlatOptions::default()
+    };
+    let correction_id = correction_id(&search, request.image_id, &options)?;
+    if let Some(existing) = state.stack_previews.get_residual_flat(&correction_id) {
+        let reusable = matches!(
+            existing.state,
+            ResidualFlatState::Queued | ResidualFlatState::Running
+        ) || (existing.state == ResidualFlatState::Completed
+            && residual_flat_artifacts_ready(&ctx.cache_dir_path, &correction_id));
+        if reusable {
+            return Ok(Json(ApiResponse::success(existing)));
+        }
+    }
+    if let Ok(bytes) = std::fs::read(residual_flat_manifest_path(
+        &ctx.cache_dir_path,
+        &correction_id,
+    )) && let Ok(existing) = serde_json::from_slice::<ResidualFlatJob>(&bytes)
+        && existing.state == ResidualFlatState::Completed
+        && residual_flat_artifacts_ready(&ctx.cache_dir_path, &correction_id)
+    {
+        let _ = state.stack_previews.insert_residual_flat(existing.clone());
+        return Ok(Json(ApiResponse::success(existing)));
+    }
+
+    let job = ResidualFlatJob {
+        schema_version: RESIDUAL_FLAT_CACHE_VERSION,
+        correction_id,
+        database_id: ctx.id.clone(),
+        search_id,
+        source_job_id: search.source_job_id,
+        source_image_id: request.image_id,
+        filter_name: result.filter_name.clone(),
+        state: ResidualFlatState::Queued,
+        phase: "Waiting for the stack processor".into(),
+        total_work_units: 0,
+        completed_work_units: 0,
+        created_unix_seconds: chrono::Utc::now().timestamp(),
+        options,
+        detector_region: None,
+        sample_count: 0,
+        dither_span_pixels: None,
+        required_dither_span_pixels: None,
+        diagnostics: None,
+        accepted_frames: 0,
+        rejected_frames: 0,
+        calibration: None,
+        notes: vec![
+            "This derived preview does not change source files, catalog grades, or the saved stack"
+                .into(),
+        ],
+        error: None,
+    };
+    if !state.stack_previews.insert_residual_flat(job.clone()) {
+        return Err(AppError::BadRequest(
+            "Too many stack jobs are active; wait for one to finish".into(),
+        ));
+    }
+    enqueue_residual_flat(state, job.clone());
+    Ok(Json(ApiResponse::success(job)))
+}
+
+pub async fn get_residual_flat(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path((_db_id, correction_id)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<ResidualFlatJob>>, AppError> {
+    validate_correction_id(&correction_id)?;
+    let job = load_residual_flat_job(&state, &ctx, &correction_id)?;
+    if job.database_id != ctx.id {
+        return Err(AppError::NotFound);
+    }
+    Ok(Json(ApiResponse::success(job)))
+}
+
+pub async fn get_residual_flat_response(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path((_db_id, correction_id)): Path<(String, String)>,
+) -> Result<Response, AppError> {
+    let job = completed_job(&state, &ctx, &correction_id)?;
+    serve_file(
+        residual_flat_response_preview_path(&ctx.cache_dir_path, &job.correction_id),
+        "image/png",
+        None,
+    )
+    .await
+}
+
+pub async fn get_residual_flat_preview(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path((_db_id, correction_id)): Path<(String, String)>,
+    Query(query): Query<StackPreviewImageQuery>,
+) -> Result<Response, AppError> {
+    let job = completed_job(&state, &ctx, &correction_id)?;
+    let path = match query.size {
+        StackPreviewImageSize::Screen => {
+            residual_flat_preview_path(&ctx.cache_dir_path, &job.correction_id)
+        }
+        StackPreviewImageSize::Original => {
+            residual_flat_original_preview_path(&ctx.cache_dir_path, &job.correction_id)
+        }
+    };
+    serve_file(path, "image/png", None).await
+}
+
+pub async fn download_residual_flat_fits(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path((_db_id, correction_id)): Path<(String, String)>,
+) -> Result<Response, AppError> {
+    let job = completed_job(&state, &ctx, &correction_id)?;
+    let filename = format!(
+        "psf-guard-dust-corrected-{}-{}.fits",
+        job.filter_name
+            .replace(|character: char| !character.is_ascii_alphanumeric(), "-"),
+        &job.correction_id[..12]
+    );
+    serve_file(
+        residual_flat_fits_path(&ctx.cache_dir_path, &job.correction_id),
+        "application/fits",
+        Some(filename),
+    )
+    .await
+}
+
+fn enqueue_residual_flat(state: Arc<AppState>, job: ResidualFlatJob) {
+    let permit = Arc::clone(&state.stack_previews.permit);
+    tokio::spawn(async move {
+        let Ok(_permit) = permit.acquire_owned().await else {
+            return;
+        };
+        let guard = state.begin_interactive_job();
+        let state_for_job = Arc::clone(&state);
+        let correction_id = job.correction_id.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let _guard = guard;
+            run_residual_flat(&state_for_job, &job)
+        })
+        .await;
+        if let Err(error) = result {
+            state
+                .stack_previews
+                .update_residual_flat(&correction_id, |entry| {
+                    entry.state = ResidualFlatState::Failed;
+                    entry.phase = "Dust-correction worker failed".into();
+                    entry.error = Some(format!("Dust-correction worker panicked: {error}"));
+                });
+        }
+    });
+}
+
+fn run_residual_flat(state: &Arc<AppState>, requested: &ResidualFlatJob) {
+    let correction_id = requested.correction_id.clone();
+    state
+        .stack_previews
+        .update_residual_flat(&correction_id, |job| {
+            job.state = ResidualFlatState::Running;
+            job.phase = "Restoring stack provenance".into();
+        });
+    let result = run_residual_flat_inner(state, requested);
+    state
+        .stack_previews
+        .update_residual_flat(&correction_id, |job| match result {
+            Ok(completed) => {
+                job.state = ResidualFlatState::Completed;
+                job.phase = "Dust-corrected preview ready".into();
+                job.completed_work_units = job.total_work_units;
+                job.detector_region = Some(completed.detector_region);
+                job.sample_count = completed.sample_count;
+                job.dither_span_pixels = Some(completed.dither_span_pixels);
+                job.required_dither_span_pixels = Some(completed.required_dither_span_pixels);
+                job.diagnostics = Some(completed.diagnostics);
+                job.accepted_frames = completed.accepted_frames;
+                job.rejected_frames = completed.rejected_frames;
+                job.calibration = Some(completed.calibration);
+                job.notes.extend(completed.notes);
+                job.error = None;
+            }
+            Err(error) => {
+                job.state = ResidualFlatState::Failed;
+                job.phase = "Dust correction stopped".into();
+                job.error = Some(error);
+            }
+        });
+    if let Some(job) = state.stack_previews.get_residual_flat(&correction_id)
+        && let Some(ctx) = state.get_database(&job.database_id)
+        && let Err(error) = persist_residual_flat_job(&ctx.cache_dir_path, &job)
+    {
+        tracing::warn!("Failed to persist residual-flat job {correction_id}: {error}");
+    }
+}
+
+fn run_residual_flat_inner(
+    state: &Arc<AppState>,
+    requested: &ResidualFlatJob,
+) -> Result<CompletedResidualFlat, String> {
+    let ctx = state
+        .get_database(&requested.database_id)
+        .ok_or_else(|| "The database is no longer configured".to_string())?;
+    let db_ctx = DbContext(Arc::clone(&ctx));
+    let search =
+        load_artifact_job(state, &db_ctx, &requested.search_id).map_err(app_error_message)?;
+    let prepared =
+        restore_prepared_mono_search(state, &db_ctx, &search).map_err(app_error_message)?;
+    let group = prepared
+        .groups
+        .iter()
+        .find(|group| {
+            group
+                .sources
+                .iter()
+                .any(|source| source.image_id == requested.source_image_id)
+        })
+        .cloned()
+        .ok_or_else(|| "The selected source frame left the stack input set".to_string())?;
+    if group.sources.len() < requested.options.minimum_samples {
+        return Err(format!(
+            "{} has {} integrated frames; dust correction needs at least {}",
+            group.label,
+            group.sources.len(),
+            requested.options.minimum_samples
+        ));
+    }
+    let evidence_sources = residual_evidence_sources(&group.sources, requested.source_image_id);
+    state
+        .stack_previews
+        .update_residual_flat(&requested.correction_id, |job| {
+            job.total_work_units = evidence_sources.len() + group.sources.len() + 4;
+            job.phase = "Resolving ordinary calibration".into();
+        });
+
+    let calibration_conn = rusqlite::Connection::open(&ctx.database_path)
+        .map_err(|error| format!("Opening calibration catalog: {error}"))?;
+    calibration_conn
+        .busy_timeout(std::time::Duration::from_secs(60))
+        .map_err(|error| format!("Configuring calibration catalog: {error}"))?;
+    let directory_tree = ctx
+        .get_directory_tree()
+        .map_err(|error| format!("Indexing calibration folders: {error}"))?;
+    let paths = group
+        .sources
+        .iter()
+        .map(|source| source.path.clone())
+        .collect::<Vec<_>>();
+    let (masters, applied) = crate::calibration::resolve_or_build_masters_for_group(
+        &calibration_conn,
+        &ctx.cache_dir_path,
+        &paths,
+        Some(&directory_tree),
+    )
+    .map_err(|error| error.to_string())?;
+    if applied.fingerprint != group.expected_calibration_fingerprint {
+        return Err("Ordinary calibration changed; rebuild the source stack first".into());
+    }
+
+    let selected = group
+        .sources
+        .iter()
+        .find(|source| source.image_id == requested.source_image_id)
+        .ok_or_else(|| "The selected source frame is missing".to_string())?;
+    let mut selected_frame = FitsFrame::open(&selected.path).map_err(|error| error.to_string())?;
+    masters
+        .apply(
+            &mut selected_frame.image,
+            selected_frame.exposure_seconds,
+            selected_frame.bayer,
+        )
+        .map_err(|error| error.to_string())?;
+    let selected_frame = selected_frame
+        .into_prepared()
+        .map_err(|error| error.to_string())?;
+    let detector_region = detector_region_for_source(
+        selected,
+        prepared.public.region,
+        selected_frame.image.width,
+        selected_frame.image.height,
+    )?;
+
+    let pixels = selected_frame.image.pixel_count();
+    let estimate = (pixels as u64)
+        .saturating_mul(selected_frame.image.channels as u64)
+        .saturating_mul(super::super::STACK_BYTES_PER_OUTPUT_SAMPLE);
+    let worker_policy = state.worker_policy();
+    if let Some(available) = crate::concurrency::available_memory_bytes()
+        && estimate > (available as f64 * worker_policy.memory_budget_fraction) as u64
+    {
+        return Err(format!(
+            "Estimated corrected-stack memory {} MiB exceeds the configured available-memory budget",
+            estimate / (1024 * 1024)
+        ));
+    }
+    let budget = crate::concurrency::plan_workers(
+        None,
+        &worker_policy,
+        crate::concurrency::Priority::Interactive,
+        Some(pixels),
+    );
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(budget.workers)
+        .thread_name(|index| format!("residual-flat-{index}"))
+        .build()
+        .map_err(|error| error.to_string())?;
+    tracing::info!(
+        "Residual-flat preview {}: {} worker(s) — {}",
+        requested.correction_id,
+        budget.workers,
+        budget.rationale
+    );
+
+    pool.install(|| {
+        let mut crops = Vec::with_capacity(evidence_sources.len());
+        let mut detector_positions = Vec::with_capacity(evidence_sources.len());
+        state
+            .stack_previews
+            .update_residual_flat(&requested.correction_id, |job| {
+                job.detector_region = Some(detector_region);
+                job.phase = "Collecting detector-aligned evidence".into();
+            });
+        for source in evidence_sources {
+            if source_fingerprint(&source.path) != source.fingerprint {
+                return Err(format!(
+                    "Image {} changed after the source stack was built",
+                    source.image_id
+                ));
+            }
+            let mut frame = FitsFrame::open(&source.path).map_err(|error| error.to_string())?;
+            masters
+                .apply(&mut frame.image, frame.exposure_seconds, frame.bayer)
+                .map_err(|error| error.to_string())?;
+            let frame = frame.into_prepared().map_err(|error| error.to_string())?;
+            if frame.image.width != selected_frame.image.width
+                || frame.image.height != selected_frame.image.height
+                || frame.image.channels != selected_frame.image.channels
+            {
+                return Err(format!(
+                    "Image {} does not share the selected detector sampling",
+                    source.image_id
+                ));
+            }
+            crops.push(crop_image(&frame.image, detector_region)?);
+            detector_positions.push(mapped_detector_center(source, detector_region));
+            state
+                .stack_previews
+                .update_residual_flat(&requested.correction_id, |job| {
+                    job.completed_work_units += 1
+                });
+        }
+
+        let (dither_span, distinct_positions) = detector_motion(&detector_positions);
+        let required_dither_span = required_motion(detector_region);
+        if distinct_positions < 3 || dither_span < required_dither_span {
+            return Err(format!(
+                "The detector feature moved only {dither_span:.1}px across the stack; need {required_dither_span:.1}px and at least three dither positions to separate it from sky structure"
+            ));
+        }
+        state
+            .stack_previews
+            .update_residual_flat(&requested.correction_id, |job| {
+                job.sample_count = crops.len();
+                job.dither_span_pixels = Some(dither_span);
+                job.required_dither_span_pixels = Some(required_dither_span);
+                job.phase = "Estimating repeated response".into();
+                job.completed_work_units += 1;
+            });
+        let built = build_residual_flat_patch(&crops, &requested.options)
+            .map_err(|error| error.to_string())?;
+
+        let output_dir = residual_flat_dir(&ctx.cache_dir_path, &requested.correction_id);
+        std::fs::create_dir_all(&output_dir).map_err(|error| error.to_string())?;
+        let response_fits =
+            residual_flat_response_fits_path(&ctx.cache_dir_path, &requested.correction_id);
+        let response_temp =
+            response_fits.with_extension(format!("{}.tmp.fits", std::process::id()));
+        seiza_stacking::write_linear_image_fits_f32(
+            &response_temp,
+            built.patch.response(),
+            &[],
+            &[],
+        )
+        .map_err(|error| error.to_string())?;
+        std::fs::rename(&response_temp, &response_fits).map_err(|error| error.to_string())?;
+        render_response_preview_atomic(
+            built.patch.response(),
+            &residual_flat_response_preview_path(&ctx.cache_dir_path, &requested.correction_id),
+        )?;
+        state
+            .stack_previews
+            .update_residual_flat(&requested.correction_id, |job| {
+                job.diagnostics = Some(built.diagnostics.clone());
+                job.phase = "Building corrected stack".into();
+                job.completed_work_units += 1;
+            });
+
+        let options = StackOptions {
+            normalization: NormalizationMode::Global,
+            ..StackOptions::default()
+        };
+        let mut accepted_frames = 0usize;
+        let mut rejected_frames = 0usize;
+        let mut notes = Vec::new();
+        if group.sources.len() > MAX_RESIDUAL_FLAT_SAMPLES {
+            notes.push(format!(
+                "Estimated the response from {} evenly spaced inputs out of {} integrated frames",
+                crops.len(),
+                group.sources.len()
+            ));
+        }
+        let mut stacker = None;
+        for source in &group.sources {
+            if source_fingerprint(&source.path) != source.fingerprint {
+                return Err(format!(
+                    "Image {} changed after the source stack was built",
+                    source.image_id
+                ));
+            }
+            let mut frame = FitsFrame::open(&source.path).map_err(|error| error.to_string())?;
+            masters
+                .apply(&mut frame.image, frame.exposure_seconds, frame.bayer)
+                .map_err(|error| error.to_string())?;
+            let mut frame = frame.into_prepared().map_err(|error| error.to_string())?;
+            built
+                .patch
+                .apply_at(&mut frame.image, detector_region.x, detector_region.y)
+                .map_err(|error| error.to_string())?;
+            match stacker.as_mut() {
+                None => {
+                    stacker = Some(
+                        LiveStacker::from_prepared_frame(frame, options.clone())
+                            .map_err(|error| error.to_string())?,
+                    );
+                    accepted_frames += 1;
+                }
+                Some(stacker) => match stacker
+                    .push_linear(frame.image)
+                    .map_err(|error| error.to_string())?
+                {
+                    FrameDisposition::Accepted(_) => accepted_frames += 1,
+                    FrameDisposition::Rejected(reason) => {
+                        rejected_frames += 1;
+                        notes.push(format!(
+                            "Corrected image {} was not integrated: {reason}",
+                            source.image_id
+                        ));
+                    }
+                },
+            }
+            state
+                .stack_previews
+                .update_residual_flat(&requested.correction_id, |job| {
+                    job.accepted_frames = accepted_frames;
+                    job.rejected_frames = rejected_frames;
+                    job.completed_work_units += 1;
+                });
+        }
+        if accepted_frames < 2 {
+            return Err("Fewer than two corrected frames could be integrated".into());
+        }
+        let stacker =
+            stacker.ok_or_else(|| "No corrected reference frame was prepared".to_string())?;
+        let reference_headers = stacker.reference_headers().to_vec();
+        let snapshot = stacker.into_snapshot().map_err(|error| error.to_string())?;
+        let fits = residual_flat_fits_path(&ctx.cache_dir_path, &requested.correction_id);
+        let fits_temp = fits.with_extension(format!("{}.tmp.fits", std::process::id()));
+        seiza_stacking::write_fits_f32(&fits_temp, &snapshot, &reference_headers)
+            .map_err(|error| error.to_string())?;
+        std::fs::rename(&fits_temp, &fits).map_err(|error| error.to_string())?;
+        state
+            .stack_previews
+            .update_residual_flat(&requested.correction_id, |job| {
+                job.phase = "Rendering corrected preview".into();
+                job.completed_work_units += 1;
+            });
+        stretch::render_image_previews_atomic(
+            &snapshot.image,
+            &stretch::default_linear_config(),
+            stretch::StackStretchSourceTransfer::Linear,
+            &residual_flat_preview_path(&ctx.cache_dir_path, &requested.correction_id),
+            &residual_flat_original_preview_path(&ctx.cache_dir_path, &requested.correction_id),
+        )?;
+        state
+            .stack_previews
+            .update_residual_flat(&requested.correction_id, |job| {
+                job.completed_work_units += 1
+            });
+
+        if applied.flat_master.is_some() {
+            notes.push(
+                "A matching flat was applied first; this patch corrects only the repeated residual"
+                    .into(),
+            );
+        } else {
+            notes.push("No matching master flat was available for these lights".into());
+        }
+        Ok(CompletedResidualFlat {
+            detector_region,
+            sample_count: crops.len(),
+            dither_span_pixels: dither_span,
+            required_dither_span_pixels: required_dither_span,
+            diagnostics: built.diagnostics,
+            accepted_frames,
+            rejected_frames,
+            calibration: applied,
+            notes,
+        })
+    })
+}
+
+fn restore_prepared_mono_search(
+    state: &Arc<AppState>,
+    ctx: &DbContext,
+    search: &ArtifactSearchJob,
+) -> Result<PreparedSearch, AppError> {
+    if search.source_kind != "mono" {
+        return Err(AppError::BadRequest(
+            "Dust correction requires one mono source stack".into(),
+        ));
+    }
+    let request = ArtifactSearchRequest {
+        artifact_revision: search.artifact_revision.clone(),
+        region: search.region,
+    };
+    let group_index = search.group_index.ok_or(AppError::NotFound)?;
+    let stack = load_stack_job(state, ctx, &search.source_job_id)?;
+    if stack.database_id != ctx.id || stack.artifact_revision != search.artifact_revision {
+        return Err(AppError::Conflict(
+            "The source stack changed; run the region search again".into(),
+        ));
+    }
+    let group = stack
+        .groups
+        .get(group_index)
+        .filter(|group| group.index == group_index && group.state == StackGroupState::Ready)
+        .cloned()
+        .ok_or(AppError::NotFound)?;
+    let prepared = prepare_search(
+        &ctx.0,
+        &search.source_job_id,
+        &search.source_kind,
+        search.group_index,
+        &request,
+        vec![(group, None, None)],
+    )?;
+    if prepared.public.search_id != search.search_id {
+        return Err(AppError::Conflict(
+            "The source-frame provenance changed; run the region search again".into(),
+        ));
+    }
+    Ok(prepared)
+}
+
+fn residual_flat_candidate(
+    evidence: &str,
+    direction: &str,
+    morphology: ArtifactMorphology,
+) -> bool {
+    matches!(evidence, "strong" | "possible")
+        && direction == "dark"
+        && matches!(
+            morphology,
+            ArtifactMorphology::Ring | ArtifactMorphology::BroadDark
+        )
+}
+
+fn app_error_message(error: AppError) -> String {
+    match error {
+        AppError::NotFound => "A required stack artifact was not found".into(),
+        AppError::NotFoundMessage(message)
+        | AppError::DatabaseError(message)
+        | AppError::BadRequest(message)
+        | AppError::Conflict(message)
+        | AppError::Forbidden(message)
+        | AppError::InternalError(message) => message,
+        AppError::NotImplemented => "This stack operation is not implemented".into(),
+    }
+}
+
+fn correction_id(
+    search: &ArtifactSearchJob,
+    image_id: i32,
+    options: &ResidualFlatOptions,
+) -> Result<String, AppError> {
+    let mut hasher = Sha256::new();
+    hasher.update(search.search_id.as_bytes());
+    hasher.update(image_id.to_le_bytes());
+    hasher.update(RESIDUAL_FLAT_CACHE_VERSION.to_le_bytes());
+    hasher.update(RESIDUAL_FLAT_ALGORITHM_VERSION.to_le_bytes());
+    hasher.update(serde_json::to_vec(options).map_err(|error| {
+        AppError::InternalError(format!("Failed to encode residual-flat options: {error}"))
+    })?);
+    Ok(hex_digest(hasher.finalize()))
+}
+
+fn detector_region_for_source(
+    source: &SearchSource,
+    output_region: ReferenceRegion,
+    source_width: usize,
+    source_height: usize,
+) -> Result<ReferenceRegion, String> {
+    let transform = source_to_output_transform(source);
+    let right = output_region
+        .x
+        .checked_add(output_region.width)
+        .ok_or_else(|| "Selected region overflows".to_string())?;
+    let bottom = output_region
+        .y
+        .checked_add(output_region.height)
+        .ok_or_else(|| "Selected region overflows".to_string())?;
+    let corners = [
+        (output_region.x as f64, output_region.y as f64),
+        (right as f64, output_region.y as f64),
+        (output_region.x as f64, bottom as f64),
+        (right as f64, bottom as f64),
+    ]
+    .map(|(x, y)| transform.inverse_apply(x, y));
+    let minimum_x = corners
+        .iter()
+        .map(|(x, _)| *x)
+        .fold(f64::INFINITY, f64::min);
+    let maximum_x = corners
+        .iter()
+        .map(|(x, _)| *x)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let minimum_y = corners
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(f64::INFINITY, f64::min);
+    let maximum_y = corners
+        .iter()
+        .map(|(_, y)| *y)
+        .fold(f64::NEG_INFINITY, f64::max);
+    if ![minimum_x, maximum_x, minimum_y, maximum_y]
+        .into_iter()
+        .all(f64::is_finite)
+    {
+        return Err("The selected region cannot be mapped to detector coordinates".into());
+    }
+    let padding =
+        ((output_region.width.min(output_region.height) as f64 * 0.25).ceil() as usize).max(16);
+    let x = (minimum_x.floor() as isize - padding as isize).max(0) as usize;
+    let y = (minimum_y.floor() as isize - padding as isize).max(0) as usize;
+    let right = (maximum_x.ceil() as usize)
+        .saturating_add(padding)
+        .min(source_width);
+    let bottom = (maximum_y.ceil() as usize)
+        .saturating_add(padding)
+        .min(source_height);
+    if right <= x + 4 || bottom <= y + 4 {
+        return Err("The detector-space correction region is too small".into());
+    }
+    Ok(ReferenceRegion {
+        x,
+        y,
+        width: right - x,
+        height: bottom - y,
+    })
+}
+
+fn source_to_output_transform(source: &SearchSource) -> SimilarityTransform {
+    match source.output_transform {
+        Some(output) => source.mapping.transform().then(output),
+        None => source.mapping.transform(),
+    }
+}
+
+fn mapped_detector_center(source: &SearchSource, region: ReferenceRegion) -> (f64, f64) {
+    source_to_output_transform(source).apply(
+        region.x as f64 + region.width as f64 * 0.5,
+        region.y as f64 + region.height as f64 * 0.5,
+    )
+}
+
+fn crop_image(image: &LinearImage, region: ReferenceRegion) -> Result<LinearImage, String> {
+    let right = region
+        .x
+        .checked_add(region.width)
+        .ok_or_else(|| "Detector crop overflows".to_string())?;
+    let bottom = region
+        .y
+        .checked_add(region.height)
+        .ok_or_else(|| "Detector crop overflows".to_string())?;
+    if right > image.width || bottom > image.height {
+        return Err("Detector crop lies outside a source frame".into());
+    }
+    let mut data = Vec::with_capacity(region.width * region.height * image.channels);
+    for y in region.y..bottom {
+        let start = (y * image.width + region.x) * image.channels;
+        let length = region.width * image.channels;
+        data.extend_from_slice(&image.data[start..start + length]);
+    }
+    LinearImage::new(region.width, region.height, image.channels, data)
+        .map_err(|error| error.to_string())
+}
+
+fn render_response_preview_atomic(
+    response: &LinearImage,
+    destination: &FsPath,
+) -> Result<(), String> {
+    let minimum = response
+        .data
+        .iter()
+        .copied()
+        .filter(|value| value.is_finite())
+        .min_by(f32::total_cmp)
+        .ok_or_else(|| "Residual-flat response has no finite samples".to_string())?;
+    let span = (1.0 - minimum).max(1.0e-6);
+    let samples = response
+        .data
+        .iter()
+        .map(|value| (((*value - minimum) / span).clamp(0.0, 1.0) * 255.0).round() as u8)
+        .collect::<Vec<_>>();
+    let image = if response.channels == 1 {
+        image::GrayImage::from_raw(response.width as u32, response.height as u32, samples)
+            .map(image::DynamicImage::ImageLuma8)
+    } else {
+        image::RgbImage::from_raw(response.width as u32, response.height as u32, samples)
+            .map(image::DynamicImage::ImageRgb8)
+    }
+    .ok_or_else(|| "Residual-flat preview dimensions do not match its samples".to_string())?;
+    let parent = destination
+        .parent()
+        .ok_or_else(|| "Residual-flat preview path has no parent".to_string())?;
+    std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let temporary = destination.with_extension(format!("{}.tmp.png", std::process::id()));
+    image.save(&temporary).map_err(|error| error.to_string())?;
+    std::fs::rename(&temporary, destination).map_err(|error| error.to_string())
+}
+
+fn detector_motion(positions: &[(f64, f64)]) -> (f64, usize) {
+    let mut xs = positions.iter().map(|(x, _)| *x).collect::<Vec<_>>();
+    let mut ys = positions.iter().map(|(_, y)| *y).collect::<Vec<_>>();
+    xs.sort_unstable_by(f64::total_cmp);
+    ys.sort_unstable_by(f64::total_cmp);
+    let low = positions.len() / 5;
+    let high = positions.len().saturating_sub(1 + low);
+    let span = if positions.is_empty() {
+        0.0
+    } else {
+        (xs[high] - xs[low]).hypot(ys[high] - ys[low])
+    };
+    let distinct = positions
+        .iter()
+        .map(|(x, y)| ((x / 2.0).round() as i64, (y / 2.0).round() as i64))
+        .collect::<HashSet<_>>()
+        .len();
+    (span, distinct)
+}
+
+fn residual_evidence_sources(
+    sources: &[SearchSource],
+    selected_image_id: i32,
+) -> Vec<&SearchSource> {
+    if sources.len() <= MAX_RESIDUAL_FLAT_SAMPLES {
+        return sources.iter().collect();
+    }
+    let mut indices = (0..MAX_RESIDUAL_FLAT_SAMPLES)
+        .map(|index| index * (sources.len() - 1) / (MAX_RESIDUAL_FLAT_SAMPLES - 1))
+        .collect::<Vec<_>>();
+    if let Some(selected_index) = sources
+        .iter()
+        .position(|source| source.image_id == selected_image_id)
+        && !indices.contains(&selected_index)
+    {
+        let replacement = indices
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, index)| index.abs_diff(selected_index))
+            .map(|(position, _)| position)
+            .unwrap_or(indices.len() - 1);
+        indices[replacement] = selected_index;
+        indices.sort_unstable();
+    }
+    indices.into_iter().map(|index| &sources[index]).collect()
+}
+
+fn required_motion(region: ReferenceRegion) -> f64 {
+    (region.width.min(region.height) as f64 * 0.08).clamp(6.0, 24.0)
+}
+
+fn validate_correction_id(correction_id: &str) -> Result<(), AppError> {
+    if correction_id.len() == 64 && correction_id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        Err(AppError::BadRequest(
+            "Invalid residual-flat correction ID".into(),
+        ))
+    }
+}
+
+fn completed_job(
+    state: &Arc<AppState>,
+    ctx: &DbContext,
+    correction_id: &str,
+) -> Result<ResidualFlatJob, AppError> {
+    validate_correction_id(correction_id)?;
+    let job = load_residual_flat_job(state, ctx, correction_id)?;
+    if job.database_id != ctx.id || job.state != ResidualFlatState::Completed {
+        return Err(AppError::NotFound);
+    }
+    Ok(job)
+}
+
+fn load_residual_flat_job(
+    state: &Arc<AppState>,
+    ctx: &DbContext,
+    correction_id: &str,
+) -> Result<ResidualFlatJob, AppError> {
+    if let Some(job) = state.stack_previews.get_residual_flat(correction_id) {
+        return Ok(job);
+    }
+    let bytes = std::fs::read(residual_flat_manifest_path(
+        &ctx.cache_dir_path,
+        correction_id,
+    ))
+    .map_err(|_| AppError::NotFound)?;
+    let job = serde_json::from_slice::<ResidualFlatJob>(&bytes).map_err(|error| {
+        AppError::InternalError(format!("Invalid residual-flat manifest: {error}"))
+    })?;
+    let _ = state.stack_previews.insert_residual_flat(job.clone());
+    Ok(job)
+}
+
+async fn serve_file(
+    path: PathBuf,
+    content_type: &'static str,
+    download_name: Option<String>,
+) -> Result<Response, AppError> {
+    let file = tokio::fs::File::open(&path)
+        .await
+        .map_err(|_| AppError::NotFound)?;
+    let length = file
+        .metadata()
+        .await
+        .map_err(|error| AppError::InternalError(format!("Failed to stat derived stack: {error}")))?
+        .len();
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, content_type)
+        .header(CONTENT_LENGTH, length)
+        .header(CACHE_CONTROL, "private, max-age=31536000, immutable");
+    if let Some(download_name) = download_name {
+        builder = builder.header(
+            CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{download_name}\""),
+        );
+    }
+    builder
+        .body(Body::from_stream(ReaderStream::new(file)))
+        .map_err(|error| AppError::InternalError(format!("Failed to serve derived stack: {error}")))
+}
+
+fn residual_flat_dir(cache_root: &FsPath, correction_id: &str) -> PathBuf {
+    cache_root
+        .join("stack-previews")
+        .join("residual-flats")
+        .join(correction_id)
+}
+
+fn residual_flat_manifest_path(cache_root: &FsPath, correction_id: &str) -> PathBuf {
+    residual_flat_dir(cache_root, correction_id).join("manifest.json")
+}
+
+fn residual_flat_response_fits_path(cache_root: &FsPath, correction_id: &str) -> PathBuf {
+    residual_flat_dir(cache_root, correction_id).join("response.fits")
+}
+
+fn residual_flat_response_preview_path(cache_root: &FsPath, correction_id: &str) -> PathBuf {
+    residual_flat_dir(cache_root, correction_id).join("response.png")
+}
+
+fn residual_flat_preview_path(cache_root: &FsPath, correction_id: &str) -> PathBuf {
+    residual_flat_dir(cache_root, correction_id).join("corrected.png")
+}
+
+fn residual_flat_original_preview_path(cache_root: &FsPath, correction_id: &str) -> PathBuf {
+    residual_flat_dir(cache_root, correction_id).join("corrected-original.png")
+}
+
+fn residual_flat_fits_path(cache_root: &FsPath, correction_id: &str) -> PathBuf {
+    residual_flat_dir(cache_root, correction_id).join("corrected.fits")
+}
+
+fn residual_flat_artifacts_ready(cache_root: &FsPath, correction_id: &str) -> bool {
+    [
+        residual_flat_response_fits_path(cache_root, correction_id),
+        residual_flat_response_preview_path(cache_root, correction_id),
+        residual_flat_preview_path(cache_root, correction_id),
+        residual_flat_original_preview_path(cache_root, correction_id),
+        residual_flat_fits_path(cache_root, correction_id),
+    ]
+    .iter()
+    .all(|path| path.is_file())
+}
+
+fn persist_residual_flat_job(cache_root: &FsPath, job: &ResidualFlatJob) -> Result<(), String> {
+    let path = residual_flat_manifest_path(cache_root, &job.correction_id);
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Residual-flat manifest path has no parent".to_string())?;
+    std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let temporary = path.with_extension(format!("{}.tmp", std::process::id()));
+    let bytes = serde_json::to_vec_pretty(job).map_err(|error| error.to_string())?;
+    std::fs::write(&temporary, bytes).map_err(|error| error.to_string())?;
+    std::fs::rename(&temporary, path).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use seiza_stacking::{NormalizationMap, RegisteredFrameMapping};
+
+    fn source(transform: SimilarityTransform) -> SearchSource {
+        let image = LinearImage::new(100, 80, 1, vec![1.0; 8_000]).unwrap();
+        SearchSource {
+            image_id: 1,
+            filter_name: "Ha".into(),
+            acquired_unix_seconds: None,
+            grading_status: 0,
+            path: PathBuf::from("one.fits"),
+            mapping: RegisteredFrameMapping::new(
+                100,
+                80,
+                transform,
+                NormalizationMap::identity(&image),
+            )
+            .unwrap(),
+            output_transform: None,
+            fingerprint: "one".into(),
+        }
+    }
+
+    #[test]
+    fn only_repeated_dark_ring_or_shadow_evidence_can_start() {
+        assert!(residual_flat_candidate(
+            "strong",
+            "dark",
+            ArtifactMorphology::Ring
+        ));
+        assert!(residual_flat_candidate(
+            "possible",
+            "dark",
+            ArtifactMorphology::BroadDark
+        ));
+        assert!(!residual_flat_candidate(
+            "low",
+            "dark",
+            ArtifactMorphology::Ring
+        ));
+        assert!(!residual_flat_candidate(
+            "strong",
+            "bright",
+            ArtifactMorphology::Ring
+        ));
+        assert!(!residual_flat_candidate(
+            "strong",
+            "dark",
+            ArtifactMorphology::Diffuse
+        ));
+    }
+
+    #[test]
+    fn output_selection_maps_back_to_a_padded_detector_region() {
+        let source = source(SimilarityTransform {
+            translation_x: 10.0,
+            translation_y: -4.0,
+            ..SimilarityTransform::IDENTITY
+        });
+        let region = detector_region_for_source(
+            &source,
+            ReferenceRegion {
+                x: 30,
+                y: 20,
+                width: 20,
+                height: 16,
+            },
+            100,
+            80,
+        )
+        .unwrap();
+        assert_eq!(region.x, 4);
+        assert_eq!(region.y, 8);
+        assert_eq!(region.width, 52);
+        assert_eq!(region.height, 48);
+    }
+
+    #[test]
+    fn motion_measure_ignores_one_extreme_mapping() {
+        let positions = [
+            (0.0, 0.0),
+            (10.0, 0.0),
+            (20.0, 0.0),
+            (30.0, 0.0),
+            (500.0, 0.0),
+        ];
+        let (span, distinct) = detector_motion(&positions);
+        assert_eq!(span, 20.0);
+        assert_eq!(distinct, 5);
+    }
+
+    #[test]
+    fn crop_keeps_interleaved_channels_and_checks_bounds() {
+        let image = LinearImage::new(3, 2, 3, (0..18).map(|value| value as f32).collect()).unwrap();
+        let crop = crop_image(
+            &image,
+            ReferenceRegion {
+                x: 1,
+                y: 0,
+                width: 2,
+                height: 2,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            crop.data,
+            [3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0]
+        );
+        assert!(crop_image(
+            &image,
+            ReferenceRegion {
+                x: 2,
+                y: 1,
+                width: 2,
+                height: 1,
+            }
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn response_preview_remains_visible_when_most_samples_are_neutral() {
+        let mut samples = vec![1.0; 100];
+        samples[44] = 0.9;
+        let response = LinearImage::new(10, 10, 1, samples).unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("response.png");
+        render_response_preview_atomic(&response, &destination).unwrap();
+        let rendered = image::open(destination).unwrap().into_luma8();
+        assert_eq!(rendered.get_pixel(4, 4).0[0], 0);
+        assert_eq!(rendered.get_pixel(0, 0).0[0], 255);
+    }
+
+    #[test]
+    fn evidence_sampling_is_bounded_and_keeps_the_selected_source() {
+        let sources = (0..100)
+            .map(|image_id| {
+                let mut source = source(SimilarityTransform::IDENTITY);
+                source.image_id = image_id;
+                source
+            })
+            .collect::<Vec<_>>();
+        let sampled = residual_evidence_sources(&sources, 50);
+        assert_eq!(sampled.len(), MAX_RESIDUAL_FLAT_SAMPLES);
+        assert!(sampled.iter().any(|source| source.image_id == 50));
+        assert_eq!(sampled.first().unwrap().image_id, 0);
+        assert_eq!(sampled.last().unwrap().image_id, 99);
+    }
+
+    #[test]
+    fn completed_cache_requires_every_derived_artifact() {
+        let directory = tempfile::tempdir().unwrap();
+        let correction_id = "a".repeat(64);
+        let paths = [
+            residual_flat_response_fits_path(directory.path(), &correction_id),
+            residual_flat_response_preview_path(directory.path(), &correction_id),
+            residual_flat_preview_path(directory.path(), &correction_id),
+            residual_flat_original_preview_path(directory.path(), &correction_id),
+            residual_flat_fits_path(directory.path(), &correction_id),
+        ];
+        std::fs::create_dir_all(paths[0].parent().unwrap()).unwrap();
+        for path in &paths {
+            std::fs::write(path, b"fixture").unwrap();
+        }
+        assert!(residual_flat_artifacts_ready(
+            directory.path(),
+            &correction_id
+        ));
+        std::fs::remove_file(&paths[3]).unwrap();
+        assert!(!residual_flat_artifacts_ready(
+            directory.path(),
+            &correction_id
+        ));
+    }
+}

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -4446,7 +4446,9 @@
 
 .stack-artifact-select,
 .stack-artifact-search,
-.stack-artifact-result button {
+.stack-artifact-result button,
+.stack-residual-flat button,
+.stack-residual-flat-actions a {
   padding: 0.45rem 0.7rem;
   color: var(--color-text-primary);
   font: inherit;
@@ -4459,7 +4461,9 @@
 
 .stack-artifact-select:hover:not(:disabled),
 .stack-artifact-select.active,
-.stack-artifact-result button:hover {
+.stack-artifact-result button:hover,
+.stack-residual-flat button:hover,
+.stack-residual-flat-actions a:hover {
   color: var(--color-primary);
   border-color: var(--color-primary);
 }
@@ -4599,6 +4603,46 @@
   border-radius: 999px;
   background: var(--color-bg-tertiary);
   font-weight: 600;
+}
+
+.stack-residual-flat {
+  margin-top: 1rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--color-bg-quaternary);
+}
+
+.stack-residual-flat > header,
+.stack-residual-flat-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.stack-residual-flat > header > span,
+.stack-residual-flat p {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+}
+
+.stack-residual-flat-response {
+  width: 100%;
+  max-height: 220px;
+  margin-top: 0.65rem;
+  object-fit: contain;
+  border: 1px solid var(--color-bg-quaternary);
+  border-radius: 5px;
+  background: #05070a;
+}
+
+.stack-residual-flat-actions {
+  align-items: stretch;
+}
+
+.stack-residual-flat-actions > * {
+  flex: 1;
+  text-align: center;
+  text-decoration: none;
 }
 
 .stack-inspector-toolbar .zoom-info-compact {

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -53,6 +53,7 @@ import type {
   SatelliteAnalysisStatus,
   StackPreviewJob,
   ArtifactSearchJob,
+  ResidualFlatJob,
   ReferenceRegion,
   LatestStackPreviews,
   StackColorCatalog,
@@ -779,6 +780,65 @@ export const apiClient = {
     return `${basePath}${dbPath(
       dbId,
       `/stack-previews/artifact-searches/${encodeURIComponent(searchId)}/crops/${imageId}`
+    )}`;
+  },
+
+  startResidualFlat: async (
+    dbId: string,
+    searchId: string,
+    imageId: number,
+    maximumGain = 1.2
+  ): Promise<ResidualFlatJob> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<ResidualFlatJob>>(
+      dbPath(
+        dbId,
+        `/stack-previews/artifact-searches/${encodeURIComponent(searchId)}/residual-flats`
+      ),
+      { image_id: imageId, maximum_gain: maximumGain }
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to start dust correction');
+    return data.data;
+  },
+
+  getResidualFlat: async (dbId: string, correctionId: string): Promise<ResidualFlatJob> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<ResidualFlatJob>>(
+      dbPath(dbId, `/stack-previews/residual-flats/${encodeURIComponent(correctionId)}`)
+    );
+    if (!data.data) throw new Error(data.error || 'Dust correction not found');
+    return data.data;
+  },
+
+  getResidualFlatResponseUrl: (dbId: string, correctionId: string): string => {
+    const serverUrl = getCachedServerUrl();
+    const basePath = serverUrl ? `${serverUrl}/api` : '/api';
+    return `${basePath}${dbPath(
+      dbId,
+      `/stack-previews/residual-flats/${encodeURIComponent(correctionId)}/response`
+    )}`;
+  },
+
+  getResidualFlatPreviewUrl: (
+    dbId: string,
+    correctionId: string,
+    size: 'screen' | 'original' = 'screen'
+  ): string => {
+    const serverUrl = getCachedServerUrl();
+    const basePath = serverUrl ? `${serverUrl}/api` : '/api';
+    const query = size === 'original' ? '?size=original' : '';
+    return `${basePath}${dbPath(
+      dbId,
+      `/stack-previews/residual-flats/${encodeURIComponent(correctionId)}/preview`
+    )}${query}`;
+  },
+
+  getResidualFlatFitsUrl: (dbId: string, correctionId: string): string => {
+    const serverUrl = getCachedServerUrl();
+    const basePath = serverUrl ? `${serverUrl}/api` : '/api';
+    return `${basePath}${dbPath(
+      dbId,
+      `/stack-previews/residual-flats/${encodeURIComponent(correctionId)}/fits`
     )}`;
   },
 

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -368,6 +368,56 @@ export interface ArtifactSearchJob {
   error: string | null;
 }
 
+export type ResidualFlatState = 'queued' | 'running' | 'completed' | 'failed';
+
+export interface ResidualFlatOptions {
+  minimum_samples: number;
+  minimum_depth: number;
+  minimum_consensus: number;
+  maximum_gain: number;
+  background_edge_fraction: number;
+  smoothing_sigma: number;
+  edge_feather_fraction: number;
+  minimum_corrected_samples: number;
+  minimum_connected_pixels: number;
+}
+
+export interface ResidualFlatDiagnostics {
+  algorithm_version: number;
+  sample_count: number;
+  corrected_samples: number;
+  total_samples: number;
+  largest_connected_pixels: number;
+  minimum_response: number;
+  maximum_applied_gain: number;
+}
+
+export interface ResidualFlatJob {
+  schema_version: number;
+  correction_id: string;
+  database_id: string;
+  search_id: string;
+  source_job_id: string;
+  source_image_id: number;
+  filter_name: string;
+  state: ResidualFlatState;
+  phase: string;
+  total_work_units: number;
+  completed_work_units: number;
+  created_unix_seconds: number;
+  options: ResidualFlatOptions;
+  detector_region: ReferenceRegion | null;
+  sample_count: number;
+  dither_span_pixels: number | null;
+  required_dither_span_pixels: number | null;
+  diagnostics: ResidualFlatDiagnostics | null;
+  accepted_frames: number;
+  rejected_frames: number;
+  calibration: AppliedCalibration | null;
+  notes: string[];
+  error: string | null;
+}
+
 export interface StackInputImage {
   image_id: number;
   grading_status: number;

--- a/static/src/components/StackPreviewInspector.tsx
+++ b/static/src/components/StackPreviewInspector.tsx
@@ -6,9 +6,14 @@ import type {
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { apiClient } from '../api/client';
-import type { ArtifactSearchJob, ArtifactSearchResult, ReferenceRegion } from '../api/types';
+import type {
+  ArtifactSearchJob,
+  ArtifactSearchResult,
+  ReferenceRegion,
+  ResidualFlatJob,
+} from '../api/types';
 import { useImageZoom } from '../hooks/useImageZoom';
-import { morphologyLabel } from './artifactMorphology';
+import { canBuildResidualFlat, morphologyLabel } from './artifactMorphology';
 import {
   artifactRegionFromPoints,
   MAX_ARTIFACT_REGION_EDGE,
@@ -46,9 +51,9 @@ interface StackPreviewInspectorProps {
   onClose: () => void;
 }
 
-const terminalSearchStates = new Set(['completed', 'failed']);
+const terminalJobStates = new Set(['completed', 'failed']);
 
-function searchProgress(job: ArtifactSearchJob): number {
+function jobProgress(job: Pick<ArtifactSearchJob | ResidualFlatJob, 'state' | 'total_work_units' | 'completed_work_units'>): number {
   if (job.state === 'completed') return 100;
   if (!job.total_work_units) return 0;
   return Math.min(100, Math.round((job.completed_work_units / job.total_work_units) * 100));
@@ -93,6 +98,8 @@ export default function StackPreviewInspector({
   const [region, setRegion] = useState<ReferenceRegion | null>(null);
   const [regionError, setRegionError] = useState<string | null>(null);
   const [searchId, setSearchId] = useState<string | null>(null);
+  const [correctionId, setCorrectionId] = useState<string | null>(null);
+  const [showCorrected, setShowCorrected] = useState(false);
   const zoom = useImageZoom({ minScale: 0.05, maxScale: 10 });
   useHotkeys('escape', () => {
     if (selecting) {
@@ -113,15 +120,14 @@ export default function StackPreviewInspector({
   }, [zoom.containerRef]);
 
   useEffect(() => {
-    setLoaded(false);
-    setError(false);
-    setDimensions(null);
     setSelecting(false);
     setDragStart(null);
     setDragEnd(null);
     setRegion(null);
     setRegionError(null);
     setSearchId(null);
+    setCorrectionId(null);
+    setShowCorrected(false);
   }, [imageUrl]);
 
   const startSearch = useMutation({
@@ -153,10 +159,65 @@ export default function StackPreviewInspector({
     initialData: searchId && startSearch.data?.search_id === searchId ? startSearch.data : undefined,
     refetchInterval: (query) => {
       const state = query.state.data?.state;
-      return state && terminalSearchStates.has(state) ? false : 500;
+      return state && terminalJobStates.has(state) ? false : 500;
     },
   });
   const activeSearch = searchId ? (search.data ?? startSearch.data) : undefined;
+
+  const startCorrection = useMutation({
+    mutationFn: async (imageId: number) => {
+      if (!artifactSource || artifactSource.kind !== 'mono' || !activeSearch) {
+        throw new Error('Dust correction requires one mono source stack');
+      }
+      return apiClient.startResidualFlat(
+        artifactSource.dbId,
+        activeSearch.search_id,
+        imageId
+      );
+    },
+    onSuccess: (job) => {
+      setCorrectionId(job.correction_id);
+      setShowCorrected(false);
+    },
+  });
+
+  const correction = useQuery({
+    queryKey: ['db', artifactSource?.dbId, 'stack-residual-flat', correctionId],
+    queryFn: () => apiClient.getResidualFlat(artifactSource!.dbId, correctionId!),
+    enabled: !!artifactSource && correctionId !== null,
+    initialData: correctionId && startCorrection.data?.correction_id === correctionId
+      ? startCorrection.data
+      : undefined,
+    refetchInterval: (query) => {
+      const state = query.state.data?.state;
+      return state && terminalJobStates.has(state) ? false : 500;
+    },
+  });
+  const activeCorrection = correctionId
+    ? (correction.data ?? startCorrection.data)
+    : undefined;
+  const correctedReady = activeCorrection?.state === 'completed' && !!artifactSource;
+  const activeImageUrl = correctedReady && showCorrected
+    ? apiClient.getResidualFlatPreviewUrl(
+      artifactSource.dbId,
+      activeCorrection.correction_id,
+      'original'
+    )
+    : imageUrl;
+  const activeFitsUrl = correctedReady && showCorrected
+    ? apiClient.getResidualFlatFitsUrl(artifactSource.dbId, activeCorrection.correction_id)
+    : fitsUrl;
+
+  useEffect(() => {
+    setLoaded(false);
+    setError(false);
+    setDimensions(null);
+    setSelecting(false);
+    setDragStart(null);
+    setDragEnd(null);
+    setRegion(null);
+    setRegionError(null);
+  }, [activeImageUrl]);
 
   const resultsByFilter = useMemo(() => {
     const groups = new Map<string, ArtifactSearchJob['results']>();
@@ -298,7 +359,7 @@ export default function StackPreviewInspector({
           <div>
             <div className="stack-preview-eyebrow">{eyebrow}</div>
             <h2 id="stack-inspector-title">
-              {title} <span>{label}</span>
+              {title} <span>{showCorrected ? `${label} · dust-corrected` : label}</span>
             </h2>
           </div>
           <div className="stack-inspector-summary">
@@ -342,7 +403,7 @@ export default function StackPreviewInspector({
             ) : (
               <img
                 ref={zoom.imageRef}
-                src={imageUrl}
+                src={activeImageUrl}
                 alt={imageAlt}
                 data-testid="stack-inspector-image"
                 draggable={false}
@@ -393,7 +454,7 @@ export default function StackPreviewInspector({
                     <strong>{activeSearch.completed_work_units} / {activeSearch.total_work_units}</strong>
                   </div>
                   <div className="stack-preview-progress-track">
-                    <span style={{ width: `${searchProgress(activeSearch)}%` }} />
+                    <span style={{ width: `${jobProgress(activeSearch)}%` }} />
                   </div>
                 </div>
               )}
@@ -440,6 +501,25 @@ export default function StackPreviewInspector({
                           {result.direction}
                         </p>
                         <ArtifactMorphologyBadge result={result} />
+                        {artifactSource
+                          && canBuildResidualFlat(result, artifactSource.kind)
+                          && (
+                            <button
+                              type="button"
+                              disabled={startCorrection.isPending}
+                              onClick={() => {
+                                setCorrectionId(null);
+                                setShowCorrected(false);
+                                startCorrection.reset();
+                                startCorrection.mutate(result.image_id);
+                              }}
+                            >
+                              {startCorrection.isPending
+                                && startCorrection.variables === result.image_id
+                                ? 'Starting correction…'
+                                : 'Build dust-corrected preview'}
+                            </button>
+                          )}
                         {onOpenImage && (
                           <button type="button" onClick={() => {
                             onOpenImage(result.image_id);
@@ -455,6 +535,80 @@ export default function StackPreviewInspector({
               ))}
               {activeSearch.state === 'completed' && activeSearch.results.length === 0 && (
                 <div className="stack-artifact-note">No source crops had enough common coverage.</div>
+              )}
+              {activeCorrection && (
+                <section className="stack-residual-flat" aria-label="Dust-correction preview">
+                  <header>
+                    <div>
+                      <div className="stack-preview-eyebrow">Experimental correction</div>
+                      <h4>Detector-space dust residual</h4>
+                    </div>
+                    <span>{activeCorrection.filter_name}</span>
+                  </header>
+                  {activeCorrection.state !== 'completed' && activeCorrection.state !== 'failed' && (
+                    <div className="stack-artifact-progress" role="status">
+                      <div>
+                        <span>{activeCorrection.phase}</span>
+                        <strong>
+                          {activeCorrection.completed_work_units} / {activeCorrection.total_work_units || '…'}
+                        </strong>
+                      </div>
+                      <div className="stack-preview-progress-track">
+                        <span style={{ width: `${jobProgress(activeCorrection)}%` }} />
+                      </div>
+                    </div>
+                  )}
+                  {activeCorrection.error && (
+                    <div className="stack-preview-message error">{activeCorrection.error}</div>
+                  )}
+                  {activeCorrection.notes.map((note) => (
+                    <div className="stack-artifact-note" key={note}>{note}</div>
+                  ))}
+                  {correctedReady && activeCorrection.diagnostics && artifactSource && (
+                    <>
+                      <img
+                        className="stack-residual-flat-response"
+                        src={apiClient.getResidualFlatResponseUrl(
+                          artifactSource.dbId,
+                          activeCorrection.correction_id
+                        )}
+                        alt="Estimated residual-flat response; dark areas receive correction"
+                      />
+                      <p>
+                        {activeCorrection.sample_count} frames ·{' '}
+                        {activeCorrection.dither_span_pixels?.toFixed(1)}px dither span ·{' '}
+                        {activeCorrection.diagnostics.maximum_applied_gain.toFixed(3)}× peak gain
+                      </p>
+                      <p>
+                        {((activeCorrection.diagnostics.corrected_samples
+                          / activeCorrection.diagnostics.total_samples) * 100).toFixed(2)}% of the patch corrected ·{' '}
+                        {activeCorrection.diagnostics.largest_connected_pixels} connected pixels ·{' '}
+                        {activeCorrection.accepted_frames} frames stacked
+                      </p>
+                      <div className="stack-residual-flat-actions">
+                        <button type="button" onClick={() => setShowCorrected((current) => !current)}>
+                          {showCorrected ? 'Show original stack' : 'Show corrected stack'}
+                        </button>
+                        <a
+                          href={apiClient.getResidualFlatFitsUrl(
+                            artifactSource.dbId,
+                            activeCorrection.correction_id
+                          )}
+                          download
+                        >
+                          Download corrected FITS
+                        </a>
+                      </div>
+                    </>
+                  )}
+                </section>
+              )}
+              {startCorrection.error && !activeCorrection && (
+                <div className="stack-preview-message error">
+                  {startCorrection.error instanceof Error
+                    ? startCorrection.error.message
+                    : 'Dust correction could not start'}
+                </div>
               )}
             </aside>
           )}
@@ -472,7 +626,7 @@ export default function StackPreviewInspector({
               <button
                 className={`stack-artifact-select ${selecting ? 'active' : ''}`}
                 type="button"
-                disabled={!loaded || !artifactEnabled || startSearch.isPending}
+                disabled={!loaded || !artifactEnabled || showCorrected || startSearch.isPending}
                 aria-pressed={selecting}
                 onClick={() => {
                   setSelecting((current) => !current);
@@ -487,7 +641,7 @@ export default function StackPreviewInspector({
                 <button
                   className="stack-artifact-search"
                   type="button"
-                  disabled={!artifactEnabled || startSearch.isPending}
+                  disabled={!artifactEnabled || showCorrected || startSearch.isPending}
                   onClick={() => {
                     setSearchId(null);
                     startSearch.reset();
@@ -504,7 +658,9 @@ export default function StackPreviewInspector({
               {startSearch.error instanceof Error ? startSearch.error.message : 'Search failed'}
             </span>
           )}
-          <a className="stack-preview-download" href={fitsUrl} download>{downloadLabel}</a>
+          <a className="stack-preview-download" href={activeFitsUrl} download>
+            {showCorrected ? 'Download corrected FITS' : downloadLabel}
+          </a>
           <div className="zoom-info-compact">
             <span className="zoom-percentage-compact">{zoom.getZoomPercentage()}%</span>
           </div>

--- a/static/src/components/__tests__/StackPreviewInspector.test.ts
+++ b/static/src/components/__tests__/StackPreviewInspector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ArtifactSearchResult } from '../../api/types';
-import { morphologyLabel } from '../artifactMorphology';
+import { canBuildResidualFlat, morphologyLabel } from '../artifactMorphology';
 import { artifactRegionFromPoints } from '../stackArtifactRegion';
 
 function result(
@@ -67,5 +67,14 @@ describe('morphologyLabel', () => {
 
   it('does not label low-evidence shape guesses', () => {
     expect(morphologyLabel(result('ring', 'low'))).toBeNull();
+  });
+
+  it('offers a residual flat only for a dark mono ring or broad shadow', () => {
+    expect(canBuildResidualFlat(result('ring'), 'mono')).toBe(true);
+    expect(canBuildResidualFlat(result('broad_dark', 'possible'), 'mono')).toBe(true);
+    expect(canBuildResidualFlat(result('ring'), 'color')).toBe(false);
+    expect(canBuildResidualFlat(result('ring', 'low'), 'mono')).toBe(false);
+    expect(canBuildResidualFlat({ ...result('ring'), direction: 'bright' }, 'mono')).toBe(false);
+    expect(canBuildResidualFlat(result('diffuse'), 'mono')).toBe(false);
   });
 });

--- a/static/src/components/artifactMorphology.ts
+++ b/static/src/components/artifactMorphology.ts
@@ -17,3 +17,13 @@ export function morphologyLabel(result: ArtifactSearchResult): string | null {
       return 'Unclassified change';
   }
 }
+
+export function canBuildResidualFlat(
+  result: ArtifactSearchResult,
+  sourceKind: 'mono' | 'color'
+): boolean {
+  return sourceKind === 'mono'
+    && result.evidence !== 'low'
+    && result.direction === 'dark'
+    && (result.morphology === 'ring' || result.morphology === 'broad_dark');
+}


### PR DESCRIPTION
## Summary

- offer an opt-in dust-corrected preview for a possible or strong dark ring or broad shadow found by the stack artifact search
- rebuild a separate linear stack after ordinary calibration, applying a bounded detector-space response patch before registration
- show response evidence, phase progress, dither span, connected area, peak gain, original/corrected comparison, and a corrected FITS download
- keep source FITS files, grades, calibration records, and the saved stack unchanged

This PR stacks on #281. It uses the residual-flat API merged in [Seiza #103](https://github.com/theatrus/seiza/pull/103), pinned to merged main commit `9ed1f5708a5cfe77567b2df5d32a5934c3031d2f` until that work ships in a release. Its correction cache key includes Seiza's residual-flat algorithm version.

## Evidence gates

The correction starts only from a completed single-stack search result with possible or strong dark ring/broad-shadow evidence. It then requires:

- at least five integrated inputs;
- at least three detector positions and enough robust dither span;
- a source and calibration fingerprint match;
- attenuation at least 0.5% deep in at least 70% of sampled inputs;
- at least 64 connected corrected detector pixels;
- a user-selected maximum gain, capped at 1.3 by the server and 1.2 by default.

Response estimation samples at most 64 evenly spaced inputs, including the selected source. An accepted patch is applied to every integrated input. Cached completion is reused only while every derived file still exists.

## Real-frame checks

- A visible C925 SII master-flat donut, repeated only as a kernel control, retained 35,020 of 360,000 samples at the 0.5% depth floor. Its lowest response was 0.9892, for a 1.011x peak correction.
- Fifteen C925 Bubble Nebula SII lights crossed the depth and consensus floors at 166 samples, but their largest connected region had only 23 pixels. The coherence gate rejected the patch.
- A separate 23-frame C925 Sh2 86 OIII sequence produced no accepted response samples in the checked region.

These runs test sensitivity and abstention. They do not claim that either light sequence contains a confirmed dust residual.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (501 passed, 5 ignored, plus all integration suites)
- `npm run lint`
- `npx vitest run src/components/__tests__/StackPreviewInspector.test.ts` (6 passed)
- `npm run build`
- `git diff --check`

After rebasing on merged Seiza #103:

- `cargo check --all-targets --all-features`
- `cargo test --all-features residual_flat` (7 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `npm run lint`
- `npx vitest run src/components/__tests__/StackPreviewInspector.test.ts` (6 passed)
- `npm run build`
- `git diff --check`

Seiza #103 passed its 82 `seiza-stacking` tests and strict clippy check before merge.
