### PR TITLE
Show quality analysis only when needed

### DIFF
--- a/docs/SCREENING.md
+++ b/docs/SCREENING.md
@@ -100,10 +100,12 @@ psf-guard screen-fits "/path/to/LIGHT" --regrade-db my-db-slug
 psf-guard move-rejects --db my-db-slug
 ```
 
-From the **web UI**: choose one target, then press **Analyze Quality** in either
-the Images grid or Sequence view. A project-wide grid keeps the action disabled
-until you choose a target, so the scan scope stays clear. The scan runs
-spatial/photometric screening and fresh plate solves in the background, then
+From the **web UI**: choose one target. **Analyze Quality** appears in the
+Images grid or Sequence view when that target/filter has new frames or cached
+results from an older quality model. It stays hidden when every frame is up to
+date. Use **Rescan All Quality** in Settings when you need to force a full
+rescan. The target scan runs spatial/photometric screening and fresh plate
+solves in the background, then
 refreshes the sequence scores. The fixed header status shows frame and solve
 progress while you move between views; Overview folds the work into its
 cross-database status. Results persist across restarts. The

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -747,6 +747,25 @@ pub struct SpatialScanRequest {
     pub force_satellites: bool,
 }
 
+/// Optional target/filter scope for the quality-scan status endpoint.
+#[derive(Debug, Deserialize, Default)]
+pub struct SpatialScanStatusQuery {
+    pub target_id: Option<i32>,
+    pub filter_name: Option<String>,
+}
+
+/// Cached pixel-quality work left in a target/filter scope.
+#[derive(Debug, Serialize)]
+pub struct QualityScanScopeStatus {
+    pub target_id: i32,
+    pub filter_name: Option<String>,
+    pub total_frames: usize,
+    pub pending_frames: usize,
+    pub new_frames: usize,
+    pub outdated_frames: usize,
+    pub needs_analysis: bool,
+}
+
 /// Status returned by both the scan-start and scan-progress endpoints.
 #[derive(Debug, Serialize)]
 pub struct SpatialScanStatusResponse {
@@ -756,6 +775,9 @@ pub struct SpatialScanStatusResponse {
     pub progress: crate::server::spatial_scan::SpatialScanProgress,
     /// Total number of images with cached spatial metrics in this database.
     pub cached_count: usize,
+    /// Work left in the requested target/filter scope. GET only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<QualityScanScopeStatus>,
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -4293,6 +4293,7 @@ async fn start_spatial_scan_with_priority(
             started: false,
             progress,
             cached_count,
+            scope: None,
         })));
     }
 
@@ -4308,6 +4309,7 @@ async fn start_spatial_scan_with_priority(
             started: false,
             progress,
             cached_count,
+            scope: None,
         })));
     }
 
@@ -4536,21 +4538,66 @@ async fn start_spatial_scan_with_priority(
         started: true,
         progress,
         cached_count,
+        scope: None,
     })))
 }
 
 /// GET /api/db/{db_id}/analysis/spatial-scan — progress + store size.
 pub async fn get_spatial_scan_progress(
     ctx: DbContext,
+    Query(query): Query<SpatialScanStatusQuery>,
 ) -> Result<Json<ApiResponse<SpatialScanStatusResponse>>, AppError> {
     use crate::server::spatial_scan as scan;
 
     scan::ensure_loaded(&ctx.spatial_metrics, &ctx.cache_dir_path);
+    let scope = if let Some(target_id) = query.target_id {
+        let images = {
+            let conn = ctx.db();
+            let conn = conn.lock().map_err(AppError::db)?;
+            Database::new(&conn)
+                .query_images_scoped(None, None, Some(target_id), None, 0)
+                .map_err(AppError::db)?
+        };
+        let mut total_frames = 0usize;
+        let mut new_frames = 0usize;
+        let mut outdated_frames = 0usize;
+        let store = ctx.spatial_metrics.read().unwrap();
+        for (image, _, _) in images.into_iter().filter(|(image, _, _)| {
+            query
+                .filter_name
+                .as_ref()
+                .is_none_or(|filter| image.filter_name == *filter)
+        }) {
+            let Some(filename) = filename_from_metadata(&image.metadata) else {
+                continue;
+            };
+            total_frames += 1;
+            match store.metrics.get(&image.id) {
+                Some(entry) if scan::quality_entry_is_current(entry, &filename) => {}
+                Some(entry) if entry.filename == filename => outdated_frames += 1,
+                _ => new_frames += 1,
+            }
+        }
+        drop(store);
+        let pending_frames = new_frames + outdated_frames;
+        Some(QualityScanScopeStatus {
+            target_id,
+            filter_name: query.filter_name,
+            total_frames,
+            pending_frames,
+            new_frames,
+            outdated_frames,
+            needs_analysis: pending_frames > 0,
+        })
+    } else {
+        None
+    };
     let (progress, cached_count) = scan::progress_snapshot(&ctx.spatial_metrics);
     Ok(Json(ApiResponse::success(SpatialScanStatusResponse {
         started: progress.running,
         progress,
         cached_count,
+        scope,
     })))
 }
 

--- a/src/server/spatial_scan.rs
+++ b/src/server/spatial_scan.rs
@@ -89,6 +89,7 @@ pub const STORED_CATALOG_STARS: usize = 300;
 /// fast detector. Rescans must use the same detector family so sequence
 /// baselines do not mix incompatible measurements.
 pub const QUALITY_DETECTOR: &str = "nina_fast";
+/// Bump when any cached pixel-quality input or measurement rule changes.
 pub const QUALITY_DETECTOR_VERSION: u32 = 1;
 
 /// Progress of the (singleton per-DB) spatial scan.
@@ -459,16 +460,20 @@ pub fn valid_quality_entry(
     image_id: i32,
     filename: &str,
 ) -> Option<StoredSpatialMetrics> {
-    valid_entry(store, image_id, filename).filter(|entry| {
-        let cells = entry.grid_cols.saturating_mul(entry.grid_rows);
-        entry.detector == QUALITY_DETECTOR
-            && entry.detector_version == QUALITY_DETECTOR_VERSION
-            && entry.width > 0
-            && entry.height > 0
-            && cells > 0
-            && entry.star_cell_counts.len() == cells
-            && entry.bg_cell_medians.len() == cells
-    })
+    valid_entry(store, image_id, filename).filter(|entry| quality_entry_is_current(entry, filename))
+}
+
+/// Whether a cached entry matches the source and current quality model.
+pub fn quality_entry_is_current(entry: &StoredSpatialMetrics, filename: &str) -> bool {
+    let cells = entry.grid_cols.saturating_mul(entry.grid_rows);
+    entry.filename == filename
+        && entry.detector == QUALITY_DETECTOR
+        && entry.detector_version == QUALITY_DETECTOR_VERSION
+        && entry.width > 0
+        && entry.height > 0
+        && cells > 0
+        && entry.star_cell_counts.len() == cells
+        && entry.bg_cell_medians.len() == cells
 }
 
 /// Snapshot of progress plus store size, for the progress endpoint.

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -672,7 +672,7 @@ test('Grid starts target quality analysis and keeps progress in the global heade
     error: null,
     status: 'ready',
   });
-  await page.route(`**/api/db/${dbId}/analysis/quality-scan`, async (route) => {
+  await page.route(`**/api/db/${dbId}/analysis/quality-scan*`, async (route) => {
     if (route.request().method() === 'POST') {
       posted = route.request().postDataJSON();
       running = true;
@@ -681,6 +681,24 @@ test('Grid starts target quality analysis and keeps progress in the global heade
     }
     if (running) {
       await route.fulfill({ json: runningStatus() });
+      return;
+    }
+    if (new URL(route.request().url()).searchParams.has('target_id')) {
+      const status = runningStatus();
+      status.data.started = false;
+      status.data.progress.running = false;
+      Object.assign(status.data, {
+        scope: {
+          target_id: 1,
+          filter_name: null,
+          total_frames: 3,
+          pending_frames: 1,
+          new_frames: 1,
+          outdated_frames: 0,
+          needs_analysis: true,
+        },
+      });
+      await route.fulfill({ json: status });
       return;
     }
     await route.continue();

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -642,6 +642,7 @@ test('All Projects loads scores without starting a quality scan', async ({
 test('Grid starts target quality analysis and keeps progress in the global header', async ({
   page,
 }) => {
+  await page.setViewportSize({ width: 420, height: 900 });
   let running = false;
   let posted: Record<string, unknown> | null = null;
   const runningStatus = () => ({
@@ -705,7 +706,18 @@ test('Grid starts target quality analysis and keeps progress in the global heade
   });
 
   await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1&target=1`);
-  await page.getByRole('button', { name: 'Analyze Quality' }).click();
+  const analyzeQuality = page.getByRole('button', { name: 'Analyze Quality' });
+  await expect(analyzeQuality).toHaveCSS('white-space', 'nowrap');
+  const buttonFitsToolbar = await analyzeQuality.evaluate((button) => {
+    const toolbar = button.closest('.toolbar-section');
+    if (!toolbar) return false;
+    const buttonBounds = button.getBoundingClientRect();
+    const toolbarBounds = toolbar.getBoundingClientRect();
+    return buttonBounds.left >= toolbarBounds.left
+      && buttonBounds.right <= toolbarBounds.right;
+  });
+  expect(buttonFitsToolbar).toBe(true);
+  await analyzeQuality.click();
 
   await expect.poll(() => posted).toMatchObject({ target_id: 1 });
   const globalStatus = page.locator('.header-cache-slot .quality-analysis-status');

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -2957,6 +2957,11 @@
   font-size: 0.8rem;
 }
 
+.quality-scan-button {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .compare-button.compact {
   padding: 0.3rem 0.6rem;
   font-size: 0.8rem;
@@ -2989,6 +2994,7 @@
   
   .toolbar-section {
     justify-content: space-between;
+    flex-wrap: wrap;
   }
   
   .controls-row-combined > .stats-section {

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -44,6 +44,7 @@ import type {
   ImageQualityResponse,
   SpatialScanRequest,
   SpatialScanStatus,
+  SpatialScanStatusRequest,
   QualityBackfillRequest,
   QualityBackfillStatus,
   PreviewDescriptor,
@@ -1146,10 +1147,14 @@ export const apiClient = {
     return data.data;
   },
 
-  getSpatialScanStatus: async (dbId: string): Promise<SpatialScanStatus> => {
+  getSpatialScanStatus: async (
+    dbId: string,
+    request?: SpatialScanStatusRequest
+  ): Promise<SpatialScanStatus> => {
     const apiInstance = await getApi();
     const { data } = await apiInstance.get<ApiResponse<SpatialScanStatus>>(
-      dbPath(dbId, '/analysis/quality-scan')
+      dbPath(dbId, '/analysis/quality-scan'),
+      { params: request }
     );
     if (!data.data) throw new Error('Failed to get spatial scan status');
     return data.data;

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1462,6 +1462,23 @@ export interface SpatialScanStatus {
   progress: SpatialScanProgress;
   /** Images with cached spatial metrics in this database. */
   cached_count: number;
+  /** Work left in a requested target/filter scope. GET only. */
+  scope?: QualityScanScopeStatus;
+}
+
+export interface QualityScanScopeStatus {
+  target_id: number;
+  filter_name: string | null;
+  total_frames: number;
+  pending_frames: number;
+  new_frames: number;
+  outdated_frames: number;
+  needs_analysis: boolean;
+}
+
+export interface SpatialScanStatusRequest {
+  target_id?: number;
+  filter_name?: string;
 }
 
 export interface SpatialScanRequest {

--- a/static/src/components/QualityScanControl.tsx
+++ b/static/src/components/QualityScanControl.tsx
@@ -15,15 +15,23 @@ export function QualityScanButton({
   canWrite,
   className,
 }: QualityScanButtonProps) {
-  let title = 'Analyze FITS pixels, then refresh sequence scores. Shift-click to recompute all cached evidence from the current catalogs.';
+  const scope = scan.scope;
+  if (targetId == null || !scope?.needs_analysis) {
+    return null;
+  }
+
+  const frameLabel = (count: number) => `${count} ${count === 1 ? 'frame' : 'frames'}`;
+  let title = scope.new_frames > 0 && scope.outdated_frames > 0
+    ? `Analyze ${frameLabel(scope.new_frames)} and update ${frameLabel(scope.outdated_frames)} for the current quality model.`
+    : scope.new_frames > 0
+      ? `Analyze ${frameLabel(scope.new_frames)} added since the last quality scan.`
+      : `Update ${frameLabel(scope.outdated_frames)} for the current quality model.`;
   if (scan.startError) {
     title = `Quality analysis did not start: ${scan.startError.message}`;
   } else if (scan.isRunning) {
     title = 'A quality scan is already running for this database.';
   } else if (!canWrite) {
     title = 'A read-only account cannot start quality analysis.';
-  } else if (targetId == null) {
-    title = 'Choose a target from the header before starting quality analysis.';
   }
 
   let label = 'Analyze Quality';
@@ -39,8 +47,8 @@ export function QualityScanButton({
     <button
       type="button"
       className={className}
-      onClick={(event) => scan.start(event.shiftKey || undefined)}
-      disabled={!canWrite || targetId == null || scan.isStarting || scan.isRunning}
+      onClick={() => scan.start(undefined)}
+      disabled={!canWrite || scan.isStarting || scan.isRunning}
       title={title}
     >
       {label}

--- a/static/src/components/__tests__/GroupedImageGrid.quality-scan.test.tsx
+++ b/static/src/components/__tests__/GroupedImageGrid.quality-scan.test.tsx
@@ -36,7 +36,11 @@ function wrapper(route: string) {
   };
 }
 
-function scanStatus(running: boolean) {
+function scanStatus(running: boolean, scope?: {
+  new_frames: number;
+  outdated_frames: number;
+  needs_analysis: boolean;
+}) {
   return {
     success: true,
     data: {
@@ -61,6 +65,15 @@ function scanStatus(running: boolean) {
         last_error: null,
       },
       cached_count: 0,
+      ...(scope ? {
+        scope: {
+          target_id: 42,
+          filter_name: 'R',
+          total_frames: 1,
+          pending_frames: scope.new_frames + scope.outdated_frames,
+          ...scope,
+        },
+      } : {}),
     },
     error: null,
     status: 'ready',
@@ -81,6 +94,14 @@ describe('GroupedImageGrid quality analysis', () => {
     let posted: unknown = null;
     server.use(
       http.get('/api/db/:dbId/images', () => HttpResponse.json(imagesResponse())),
+      http.get('/api/db/:dbId/analysis/quality-scan', ({ request }) => {
+        const scoped = new URL(request.url).searchParams.has('target_id');
+        return HttpResponse.json(scanStatus(false, scoped ? {
+          new_frames: 1,
+          outdated_frames: 0,
+          needs_analysis: true,
+        } : undefined));
+      }),
       http.post('/api/db/:dbId/analysis/quality-scan', async ({ request }) => {
         posted = await request.json();
         return HttpResponse.json(scanStatus(true));
@@ -92,6 +113,10 @@ describe('GroupedImageGrid quality analysis', () => {
     });
 
     const button = await screen.findByRole('button', { name: 'Analyze Quality' });
+    expect(button).toHaveAttribute(
+      'title',
+      'Analyze 1 frame added since the last quality scan.',
+    );
     await userEvent.click(button);
 
     await waitFor(() => {
@@ -100,7 +125,7 @@ describe('GroupedImageGrid quality analysis', () => {
     expect(await screen.findByRole('button', { name: 'Analysis running…' })).toBeDisabled();
   });
 
-  it('asks for a target before starting a project-wide grid scan', async () => {
+  it('does not offer target analysis for a project-wide grid', async () => {
     server.use(
       http.get('/api/db/:dbId/images', () => HttpResponse.json(imagesResponse())),
     );
@@ -109,11 +134,30 @@ describe('GroupedImageGrid quality analysis', () => {
       wrapper: wrapper('/grid?db=test&project=1'),
     });
 
-    const button = await screen.findByRole('button', { name: 'Analyze Quality' });
-    expect(button).toBeDisabled();
-    expect(button).toHaveAttribute(
-      'title',
-      'Choose a target from the header before starting quality analysis.',
+    await screen.findAllByText('Sh2 86');
+    expect(screen.queryByRole('button', { name: 'Analyze Quality' })).not.toBeInTheDocument();
+  });
+
+  it('hides analysis when every frame uses the current quality model', async () => {
+    server.use(
+      http.get('/api/db/:dbId/images', () => HttpResponse.json(imagesResponse())),
+      http.get('/api/db/:dbId/analysis/quality-scan', ({ request }) => {
+        const scoped = new URL(request.url).searchParams.has('target_id');
+        return HttpResponse.json(scanStatus(false, scoped ? {
+          new_frames: 0,
+          outdated_frames: 0,
+          needs_analysis: false,
+        } : undefined));
+      }),
     );
+
+    render(<GroupedImageGrid />, {
+      wrapper: wrapper('/grid?db=test&project=1&target=42&filter=R'),
+    });
+
+    await screen.findAllByText('Sh2 86');
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Analyze Quality' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -1084,6 +1084,41 @@ describe('SequenceView: batch operations', () => {
     setupDefaultHandlers();
     let scanRequests = 0;
     server.use(
+      http.get('/api/db/:dbId/analysis/quality-scan', ({ request }) => {
+        const scoped = new URL(request.url).searchParams.has('target_id');
+        return HttpResponse.json({
+          success: true,
+          data: {
+            started: false,
+            progress: {
+              running: false,
+              target_id: null,
+              filter_name: null,
+              total: 0,
+              processed: 0,
+              skipped_cached: 0,
+              errors: 0,
+              current_file: null,
+              last_error: null,
+              stage: 'idle',
+            },
+            cached_count: 0,
+            ...(scoped ? {
+              scope: {
+                target_id: 1,
+                filter_name: null,
+                total_frames: 2,
+                pending_frames: 1,
+                new_frames: 0,
+                outdated_frames: 1,
+                needs_analysis: true,
+              },
+            } : {}),
+          },
+          error: null,
+          status: 'ready',
+        });
+      }),
       http.post('/api/db/:dbId/analysis/quality-scan', () => {
         scanRequests += 1;
         return HttpResponse.json({
@@ -1114,6 +1149,10 @@ describe('SequenceView: batch operations', () => {
     render(<SequenceView />, { wrapper: createWrapper('/sequence?db=test&project=1&target=1') });
 
     const analyzeQuality = await screen.findByRole('button', { name: 'Analyze Quality' });
+    expect(analyzeQuality).toHaveAttribute(
+      'title',
+      'Update 1 frame for the current quality model.',
+    );
     expect(screen.queryByRole('button', { name: 'Re-analyze' })).not.toBeInTheDocument();
 
     await user.click(analyzeQuality);

--- a/static/src/hooks/__tests__/useSpatialScan.test.tsx
+++ b/static/src/hooks/__tests__/useSpatialScan.test.tsx
@@ -12,6 +12,15 @@ function scanStatus(overrides: {
   total?: number;
   processed?: number;
   cached_count?: number;
+  scope?: {
+    target_id: number;
+    filter_name: string | null;
+    total_frames: number;
+    pending_frames: number;
+    new_frames: number;
+    outdated_frames: number;
+    needs_analysis: boolean;
+  };
 }) {
   return {
     success: true,
@@ -31,6 +40,7 @@ function scanStatus(overrides: {
         last_error: null,
       },
       cached_count: overrides.cached_count ?? 0,
+      ...(overrides.scope ? { scope: overrides.scope } : {}),
     },
     error: null,
     status: 'ready',
@@ -66,6 +76,36 @@ describe('useSpatialScan', () => {
     expect(result.current.status?.cached_count).toBe(0);
   });
 
+  it('reports whether the selected target has quality work', async () => {
+    server.use(
+      http.get('/api/db/:dbId/analysis/quality-scan', ({ request }) => {
+        const params = new URL(request.url).searchParams;
+        if (!params.has('target_id')) {
+          return HttpResponse.json(scanStatus({}));
+        }
+        return HttpResponse.json(scanStatus({
+          scope: {
+            target_id: 42,
+            filter_name: 'R',
+            total_frames: 5,
+            pending_frames: 2,
+            new_frames: 1,
+            outdated_frames: 1,
+            needs_analysis: true,
+          },
+        }));
+      }),
+    );
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSpatialScan('test', 42, 'R'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.scope?.pending_frames).toBe(2);
+    });
+    expect(result.current.scope?.needs_analysis).toBe(true);
+  });
+
   it('start() posts the scan request and seeds running progress', async () => {
     let postedBody: unknown = null;
     server.use(
@@ -75,9 +115,22 @@ describe('useSpatialScan', () => {
           scanStatus({ started: true, running: true, total: 12, processed: 0 })
         );
       }),
-      http.get('/api/db/:dbId/analysis/quality-scan', () =>
-        HttpResponse.json(scanStatus({ running: true, total: 12, processed: 3 }))
-      )
+      http.get('/api/db/:dbId/analysis/quality-scan', ({ request }) => {
+        if (new URL(request.url).searchParams.has('target_id')) {
+          return HttpResponse.json(scanStatus({
+            scope: {
+              target_id: 42,
+              filter_name: 'R',
+              total_frames: 12,
+              pending_frames: 12,
+              new_frames: 12,
+              outdated_frames: 0,
+              needs_analysis: true,
+            },
+          }));
+        }
+        return HttpResponse.json(scanStatus({ running: true, total: 12, processed: 3 }));
+      })
     );
 
     const { wrapper } = createWrapper();
@@ -98,7 +151,20 @@ describe('useSpatialScan', () => {
     // First poll: running. Later polls: finished.
     let polls = 0;
     server.use(
-      http.get('/api/db/:dbId/analysis/quality-scan', () => {
+      http.get('/api/db/:dbId/analysis/quality-scan', ({ request }) => {
+        if (new URL(request.url).searchParams.has('target_id')) {
+          return HttpResponse.json(scanStatus({
+            scope: {
+              target_id: 1,
+              filter_name: null,
+              total_frames: 5,
+              pending_frames: 0,
+              new_frames: 0,
+              outdated_frames: 0,
+              needs_analysis: false,
+            },
+          }));
+        }
         polls += 1;
         return HttpResponse.json(
           scanStatus({ running: polls < 2, total: 5, processed: polls < 2 ? 2 : 5 })
@@ -128,6 +194,11 @@ describe('useSpatialScan', () => {
       expect(
         invalidated.some(
           (key) => Array.isArray(key) && key.includes('sequence-analysis')
+        )
+      ).toBe(true);
+      expect(
+        invalidated.some(
+          (key) => Array.isArray(key) && key.includes('quality-scan-scope')
         )
       ).toBe(true);
     });

--- a/static/src/hooks/useSpatialScan.ts
+++ b/static/src/hooks/useSpatialScan.ts
@@ -23,6 +23,7 @@ export function useSpatialScanStatus(dbId: string | null | undefined) {
     if (wasRunning.current && !isRunning) {
       queryClient.invalidateQueries({ queryKey: ['db', dbId, 'sequence-analysis'] });
       queryClient.invalidateQueries({ queryKey: ['db', dbId, 'image-quality'] });
+      queryClient.invalidateQueries({ queryKey: ['db', dbId, 'quality-scan-scope'] });
     }
     wasRunning.current = isRunning;
   }, [isRunning, dbId, queryClient]);
@@ -42,6 +43,14 @@ export function useSpatialScan(
 ) {
   const queryClient = useQueryClient();
   const status = useSpatialScanStatus(dbId);
+  const scopeQuery = useQuery<SpatialScanStatus>({
+    queryKey: ['db', dbId, 'quality-scan-scope', targetId, filterName ?? null],
+    queryFn: () => apiClient.getSpatialScanStatus(dbId!, {
+      target_id: targetId,
+      filter_name: filterName,
+    }),
+    enabled: !!dbId && targetId != null,
+  });
 
   const startMutation = useMutation({
     mutationFn: (force?: boolean) =>
@@ -56,6 +65,7 @@ export function useSpatialScan(
       if (!status.started && !status.progress.running) {
         // Nothing needed computing; metrics may still be newly relevant.
         queryClient.invalidateQueries({ queryKey: ['db', dbId, 'sequence-analysis'] });
+        queryClient.invalidateQueries({ queryKey: ['db', dbId, 'quality-scan-scope'] });
       }
     },
   });
@@ -65,5 +75,8 @@ export function useSpatialScan(
     start: startMutation.mutate,
     isStarting: startMutation.isPending,
     startError: startMutation.error,
+    scope: scopeQuery.data?.scope,
+    scopeError: scopeQuery.error,
+    isScopeLoading: scopeQuery.isLoading,
   };
 }

--- a/tests/integration_spatial_scan.rs
+++ b/tests/integration_spatial_scan.rs
@@ -186,6 +186,53 @@ async fn spatial_scan_progress_idle_by_default() {
     assert_eq!(json["data"]["started"], false);
     assert_eq!(json["data"]["progress"]["running"], false);
     assert_eq!(json["data"]["cached_count"], 0);
+    assert!(json["data"].get("scope").is_none());
+}
+
+#[tokio::test]
+async fn scoped_status_reports_new_and_outdated_quality_work() {
+    let conn = Connection::open_in_memory().unwrap();
+    create_test_schema(&conn);
+    seed_target_with_images(&conn, 3);
+    let tmp = tempfile::tempdir().unwrap();
+    let (app, state) = create_test_app(conn, tmp.path());
+
+    let uri = "/api/db/test/analysis/spatial-scan?target_id=1&filter_name=R";
+    let (status, json) = get_json(app.clone(), uri).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["data"]["scope"]["total_frames"], 3);
+    assert_eq!(json["data"]["scope"]["pending_frames"], 3);
+    assert_eq!(json["data"]["scope"]["new_frames"], 3);
+    assert_eq!(json["data"]["scope"]["outdated_frames"], 0);
+    assert_eq!(json["data"]["scope"]["needs_analysis"], true);
+
+    {
+        let ctx = state.get_database("test").unwrap();
+        let mut store = ctx.spatial_metrics.write().unwrap();
+        for i in 0..3i32 {
+            store.metrics.insert(
+                i + 1,
+                stored_entry(i + 1, &format!("frame_{i:04}.fits"), 0.02, 0.05),
+            );
+        }
+    }
+
+    let (_, json) = get_json(app.clone(), uri).await;
+    assert_eq!(json["data"]["scope"]["pending_frames"], 0);
+    assert_eq!(json["data"]["scope"]["needs_analysis"], false);
+
+    {
+        let ctx = state.get_database("test").unwrap();
+        let mut store = ctx.spatial_metrics.write().unwrap();
+        store.metrics.get_mut(&2).unwrap().detector_version =
+            psf_guard::server::spatial_scan::QUALITY_DETECTOR_VERSION.saturating_sub(1);
+    }
+
+    let (_, json) = get_json(app, uri).await;
+    assert_eq!(json["data"]["scope"]["pending_frames"], 1);
+    assert_eq!(json["data"]["scope"]["new_frames"], 0);
+    assert_eq!(json["data"]["scope"]["outdated_frames"], 1);
+    assert_eq!(json["data"]["scope"]["needs_analysis"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- report new and old-model quality work for a target/filter scope
- show **Analyze Quality** only when that scope needs work
- refresh the scoped state after a scan and explain why the action appeared
- document the conditional action and the forced rescan path

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (494 unit tests plus all integration suites)
- `npm run lint -- --quiet`
- `npm run build`
- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run --reporter=dot` (230 tests)
- `PSF_GUARD_E2E_BINARY=../target/debug/psf-guard npx playwright test e2e/navigation.spec.ts --grep "Grid starts target quality analysis"`
