### PR TITLE
Keep the project when the Overview is in the way

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,9 @@ before the GitHub release fallback. See [docs/UPDATES.md](docs/UPDATES.md).
 - Open a source database read-only during sync. Refuse the same source and
   destination path. Preview every UI transfer before Apply.
 - The Overview merges databases, but Grid, Detail, Comparison, and Sequence
-  routes must keep the `db` slug in URL state.
+  routes must keep the `db` slug in URL state. The Overview carries the same
+  scope so it can mark where the user was and hand it back, so anything that
+  scopes to one database must read `useScopedDbId` and ignore the slug there.
 
 Design records: [multi-database](docs/design/multi-database.md),
 [data transfer](docs/design/data-transfer.md), and

--- a/static/README.md
+++ b/static/README.md
@@ -54,7 +54,9 @@ cargo run --release -- server catalog.sqlite /path/to/images \
 
 ## Features
 
-- **Catalog overview** across every configured database.
+- **Catalog overview** across every configured database. It keeps the scope of
+  the view you came from, so it marks and scrolls to the project you were
+  working in, and Images or Sequence takes you straight back to it.
 - **Grid and sequence review** with project, target, grade, filter, date,
   search, and grouping controls.
 - **Keyboard-first grading**: arrows or `J`/`K` navigate, `Space` toggles

--- a/static/e2e/navigation.spec.ts
+++ b/static/e2e/navigation.spec.ts
@@ -195,6 +195,27 @@ test('direct deep link to the grid loads when ?db= matches a configured DB', asy
   });
 });
 
+test('the Overview keeps the project scope and points back at it', async ({
+  page,
+}) => {
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+  await expect(page.locator('.image-card').first()).toBeVisible({ timeout: 15_000 });
+
+  await page.getByRole('button', { name: 'Overview', exact: true }).click();
+
+  // The project the user left is marked, and the scope stays in the URL.
+  const current = page.locator('[data-current-project="true"]');
+  await expect(current).toHaveCount(1);
+  await expect(current).toContainText('Project Alpha');
+  expect(page.url()).toContain(`db=${encodeURIComponent(dbId)}`);
+  expect(page.url()).toContain('project=1');
+
+  // Going back to Images returns to the same project rather than an empty view.
+  await page.getByRole('button', { name: 'Images', exact: true }).click();
+  expect(page.url()).toContain('project=1');
+  await expect(page.locator('.image-card').first()).toBeVisible({ timeout: 15_000 });
+});
+
 test('session grouping opens the newest time run and keeps its URL state intact', async ({
   page,
 }) => {

--- a/static/src/App.tsx
+++ b/static/src/App.tsx
@@ -10,7 +10,7 @@ import UpdateNotice from './components/UpdateNotice';
 import DatabaseActivityStatus from './components/DatabaseActivityStatus';
 import AggregatedCacheStatus from './components/AggregatedCacheStatus';
 import TauriSettings from './components/TauriSettings';
-import { useGridState } from './hooks/useUrlState';
+import { isOverviewPath, useGridState } from './hooks/useUrlState';
 import { isTauriApp, tauriConfig } from './utils/tauri';
 import {
   OPEN_SETTINGS_EVENT,
@@ -33,8 +33,10 @@ function AppContent() {
   });
 
   // Carry the active (db, project, target, filter…) query context when switching
-  // between scoped views, so navigation never drops the ?db= slug and strands
-  // the user on an empty view.
+  // between views, so navigation never drops the ?db= slug and strands the user
+  // on an empty view. The Overview keeps it too: it shows every database, but
+  // holding the scope lets it point at the project the user left and hand the
+  // same scope back to Images or Sequence.
   const toScoped = (path: string) =>
     location.search ? `${path}${location.search}` : path;
   const [showHelp, setShowHelp] = useState(false);
@@ -111,7 +113,7 @@ function AppContent() {
   // Keyboard shortcut for help
   useHotkeys('?', () => setShowHelp(true), []);
   
-  const isOnOverview = location.pathname === '/' || location.pathname === '/overview';
+  const isOnOverview = isOverviewPath(location.pathname);
   const isOnGrid = location.pathname === '/grid';
   const isOnSequence = location.pathname === '/sequence';
 
@@ -122,7 +124,7 @@ function AppContent() {
           <button
             type="button"
             className="brand-button"
-            onClick={() => navigate('/')}
+            onClick={() => navigate(toScoped('/'))}
             title="Go to Overview"
           >
             <img
@@ -149,7 +151,7 @@ function AppContent() {
         <nav className="header-view-tabs" aria-label="Views">
           <button
             type="button"
-            onClick={() => navigate('/')}
+            onClick={() => navigate(toScoped('/'))}
             className="header-button"
             aria-current={isOnOverview ? 'page' : undefined}
           >

--- a/static/src/components/CacheRefreshStatus.tsx
+++ b/static/src/components/CacheRefreshStatus.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import type { CacheRefreshProgress } from '../api/types';
-import { useDbProjectTarget } from '../hooks/useUrlState';
+import { useScopedDbId } from '../hooks/useUrlState';
 import './CacheRefreshStatus.css';
 
 interface CacheRefreshStatusProps {
@@ -21,7 +21,7 @@ const STAGE_LABELS: Record<string, string> = {
 
 export default function CacheRefreshStatus({ className = '' }: CacheRefreshStatusProps) {
   const queryClient = useQueryClient();
-  const { dbId } = useDbProjectTarget();
+  const dbId = useScopedDbId();
   const [isVisible, setIsVisible] = useState(false);
   const [animationPhase, setAnimationPhase] = useState<'fade-in' | 'visible' | 'fade-out'>('fade-in');
   const [wasRefreshing, setWasRefreshing] = useState(false);

--- a/static/src/components/DatabaseActivityStatus.tsx
+++ b/static/src/components/DatabaseActivityStatus.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useDbProjectTarget } from '../hooks/useUrlState';
+import { useScopedDbId } from '../hooks/useUrlState';
 import { useQualityBackfillStatus } from '../hooks/useQualityBackfill';
 import { useSpatialScanStatus } from '../hooks/useSpatialScan';
 import CacheRefreshStatus from './CacheRefreshStatus';
@@ -21,7 +21,7 @@ interface QualityCompletion {
 export default function DatabaseActivityStatus({
   className = '',
 }: DatabaseActivityStatusProps) {
-  const { dbId } = useDbProjectTarget();
+  const dbId = useScopedDbId();
   const qualityScan = useSpatialScanStatus(dbId);
   const qualityBackfill = useQualityBackfillStatus(dbId);
   const scanProgress = qualityScan.status?.progress;

--- a/static/src/components/Overview.css
+++ b/static/src/components/Overview.css
@@ -426,6 +426,14 @@
     var(--color-bg-elevated);
 }
 
+/* The project the user was working in before they opened the Overview. The
+   ring says "you were here" without competing with the new-images accent. */
+.project-card.is-current,
+.project-archive-item.is-current {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-primary-alpha-20);
+}
+
 .project-card.no-files {
   opacity: 0.6;
   background: var(--color-bg-hover);

--- a/static/src/components/Overview.tsx
+++ b/static/src/components/Overview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../api/client';
@@ -27,6 +27,7 @@ import {
   saveProjectSeenState,
 } from '../utils/projectRecency';
 import { formatRelativeTime } from '../utils/relativeTime';
+import { useDbProjectTarget } from '../hooks/useUrlState';
 import { imageDetailPath } from '../utils/imageDetailRoutes';
 import {
   groupProjectsByActivity,
@@ -48,6 +49,10 @@ type Organizing =
 
 function recentImageKey(dbId: string, projectId: number, imageId: number): string {
   return `${dbId}:${projectId}:${imageId}`;
+}
+
+function projectKey(dbId: string, projectId: number): string {
+  return `${dbId}:${projectId}`;
 }
 
 export default function Overview() {
@@ -204,6 +209,32 @@ export default function Overview() {
     [filteredProjects, projectSort]
   );
 
+  // The scope the user came from. Returning to a long project list at the top
+  // hides where they were, so mark that project and bring it into view once.
+  const { dbId: scopeDbId, projectId: scopeProjectId } = useDbProjectTarget();
+  const currentProjectKey =
+    scopeDbId && scopeProjectId !== null ? projectKey(scopeDbId, scopeProjectId) : null;
+  const revealedProjectKey = useRef<string | null>(null);
+  const revealProject = useCallback(
+    (node: HTMLElement | null) => {
+      if (!node || !currentProjectKey) return;
+      if (revealedProjectKey.current === currentProjectKey) return;
+      revealedProjectKey.current = currentProjectKey;
+      // jsdom has no layout, so guard for tests and older embedded webviews.
+      node.scrollIntoView?.({ block: 'center' });
+    },
+    [currentProjectKey]
+  );
+
+  // An archived project is behind a collapsed section: open it so the card the
+  // user is being sent back to exists.
+  const currentIsArchived = archivedProjects.some(
+    (project) => projectKey(project.db_id, project.id) === currentProjectKey
+  );
+  useEffect(() => {
+    if (currentIsArchived) setArchivedOpen(true);
+  }, [currentIsArchived]);
+
   const newestImageKey = useMemo(() => {
     let newest: { key: string; acquiredDate: number } | null = null;
     for (const project of projects) {
@@ -347,8 +378,6 @@ export default function Overview() {
       `/grid?db=${encodeURIComponent(target.db_id)}&project=${target.project_id}&target=${target.id}`
     );
   };
-
-  const projectKey = (dbId: string, projectId: number) => `${dbId}:${projectId}`;
 
   if (statsLoading || projectsLoading || targetsLoading) {
     return <div className="overview-loading">Loading overview...</div>;
@@ -564,13 +593,19 @@ export default function Overview() {
                 project.recent_images.length
               );
 
+              const isCurrent = key === currentProjectKey;
+
               return (
                 <div
                   key={key}
+                  ref={isCurrent ? revealProject : undefined}
+                  data-project-key={key}
+                  data-current-project={isCurrent ? 'true' : undefined}
                   className={[
                     'project-card',
                     !project.has_files ? 'no-files' : '',
                     projectNewImages > 0 ? 'has-new-images' : '',
+                    isCurrent ? 'is-current' : '',
                   ].filter(Boolean).join(' ')}
                 >
                   <div className="project-header">
@@ -1090,26 +1125,33 @@ export default function Overview() {
               </button>
               {(archivedOpen || Boolean(projectSearch)) && (
                 <div className="project-archive-list">
-                  {archivedProjects.map((project) => (
-                    <button
-                      key={`${project.db_id}:${project.id}`}
-                      type="button"
-                      className="project-archive-item"
-                      onClick={() => project.has_files && handleSelectProject(project)}
-                      disabled={!project.has_files}
-                    >
-                      <span>
-                        <strong>{project.display_name}</strong>
-                        <small>{project.db_name}</small>
-                      </span>
-                      <span>
-                        {project.total_images} images
-                        {project.date_range.latest
-                          ? ` · ${formatRelativeTime(project.date_range.latest, relativeNow)}`
-                          : ''}
-                      </span>
-                    </button>
-                  ))}
+                  {archivedProjects.map((project) => {
+                    const key = projectKey(project.db_id, project.id);
+                    const isCurrent = key === currentProjectKey;
+                    return (
+                      <button
+                        key={key}
+                        ref={isCurrent ? revealProject : undefined}
+                        data-project-key={key}
+                        data-current-project={isCurrent ? 'true' : undefined}
+                        type="button"
+                        className={`project-archive-item${isCurrent ? ' is-current' : ''}`}
+                        onClick={() => project.has_files && handleSelectProject(project)}
+                        disabled={!project.has_files}
+                      >
+                        <span>
+                          <strong>{project.display_name}</strong>
+                          <small>{project.db_name}</small>
+                        </span>
+                        <span>
+                          {project.total_images} images
+                          {project.date_range.latest
+                            ? ` · ${formatRelativeTime(project.date_range.latest, relativeNow)}`
+                            : ''}
+                        </span>
+                      </button>
+                    );
+                  })}
                 </div>
               )}
             </section>

--- a/static/src/components/__tests__/CacheRefreshStatus.quality.test.tsx
+++ b/static/src/components/__tests__/CacheRefreshStatus.quality.test.tsx
@@ -7,16 +7,14 @@ import { http, HttpResponse } from 'msw';
 import { server } from '../../test/msw-server';
 import DatabaseActivityStatus from '../DatabaseActivityStatus';
 
-function wrapper() {
+function wrapper(route = '/grid?db=test&project=1&target=42') {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={['/grid?db=test&project=1&target=42']}>
-          {children}
-        </MemoryRouter>
+        <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
       </QueryClientProvider>
     );
   };
@@ -164,5 +162,52 @@ describe('DatabaseActivityStatus quality activity', () => {
 
     expect(await screen.findByText('Analyzing database quality')).toBeInTheDocument();
     expect(screen.getByText(/2\/5 targets · Scanning 4\/10 frames/)).toBeInTheDocument();
+  });
+
+  it('ignores the return scope the Overview parks in the URL', async () => {
+    // The Overview shows every database, so the slug it holds for the trip
+    // back must not turn this into a scoped status: the merged indicator
+    // reports cross-database work there.
+    let scanPolls = 0;
+    server.use(
+      http.get('/api/db/:dbId/analysis/quality-scan', () => {
+        scanPolls += 1;
+        return HttpResponse.json({
+          success: true,
+          data: {
+            started: false,
+            progress: {
+              running: true,
+              stage: 'spatial',
+              target_id: 42,
+              filter_name: null,
+              total: 10,
+              processed: 4,
+              skipped_cached: 0,
+              spatial_processed: 4,
+              astrometry_processed: 0,
+              solved: 0,
+              solve_failed: 0,
+              operational_errors: 0,
+              errors: 0,
+              current_file: 'sh2-86-r-004.fits',
+              started_at: 1_705_352_400,
+              finished_at: null,
+              last_error: null,
+            },
+            cached_count: 4,
+          },
+          error: null,
+          status: 'ready',
+        });
+      }),
+    );
+
+    render(<DatabaseActivityStatus />, { wrapper: wrapper('/?db=test&project=1') });
+
+    // Long enough that a scoped status would have fetched and rendered.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(scanPolls).toBe(0);
+    expect(screen.queryByText('Analyzing quality')).not.toBeInTheDocument();
   });
 });

--- a/static/src/components/__tests__/Overview.current-project.test.tsx
+++ b/static/src/components/__tests__/Overview.current-project.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import Overview from '../Overview';
+import { CLOSED_PROJECT_STATE } from '../../utils/projectNavigation';
+
+function ok(data: unknown) {
+  return HttpResponse.json({ success: true, data, error: null, status: 'ready' });
+}
+
+function project(id: number, name: string, state = 1) {
+  return {
+    id,
+    profile_id: 'profile',
+    profile_name: 'Profile',
+    name,
+    display_name: name,
+    has_files: true,
+    state,
+    target_count: 1,
+    total_images: 10,
+    accepted_images: 5,
+    rejected_images: 2,
+    pending_images: 3,
+    total_desired: 20,
+    files_found: 10,
+    files_missing: 0,
+    date_range: { earliest: 1_705_000_000, latest: 1_705_352_400 },
+    filters_used: ['Ha'],
+    recent_images: [],
+  };
+}
+
+function wrapper(route: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function useOverviewData(projects: ReturnType<typeof project>[]) {
+  server.use(
+    http.get('/api/databases', () => ok([
+      { id: 'test', name: 'Demo catalog', path: '/demo.sqlite' },
+    ])),
+    http.get('/api/db/:dbId/projects/overview', () => ok(projects)),
+    http.get('/api/db/:dbId/targets/overview', () => ok([])),
+    http.get('/api/db/:dbId/stats/overall', () => ok({
+      total_projects: projects.length,
+      active_projects: projects.length,
+      total_targets: 1,
+      active_targets: 1,
+      total_images: 10,
+      accepted_images: 5,
+      rejected_images: 2,
+      pending_images: 3,
+      total_desired: 20,
+      files_found: 10,
+      files_missing: 0,
+      unique_filters: ['Ha'],
+      date_range: { earliest: 1_705_000_000, latest: 1_705_352_400 },
+      recent_activity: [],
+    })),
+  );
+}
+
+describe('Overview return scope', () => {
+  it('marks and reveals the project the user came from', async () => {
+    useOverviewData([project(1, 'Sh2 86'), project(2, 'NGC 6820')]);
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    render(<Overview />, { wrapper: wrapper('/?db=test&project=2') });
+
+    const current = await screen.findByText('NGC 6820');
+    const card = current.closest('.project-card');
+    expect(card).toHaveAttribute('data-current-project', 'true');
+    expect(
+      screen.getByText('Sh2 86').closest('.project-card')
+    ).not.toHaveAttribute('data-current-project');
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(1));
+  });
+
+  it('leaves every card unmarked without a project in the URL', async () => {
+    useOverviewData([project(1, 'Sh2 86')]);
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    const { container } = render(<Overview />, { wrapper: wrapper('/') });
+
+    await screen.findByText('Sh2 86');
+    expect(container.querySelector('[data-current-project]')).toBeNull();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('opens the archive when the project the user came from is archived', async () => {
+    useOverviewData([project(1, 'Sh2 86'), project(9, 'Old survey', CLOSED_PROJECT_STATE)]);
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    render(<Overview />, { wrapper: wrapper('/?db=test&project=9') });
+
+    const archived = await screen.findByText('Old survey');
+    expect(archived.closest('.project-archive-item')).toHaveAttribute(
+      'data-current-project',
+      'true'
+    );
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(1));
+  });
+});

--- a/static/src/hooks/useUrlState.ts
+++ b/static/src/hooks/useUrlState.ts
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { useCallback, useMemo, useRef } from 'react';
 import { type GroupingMode, DEFAULT_SINGLE_PROJECT_MODE } from '../types/grouping';
 
@@ -116,6 +116,23 @@ export function useDbProjectTarget() {
     setProjectId,
     setTargetId,
   };
+}
+
+/** The Overview route, which merges every database instead of scoping to one. */
+export function isOverviewPath(pathname: string): boolean {
+  return pathname === '/' || pathname === '/overview';
+}
+
+/**
+ * The database a status widget should follow. The Overview carries the scope
+ * of the view the user came from so it can return them there, but it shows
+ * every database at once — so widgets that scope to one must ignore the slug
+ * parked in the URL while it is on screen.
+ */
+export function useScopedDbId(): string | null {
+  const { dbId } = useDbProjectTarget();
+  const { pathname } = useLocation();
+  return isOverviewPath(pathname) ? null : dbId;
 }
 
 /**


### PR DESCRIPTION
## Problem

The Overview button navigated to `/` with no query string, so the active `?db=&project=` scope was thrown away. Two things followed: **Images** sent the user to an unscoped view instead of the project they were just in, and the Overview opened at the top of a long project list with nothing showing where they had been.

## Change

- The Overview keeps the same scope as the views around it. Both the header tab and the brand button now use `toScoped('/')`, so Images and Sequence hand the user straight back to the project — and its target, filters, and grouping — they left.
- The Overview marks that project (`data-current-project`, a `.is-current` ring) and scrolls it into view once. The scroll is guarded by a ref so a re-render, a background refresh, or the one-minute relative-time tick can't yank the page again after the user starts scrolling.
- If the project is archived, the collapsed archive section opens so the card exists to scroll to.
- The Overview merges every database, so the header's scoped status widgets must not treat the parked slug as scope: `CacheRefreshStatus` and `DatabaseActivityStatus` now read a new `useScopedDbId`, which returns null on the Overview route. Without this, the scoped chip and the cross-database chip would both report the same job.

## Tests

- Vitest: the Overview marks and reveals the project from the URL, leaves every card unmarked without one, and opens the archive when the project is archived.
- Vitest: `DatabaseActivityStatus` issues no scoped poll and renders no scoped status on the Overview route.
- Playwright: grid → Overview keeps `db` and `project` in the URL and marks exactly one project card, and Images returns to that project's grid.

Ran locally: `cargo fmt --check`, `cargo test`, `npm run lint`, `tsc`, `npm run build`, `npx vitest run`, and the full `npx playwright test` (92 passed). One pre-existing vitest file, `useColorPreview.test.tsx`, fails on this machine because the local Node build has no `localStorage`; it fails the same way on an unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)