### PR TITLE
Fix sky-oriented background protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,9 +2776,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.14.0"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
 ]
@@ -3821,7 +3821,7 @@ checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.3",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -4098,15 +4098,6 @@ name = "quick-xml"
 version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4915,7 +4906,8 @@ dependencies = [
 [[package]]
 name = "seiza"
 version = "0.14.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796848f820f8b3a4d30bc6b3df976757f1371eb1cdc8f3ba74f82b32ae62463d"
 dependencies = [
  "directories",
  "image",
@@ -4936,7 +4928,8 @@ dependencies = [
 [[package]]
 name = "seiza-background"
 version = "0.2.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce27c654312993dceef01e654de2fdce5d3adeddbac19ea0c45c0b94a91b271b"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -4947,7 +4940,8 @@ dependencies = [
 [[package]]
 name = "seiza-calibration"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3efb42a2d6f61b63a95de257e1b8b30495b6347c466ed9bd5982df333d30d9"
 dependencies = [
  "seiza-imgproc",
  "seiza-stats",
@@ -4958,7 +4952,8 @@ dependencies = [
 [[package]]
 name = "seiza-deconvolution"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaceca0f83c0e33737d4180166c0a50ac0af4b17c3621f44346872f134871cd0"
 dependencies = [
  "rayon",
  "serde",
@@ -4968,7 +4963,8 @@ dependencies = [
 [[package]]
 name = "seiza-download"
 version = "0.6.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef1b97548079179df46c445b19056a4e0d9e332899b1980ba505ad479095ab0"
 dependencies = [
  "async-compression",
  "directories",
@@ -4986,7 +4982,8 @@ dependencies = [
 [[package]]
 name = "seiza-fits"
 version = "0.2.1"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b956875bf6b87e92eb0aab29b9fe36ffb0575cbab0f802e386bbab0d88b022e"
 dependencies = [
  "multiversion",
  "seiza-stretch",
@@ -4996,7 +4993,8 @@ dependencies = [
 [[package]]
 name = "seiza-imgproc"
 version = "0.3.1"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7838c64e51a8b068a684c25cea2d5333b38d5945c236f89d836408596dea6f1e"
 dependencies = [
  "rayon",
 ]
@@ -5004,7 +5002,8 @@ dependencies = [
 [[package]]
 name = "seiza-satellites"
 version = "0.4.4"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2170d88df9e3486e2ba7b188d60304153163f1c467b50126b38a89f1328adef"
 dependencies = [
  "directories",
  "fs2",
@@ -5022,7 +5021,8 @@ dependencies = [
 [[package]]
 name = "seiza-stacking"
 version = "0.2.2"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef51340d179fa30ee7291bc3132579c3ef0b3d79891fa0745b1d7cc641047e"
 dependencies = [
  "rayon",
  "seiza",
@@ -5042,12 +5042,14 @@ dependencies = [
 [[package]]
 name = "seiza-stats"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02427eea0eebef160eba79502519b73272924ccea855462292006af2320ef9e2"
 
 [[package]]
 name = "seiza-stretch"
 version = "0.2.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e449c39ffe12c989a715479ce8e60990d0c9e8108d18d4f272a4631abbac27"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -5058,11 +5060,12 @@ dependencies = [
 [[package]]
 name = "seiza-xisf"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=12b43ddc6aa3e306399986041e231f63eafb1a57#12b43ddc6aa3e306399986041e231f63eafb1a57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c58629034c4197cf415a86ad91fc044dbf9f1ea892ec5617d611e530af990c"
 dependencies = [
  "flate2",
  "lz4_flex",
- "quick-xml 0.41.0",
+ "quick-xml",
  "seiza-fits",
  "sha1",
  "sha2 0.11.0",
@@ -5309,13 +5312,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.14.0" }
-seiza-download = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.6.0" }
-seiza-imgproc = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.3.1", features = ["parallel"] }
-seiza-fits = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "=0.2.1" }
-seiza-satellites = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.4.4", features = ["serde"] }
-seiza-stacking = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.2.2" }
-seiza-stretch = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.2.0" }
-seiza-background = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.2.0" }
-seiza-deconvolution = { git = "https://github.com/theatrus/seiza.git", rev = "12b43ddc6aa3e306399986041e231f63eafb1a57", version = "0.1.0" }
+seiza = "0.14.0"
+seiza-download = "0.6.0"
+seiza-imgproc = { version = "0.3.1", features = ["parallel"] }
+seiza-fits = "=0.2.1"
+seiza-satellites = { version = "0.4.4", features = ["serde"] }
+seiza-stacking = "0.2.2"
+seiza-stretch = "0.2.0"
+seiza-background = "0.2.0"
+seiza-deconvolution = "0.1.0"
 sha2 = "0.11"
 base64 = "0.23"
 rayon = "1"

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -262,11 +262,12 @@ When a channel stack has a fresh pixel-derived plate solve, PSF Guard protects
 large cataloged emission regions from background sampling. It uses closed
 catalog or curated contours when the object catalog supplies them, then falls
 back to the object's projected ellipse. Embedded FITS WCS alone does not enable
-this protection. Each channel uses its own stack reference frame. The manifest
-records the reference image, catalog version, object names, and normalized
-regions. These values also form part of the cache key, so a new solve or
-catalog projection cannot reuse a fit made with stale bounds. After correction,
-each
+this protection. Each channel uses its own stack reference frame, and PSF Guard
+maps its catalog bounds through the stack's saved sky-up transform before it
+fits the background. The manifest records the reference image, catalog version,
+object names, region count, and a geometry fingerprint. These values form part
+of the cache key and stale check, so a new solve or catalog projection cannot
+reuse or present a fit made with stale bounds. After correction, each
 non-reference stack is registered to R for RGB, L for LRGB, or H-alpha for
 narrowband, using the same bounded Seiza star/similarity registration used by
 the Seiza color CLI.

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -120,7 +120,7 @@ pub struct StackInputImage {
     pub grading_status: i32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StackSkyOrientation {
     pub convention: String,
     pub version: u32,

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -40,7 +40,7 @@ use crate::server::extract::DbContext;
 use crate::server::handlers::AppError;
 use crate::server::state::AppState;
 
-const STACK_COLOR_CACHE_VERSION: u32 = 7;
+const STACK_COLOR_CACHE_VERSION: u32 = 8;
 const COLOR_INPUT_CACHE_VERSION: u32 = 3;
 const SEIZA_BACKGROUND_VERSION: &str = "0.2.0";
 const MAX_REGISTRATION_RMS_PIXELS: f64 = 2.0;
@@ -246,6 +246,8 @@ pub struct StackColorSource {
     #[serde(default)]
     pub reference_image_id: Option<i32>,
     #[serde(default)]
+    pub sky_orientation: Option<super::StackSkyOrientation>,
+    #[serde(default)]
     pub registration_transform: Option<seiza_stacking::SimilarityTransform>,
 }
 
@@ -257,7 +259,15 @@ pub struct StackBackgroundProtection {
     #[serde(default)]
     pub object_names: Vec<String>,
     #[serde(default)]
-    pub regions: Vec<ProtectedRegion>,
+    pub region_count: usize,
+    #[serde(default)]
+    pub region_fingerprint: String,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedBackgroundProtection {
+    summary: StackBackgroundProtection,
+    regions: Vec<ProtectedRegion>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -369,6 +379,7 @@ struct TargetSources {
 struct PreparedColorJob {
     public: StackColorJob,
     cache_root: PathBuf,
+    background_regions: BTreeMap<StackColorRole, Vec<ProtectedRegion>>,
 }
 
 fn color_progress(
@@ -648,7 +659,7 @@ pub async fn get_stack_color_catalog(
     let targets = availability(&sources);
     let mut jobs = load_latest_colors(&ctx, project_id)?.jobs;
     for job in &mut jobs {
-        job.outdated_reason = color_job_outdated_reason(&ctx.cache_dir_path, job, &latest);
+        job.outdated_reason = color_job_outdated_reason(&ctx, job, &latest)?;
         job.outdated = job.outdated_reason.is_some();
     }
     jobs.sort_by(|left, right| {
@@ -953,10 +964,16 @@ fn prepare_color_job(
         .as_ref()
         .is_some_and(|processing| processing.background_extraction.is_some())
     {
-        resolve_background_protection(ctx, &sources)
+        resolve_background_protection(ctx, &sources)?
     } else {
         BTreeMap::new()
     };
+    let mut background_regions = BTreeMap::new();
+    let mut background_protection_summary = BTreeMap::new();
+    for (role, protection) in resolved_background_protection {
+        background_regions.insert(role, protection.regions);
+        background_protection_summary.insert(role, protection.summary);
+    }
     let label = composition_label(request.kind, request.palette).to_string();
     let linear_input_id = request
         .processing
@@ -968,7 +985,7 @@ fn prepare_color_job(
                 request.target_id,
                 processing,
                 &sources,
-                &resolved_background_protection,
+                &background_protection_summary,
             )
         })
         .transpose()?;
@@ -993,7 +1010,7 @@ fn prepare_color_job(
         ))
     })?);
     hasher.update(
-        serde_json::to_vec(&resolved_background_protection).map_err(|error| {
+        serde_json::to_vec(&background_protection_summary).map_err(|error| {
             AppError::InternalError(format!("Failed to encode background protection: {error}"))
         })?,
     );
@@ -1045,7 +1062,7 @@ fn prepare_color_job(
             resolved_input_deconvolutions: BTreeMap::new(),
             resolved_output_stretches: Vec::new(),
             resolved_backgrounds: BTreeMap::new(),
-            resolved_background_protection,
+            resolved_background_protection: background_protection_summary,
             preview_url: format!(
                 "/api/db/{}/stack-previews/color/{job_id}/preview?v={artifact_revision}",
                 ctx.id
@@ -1059,6 +1076,7 @@ fn prepare_color_job(
             outdated_reason: None,
         },
         cache_root: ctx.cache_dir_path.clone(),
+        background_regions,
     })
 }
 
@@ -1109,36 +1127,60 @@ fn color_input_cache_id(
 fn resolve_background_protection(
     ctx: &crate::server::database_context::DatabaseContext,
     sources: &[StackColorSource],
-) -> BTreeMap<StackColorRole, StackBackgroundProtection> {
-    sources
-        .iter()
-        .filter_map(|source| {
-            let reference_image_id = source.reference_image_id?;
-            let analysis = ctx.astrometry_evidence.evidence_for_source(
-                &ctx.cache_dir_path,
-                reference_image_id,
-                None,
-            )?;
-            let solution = analysis.solution.as_ref()?;
-            let (regions, object_names) = background_regions_from_solution(solution);
-            Some((
-                source.role,
-                StackBackgroundProtection {
+) -> Result<BTreeMap<StackColorRole, ResolvedBackgroundProtection>, AppError> {
+    let mut resolved = BTreeMap::new();
+    for source in sources {
+        let Some(reference_image_id) = source.reference_image_id else {
+            continue;
+        };
+        let Some(orientation) = source.sky_orientation.as_ref() else {
+            continue;
+        };
+        let Some(analysis) = ctx.astrometry_evidence.evidence_for_source(
+            &ctx.cache_dir_path,
+            reference_image_id,
+            None,
+        ) else {
+            continue;
+        };
+        let Some(solution) = analysis.solution.as_ref() else {
+            continue;
+        };
+        let (regions, object_names) = background_regions_from_solution(solution, orientation);
+        let bytes = serde_json::to_vec(&regions).map_err(|error| {
+            AppError::InternalError(format!(
+                "Failed to encode background-protection regions: {error}"
+            ))
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let mut region_fingerprint = String::with_capacity(64);
+        for byte in hasher.finalize() {
+            write!(&mut region_fingerprint, "{byte:02x}").expect("writing to a String cannot fail");
+        }
+        resolved.insert(
+            source.role,
+            ResolvedBackgroundProtection {
+                summary: StackBackgroundProtection {
                     reference_image_id,
                     catalog_version: solution.catalog_version.clone(),
                     object_names,
-                    regions,
+                    region_count: regions.len(),
+                    region_fingerprint,
                 },
-            ))
-        })
-        .collect()
+                regions,
+            },
+        );
+    }
+    Ok(resolved)
 }
 
 fn background_regions_from_solution(
     solution: &crate::astrometry::AstrometrySolutionResponse,
+    orientation: &super::StackSkyOrientation,
 ) -> (Vec<ProtectedRegion>, Vec<String>) {
-    let width = solution.image_width as usize;
-    let height = solution.image_height as usize;
+    let width = orientation.output_width;
+    let height = orientation.output_height;
     if width < 2 || height < 2 {
         return (Vec::new(), Vec::new());
     }
@@ -1152,11 +1194,19 @@ fn background_regions_from_solution(
                 continue;
             }
             for contour in &outline.contours {
-                if contour.closed
-                    && let Ok(region) =
-                        ProtectedRegion::polygon_from_pixels(&contour.points, width, height)
-                {
-                    regions.push(region);
+                if contour.closed {
+                    let points = contour
+                        .points
+                        .iter()
+                        .map(|point| {
+                            let (x, y) = orientation.source_to_output.apply(point[0], point[1]);
+                            [x, y]
+                        })
+                        .collect::<Vec<_>>();
+                    if let Ok(region) = ProtectedRegion::polygon_from_pixels(&points, width, height)
+                    {
+                        regions.push(region);
+                    }
                 }
             }
         }
@@ -1174,11 +1224,12 @@ fn background_regions_from_solution(
                     let phase = std::f64::consts::TAU * index as f64 / 48.0;
                     let major = object.semi_major_px * phase.cos();
                     let minor = object.semi_minor_px * phase.sin();
-                    [
+                    orientation.source_to_output.apply(
                         object.x + major * angle.cos() - minor * angle.sin(),
                         object.y + major * angle.sin() + minor * angle.cos(),
-                    ]
+                    )
                 })
+                .map(|(x, y)| [x, y])
                 .collect::<Vec<_>>();
             if let Ok(region) = ProtectedRegion::polygon_from_pixels(&points, width, height) {
                 regions.push(region);
@@ -1266,7 +1317,12 @@ fn run_color_job(state: &Arc<AppState>, prepared: PreparedColorJob) {
         job.phase = "Loading channel stacks".into();
     });
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        compose_color(state, &prepared.public, &prepared.cache_root)
+        compose_color(
+            state,
+            &prepared.public,
+            &prepared.background_regions,
+            &prepared.cache_root,
+        )
     }));
     let progress = ColorProgressTracker {
         state,
@@ -1350,6 +1406,7 @@ fn finish_color_job(job: &mut StackColorJob) {
 fn compose_color(
     state: &Arc<AppState>,
     job: &StackColorJob,
+    background_regions: &BTreeMap<StackColorRole, Vec<ProtectedRegion>>,
     cache_root: &FsPath,
 ) -> Result<(), String> {
     let progress = ColorProgressTracker {
@@ -1524,10 +1581,9 @@ fn compose_color(
                     None,
                 );
                 let mut config = extraction.config.clone();
-                config.protected_regions = job
-                    .resolved_background_protection
+                config.protected_regions = background_regions
                     .get(&source.role)
-                    .map(|protection| protection.regions.clone())
+                    .cloned()
                     .unwrap_or_default();
                 let fit = seiza_background::fit_background(
                     &frame.image.data,
@@ -2186,6 +2242,7 @@ fn collect_sources(
                 artifact_revision: entry.artifact_revision.clone(),
                 accepted_frames: entry.group.accepted_frames,
                 reference_image_id: entry.group.reference_image_id,
+                sky_orientation: entry.group.sky_orientation.clone(),
                 registration_transform: None,
             });
     }
@@ -2339,10 +2396,10 @@ fn color_artifacts_exist(cache_root: &FsPath, job_id: &str) -> bool {
 }
 
 fn color_job_outdated_reason(
-    cache_root: &FsPath,
+    ctx: &crate::server::database_context::DatabaseContext,
     job: &StackColorJob,
     latest: &LatestStackPreviews,
-) -> Option<String> {
+) -> Result<Option<String>, AppError> {
     if job.cache_version != STACK_COLOR_CACHE_VERSION
         || job.stacking_version != SEIZA_STACKING_VERSION
         || job.background_version != SEIZA_BACKGROUND_VERSION
@@ -2352,18 +2409,31 @@ fn color_job_outdated_reason(
             .is_some_and(|processing| !processing.input_deconvolutions.is_empty())
             && job.deconvolution_version != super::stretch::deconvolution_version())
     {
-        return Some("the color processing version changed".into());
+        return Ok(Some("the color processing version changed".into()));
     }
     if !job.sources.iter().all(|source| {
         source_is_current(source, latest)
-            && super::fits_path(cache_root, &source.job_id, source.group_index).is_file()
+            && super::fits_path(&ctx.cache_dir_path, &source.job_id, source.group_index).is_file()
     }) {
-        return Some("one or more source channel stacks changed".into());
+        return Ok(Some("one or more source channel stacks changed".into()));
     }
-    if !color_artifacts_exist(cache_root, &job.job_id) {
-        return Some("a cached color artifact is missing".into());
+    if job
+        .processing
+        .as_ref()
+        .is_some_and(|processing| processing.background_extraction.is_some())
+    {
+        let current = resolve_background_protection(ctx, &job.sources)?
+            .into_iter()
+            .map(|(role, protection)| (role, protection.summary))
+            .collect::<BTreeMap<_, _>>();
+        if current != job.resolved_background_protection {
+            return Ok(Some("the plate-solve background protection changed".into()));
+        }
     }
-    None
+    if !color_artifacts_exist(&ctx.cache_dir_path, &job.job_id) {
+        return Ok(Some("a cached color artifact is missing".into()));
+    }
+    Ok(None)
 }
 
 fn persist_color_manifest(cache_root: &FsPath, job: &StackColorJob) -> Result<(), String> {
@@ -2477,6 +2547,21 @@ mod tests {
         LatestStackPreviewGroup, StackGroupState, StackGroupStatus, StackSkyOrientation,
     };
 
+    fn stack_orientation(
+        output_width: usize,
+        output_height: usize,
+        source_to_output: seiza_stacking::AffineTransform,
+    ) -> StackSkyOrientation {
+        StackSkyOrientation {
+            convention: seiza_stacking::SKY_ORIENTATION_NAME.into(),
+            version: seiza_stacking::SKY_ORIENTATION_VERSION,
+            source: "embedded_wcs".into(),
+            output_width,
+            output_height,
+            source_to_output,
+        }
+    }
+
     fn source_group(filter_name: &str, index: usize) -> LatestStackPreviewGroup {
         LatestStackPreviewGroup {
             job_id: format!("{index:064x}"),
@@ -2499,14 +2584,11 @@ mod tests {
                 accepted_frames: 3,
                 rejected_frames: 0,
                 output_channels: 1,
-                sky_orientation: Some(StackSkyOrientation {
-                    convention: seiza_stacking::SKY_ORIENTATION_NAME.into(),
-                    version: seiza_stacking::SKY_ORIENTATION_VERSION,
-                    source: "embedded_wcs".into(),
-                    output_width: 100,
-                    output_height: 80,
-                    source_to_output: seiza_stacking::AffineTransform::IDENTITY,
-                }),
+                sky_orientation: Some(stack_orientation(
+                    100,
+                    80,
+                    seiza_stacking::AffineTransform::IDENTITY,
+                )),
                 reference_image_id: Some(1),
                 total_exposure_seconds: 180.0,
                 preview_url: None,
@@ -2584,13 +2666,46 @@ mod tests {
             }],
         }]);
 
-        let (regions, names) = background_regions_from_solution(&solution);
+        let orientation = stack_orientation(101, 101, seiza_stacking::AffineTransform::IDENTITY);
+        let (regions, names) = background_regions_from_solution(&solution, &orientation);
 
         assert_eq!(names, ["California Nebula"]);
         assert!(matches!(
             regions.as_slice(),
             [ProtectedRegion::Polygon { .. }]
         ));
+    }
+
+    #[test]
+    fn background_protection_follows_the_sky_orientation_transform() {
+        use crate::astrometry::{OverlayContourResponse, OverlayOutlineResponse};
+        let solution = background_solution(vec![OverlayOutlineResponse {
+            geometry_id: "outline".into(),
+            source_record_id: "ngc1499".into(),
+            role: "catalog-extent".into(),
+            quality: "catalog".into(),
+            level: None,
+            contours: vec![OverlayContourResponse {
+                closed: true,
+                points: vec![[10.0, 20.0], [90.0, 20.0], [50.0, 80.0]],
+            }],
+        }]);
+        let orientation = stack_orientation(
+            101,
+            101,
+            seiza_stacking::AffineTransform {
+                matrix: [[0.0, -1.0], [1.0, 0.0]],
+                translation_x: 100.0,
+                translation_y: 0.0,
+            },
+        );
+
+        let (regions, _) = background_regions_from_solution(&solution, &orientation);
+
+        let [ProtectedRegion::Polygon { points }] = regions.as_slice() else {
+            panic!("expected one transformed polygon");
+        };
+        assert_eq!(points, &[[0.8, 0.1], [0.8, 0.9], [0.2, 0.5]]);
     }
 
     #[test]
@@ -2608,7 +2723,8 @@ mod tests {
             }],
         }]);
 
-        let (regions, _) = background_regions_from_solution(&solution);
+        let orientation = stack_orientation(101, 101, seiza_stacking::AffineTransform::IDENTITY);
+        let (regions, _) = background_regions_from_solution(&solution, &orientation);
 
         assert!(matches!(
             regions.as_slice(),
@@ -2902,6 +3018,11 @@ mod tests {
             artifact_revision: format!("revision-{index}"),
             accepted_frames: 4,
             reference_image_id: Some(index as i32 + 1),
+            sky_orientation: Some(stack_orientation(
+                100,
+                80,
+                seiza_stacking::AffineTransform::IDENTITY,
+            )),
             registration_transform: None,
         })
         .collect::<Vec<_>>();
@@ -2945,11 +3066,8 @@ mod tests {
                 reference_image_id: 1,
                 catalog_version: Some("catalog-v2".into()),
                 object_names: vec!["California Nebula".into()],
-                regions: vec![ProtectedRegion::Ellipse {
-                    center: [0.5, 0.5],
-                    radii: [0.3, 0.2],
-                    rotation_degrees: 0.0,
-                }],
+                region_count: 1,
+                region_fingerprint: "changed-region".into(),
             },
         )]);
         let changed_protection_id =

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -556,6 +556,7 @@ export interface StackColorSource {
   artifact_revision: string;
   accepted_frames: number;
   reference_image_id: number | null;
+  sky_orientation: StackSkyOrientation | null;
   registration_transform: SimilarityTransform | null;
 }
 
@@ -636,7 +637,8 @@ export interface StackBackgroundProtection {
   reference_image_id: number;
   catalog_version: string | null;
   object_names: string[];
-  regions: unknown[];
+  region_count: number;
+  region_fingerprint: string;
 }
 
 export type StackColorProgressState =


### PR DESCRIPTION
## Summary

- map catalog protection regions through each stack's saved sky-up transform
- mark color previews stale when a fresh solve changes the protected geometry
- keep full protection polygons inside the worker and store a compact count and fingerprint in manifests
- bump the color cache version so previews built with the old coordinates rebuild
- use the published Seiza 0.14 crates instead of the temporary git revision

## Review findings fixed

1. PR #286 projected protected nebula bounds in the reference image's pixel grid, then applied them to a north-up stack. Rotated or flipped stacks could protect the wrong part of the image during background fitting.
2. A completed color preview stayed current in the catalog after a new plate solve or catalog projection changed its protected regions.
3. The API and saved manifest exposed every polygon point even though the UI only uses object names. Large catalog outlines could make catalog responses and manifests needlessly large.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`
- `cargo test -q server::stack_preview::color::tests`
- `npm run lint`
- `NODE_OPTIONS=--localstorage-file=/tmp/psf-guard-vitest-storage-review npx vitest run`
- `npm run build`
- `PSF_GUARD_E2E_PORT=13299 npx playwright test e2e/stack-preview.spec.ts --grep 'composes cached channel stacks'`
- `git diff --check`
