### PR TITLE
Add automatic gradient correction to stack previews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,7 +4915,7 @@ dependencies = [
 [[package]]
 name = "seiza"
 version = "0.14.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "directories",
  "image",
@@ -4924,6 +4924,7 @@ dependencies = [
  "postcard",
  "rayon",
  "rustc-hash",
+ "seiza-calibration",
  "seiza-stats",
  "serde",
  "serde_json",
@@ -4935,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "seiza-background"
 version = "0.2.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -4944,9 +4945,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "seiza-calibration"
+version = "0.1.0"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+dependencies = [
+ "seiza-imgproc",
+ "seiza-stats",
+ "serde",
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "seiza-deconvolution"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "rayon",
  "serde",
@@ -4956,7 +4968,7 @@ dependencies = [
 [[package]]
 name = "seiza-download"
 version = "0.6.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "async-compression",
  "directories",
@@ -4974,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "seiza-fits"
 version = "0.2.1"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "multiversion",
  "seiza-stretch",
@@ -4983,8 +4995,8 @@ dependencies = [
 
 [[package]]
 name = "seiza-imgproc"
-version = "0.3.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+version = "0.3.1"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "rayon",
 ]
@@ -4992,7 +5004,7 @@ dependencies = [
 [[package]]
 name = "seiza-satellites"
 version = "0.4.4"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "directories",
  "fs2",
@@ -5010,10 +5022,11 @@ dependencies = [
 [[package]]
 name = "seiza-stacking"
 version = "0.2.2"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "rayon",
  "seiza",
+ "seiza-calibration",
  "seiza-fits",
  "seiza-imgproc",
  "seiza-stats",
@@ -5029,12 +5042,12 @@ dependencies = [
 [[package]]
 name = "seiza-stats"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 
 [[package]]
 name = "seiza-stretch"
 version = "0.2.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -5045,7 +5058,7 @@ dependencies = [
 [[package]]
 name = "seiza-xisf"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
+source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
 dependencies = [
  "flate2",
  "lz4_flex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4914,8 +4914,8 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.13.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+version = "0.14.0"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "directories",
  "image",
@@ -4934,8 +4934,8 @@ dependencies = [
 
 [[package]]
 name = "seiza-background"
-version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+version = "0.2.0"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "seiza-deconvolution"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "rayon",
  "serde",
@@ -4956,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "seiza-download"
 version = "0.6.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "async-compression",
  "directories",
@@ -4974,7 +4974,7 @@ dependencies = [
 [[package]]
 name = "seiza-fits"
 version = "0.2.1"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "multiversion",
  "seiza-stretch",
@@ -4984,15 +4984,15 @@ dependencies = [
 [[package]]
 name = "seiza-imgproc"
 version = "0.3.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "seiza-satellites"
-version = "0.4.3"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+version = "0.4.4"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "directories",
  "fs2",
@@ -5009,8 +5009,8 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.2.1"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+version = "0.2.2"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "rayon",
  "seiza",
@@ -5029,12 +5029,12 @@ dependencies = [
 [[package]]
 name = "seiza-stats"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 
 [[package]]
 name = "seiza-stretch"
 version = "0.2.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -5045,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "seiza-xisf"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=3c6d2ad96802051148d5b47608b9205a5fa0bf9a#3c6d2ad96802051148d5b47608b9205a5fa0bf9a"
+source = "git+https://github.com/theatrus/seiza.git?rev=2de60d856388e6dc954587a0ae9aa2046b0a38e5#2de60d856388e6dc954587a0ae9aa2046b0a38e5"
 dependencies = [
  "flate2",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = { git = "https://github.com/theatrus/seiza.git", rev = "3c6d2ad96802051148d5b47608b9205a5fa0bf9a", version = "0.13.0" }
-seiza-download = { git = "https://github.com/theatrus/seiza.git", rev = "3c6d2ad96802051148d5b47608b9205a5fa0bf9a", version = "0.6.0" }
-seiza-imgproc = { git = "https://github.com/theatrus/seiza.git", rev = "3c6d2ad96802051148d5b47608b9205a5fa0bf9a", version = "0.3.0", features = ["parallel"] }
-seiza-fits = { git = "https://github.com/theatrus/seiza.git", rev = "3c6d2ad96802051148d5b47608b9205a5fa0bf9a", version = "=0.2.1" }
-seiza-satellites = { git = "https://github.com/theatrus/seiza.git", rev = "3c6d2ad96802051148d5b47608b9205a5fa0bf9a", version = "0.4.2", features = ["serde"] }
-seiza-stacking = { git = "https://github.com/theatrus/seiza.git", rev = "3c6d2ad96802051148d5b47608b9205a5fa0bf9a", version = "0.2.1" }
-seiza-stretch = { git = "https://github.com/theatrus/seiza.git", rev = "3c6d2ad96802051148d5b47608b9205a5fa0bf9a", version = "0.2.0" }
-seiza-background = { git = "https://github.com/theatrus/seiza.git", rev = "3c6d2ad96802051148d5b47608b9205a5fa0bf9a", version = "0.1.0" }
-seiza-deconvolution = { git = "https://github.com/theatrus/seiza.git", rev = "3c6d2ad96802051148d5b47608b9205a5fa0bf9a", version = "0.1.0" }
+seiza = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.14.0" }
+seiza-download = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.6.0" }
+seiza-imgproc = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.3.0", features = ["parallel"] }
+seiza-fits = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "=0.2.1" }
+seiza-satellites = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.4.4", features = ["serde"] }
+seiza-stacking = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.2.2" }
+seiza-stretch = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.2.0" }
+seiza-background = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.2.0" }
+seiza-deconvolution = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.1.0" }
 sha2 = "0.11"
 base64 = "0.23"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.14.0" }
-seiza-download = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.6.0" }
-seiza-imgproc = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.3.0", features = ["parallel"] }
-seiza-fits = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "=0.2.1" }
-seiza-satellites = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.4.4", features = ["serde"] }
-seiza-stacking = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.2.2" }
-seiza-stretch = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.2.0" }
-seiza-background = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.2.0" }
-seiza-deconvolution = { git = "https://github.com/theatrus/seiza.git", rev = "2de60d856388e6dc954587a0ae9aa2046b0a38e5", version = "0.1.0" }
+seiza = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.14.0" }
+seiza-download = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.6.0" }
+seiza-imgproc = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.3.1", features = ["parallel"] }
+seiza-fits = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "=0.2.1" }
+seiza-satellites = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.4.4", features = ["serde"] }
+seiza-stacking = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.2.2" }
+seiza-stretch = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.2.0" }
+seiza-background = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.2.0" }
+seiza-deconvolution = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.1.0" }
 sha2 = "0.11"
 base64 = "0.23"
 rayon = "1"

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -248,15 +248,33 @@ linear channel independently. Background extraction is enabled for new UI
 builds and defaults to additive subtraction, which removes the fitted gradient
 while preserving that channel's robust sky reference level. Multiplicative
 division is available for vignetting-like fields, and extraction can be
-disabled when the source stacks are already corrected. After correction, each
+disabled when the source stacks are already corrected. A strength control can
+apply part of the fitted correction when a full pass is too strong.
+
+The default automatic model compares constant, linear, and quadratic surfaces
+on held-out samples, then picks the simplest model that earns a clear
+improvement. It does not consider a radial-basis surface by default. That model
+can follow smaller-scale variation, but costs more to apply and can mistake
+real extended emission for sky. Enable it only as an advanced option, or select
+a fixed polynomial or radial-basis model for manual control.
+
+When a channel stack has a fresh pixel-derived plate solve, PSF Guard protects
+large cataloged emission regions from background sampling. It uses closed
+catalog or curated contours when the object catalog supplies them, then falls
+back to the object's projected ellipse. Embedded FITS WCS alone does not enable
+this protection. Each channel uses its own stack reference frame. The manifest
+records the reference image, catalog version, object names, and normalized
+regions. These values also form part of the cache key, so a new solve or
+catalog projection cannot reuse a fit made with stale bounds. After correction,
+each
 non-reference stack is registered to R for RGB, L for LRGB, or H-alpha for
 narrowband, using the same bounded Seiza star/similarity registration used by
 the Seiza color CLI.
 
-The **Processing stack** editor exposes the background correction mode plus
-Seiza's polynomial degree, sample-grid density and radius, sample-search steps,
-sample and fit rejection thresholds, rejection passes, border exclusion, and
-ridge regularization. After registration it applies optional per-role
+The **Processing stack** editor exposes correction mode and strength, automatic
+or fixed surface selection, sample-grid density and radius, sample-search
+steps, sample and fit rejection thresholds, rejection passes, border exclusion,
+and model-specific controls. After registration it applies optional per-role
 deconvolution while each physical input is still linear, then robustly
 normalizes the result and applies that role's ordered stretch stages before
 composition. Deconvolution is independently opt-in for L/R/G/B or
@@ -279,9 +297,10 @@ the exact processed color result, records `COLORSPC`, `SEIZACLR`, and
 stack. The manifest retains the requested background configuration,
 per-channel deconvolution parameters and peak/flux diagnostics, and stage
 arrays, plus each resolved background model and Seiza stretch plan. The UI
-reports accepted/candidate sample counts and the resolved sample radius for
-every input role. The complete processing definition,
-resolved dependency versions, and source revisions are part of the job ID, so
+reports the chosen surface, accepted/candidate sample counts, resolved sample
+radius, protected-region count, and protected object names for every input
+role. The complete processing definition, resolved dependency versions, source
+revisions, and solver-derived protection are part of the job ID, so
 applying the same pipeline restores its prior artifact. Artifacts from before
 background extraction are rebuilt with the new additive default; a current
 artifact whose extraction was explicitly disabled keeps that choice.
@@ -439,7 +458,10 @@ endpoint returns the durable last-successful result for each target/channel.
 The color catalog reports role/palette availability and durable results. Its
 POST body is `{ "target_id": 42, "kind": "rgb", "force": false,
 "processing": { "background_extraction": { "correction_mode": "subtract",
-"config": { "model": { "kind": "polynomial", "degree": 2, "ridge": 1e-8 },
+"strength": 1.0, "config": { "model": { "kind": "automatic",
+"max_degree": 2, "ridge": 1e-8, "rbf_smoothing": 0.01,
+"max_control_points": 192, "allow_radial_basis": false,
+"minimum_improvement": 0.08 },
 "samples_per_axis": 12, "sample_radius": null, "search_steps": 4,
 "sample_rejection_sigma": 3.5, "fit_rejection_sigma": 3.0,
 "fit_rejection_iterations": 3, "border_fraction": 0.03 } },
@@ -452,7 +474,9 @@ POST body is `{ "target_id": 42, "kind": "rgb", "force": false,
 `{ "target_id": 42, "kind": "lrgb", "force": false }`, or
 `{ "target_id": 42, "kind": "narrowband", "palette": "foraxx-hoo",
 "force": false }`. Omitting `processing` retains the earlier linear quick-look
-behavior for API compatibility. Mono stretch POST bodies use Seiza's tagged model shape, for
+behavior for API compatibility. Clients cannot submit `protected_regions`;
+the server derives them from fresh plate-solve evidence. Mono stretch POST
+bodies use Seiza's tagged model shape, for
 example `{ "model": { "type": "percentile-asinh", "black_percentile":
 0.01, "white_percentile": 0.995, "strength": 8.0 }, "color_strategy":
 "luminance-preserving", "deconvolution": null }`. Replace `null` with the

--- a/src/sequence_analysis.rs
+++ b/src/sequence_analysis.rs
@@ -219,6 +219,30 @@ pub fn astrometry_metrics_from_analysis(
 fn cataloged_extended_emission(
     solution: &crate::astrometry::AstrometrySolutionResponse,
 ) -> Vec<CatalogedExtendedEmission> {
+    cataloged_extended_emission_objects(solution)
+        .into_iter()
+        .map(|object| CatalogedExtendedEmission {
+            name: if object.common_name.is_empty() {
+                object.name.clone()
+            } else {
+                object.common_name.clone()
+            },
+            kind: object.kind.clone(),
+            x: object.x,
+            y: object.y,
+            semi_major_px: object.semi_major_px,
+            semi_minor_px: object.semi_minor_px,
+            angle_deg: object.angle_deg,
+        })
+        .collect()
+}
+
+/// Return solved catalog objects large enough to affect a background model.
+/// Grading and stack correction share this filter so they protect the same
+/// real emission instead of making separate guesses.
+pub(crate) fn cataloged_extended_emission_objects(
+    solution: &crate::astrometry::AstrometrySolutionResponse,
+) -> Vec<&crate::astrometry::OverlayObjectResponse> {
     let width = f64::from(solution.image_width);
     let height = f64::from(solution.image_height);
     let short_axis = width.min(height);
@@ -249,19 +273,6 @@ fn cataloged_extended_emission(
                 && object.x - radius <= width
                 && object.y + radius >= 0.0
                 && object.y - radius <= height
-        })
-        .map(|object| CatalogedExtendedEmission {
-            name: if object.common_name.is_empty() {
-                object.name.clone()
-            } else {
-                object.common_name.clone()
-            },
-            kind: object.kind.clone(),
-            x: object.x,
-            y: object.y,
-            semi_major_px: object.semi_major_px,
-            semi_minor_px: object.semi_minor_px,
-            angle_deg: object.angle_deg,
         })
         .collect()
 }

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -19,7 +19,7 @@ use axum::{
     Json,
 };
 use rayon::ThreadPoolBuilder;
-use seiza_background::{BackgroundConfig, BackgroundFit, CorrectionMode};
+use seiza_background::{BackgroundConfig, BackgroundFit, CorrectionMode, ProtectedRegion};
 use seiza_stacking::{
     combine_lrgb, combine_narrowband, combine_rgb, resample_to_reference, write_color_fits_f32,
     write_processed_image_fits_f32, ColorComposition, ColorNormalization, ColorOptions,
@@ -42,7 +42,7 @@ use crate::server::state::AppState;
 
 const STACK_COLOR_CACHE_VERSION: u32 = 7;
 const COLOR_INPUT_CACHE_VERSION: u32 = 3;
-const SEIZA_BACKGROUND_VERSION: &str = "0.1.0";
+const SEIZA_BACKGROUND_VERSION: &str = "0.2.0";
 const MAX_REGISTRATION_RMS_PIXELS: f64 = 2.0;
 const COLOR_BYTES_PER_PIXEL: u64 = 64;
 const COLOR_DECONVOLUTION_BYTES_PER_PIXEL: u64 = 40;
@@ -178,6 +178,13 @@ pub struct StackBackgroundExtraction {
     pub config: BackgroundConfig,
     #[serde(default)]
     pub correction_mode: CorrectionMode,
+    /// Fraction of the fitted correction applied to each channel.
+    #[serde(default = "full_background_strength")]
+    pub strength: f64,
+}
+
+const fn full_background_strength() -> f64 {
+    1.0
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -237,7 +244,20 @@ pub struct StackColorSource {
     pub artifact_revision: String,
     pub accepted_frames: usize,
     #[serde(default)]
+    pub reference_image_id: Option<i32>,
+    #[serde(default)]
     pub registration_transform: Option<seiza_stacking::SimilarityTransform>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StackBackgroundProtection {
+    pub reference_image_id: i32,
+    #[serde(default)]
+    pub catalog_version: Option<String>,
+    #[serde(default)]
+    pub object_names: Vec<String>,
+    #[serde(default)]
+    pub regions: Vec<ProtectedRegion>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -279,6 +299,10 @@ pub struct StackColorJob {
     pub resolved_output_stretches: Vec<serde_json::Value>,
     #[serde(default)]
     pub resolved_backgrounds: BTreeMap<StackColorRole, BackgroundFit>,
+    /// Fresh pixel-solve catalog regions used to keep real extended emission
+    /// out of the background samples. These are part of the cache identity.
+    #[serde(default)]
+    pub resolved_background_protection: BTreeMap<StackColorRole, StackBackgroundProtection>,
     pub preview_url: String,
     pub fits_url: String,
     pub error: Option<String>,
@@ -834,6 +858,22 @@ fn validate_request(request: &StackColorRequest) -> Result<(), AppError> {
                     composition_label(request.kind, request.palette)
                 )));
             }
+            if let Some(extraction) = &processing.background_extraction {
+                if !extraction.config.protected_regions.is_empty() {
+                    return Err(AppError::BadRequest(
+                        "Background protected regions come from fresh plate solves and cannot be supplied by the client"
+                            .into(),
+                    ));
+                }
+                if !extraction.strength.is_finite() || !(0.0..=1.0).contains(&extraction.strength) {
+                    return Err(AppError::BadRequest(
+                        "Background correction strength must be between 0 and 1".into(),
+                    ));
+                }
+                extraction.config.validate().map_err(|error| {
+                    AppError::BadRequest(format!("Invalid background settings: {error}"))
+                })?;
+            }
             if let Some(error) = processing
                 .input_deconvolutions
                 .values()
@@ -908,12 +948,28 @@ fn prepare_color_job(
         }
     }
 
+    let resolved_background_protection = if request
+        .processing
+        .as_ref()
+        .is_some_and(|processing| processing.background_extraction.is_some())
+    {
+        resolve_background_protection(ctx, &sources)
+    } else {
+        BTreeMap::new()
+    };
     let label = composition_label(request.kind, request.palette).to_string();
     let linear_input_id = request
         .processing
         .as_ref()
         .map(|processing| {
-            color_input_cache_id(&ctx.id, project_id, request.target_id, processing, &sources)
+            color_input_cache_id(
+                &ctx.id,
+                project_id,
+                request.target_id,
+                processing,
+                &sources,
+                &resolved_background_protection,
+            )
         })
         .transpose()?;
     let mut hasher = Sha256::new();
@@ -936,6 +992,11 @@ fn prepare_color_job(
             "Failed to encode color processing options: {error}"
         ))
     })?);
+    hasher.update(
+        serde_json::to_vec(&resolved_background_protection).map_err(|error| {
+            AppError::InternalError(format!("Failed to encode background protection: {error}"))
+        })?,
+    );
     for source in &sources {
         hasher.update([source.role as u8]);
         hasher.update(source.filter_name.as_bytes());
@@ -984,6 +1045,7 @@ fn prepare_color_job(
             resolved_input_deconvolutions: BTreeMap::new(),
             resolved_output_stretches: Vec::new(),
             resolved_backgrounds: BTreeMap::new(),
+            resolved_background_protection,
             preview_url: format!(
                 "/api/db/{}/stack-previews/color/{job_id}/preview?v={artifact_revision}",
                 ctx.id
@@ -1006,6 +1068,7 @@ fn color_input_cache_id(
     target_id: i32,
     processing: &StackColorProcessing,
     sources: &[StackColorSource],
+    resolved_background_protection: &BTreeMap<StackColorRole, StackBackgroundProtection>,
 ) -> Result<String, AppError> {
     let mut hasher = Sha256::new();
     hasher.update(database_id.as_bytes());
@@ -1023,6 +1086,7 @@ fn color_input_cache_id(
         serde_json::to_vec(&(
             &processing.background_extraction,
             &processing.input_deconvolutions,
+            resolved_background_protection,
         ))
         .map_err(|error| {
             AppError::InternalError(format!("Failed to encode color input processing: {error}"))
@@ -1040,6 +1104,97 @@ fn color_input_cache_id(
         write!(&mut id, "{byte:02x}").expect("writing to a String cannot fail");
     }
     Ok(id)
+}
+
+fn resolve_background_protection(
+    ctx: &crate::server::database_context::DatabaseContext,
+    sources: &[StackColorSource],
+) -> BTreeMap<StackColorRole, StackBackgroundProtection> {
+    sources
+        .iter()
+        .filter_map(|source| {
+            let reference_image_id = source.reference_image_id?;
+            let analysis = ctx.astrometry_evidence.evidence_for_source(
+                &ctx.cache_dir_path,
+                reference_image_id,
+                None,
+            )?;
+            let solution = analysis.solution.as_ref()?;
+            let (regions, object_names) = background_regions_from_solution(solution);
+            Some((
+                source.role,
+                StackBackgroundProtection {
+                    reference_image_id,
+                    catalog_version: solution.catalog_version.clone(),
+                    object_names,
+                    regions,
+                },
+            ))
+        })
+        .collect()
+}
+
+fn background_regions_from_solution(
+    solution: &crate::astrometry::AstrometrySolutionResponse,
+) -> (Vec<ProtectedRegion>, Vec<String>) {
+    let width = solution.image_width as usize;
+    let height = solution.image_height as usize;
+    if width < 2 || height < 2 {
+        return (Vec::new(), Vec::new());
+    }
+
+    let mut regions = Vec::new();
+    let mut object_names = Vec::new();
+    for object in crate::sequence_analysis::cataloged_extended_emission_objects(solution) {
+        let before = regions.len();
+        for outline in &object.outlines {
+            if !matches!(outline.quality.as_str(), "catalog" | "curated") {
+                continue;
+            }
+            for contour in &outline.contours {
+                if contour.closed
+                    && let Ok(region) =
+                        ProtectedRegion::polygon_from_pixels(&contour.points, width, height)
+                {
+                    regions.push(region);
+                }
+            }
+        }
+        if regions.len() == before
+            && object.x.is_finite()
+            && object.y.is_finite()
+            && object.semi_major_px.is_finite()
+            && object.semi_minor_px.is_finite()
+            && object.semi_major_px > 0.0
+            && object.semi_minor_px > 0.0
+        {
+            let angle = object.angle_deg.unwrap_or(0.0).to_radians();
+            let points = (0..48)
+                .map(|index| {
+                    let phase = std::f64::consts::TAU * index as f64 / 48.0;
+                    let major = object.semi_major_px * phase.cos();
+                    let minor = object.semi_minor_px * phase.sin();
+                    [
+                        object.x + major * angle.cos() - minor * angle.sin(),
+                        object.y + major * angle.sin() + minor * angle.cos(),
+                    ]
+                })
+                .collect::<Vec<_>>();
+            if let Ok(region) = ProtectedRegion::polygon_from_pixels(&points, width, height) {
+                regions.push(region);
+            }
+        }
+        if regions.len() > before {
+            object_names.push(if object.common_name.is_empty() {
+                object.name.clone()
+            } else {
+                object.common_name.clone()
+            });
+        }
+    }
+    object_names.sort();
+    object_names.dedup();
+    (regions, object_names)
 }
 
 fn required_roles(
@@ -1368,12 +1523,18 @@ fn compose_color(
                     Some(source.role),
                     None,
                 );
+                let mut config = extraction.config.clone();
+                config.protected_regions = job
+                    .resolved_background_protection
+                    .get(&source.role)
+                    .map(|protection| protection.regions.clone())
+                    .unwrap_or_default();
                 let fit = seiza_background::fit_background(
                     &frame.image.data,
                     frame.image.width,
                     frame.image.height,
                     frame.image.channels,
-                    &extraction.config,
+                    &config,
                 )
                 .map_err(|error| {
                     format!("Failed to fit {} background: {error}", source.role.label())
@@ -1385,13 +1546,17 @@ fn compose_color(
                     Some(source.role),
                     None,
                 );
-                fit.correct_in_place(&mut frame.image.data, extraction.correction_mode)
-                    .map_err(|error| {
-                        format!(
-                            "Failed to correct {} background: {error}",
-                            source.role.label()
-                        )
-                    })?;
+                fit.correct_in_place_with_strength(
+                    &mut frame.image.data,
+                    extraction.correction_mode,
+                    extraction.strength,
+                )
+                .map_err(|error| {
+                    format!(
+                        "Failed to correct {} background: {error}",
+                        source.role.label()
+                    )
+                })?;
                 progress.advance(StackColorProgressPhase::BackgroundPreparation, 1);
                 state.stack_previews.update_color(&job.job_id, |current| {
                     current
@@ -2020,6 +2185,7 @@ fn collect_sources(
                 group_index: entry.group.index,
                 artifact_revision: entry.artifact_revision.clone(),
                 accepted_frames: entry.group.accepted_frames,
+                reference_image_id: entry.group.reference_image_id,
                 registration_transform: None,
             });
     }
@@ -2353,6 +2519,103 @@ mod tests {
         }
     }
 
+    fn background_solution(
+        outlines: Vec<crate::astrometry::OverlayOutlineResponse>,
+    ) -> crate::astrometry::AstrometrySolutionResponse {
+        use crate::astrometry::{
+            AstrometrySolutionResponse, CatalogObjectIdentity, OverlayObjectResponse, WcsResponse,
+        };
+        AstrometrySolutionResponse {
+            center_ra_deg: 0.0,
+            center_dec_deg: 0.0,
+            pixel_scale_arcsec_per_pixel: 1.0,
+            matched_stars: 30,
+            rms_arcsec: 0.5,
+            image_width: 101,
+            image_height: 101,
+            wcs: WcsResponse {
+                crval: [0.0, 0.0],
+                crpix: [50.0, 50.0],
+                cd: [[0.0, 0.0], [0.0, 0.0]],
+                ctype: ["RA---TAN".into(), "DEC--TAN".into()],
+                cunit: ["deg".into(), "deg".into()],
+                radesys: "ICRS".into(),
+                equinox: 2000.0,
+            },
+            footprint: Vec::new(),
+            objects: vec![OverlayObjectResponse {
+                identity: CatalogObjectIdentity::default(),
+                name: "NGC 1499".into(),
+                common_name: "California Nebula".into(),
+                kind: "nebula".into(),
+                mag: None,
+                x: 50.0,
+                y: 50.0,
+                semi_major_px: 30.0,
+                semi_minor_px: 18.0,
+                angle_deg: Some(12.0),
+                ra_deg: 0.0,
+                dec_deg: 0.0,
+                prominence: None,
+                discovered: None,
+                near_capture: None,
+                distance_au: None,
+                direction_pa_deg: None,
+                direction_angle_deg: None,
+                outlines,
+            }],
+            catalog_version: Some("openngc-test".into()),
+            capture_time: None,
+        }
+    }
+
+    #[test]
+    fn catalog_outline_is_preferred_for_background_protection() {
+        use crate::astrometry::{OverlayContourResponse, OverlayOutlineResponse};
+        let solution = background_solution(vec![OverlayOutlineResponse {
+            geometry_id: "outline".into(),
+            source_record_id: "ngc1499".into(),
+            role: "catalog-extent".into(),
+            quality: "catalog".into(),
+            level: None,
+            contours: vec![OverlayContourResponse {
+                closed: true,
+                points: vec![[10.0, 20.0], [90.0, 20.0], [50.0, 80.0]],
+            }],
+        }]);
+
+        let (regions, names) = background_regions_from_solution(&solution);
+
+        assert_eq!(names, ["California Nebula"]);
+        assert!(matches!(
+            regions.as_slice(),
+            [ProtectedRegion::Polygon { .. }]
+        ));
+    }
+
+    #[test]
+    fn estimated_outline_falls_back_to_projected_catalog_ellipse() {
+        use crate::astrometry::{OverlayContourResponse, OverlayOutlineResponse};
+        let solution = background_solution(vec![OverlayOutlineResponse {
+            geometry_id: "estimate".into(),
+            source_record_id: "ngc1499".into(),
+            role: "fallback-extent".into(),
+            quality: "estimated".into(),
+            level: None,
+            contours: vec![OverlayContourResponse {
+                closed: true,
+                points: vec![[10.0, 20.0], [90.0, 20.0], [50.0, 80.0]],
+            }],
+        }]);
+
+        let (regions, _) = background_regions_from_solution(&solution);
+
+        assert!(matches!(
+            regions.as_slice(),
+            [ProtectedRegion::Polygon { .. }]
+        ));
+    }
+
     #[test]
     fn recognizes_common_scheduler_filter_names_conservatively() {
         assert_eq!(
@@ -2514,11 +2777,43 @@ mod tests {
     }
 
     #[test]
+    fn rejects_client_background_regions_and_invalid_strength() {
+        let request = |extraction| StackColorRequest {
+            target_id: 1,
+            kind: StackColorKind::Rgb,
+            palette: None,
+            force: false,
+            processing: Some(StackColorProcessing {
+                background_extraction: Some(extraction),
+                ..StackColorProcessing::default()
+            }),
+        };
+        let mut invalid_strength = StackBackgroundExtraction {
+            config: BackgroundConfig::default(),
+            correction_mode: CorrectionMode::Subtract,
+            strength: 1.1,
+        };
+        assert!(validate_request(&request(invalid_strength.clone())).is_err());
+
+        invalid_strength.strength = 1.0;
+        invalid_strength
+            .config
+            .protected_regions
+            .push(ProtectedRegion::Ellipse {
+                center: [0.5, 0.5],
+                radii: [0.2, 0.1],
+                rotation_degrees: 0.0,
+            });
+        assert!(validate_request(&request(invalid_strength)).is_err());
+    }
+
+    #[test]
     fn progress_ledger_accounts_for_every_pipeline_phase() {
         let processing = StackColorProcessing {
             background_extraction: Some(StackBackgroundExtraction {
                 config: BackgroundConfig::default(),
                 correction_mode: CorrectionMode::Subtract,
+                strength: 1.0,
             }),
             input_deconvolutions: BTreeMap::from([(
                 StackColorRole::Red,
@@ -2606,6 +2901,7 @@ mod tests {
             group_index: 0,
             artifact_revision: format!("revision-{index}"),
             accepted_frames: 4,
+            reference_image_id: Some(index as i32 + 1),
             registration_transform: None,
         })
         .collect::<Vec<_>>();
@@ -2631,9 +2927,10 @@ mod tests {
                 }),
                 color_strategy: seiza_stretch::ColorStrategy::Linked,
             });
-        let first_id = color_input_cache_id("db", 2, 3, &first, &sources).unwrap();
+        let protection = BTreeMap::new();
+        let first_id = color_input_cache_id("db", 2, 3, &first, &sources, &protection).unwrap();
         let changed_stretch_id =
-            color_input_cache_id("db", 2, 3, &changed_stretch, &sources).unwrap();
+            color_input_cache_id("db", 2, 3, &changed_stretch, &sources, &protection).unwrap();
         let mut changed_linear = first;
         changed_linear
             .input_deconvolutions
@@ -2641,10 +2938,27 @@ mod tests {
             .unwrap()
             .amount = 0.5;
         let changed_linear_id =
-            color_input_cache_id("db", 2, 3, &changed_linear, &sources).unwrap();
+            color_input_cache_id("db", 2, 3, &changed_linear, &sources, &protection).unwrap();
+        let changed_protection = BTreeMap::from([(
+            StackColorRole::Red,
+            StackBackgroundProtection {
+                reference_image_id: 1,
+                catalog_version: Some("catalog-v2".into()),
+                object_names: vec!["California Nebula".into()],
+                regions: vec![ProtectedRegion::Ellipse {
+                    center: [0.5, 0.5],
+                    radii: [0.3, 0.2],
+                    rotation_degrees: 0.0,
+                }],
+            },
+        )]);
+        let changed_protection_id =
+            color_input_cache_id("db", 2, 3, &changed_stretch, &sources, &changed_protection)
+                .unwrap();
 
         assert_eq!(first_id, changed_stretch_id);
         assert_ne!(first_id, changed_linear_id);
+        assert_ne!(first_id, changed_protection_id);
     }
 
     #[test]

--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -529,8 +529,14 @@ test('composes cached channel stacks into RGB, LRGB, and selectable narrowband p
   await expect(backgroundControls.getByRole('checkbox', { name: 'Background extraction' }))
     .toBeChecked();
   await expect(backgroundControls.getByLabel('Background fit diagnostics')).toContainText('samples');
-  await backgroundControls.getByRole('spinbutton', { name: 'Background Polynomial degree' })
+  await expect(backgroundControls.getByRole('combobox', { name: 'Background surface model' }))
+    .toHaveValue('automatic');
+  await expect(backgroundControls.getByRole('checkbox', {
+    name: 'Allow radial-basis background model',
+  })).not.toBeChecked();
+  await backgroundControls.getByRole('spinbutton', { name: 'Background Maximum degree' })
     .fill('1');
+  await backgroundControls.getByRole('spinbutton', { name: 'Background Strength' }).fill('0.8');
   await expect(rgbProcessing.getByRole('region', { name: 'R input stretch stack' }))
     .toContainText('1 stage');
   await expect(rgbProcessing.getByRole('region', { name: 'G input stretch stack' }))

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -4143,6 +4143,12 @@
   margin-top: 0.5rem;
 }
 
+.stack-background-rbf-toggle input[type='checkbox'] {
+  width: 18px;
+  min-height: 18px;
+  justify-self: start;
+}
+
 .stack-background-diagnostics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -555,6 +555,7 @@ export interface StackColorSource {
   group_index: number;
   artifact_revision: string;
   accepted_frames: number;
+  reference_image_id: number | null;
   registration_transform: SimilarityTransform | null;
 }
 
@@ -566,7 +567,18 @@ export interface StackColorProcessing {
 }
 
 export interface StackBackgroundConfig {
-  model: { kind: 'polynomial'; degree: number; ridge: number };
+  model:
+    | {
+        kind: 'automatic';
+        max_degree: number;
+        ridge: number;
+        rbf_smoothing: number;
+        max_control_points: number;
+        allow_radial_basis: boolean;
+        minimum_improvement: number;
+      }
+    | { kind: 'polynomial'; degree: number; ridge: number }
+    | { kind: 'radial_basis'; smoothing: number; max_control_points: number };
   samples_per_axis: number;
   sample_radius: number | null;
   search_steps: number;
@@ -574,18 +586,28 @@ export interface StackBackgroundConfig {
   fit_rejection_sigma: number;
   fit_rejection_iterations: number;
   border_fraction: number;
+  /** The server derives these from fresh pixel solves. */
+  protected_regions?: never[];
 }
 
 export interface StackBackgroundExtraction {
   config: StackBackgroundConfig;
   correction_mode: 'subtract' | 'divide';
+  strength: number;
 }
 
 export interface StackBackgroundFit {
   width: number;
   height: number;
   channels: number;
-  model: { kind: 'polynomial'; degree: number; coefficients: number[][] };
+  model:
+    | { kind: 'polynomial'; degree: number; coefficients: number[][] }
+    | {
+        kind: 'radial_basis';
+        smoothing: number;
+        centers: number[][];
+        coefficients: number[][];
+      };
   reference: number[];
   samples: Array<{
     x: number;
@@ -602,7 +624,19 @@ export interface StackBackgroundFit {
     rejected_residual: number;
     rejection_iterations: number;
     sample_radius: number;
+    protected_regions: number;
+    model_selection?: {
+      selected: string;
+      candidates: Array<{ model: string; validation_error: number }>;
+    };
   };
+}
+
+export interface StackBackgroundProtection {
+  reference_image_id: number;
+  catalog_version: string | null;
+  object_names: string[];
+  regions: unknown[];
 }
 
 export type StackColorProgressState =
@@ -673,6 +707,7 @@ export interface StackColorJob {
   resolved_input_deconvolutions: Partial<Record<StackColorRole, StackDeconvolutionResult>>;
   resolved_output_stretches: unknown[];
   resolved_backgrounds: Partial<Record<StackColorRole, StackBackgroundFit>>;
+  resolved_background_protection: Partial<Record<StackColorRole, StackBackgroundProtection>>;
   preview_url: string;
   fits_url: string;
   error: string | null;

--- a/static/src/components/StackColorPreviewPanel.tsx
+++ b/static/src/components/StackColorPreviewPanel.tsx
@@ -301,6 +301,7 @@ function ColorCard({
         roles={requiredRoles(kind, palette)}
         applied={artifact?.processing ?? null}
         backgrounds={artifact?.resolved_backgrounds ?? {}}
+        protections={artifact?.resolved_background_protection ?? {}}
         deconvolutions={artifact?.resolved_input_deconvolutions ?? {}}
         disabled={!canCompute || busy || unavailable}
         onApply={onProcessingApply}

--- a/static/src/components/StackColorProcessingControls.tsx
+++ b/static/src/components/StackColorProcessingControls.tsx
@@ -3,6 +3,7 @@ import type {
   StackBackgroundConfig,
   StackBackgroundExtraction,
   StackBackgroundFit,
+  StackBackgroundProtection,
   StackColorProcessing,
   StackColorRole,
   StackDeconvolutionResult,
@@ -13,6 +14,7 @@ import { validateDeconvolution } from './stackDeconvolution';
 import StackStretchStageEditor from './StackStretchStageEditor';
 import { defaultStretchRequest, stretchModelLabels } from './stackStretchModels';
 import {
+  defaultBackgroundModel,
   defaultBackgroundExtraction,
   defaultColorProcessing,
 } from './stackColorProcessing';
@@ -20,6 +22,16 @@ import {
 const roleLabels: Record<StackColorRole, string> = {
   luminance: 'L', red: 'R', green: 'G', blue: 'B', ha: 'Hα', oiii: 'OIII', sii: 'SII',
 };
+
+type AutomaticBackgroundModel = Extract<
+  StackBackgroundConfig['model'], { kind: 'automatic' }
+>;
+type PolynomialBackgroundModel = Extract<
+  StackBackgroundConfig['model'], { kind: 'polynomial' }
+>;
+type RadialBasisBackgroundModel = Extract<
+  StackBackgroundConfig['model'], { kind: 'radial_basis' }
+>;
 
 function cloneProcessing(processing: StackColorProcessing): StackColorProcessing {
   return JSON.parse(JSON.stringify(processing)) as StackColorProcessing;
@@ -40,11 +52,33 @@ function hasInvalidNumbers(processing: StackColorProcessing): boolean {
 function validateBackground(extraction: StackBackgroundExtraction | null): string | null {
   if (!extraction) return null;
   const { config } = extraction;
-  if (!Number.isInteger(config.model.degree) || config.model.degree < 0 || config.model.degree > 4) {
-    return 'Background polynomial degree must be an integer from 0 to 4';
+  if (!Number.isFinite(extraction.strength) || extraction.strength < 0 || extraction.strength > 1) {
+    return 'Background correction strength must be between 0 and 1';
   }
-  if (!Number.isFinite(config.model.ridge) || config.model.ridge < 0) {
-    return 'Background ridge must be finite and non-negative';
+  if (config.model.kind === 'polynomial') {
+    if (!Number.isInteger(config.model.degree) || config.model.degree < 0 || config.model.degree > 4) {
+      return 'Background polynomial degree must be an integer from 0 to 4';
+    }
+    if (!Number.isFinite(config.model.ridge) || config.model.ridge < 0) {
+      return 'Background ridge must be finite and non-negative';
+    }
+  } else if (config.model.kind === 'radial_basis') {
+    if (!Number.isFinite(config.model.smoothing) || config.model.smoothing < 0 ||
+        !Number.isInteger(config.model.max_control_points) ||
+        config.model.max_control_points < 16 || config.model.max_control_points > 512) {
+      return 'Radial-basis smoothing must be non-negative and control points must be 16 to 512';
+    }
+  } else {
+    if (!Number.isInteger(config.model.max_degree) ||
+        config.model.max_degree < 0 || config.model.max_degree > 4 ||
+        !Number.isFinite(config.model.ridge) || config.model.ridge < 0 ||
+        !Number.isFinite(config.model.rbf_smoothing) || config.model.rbf_smoothing < 0 ||
+        !Number.isInteger(config.model.max_control_points) ||
+        config.model.max_control_points < 16 || config.model.max_control_points > 512 ||
+        !Number.isFinite(config.model.minimum_improvement) ||
+        config.model.minimum_improvement < 0 || config.model.minimum_improvement > 0.75) {
+      return 'Automatic background model settings are outside their supported ranges';
+    }
   }
   if (!Number.isInteger(config.samples_per_axis) ||
       config.samples_per_axis < 3 || config.samples_per_axis > 512) {
@@ -105,10 +139,11 @@ function BackgroundNumberField({
 }
 
 function BackgroundControls({
-  extraction, backgrounds, disabled, onChange,
+  extraction, backgrounds, protections, disabled, onChange,
 }: {
   extraction: StackBackgroundExtraction | null;
   backgrounds: Partial<Record<StackColorRole, StackBackgroundFit>>;
+  protections: Partial<Record<StackColorRole, StackBackgroundProtection>>;
   disabled: boolean;
   onChange: (extraction: StackBackgroundExtraction | null) => void;
 }) {
@@ -116,9 +151,24 @@ function BackgroundControls({
     if (!extraction) return;
     onChange({ ...extraction, config: { ...extraction.config, ...change } });
   };
-  const updateModel = (change: Partial<StackBackgroundConfig['model']>) => {
+  const updateModel = (model: StackBackgroundConfig['model']) => {
     if (!extraction) return;
-    updateConfig({ model: { ...extraction.config.model, ...change } });
+    updateConfig({ model });
+  };
+  const selectModel = (kind: StackBackgroundConfig['model']['kind']) => {
+    updateModel(defaultBackgroundModel(kind));
+  };
+  const updateAutomaticModel = (change: Partial<AutomaticBackgroundModel>) => {
+    const model = extraction?.config.model;
+    if (model?.kind === 'automatic') updateModel({ ...model, ...change });
+  };
+  const updatePolynomialModel = (change: Partial<PolynomialBackgroundModel>) => {
+    const model = extraction?.config.model;
+    if (model?.kind === 'polynomial') updateModel({ ...model, ...change });
+  };
+  const updateRadialBasisModel = (change: Partial<RadialBasisBackgroundModel>) => {
+    const model = extraction?.config.model;
+    if (model?.kind === 'radial_basis') updateModel({ ...model, ...change });
   };
   const fits = Object.entries(backgrounds) as Array<[StackColorRole, StackBackgroundFit]>;
 
@@ -159,9 +209,82 @@ function BackgroundControls({
               <option value="divide">Divide</option>
             </select>
           </label>
-          <BackgroundNumberField label="Polynomial degree" value={extraction.config.model.degree}
-            min={0} max={4} step={1} disabled={disabled}
-            onChange={(degree) => updateModel({ degree: degree ?? 0 })} />
+          <BackgroundNumberField label="Strength" value={extraction.strength}
+            min={0} max={1} step={0.05} disabled={disabled}
+            onChange={(strength) => onChange({ ...extraction, strength: strength ?? 0 })} />
+          <label className="stack-stretch-field">
+            <span>Surface model</span>
+            <select
+              aria-label="Background surface model"
+              value={extraction.config.model.kind}
+              disabled={disabled}
+              onChange={(event) => selectModel(
+                event.target.value as StackBackgroundConfig['model']['kind']
+              )}
+            >
+              <option value="automatic">Automatic</option>
+              <option value="polynomial">Polynomial</option>
+              <option value="radial_basis">Radial basis (advanced)</option>
+            </select>
+          </label>
+          {extraction.config.model.kind === 'automatic' && (
+            <>
+              <BackgroundNumberField label="Maximum degree"
+                value={extraction.config.model.max_degree}
+                min={0} max={4} step={1} disabled={disabled}
+                onChange={(max_degree) => updateAutomaticModel({ max_degree: max_degree ?? 0 })} />
+              <BackgroundNumberField label="Minimum improvement"
+                value={extraction.config.model.minimum_improvement}
+                min={0} max={0.75} step={0.01} disabled={disabled}
+                onChange={(minimum_improvement) => updateAutomaticModel({
+                  minimum_improvement: minimum_improvement ?? 0,
+                })} />
+              <label className="stack-stretch-field stack-background-rbf-toggle">
+                <span>Flexible surface</span>
+                <input type="checkbox" aria-label="Allow radial-basis background model"
+                  checked={extraction.config.model.allow_radial_basis} disabled={disabled}
+                  onChange={(event) => updateAutomaticModel({
+                    allow_radial_basis: event.target.checked,
+                  })} />
+              </label>
+              {extraction.config.model.allow_radial_basis && (
+                <>
+                  <BackgroundNumberField label="RBF smoothing"
+                    value={extraction.config.model.rbf_smoothing}
+                    min={0} step="any" disabled={disabled}
+                    onChange={(rbf_smoothing) => updateAutomaticModel({
+                      rbf_smoothing: rbf_smoothing ?? 0,
+                    })} />
+                  <BackgroundNumberField label="RBF control points"
+                    value={extraction.config.model.max_control_points}
+                    min={16} max={512} step={1} disabled={disabled}
+                    onChange={(max_control_points) => updateAutomaticModel({
+                      max_control_points: max_control_points ?? 16,
+                    })} />
+                </>
+              )}
+            </>
+          )}
+          {extraction.config.model.kind === 'polynomial' && (
+            <BackgroundNumberField label="Polynomial degree"
+              value={extraction.config.model.degree}
+              min={0} max={4} step={1} disabled={disabled}
+              onChange={(degree) => updatePolynomialModel({ degree: degree ?? 0 })} />
+          )}
+          {extraction.config.model.kind === 'radial_basis' && (
+            <>
+              <BackgroundNumberField label="RBF smoothing"
+                value={extraction.config.model.smoothing}
+                min={0} step="any" disabled={disabled}
+                onChange={(smoothing) => updateRadialBasisModel({ smoothing: smoothing ?? 0 })} />
+              <BackgroundNumberField label="RBF control points"
+                value={extraction.config.model.max_control_points}
+                min={16} max={512} step={1} disabled={disabled}
+                onChange={(max_control_points) => updateRadialBasisModel({
+                  max_control_points: max_control_points ?? 16,
+                })} />
+            </>
+          )}
           <BackgroundNumberField label="Samples per axis" value={extraction.config.samples_per_axis}
             min={3} max={512} step={1} disabled={disabled}
             onChange={(samples_per_axis) => updateConfig({ samples_per_axis: samples_per_axis ?? 3 })} />
@@ -190,10 +313,22 @@ function BackgroundControls({
           <BackgroundNumberField label="Border fraction" value={extraction.config.border_fraction}
             min={0} max={0.449} step={0.01} disabled={disabled}
             onChange={(border_fraction) => updateConfig({ border_fraction: border_fraction ?? 0 })} />
-          <BackgroundNumberField label="Ridge" value={extraction.config.model.ridge}
-            min={0} step="any" disabled={disabled}
-            onChange={(ridge) => updateModel({ ridge: ridge ?? 0 })} />
+          {extraction.config.model.kind !== 'radial_basis' && (
+            <BackgroundNumberField label="Ridge" value={extraction.config.model.ridge}
+              min={0} step="any" disabled={disabled}
+              onChange={(ridge) => extraction.config.model.kind === 'automatic'
+                ? updateAutomaticModel({ ridge: ridge ?? 0 })
+                : updatePolynomialModel({ ridge: ridge ?? 0 })} />
+          )}
         </div>
+      )}
+      {extraction && (extraction.config.model.kind === 'radial_basis' ||
+        (extraction.config.model.kind === 'automatic' &&
+          extraction.config.model.allow_radial_basis)) && (
+        <p>
+          Radial-basis fitting is slower and can follow real nebulosity. Check the result against
+          the original stack.
+        </p>
       )}
       {fits.length > 0 && (
         <div className="stack-background-diagnostics" aria-label="Background fit diagnostics">
@@ -201,7 +336,16 @@ function BackgroundControls({
             <span key={role}>
               <strong>{roleLabels[role]}</strong>
               {fit.diagnostics.accepted_samples}/{fit.diagnostics.candidate_samples} samples
-              <small>radius {fit.diagnostics.sample_radius}</small>
+              <small>
+                {fit.diagnostics.model_selection?.selected ?? fit.model.kind}
+                {' · '}radius {fit.diagnostics.sample_radius}
+                {' · '}{fit.diagnostics.protected_regions ?? 0} protected
+              </small>
+              {!!protections[role]?.object_names.length && (
+                <small title={protections[role]?.object_names.join(', ')}>
+                  Protected: {protections[role]?.object_names.join(', ')}
+                </small>
+              )}
             </span>
           ))}
         </div>
@@ -292,12 +436,13 @@ function StageLane({
 }
 
 export default function StackColorProcessingControls({
-  label, roles, applied, backgrounds, deconvolutions, disabled, onApply,
+  label, roles, applied, backgrounds, protections, deconvolutions, disabled, onApply,
 }: {
   label: string;
   roles: StackColorRole[];
   applied: StackColorProcessing | null;
   backgrounds: Partial<Record<StackColorRole, StackBackgroundFit>>;
+  protections: Partial<Record<StackColorRole, StackBackgroundProtection>>;
   deconvolutions: Partial<Record<StackColorRole, StackDeconvolutionResult>>;
   disabled: boolean;
   onApply: (processing: StackColorProcessing) => void;
@@ -363,6 +508,7 @@ export default function StackColorProcessingControls({
         <BackgroundControls
           extraction={draft.background_extraction}
           backgrounds={backgrounds}
+          protections={protections}
           disabled={disabled}
           onChange={(background_extraction) => setDraft((current) => ({
             ...current, background_extraction,

--- a/static/src/components/__tests__/stackColorProcessing.test.ts
+++ b/static/src/components/__tests__/stackColorProcessing.test.ts
@@ -26,7 +26,12 @@ describe('stack color processing defaults', () => {
     expect(processing.output_stretches).toEqual([]);
     expect(processing.input_deconvolutions).toEqual({});
     expect(processing.background_extraction?.correction_mode).toBe('subtract');
-    expect(processing.background_extraction?.config.model.degree).toBe(2);
+    expect(processing.background_extraction?.strength).toBe(1);
+    expect(processing.background_extraction?.config.model).toMatchObject({
+      kind: 'automatic',
+      max_degree: 2,
+      allow_radial_basis: false,
+    });
   });
 
   it('does not alias stage objects between channel lanes', () => {
@@ -69,6 +74,18 @@ describe('stack color processing defaults', () => {
       cache_version: BACKGROUND_COLOR_CACHE_VERSION,
       processing: legacy as typeof processing,
     }, ['red', 'green', 'blue']).input_deconvolutions).toEqual({});
+  });
+
+  it('gives an older background request full correction strength', () => {
+    const processing = defaultColorProcessing(['red', 'green', 'blue']);
+    delete (processing.background_extraction as Partial<
+      NonNullable<typeof processing.background_extraction>
+    >).strength;
+
+    expect(processingForColorBuild({
+      cache_version: BACKGROUND_COLOR_CACHE_VERSION,
+      processing,
+    }, ['red', 'green', 'blue']).background_extraction?.strength).toBe(1);
   });
 
   it('uses conservative upstream defaults only after deconvolution is enabled', () => {

--- a/static/src/components/stackColorProcessing.ts
+++ b/static/src/components/stackColorProcessing.ts
@@ -1,4 +1,5 @@
 import type {
+  StackBackgroundConfig,
   StackBackgroundExtraction,
   StackColorJob,
   StackColorProcessing,
@@ -8,10 +9,26 @@ import { defaultStretchRequest } from './stackStretchModels';
 
 export const BACKGROUND_COLOR_CACHE_VERSION = 4;
 
+export function defaultBackgroundModel(
+  kind: StackBackgroundConfig['model']['kind'] = 'automatic'
+): StackBackgroundConfig['model'] {
+  if (kind === 'polynomial') return { kind, degree: 2, ridge: 1e-8 };
+  if (kind === 'radial_basis') return { kind, smoothing: 0.01, max_control_points: 192 };
+  return {
+    kind,
+    max_degree: 2,
+    ridge: 1e-8,
+    rbf_smoothing: 0.01,
+    max_control_points: 192,
+    allow_radial_basis: false,
+    minimum_improvement: 0.08,
+  };
+}
+
 export function defaultBackgroundExtraction(): StackBackgroundExtraction {
   return {
     config: {
-      model: { kind: 'polynomial', degree: 2, ridge: 1e-8 },
+      model: defaultBackgroundModel(),
       samples_per_axis: 12,
       sample_radius: null,
       search_steps: 4,
@@ -21,6 +38,7 @@ export function defaultBackgroundExtraction(): StackBackgroundExtraction {
       border_fraction: 0.03,
     },
     correction_mode: 'subtract',
+    strength: 1,
   };
 }
 
@@ -45,6 +63,12 @@ export function processingForColorBuild(
   const processing = artifact.processing ?? defaultColorProcessing(roles);
   return {
     ...processing,
+    background_extraction: processing.background_extraction
+      ? {
+          ...processing.background_extraction,
+          strength: processing.background_extraction.strength ?? 1,
+        }
+      : null,
     input_deconvolutions: processing.input_deconvolutions ?? {},
   };
 }


### PR DESCRIPTION
## Summary

- adopt Seiza's merged automatic polynomial and optional radial-basis background models
- add correction strength and model controls to color stack previews
- protect large cataloged emission from sampling with the fresh reference-frame solves added in #284
- record protection provenance and include it in both color and prepared-input cache keys
- show the selected model, sample counts, protected-region count, and protected object names in the UI

## Safety and cache behavior

Automatic mode considers polynomial models by default. Radial-basis fitting stays opt-in and the UI warns that it can follow real nebulosity.

PSF Guard accepts protected regions only from its fresh pixel-solve cache. It uses catalog or curated closed contours first, with a projected catalog ellipse as fallback. The client cannot submit regions. Each role records its reference image, catalog version, object names, and normalized regions. A changed solve or catalog projection creates a new cache identity.

## Seiza dependency

This PR pins merged Seiza main at `12b43ddc`. That commit includes gradient correction from #105, the calibration-core move from #104, and canonical sky orientation from #106. No PR-branch SHA remains.

## Validation

- `cargo check`
- `cargo fmt --all -- --check`
- `cargo test --quiet` (496 passed, 5 ignored, plus all integration suites)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm run lint`
- `npm run build`
- `NODE_OPTIONS=--localstorage-file=/tmp/psf-guard-vitest-storage npx vitest run` (231 passed)
- `npx playwright test e2e/stack-preview.spec.ts --grep "composes cached channel stacks"` (Chromium, 1 passed)
- `git diff origin/main...HEAD --check`

The plain full Vitest command on this local Node build exposes no `window.localStorage`; the same full suite passes with Node's local-storage file flag shown above. The focused test for this feature also passes without that flag.
