### PR TITLE
Keep the source rotation in stack previews

### DIFF
--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -39,32 +39,45 @@ the running job, so leaving the page and coming back restores the live per-card
 progress instead of an idle panel. The indicator names the target and channel
 being stacked, its frame counts, and how many further builds are waiting.
 
-## Sky orientation
+## Stack orientation
 
-Every completed mono and color stack uses the same celestial display frame:
-north is up and east is left. PSF Guard reprojects the integrated image after
-registration and expands the output grid to keep the source frame's four
-corners. A rotated camera can therefore produce blank, masked wedges around the
-valid sky footprint instead of losing data to a crop.
+A stack keeps the rotation of its reference frame. Registration matches star
+triangles at any angle, so frames taken on either side of a meridian flip land
+on the same grid without a reprojection, and the result looks like the frames
+you graded. The downloaded FITS carries the reference frame's own WCS when it
+has one.
 
-PSF Guard first uses a current pixel-derived solve, then a valid embedded FITS
-WCS. If neither exists, it plate-solves the reference frame before it publishes
-the result. The stack fails with a catalog or solve error when it cannot prove
-the orientation; it never marks an unknown view as sky-up. Install the Seiza
-solver catalogs or solve one of the source images, then rebuild the channel.
+PSF Guard records the source-to-output mapping on every stack, so
+source-artifact search maps a selected stack region back to the right source
+pixels, and background protection maps catalog bounds forward onto the stack.
+For an unrotated build that mapping is the identity.
 
-The downloaded FITS contains a replacement TAN WCS for the reprojected pixels
-and records `SKYORIEN='N-UP E-LEFT'`. Color previews register their channel
-stacks onto one of these canonical grids, so RGB, LRGB, and narrowband outputs
-keep the same convention. The small `N ↑ · E ←` marker on each result makes the
-display contract clear. Source-artifact search retains the exact affine
-mapping, including a camera parity flip, so a selected stack region still maps
-back to the right source pixels.
+### The shared north-up grid
+
+A caller can ask for the canonical celestial frame instead — north up, east
+left — by sending `north_up: true` when it starts a build. Several stacks then
+share one grid, which is what a sky mosaic needs. The UI never sets it; each
+card and inspector shows the `N ↑ · E ←` marker only for a stack built this
+way.
+
+An oriented build reprojects the integration after registration and expands the
+output grid to keep the source frame's four corners, so a rotated camera
+produces blank, masked wedges around the valid sky footprint instead of losing
+data to a crop. PSF Guard first uses a current pixel-derived solve, then a valid
+embedded FITS WCS. If neither exists, it plate-solves the reference frame before
+it publishes the result. The build fails with a catalog or solve error when it
+cannot prove the orientation; it never marks an unknown view as sky-up. The
+FITS then contains a replacement TAN WCS for the reprojected pixels and records
+`SKYORIEN='N-UP E-LEFT'`. A color preview registers its channel stacks onto the
+reference channel's grid, so RGB, LRGB, and narrowband outputs inherit whichever
+frame their channels were built in.
+
+## Cached results
 
 PSF Guard remembers the last successful preview for every target/channel in the
 project cache and restores those cards after navigation, page reload, or server
 restart. Each card retains the exact input image IDs and scheduler grades used
-to build it. PSF Guard hides previews made before the sky-orientation rule; build
+to build it. PSF Guard hides previews built by an older orientation rule; build
 each channel once to replace them. The card is marked **Out of date**—without
 hiding the usable older preview—when the current filter/selection changes the
 image set, an image is
@@ -128,9 +141,9 @@ opened, so the project grid continues to use the smaller screen preview.
 
 Choose **Download linear FITS** on the card or in the inspector to retrieve the
 full-resolution floating-point integration from the cache. The FITS is
-unstretched and contains the canonical north-up, east-left WCS plus Seiza's
-accepted/rejected frame counters, making it suitable for inspection or as an
-input to a separate processing workflow.
+unstretched and contains the stack's WCS plus Seiza's accepted/rejected frame
+counters, making it suitable for inspection or as an input to a separate
+processing workflow.
 
 ![Frame-by-frame stack admission details](stack-preview-decisions.png)
 
@@ -271,14 +284,14 @@ large cataloged emission regions from background sampling. It uses closed
 catalog or curated contours when the object catalog supplies them, then falls
 back to the object's projected ellipse. Embedded FITS WCS alone does not enable
 this protection. Each channel uses its own stack reference frame, and PSF Guard
-maps its catalog bounds through the stack's saved sky-up transform before it
-fits the background. The manifest records the reference image, catalog version,
-object names, region count, and a geometry fingerprint. These values form part
-of the cache key and stale check, so a new solve or catalog projection cannot
-reuse or present a fit made with stale bounds. After correction, each
-non-reference stack is registered to R for RGB, L for LRGB, or H-alpha for
-narrowband, using the same bounded Seiza star/similarity registration used by
-the Seiza color CLI.
+maps its catalog bounds through the stack's saved source-to-output transform
+before it fits the background. The manifest records the reference image,
+catalog version, object names, region count, and a geometry fingerprint. These
+values form part of the cache key and stale check, so a new solve or catalog
+projection cannot reuse or present a fit made with stale bounds. After
+correction, each non-reference stack is registered to R for RGB, L for LRGB, or
+H-alpha for narrowband, using the same bounded Seiza star/similarity
+registration used by the Seiza color CLI.
 
 The **Processing stack** editor exposes correction mode and strength, automatic
 or fixed surface selection, sample-grid density and radius, sample-search

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -47,10 +47,27 @@ on the same grid without a reprojection, and the result looks like the frames
 you graded. The downloaded FITS carries the reference frame's own WCS when it
 has one.
 
+### Which side of a meridian flip
+
+A German equatorial mount turns the field 180 degrees when it flips. Both
+halves of such a night stack cleanly, but the reference frame alone decides
+which way up the result comes out, and the reference is whichever frame scored
+best — it can sit on either side of the flip, and it can move to the other
+side when a regrade or a quality rescan changes the scores.
+
+So PSF Guard follows the exposure instead. If most of the integrated seconds
+came from frames half a turn from the reference, it turns the finished stack
+half a turn to match them. That is an exact reversal of the pixel order, so it
+costs no resampling and loses no accuracy. A night that never flipped is never
+turned, an even split keeps the reference frame's rotation, and the choice does
+not move when scores do.
+
 PSF Guard records the source-to-output mapping on every stack, so
 source-artifact search maps a selected stack region back to the right source
 pixels, and background protection maps catalog bounds forward onto the stack.
-For an unrotated build that mapping is the identity.
+That mapping is the identity for an untouched build and the half turn for a
+turned one, so both consumers follow the published pixels without special
+cases.
 
 ### The shared north-up grid
 

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -45,7 +45,7 @@ use crate::server::state::AppState;
 pub const SEIZA_STACKING_VERSION: &str = "0.2.1";
 /// Bump whenever stack admission, rendering, or persisted artifact semantics
 /// change. This deliberately versions PSF Guard policy separately from Seiza.
-pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 9;
+pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 10;
 const MAX_REQUEST_IMAGES: usize = 10_000;
 const MAX_REMEMBERED_JOBS: usize = 64;
 const PREVIEW_MAX_DIMENSION: u32 = 2400;
@@ -131,6 +131,10 @@ pub struct StackInputImage {
 /// works the same way for an oriented and an unoriented stack.
 pub const SOURCE_ORIENTATION_NAME: &str = "source_frame";
 
+/// Recorded when the stack was turned half a turn so it faces the same way as
+/// the side of a meridian flip most of its exposure came from.
+pub const MAJORITY_HALF_TURN_SOURCE: &str = "majority_half_turn";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StackSkyOrientation {
     pub convention: String,
@@ -152,6 +156,16 @@ impl StackSkyOrientation {
             output_width: width,
             output_height: height,
             source_to_output: seiza_stacking::AffineTransform::IDENTITY,
+        }
+    }
+
+    /// The mapping recorded when the integration is turned half a turn out of
+    /// the reference frame's rotation to match the rest of its exposure.
+    fn source_frame_half_turn(width: usize, height: usize) -> Self {
+        Self {
+            source: MAJORITY_HALF_TURN_SOURCE.into(),
+            source_to_output: half_turn_transform(width, height),
+            ..Self::source_frame(width, height)
         }
     }
 
@@ -492,6 +506,81 @@ struct PreparedJob {
     groups: Vec<PreparedGroup>,
     cache_root: PathBuf,
     north_up: bool,
+}
+
+/// Weighs how much integrated exposure faces the same way as the reference
+/// frame against how much faces half a turn away.
+///
+/// A German equatorial mount turns the field 180 degrees across a meridian
+/// flip. Registration matches star triangles at any angle, so both halves of
+/// such a night stack cleanly, but the reference frame alone decides which way
+/// up the result comes out — and the reference is the best-scoring frame, which
+/// may sit on either side of the flip and may move between rebuilds. Following
+/// the exposure instead keeps the published stack facing the way most of the
+/// night was shot, and keeps it there when scores change.
+#[derive(Debug, Default)]
+struct OrientationVote {
+    upright: f64,
+    half_turned: f64,
+}
+
+impl OrientationVote {
+    /// Count one integrated frame at its registered rotation. Frames without a
+    /// usable exposure time count once each, so a session that records no
+    /// exposure still votes by frame.
+    fn add(&mut self, rotation_radians: f64, exposure_seconds: f64) {
+        let weight = if exposure_seconds > 0.0 {
+            exposure_seconds
+        } else {
+            1.0
+        };
+        if is_half_turn(rotation_radians) {
+            self.half_turned += weight;
+        } else {
+            self.upright += weight;
+        }
+    }
+
+    /// Whether most of the integrated exposure sits half a turn from the
+    /// reference frame. A tie keeps the reference frame's own rotation.
+    fn prefers_half_turn(&self) -> bool {
+        self.half_turned > self.upright
+    }
+}
+
+/// Whether a registered rotation lies closer to half a turn than to none.
+/// Ordinary field rotation and guiding drift stay near zero; only a meridian
+/// flip lands a frame out here.
+fn is_half_turn(rotation_radians: f64) -> bool {
+    if !rotation_radians.is_finite() {
+        return false;
+    }
+    let wrapped = rotation_radians.rem_euclid(std::f64::consts::TAU);
+    let from_upright = wrapped.min(std::f64::consts::TAU - wrapped);
+    from_upright > std::f64::consts::FRAC_PI_2
+}
+
+/// Turn a row-major, channel-interleaved image half a turn about its centre.
+/// This is an exact reversal of the pixel order, so it costs no resampling and
+/// loses no accuracy.
+fn half_turn(mut image: seiza_stacking::LinearImage) -> seiza_stacking::LinearImage {
+    let channels = image.channels;
+    let mut turned = Vec::with_capacity(image.data.len());
+    for pixel in image.data.chunks_exact(channels).rev() {
+        turned.extend_from_slice(pixel);
+    }
+    image.data = turned;
+    image
+}
+
+/// The source-to-output mapping matching [`half_turn`]: pixel `(0, 0)` lands at
+/// the far corner and the grid keeps its size.
+fn half_turn_transform(width: usize, height: usize) -> seiza_stacking::AffineTransform {
+    seiza_stacking::AffineTransform {
+        matrix: [[-1.0, 0.0], [0.0, -1.0]],
+        translation_x: width.saturating_sub(1) as f64,
+        translation_y: height.saturating_sub(1) as f64,
+    }
 }
 
 pub async fn start_stack_previews(
@@ -1342,6 +1431,9 @@ fn run_group(
 
     pool.install(|| {
         let reference_exposure = reference_frame.exposure_seconds.unwrap_or(0.0);
+        // The reference frame defines zero rotation, so it always votes upright.
+        let mut orientation_vote = OrientationVote::default();
+        orientation_vote.add(0.0, reference_exposure);
         let options = StackOptions {
             normalization: NormalizationMode::Global,
             ..StackOptions::default()
@@ -1381,21 +1473,25 @@ fn run_group(
                 .unwrap_or(0.0);
             let decision = match opened {
                 Ok(opened) => match stacker.push(opened).map_err(|error| error.to_string())? {
-                    FrameDisposition::Accepted(diagnostics) => StackFrameDecision {
-                        image_id: frame.image_id,
-                        disposition: "accepted".into(),
-                        reason: None,
-                        quality_score: frame.quality_score,
-                        matched_stars: Some(diagnostics.matched_stars),
-                        registration_rms_pixels: Some(diagnostics.registration_rms_pixels),
-                        registration_drift_pixels: Some(diagnostics.registration_drift_pixels),
-                        registered_mapping: Some(*diagnostics.mapping),
-                        normalization_mean_gain: Some(diagnostics.normalization_mean_gain),
-                        normalization_mean_offset: Some(diagnostics.normalization_mean_offset),
-                        source_fingerprint: Some(frame.source_fingerprint.clone()),
-                        overlap_fraction: Some(diagnostics.overlap_fraction),
-                        integrated_fraction: Some(diagnostics.integrated_fraction),
-                    },
+                    FrameDisposition::Accepted(diagnostics) => {
+                        orientation_vote
+                            .add(diagnostics.mapping.transform().rotation_radians, exposure);
+                        StackFrameDecision {
+                            image_id: frame.image_id,
+                            disposition: "accepted".into(),
+                            reason: None,
+                            quality_score: frame.quality_score,
+                            matched_stars: Some(diagnostics.matched_stars),
+                            registration_rms_pixels: Some(diagnostics.registration_rms_pixels),
+                            registration_drift_pixels: Some(diagnostics.registration_drift_pixels),
+                            registered_mapping: Some(*diagnostics.mapping),
+                            normalization_mean_gain: Some(diagnostics.normalization_mean_gain),
+                            normalization_mean_offset: Some(diagnostics.normalization_mean_offset),
+                            source_fingerprint: Some(frame.source_fingerprint.clone()),
+                            overlap_fraction: Some(diagnostics.overlap_fraction),
+                            integrated_fraction: Some(diagnostics.integrated_fraction),
+                        }
+                    }
                     FrameDisposition::Rejected(reason) => StackFrameDecision {
                         image_id: frame.image_id,
                         disposition: "rejected".into(),
@@ -1451,7 +1547,9 @@ fn run_group(
         let rejected_frames = snapshot.rejected_frames;
         // Registration already absorbs a meridian flip, so a stack is published
         // in the reference frame's own rotation unless the caller asks for the
-        // shared north-up grid that a mosaic needs.
+        // shared north-up grid that a mosaic needs. The one correction it still
+        // makes is a half turn when the reference sits on the thinner side of a
+        // flip, so the result faces the way most of the night was shot.
         let (image, sky_orientation, mut output_cards) = if north_up {
             let (source_wcs, orientation_source) =
                 resolve_stack_wcs(state, &ctx, &group.frames[0], &reference_headers)?;
@@ -1473,6 +1571,18 @@ fn run_group(
                 source_to_output: orientation.source_to_output(),
             };
             (oriented, record, orientation.fits_header_cards())
+        } else if orientation_vote.prefers_half_turn() {
+            let record = StackSkyOrientation::source_frame_half_turn(
+                snapshot.image.width,
+                snapshot.image.height,
+            );
+            tracing::info!(
+                "Stack preview {} group {}: turning the result half a turn; the reference frame \
+                 faces the thinner side of a meridian flip",
+                job_id,
+                group.index
+            );
+            (half_turn(snapshot.image), record, Vec::new())
         } else {
             let record =
                 StackSkyOrientation::source_frame(snapshot.image.width, snapshot.image.height);
@@ -1993,6 +2103,110 @@ mod tests {
             (orientation.output_width, orientation.output_height),
             (120, 90)
         );
+    }
+
+    #[test]
+    fn only_a_meridian_flip_counts_as_half_a_turn() {
+        use std::f64::consts::{FRAC_PI_2, PI, TAU};
+
+        // Guiding drift and ordinary field rotation stay upright.
+        assert!(!is_half_turn(0.0));
+        assert!(!is_half_turn(0.02));
+        assert!(!is_half_turn(-0.02));
+        assert!(!is_half_turn(FRAC_PI_2));
+        assert!(!is_half_turn(TAU));
+
+        // A meridian flip lands near half a turn, from either direction.
+        assert!(is_half_turn(PI));
+        assert!(is_half_turn(-PI));
+        assert!(is_half_turn(PI - 0.02));
+        assert!(is_half_turn(PI + 0.02));
+
+        // A rotation that never fitted must not vote.
+        assert!(!is_half_turn(f64::NAN));
+        assert!(!is_half_turn(f64::INFINITY));
+    }
+
+    #[test]
+    fn the_stack_faces_the_side_of_the_flip_it_mostly_came_from() {
+        use std::f64::consts::PI;
+
+        // Reference on the thin side: three 60 s frames outvote it.
+        let mut minority_reference = OrientationVote::default();
+        minority_reference.add(0.0, 60.0);
+        for _ in 0..3 {
+            minority_reference.add(PI, 60.0);
+        }
+        assert!(minority_reference.prefers_half_turn());
+
+        // Reference on the thick side: the stack stays as it is.
+        let mut majority_reference = OrientationVote::default();
+        for _ in 0..3 {
+            majority_reference.add(0.0, 60.0);
+        }
+        majority_reference.add(PI, 60.0);
+        assert!(!majority_reference.prefers_half_turn());
+
+        // Long subs outweigh a larger count of short ones.
+        let mut by_exposure = OrientationVote::default();
+        by_exposure.add(0.0, 30.0);
+        by_exposure.add(0.0, 30.0);
+        by_exposure.add(PI, 300.0);
+        assert!(by_exposure.prefers_half_turn());
+
+        // Missing exposure times fall back to counting frames.
+        let mut unmeasured = OrientationVote::default();
+        unmeasured.add(0.0, 0.0);
+        unmeasured.add(PI, 0.0);
+        unmeasured.add(PI, 0.0);
+        assert!(unmeasured.prefers_half_turn());
+
+        // An even split keeps the reference frame's own rotation.
+        let mut tied = OrientationVote::default();
+        tied.add(0.0, 60.0);
+        tied.add(PI, 60.0);
+        assert!(!tied.prefers_half_turn());
+
+        // A night that never flipped is never turned.
+        let mut unflipped = OrientationVote::default();
+        for _ in 0..5 {
+            unflipped.add(0.001, 60.0);
+        }
+        assert!(!unflipped.prefers_half_turn());
+    }
+
+    #[test]
+    fn a_half_turn_reverses_the_pixels_and_records_its_mapping() {
+        let mono =
+            seiza_stacking::LinearImage::new(3, 2, 1, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        let turned = half_turn(mono.clone());
+        assert_eq!(turned.data, vec![6.0, 5.0, 4.0, 3.0, 2.0, 1.0]);
+        assert_eq!((turned.width, turned.height), (3, 2));
+        // Turning twice returns the original, so the operation loses nothing.
+        assert_eq!(half_turn(turned), mono);
+
+        // RGB samples are interleaved, so channel order survives the reversal.
+        let rgb =
+            seiza_stacking::LinearImage::new(2, 1, 3, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        assert_eq!(half_turn(rgb).data, vec![4.0, 5.0, 6.0, 1.0, 2.0, 3.0]);
+
+        // The recorded mapping must match what the pixels did: the first pixel
+        // lands in the far corner, and the grid keeps its size.
+        let orientation = StackSkyOrientation::source_frame_half_turn(3, 2);
+        assert!(orientation.is_current());
+        assert_eq!(orientation.convention, SOURCE_ORIENTATION_NAME);
+        assert_eq!(orientation.source, MAJORITY_HALF_TURN_SOURCE);
+        assert_eq!(
+            (orientation.output_width, orientation.output_height),
+            (3, 2)
+        );
+        assert_eq!(orientation.source_to_output.apply(0.0, 0.0), (2.0, 1.0));
+        assert_eq!(orientation.source_to_output.apply(2.0, 1.0), (0.0, 0.0));
+        assert_eq!(orientation.source_to_output.apply(1.0, 0.0), (1.0, 1.0));
+        orientation
+            .source_to_output
+            .validate()
+            .expect("the half-turn mapping is a usable affine");
     }
 
     #[test]

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -45,7 +45,7 @@ use crate::server::state::AppState;
 pub const SEIZA_STACKING_VERSION: &str = "0.2.1";
 /// Bump whenever stack admission, rendering, or persisted artifact semantics
 /// change. This deliberately versions PSF Guard policy separately from Seiza.
-pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 8;
+pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 9;
 const MAX_REQUEST_IMAGES: usize = 10_000;
 const MAX_REMEMBERED_JOBS: usize = 64;
 const PREVIEW_MAX_DIMENSION: u32 = 2400;
@@ -58,6 +58,12 @@ pub struct StackPreviewRequest {
     pub accepted_only: bool,
     #[serde(default)]
     pub force: bool,
+    /// Reproject the integration onto the canonical north-up, east-left grid.
+    /// Off by default: a stack keeps the rotation of its reference frame, and
+    /// registration already absorbs a meridian flip. Turn this on when several
+    /// stacks must share one sky frame, such as a mosaic.
+    #[serde(default)]
+    pub north_up: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]
@@ -120,6 +126,11 @@ pub struct StackInputImage {
     pub grading_status: i32,
 }
 
+/// Convention recorded when a stack keeps the rotation of its reference frame.
+/// The stored mapping is the identity, so every consumer of `source_to_output`
+/// works the same way for an oriented and an unoriented stack.
+pub const SOURCE_ORIENTATION_NAME: &str = "source_frame";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StackSkyOrientation {
     pub convention: String,
@@ -128,6 +139,31 @@ pub struct StackSkyOrientation {
     pub output_width: usize,
     pub output_height: usize,
     pub source_to_output: seiza_stacking::AffineTransform,
+}
+
+impl StackSkyOrientation {
+    /// The mapping recorded when the integration is published in the reference
+    /// frame's own rotation.
+    fn source_frame(width: usize, height: usize) -> Self {
+        Self {
+            convention: SOURCE_ORIENTATION_NAME.into(),
+            version: seiza_stacking::SKY_ORIENTATION_VERSION,
+            source: SOURCE_ORIENTATION_NAME.into(),
+            output_width: width,
+            output_height: height,
+            source_to_output: seiza_stacking::AffineTransform::IDENTITY,
+        }
+    }
+
+    /// Whether this record still describes how the current code lays out a
+    /// stack. Artifacts written before stacks recorded a mapping fail here.
+    pub(super) fn is_current(&self) -> bool {
+        self.version == seiza_stacking::SKY_ORIENTATION_VERSION
+            && matches!(
+                self.convention.as_str(),
+                seiza_stacking::SKY_ORIENTATION_NAME | SOURCE_ORIENTATION_NAME
+            )
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -455,6 +491,7 @@ struct PreparedJob {
     public: StackPreviewJob,
     groups: Vec<PreparedGroup>,
     cache_root: PathBuf,
+    north_up: bool,
 }
 
 pub async fn start_stack_previews(
@@ -795,6 +832,7 @@ fn prepare_job(
     hasher.update(ctx.id.as_bytes());
     hasher.update(project_id.to_le_bytes());
     hasher.update([request.accepted_only as u8]);
+    hasher.update([request.north_up as u8]);
     hasher.update(STACK_PREVIEW_CACHE_VERSION.to_le_bytes());
     hasher.update(SEIZA_STACKING_VERSION.as_bytes());
     hasher.update(seiza_stacking::SKY_ORIENTATION_VERSION.to_le_bytes());
@@ -969,6 +1007,7 @@ fn prepare_job(
         },
         groups: prepared_groups,
         cache_root: ctx.cache_dir_path.clone(),
+        north_up: request.north_up,
     })
 }
 
@@ -1164,6 +1203,7 @@ fn run_job(state: &Arc<AppState>, prepared: PreparedJob) {
         public: _,
         groups,
         cache_root,
+        north_up,
     } = prepared;
     state.stack_previews.update(&job_id, |job| {
         job.state = StackJobState::Running;
@@ -1184,6 +1224,7 @@ fn run_job(state: &Arc<AppState>, prepared: PreparedJob) {
                 &job_id,
                 &cache_root,
                 group.clone(),
+                north_up,
                 &worker_policy,
             );
             state.stack_previews.update(&job_id, |job| match result {
@@ -1225,6 +1266,7 @@ fn run_group(
     job_id: &str,
     cache_root: &FsPath,
     group: PreparedGroup,
+    north_up: bool,
     worker_policy: &crate::concurrency::WorkerPolicy,
 ) -> Result<(), String> {
     use seiza_stacking::{
@@ -1398,29 +1440,43 @@ fn run_group(
                 status.frames.push(decision);
             });
         }
-        state.stack_previews.update(job_id, |job| {
-            job.groups[group.index].phase = "orienting".into();
-        });
+        if north_up {
+            state.stack_previews.update(job_id, |job| {
+                job.groups[group.index].phase = "orienting".into();
+            });
+        }
         let reference_headers = stacker.reference_headers().to_vec();
         let snapshot = stacker.into_snapshot().map_err(|error| error.to_string())?;
-        let (source_wcs, orientation_source) =
-            resolve_stack_wcs(state, &ctx, &group.frames[0], &reference_headers)?;
-        let orientation = seiza_stacking::SkyOrientationPlan::new(
-            snapshot.image.width,
-            snapshot.image.height,
-            &source_wcs,
-        )
-        .map_err(|error| error.to_string())?;
-        let oriented = orientation
-            .apply(&snapshot.image)
+        let accepted_frames = snapshot.accepted_frames;
+        let rejected_frames = snapshot.rejected_frames;
+        // Registration already absorbs a meridian flip, so a stack is published
+        // in the reference frame's own rotation unless the caller asks for the
+        // shared north-up grid that a mosaic needs.
+        let (image, sky_orientation, mut output_cards) = if north_up {
+            let (source_wcs, orientation_source) =
+                resolve_stack_wcs(state, &ctx, &group.frames[0], &reference_headers)?;
+            let orientation = seiza_stacking::SkyOrientationPlan::new(
+                snapshot.image.width,
+                snapshot.image.height,
+                &source_wcs,
+            )
             .map_err(|error| error.to_string())?;
-        let sky_orientation = StackSkyOrientation {
-            convention: seiza_stacking::SKY_ORIENTATION_NAME.into(),
-            version: seiza_stacking::SKY_ORIENTATION_VERSION,
-            source: orientation_source,
-            output_width: orientation.output_width(),
-            output_height: orientation.output_height(),
-            source_to_output: orientation.source_to_output(),
+            let oriented = orientation
+                .apply(&snapshot.image)
+                .map_err(|error| error.to_string())?;
+            let record = StackSkyOrientation {
+                convention: seiza_stacking::SKY_ORIENTATION_NAME.into(),
+                version: seiza_stacking::SKY_ORIENTATION_VERSION,
+                source: orientation_source,
+                output_width: orientation.output_width(),
+                output_height: orientation.output_height(),
+                source_to_output: orientation.source_to_output(),
+            };
+            (oriented, record, orientation.fits_header_cards())
+        } else {
+            let record =
+                StackSkyOrientation::source_frame(snapshot.image.width, snapshot.image.height);
+            (snapshot.image, record, Vec::new())
         };
         state.stack_previews.update(job_id, |job| {
             let status = &mut job.groups[group.index];
@@ -1434,31 +1490,30 @@ fn run_group(
         std::fs::create_dir_all(fits_parent).map_err(|error| error.to_string())?;
         let fits_temporary =
             fits_destination.with_extension(format!("{}.tmp.fits", std::process::id()));
-        let mut output_cards = orientation.fits_header_cards();
         output_cards.push(
             seiza_fits::WriteHeaderCard::new(
                 "STACKCNT",
-                seiza_fits::HeaderValue::Integer(i64::from(snapshot.accepted_frames)),
+                seiza_fits::HeaderValue::Integer(i64::from(accepted_frames)),
             )
             .with_comment("accepted input frames"),
         );
         output_cards.push(
             seiza_fits::WriteHeaderCard::new(
                 "STACKREJ",
-                seiza_fits::HeaderValue::Integer(i64::from(snapshot.rejected_frames)),
+                seiza_fits::HeaderValue::Integer(i64::from(rejected_frames)),
             )
             .with_comment("rejected input frames"),
         );
         seiza_stacking::write_linear_image_fits_f32(
             &fits_temporary,
-            &oriented,
+            &image,
             &reference_headers,
             &output_cards,
         )
         .map_err(|error| error.to_string())?;
         std::fs::rename(&fits_temporary, &fits_destination).map_err(|error| error.to_string())?;
         stretch::render_image_previews_atomic(
-            &oriented,
+            &image,
             &stretch::default_linear_config(),
             stretch::StackStretchSourceTransfer::Linear,
             &preview_path(cache_root, job_id, group.index),
@@ -1611,10 +1666,7 @@ pub(super) fn current_latest_stacks(mut latest: LatestStackPreviews) -> LatestSt
                 .group
                 .sky_orientation
                 .as_ref()
-                .is_some_and(|orientation| {
-                    orientation.version == seiza_stacking::SKY_ORIENTATION_VERSION
-                        && orientation.convention == seiza_stacking::SKY_ORIENTATION_NAME
-                })
+                .is_some_and(StackSkyOrientation::is_current)
     });
     latest
 }
@@ -1650,14 +1702,7 @@ mod tests {
     use super::*;
 
     fn sky_orientation() -> StackSkyOrientation {
-        StackSkyOrientation {
-            convention: seiza_stacking::SKY_ORIENTATION_NAME.into(),
-            version: seiza_stacking::SKY_ORIENTATION_VERSION,
-            source: "embedded_wcs".into(),
-            output_width: 100,
-            output_height: 80,
-            source_to_output: seiza_stacking::AffineTransform::IDENTITY,
-        }
+        StackSkyOrientation::source_frame(100, 80)
     }
 
     fn ready_group(target_id: i32, filter_name: &str, image_id: i32) -> StackGroupStatus {
@@ -1785,18 +1830,21 @@ mod tests {
             image_ids: vec![1],
             accepted_only: false,
             force: false,
+            north_up: false,
         })
         .is_err());
         assert!(validate_request(&StackPreviewRequest {
             image_ids: vec![1, 1],
             accepted_only: false,
             force: false,
+            north_up: false,
         })
         .is_err());
         assert!(validate_request(&StackPreviewRequest {
             image_ids: vec![1, 2],
             accepted_only: false,
             force: false,
+            north_up: false,
         })
         .is_ok());
     }
@@ -1887,6 +1935,64 @@ mod tests {
 
         assert_eq!(latest.groups.len(), 1);
         assert_eq!(latest.groups[0].job_id, "current");
+    }
+
+    #[test]
+    fn latest_index_keeps_both_orientation_conventions() {
+        let source_frame = LatestStackPreviewGroup {
+            job_id: "source-frame".into(),
+            artifact_revision: "source-revision".into(),
+            accepted_only: false,
+            created_unix_seconds: 100,
+            cache_version: STACK_PREVIEW_CACHE_VERSION,
+            group: ready_group(10, "B", 1),
+        };
+        let mut north_up = source_frame.clone();
+        north_up.job_id = "north-up".into();
+        north_up.group.filter_name = "R".into();
+        north_up.group.sky_orientation = Some(StackSkyOrientation {
+            convention: seiza_stacking::SKY_ORIENTATION_NAME.into(),
+            version: seiza_stacking::SKY_ORIENTATION_VERSION,
+            source: "embedded_wcs".into(),
+            output_width: 120,
+            output_height: 90,
+            source_to_output: seiza_stacking::AffineTransform::IDENTITY,
+        });
+        let latest = current_latest_stacks(LatestStackPreviews {
+            schema_version: 2,
+            database_id: "db-test".into(),
+            project_id: 7,
+            updated_unix_seconds: 100,
+            groups: vec![source_frame, north_up],
+        });
+
+        assert_eq!(latest.groups.len(), 2);
+    }
+
+    #[test]
+    fn requests_keep_the_source_rotation_by_default() {
+        let request: StackPreviewRequest =
+            serde_json::from_str(r#"{"image_ids":[1,2]}"#).expect("request parses");
+        assert!(!request.north_up);
+
+        let request: StackPreviewRequest =
+            serde_json::from_str(r#"{"image_ids":[1,2],"north_up":true}"#).expect("request parses");
+        assert!(request.north_up);
+    }
+
+    #[test]
+    fn a_source_frame_stack_records_an_identity_mapping() {
+        let orientation = StackSkyOrientation::source_frame(120, 90);
+        assert!(orientation.is_current());
+        assert_eq!(orientation.convention, SOURCE_ORIENTATION_NAME);
+        assert_eq!(
+            orientation.source_to_output,
+            seiza_stacking::AffineTransform::IDENTITY
+        );
+        assert_eq!(
+            (orientation.output_width, orientation.output_height),
+            (120, 90)
+        );
     }
 
     #[test]

--- a/src/server/stack_preview/artifact.rs
+++ b/src/server/stack_preview/artifact.rs
@@ -210,15 +210,11 @@ pub async fn start_mono_artifact_search(
     let output_transform = group
         .sky_orientation
         .as_ref()
-        .filter(|orientation| {
-            orientation.version == seiza_stacking::SKY_ORIENTATION_VERSION
-                && orientation.convention == seiza_stacking::SKY_ORIENTATION_NAME
-        })
+        .filter(|orientation| orientation.is_current())
         .map(|orientation| orientation.source_to_output)
         .ok_or_else(|| {
             AppError::BadRequest(
-                "Rebuild this stack before searching; its sky-orientation mapping is missing"
-                    .into(),
+                "Rebuild this stack before searching; its output mapping is missing".into(),
             )
         })?;
     let ctx_arc = Arc::clone(&ctx.0);
@@ -433,23 +429,20 @@ fn load_color_stack_sources(
                 })
                 .ok_or(AppError::NotFound)?
                 .clone();
-            let sky_transform = group
+            let stack_transform = group
                 .sky_orientation
                 .as_ref()
-                .filter(|orientation| {
-                    orientation.version == seiza_stacking::SKY_ORIENTATION_VERSION
-                        && orientation.convention == seiza_stacking::SKY_ORIENTATION_NAME
-                })
+                .filter(|orientation| orientation.is_current())
                 .map(|orientation| orientation.source_to_output)
                 .ok_or_else(|| {
                     AppError::BadRequest(format!(
-                        "Rebuild the {} stack before searching; its sky-orientation mapping is missing",
+                        "Rebuild the {} stack before searching; its output mapping is missing",
                         source.role.label()
                     ))
                 })?;
             Ok((
                 group,
-                Some(sky_transform.then(transform.as_affine())),
+                Some(stack_transform.then(transform.as_affine())),
                 Some(source.role.label().to_string()),
             ))
         })

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -40,7 +40,7 @@ use crate::server::extract::DbContext;
 use crate::server::handlers::AppError;
 use crate::server::state::AppState;
 
-const STACK_COLOR_CACHE_VERSION: u32 = 9;
+const STACK_COLOR_CACHE_VERSION: u32 = 10;
 const COLOR_INPUT_CACHE_VERSION: u32 = 3;
 const SEIZA_BACKGROUND_VERSION: &str = "0.2.0";
 const MAX_REGISTRATION_RMS_PIXELS: f64 = 2.0;

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -40,7 +40,7 @@ use crate::server::extract::DbContext;
 use crate::server::handlers::AppError;
 use crate::server::state::AppState;
 
-const STACK_COLOR_CACHE_VERSION: u32 = 8;
+const STACK_COLOR_CACHE_VERSION: u32 = 9;
 const COLOR_INPUT_CACHE_VERSION: u32 = 3;
 const SEIZA_BACKGROUND_VERSION: &str = "0.2.0";
 const MAX_REGISTRATION_RMS_PIXELS: f64 = 2.0;

--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -106,7 +106,7 @@ function seedSyntheticColorStacks(databaseId: string, projectId: number): void {
       artifact_revision: `synthetic-${index}`,
       accepted_only: false,
       created_unix_seconds: 1_760_000_000 + index,
-      cache_version: 9,
+      cache_version: 10,
       group: {
         index: 0,
         target_id: 2,
@@ -237,6 +237,18 @@ test('builds a real three-frame Seiza stack and exposes its frame decisions', as
   // the pixels nor stamps the canonical sky-up WCS over them.
   expect(fitsHeaderText).not.toContain('SKYORIEN');
   expect(fitsHeaderText).not.toContain('N-UP E-LEFT');
+
+  // The published mapping is what artifact search and background protection
+  // read back, so the build must record which way it laid the pixels out.
+  const jobResponse = await page.request.get(
+    `/api/db/${encodeURIComponent(dbId)}/projects/1/stack-previews/${jobId}`
+  );
+  expect(jobResponse.status()).toBe(200);
+  const orientation = (await jobResponse.json()).data.groups[0].sky_orientation;
+  expect(orientation.convention).toBe('source_frame');
+  expect(['source_frame', 'majority_half_turn']).toContain(orientation.source);
+  expect(orientation.output_width).toBeGreaterThan(0);
+  expect(orientation.output_height).toBeGreaterThan(0);
 
   const defaultPreviewSrc = await preview.getAttribute('src');
   const stretchControls = panel.locator('.stack-preview-card .stack-stretch-controls');

--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -79,7 +79,6 @@ function writeSyntheticMonoStack(destination: string, variant: number): void {
     fitsFloatCard('CD1_2', 0),
     fitsFloatCard('CD2_1', 0),
     fitsFloatCard('CD2_2', -0.0004160277777778),
-    fitsStringCard('SKYORIEN', 'N-UP E-LEFT'),
     'END'.padEnd(80),
   ];
   const headerText = cards.join('');
@@ -107,7 +106,7 @@ function seedSyntheticColorStacks(databaseId: string, projectId: number): void {
       artifact_revision: `synthetic-${index}`,
       accepted_only: false,
       created_unix_seconds: 1_760_000_000 + index,
-      cache_version: 8,
+      cache_version: 9,
       group: {
         index: 0,
         target_id: 2,
@@ -124,9 +123,9 @@ function seedSyntheticColorStacks(databaseId: string, projectId: number): void {
         rejected_frames: 0,
         output_channels: 1,
         sky_orientation: {
-          convention: 'north_up_east_left',
+          convention: 'source_frame',
           version: 1,
-          source: 'embedded_wcs',
+          source: 'source_frame',
           output_width: 512,
           output_height: 384,
           source_to_output: {
@@ -204,7 +203,8 @@ test('builds a real three-frame Seiza stack and exposes its frame decisions', as
   await expect(panel).toContainText('Alpha M44');
   await expect(panel.locator('.stack-preview-channel')).toHaveText('B');
   await expect(panel).toContainText('Stack preview');
-  await expect(panel.locator('.stack-preview-orientation')).toHaveText('N ↑ · E ←');
+  // Builds keep the reference frame's rotation, so no sky-orientation marker.
+  await expect(panel.locator('.stack-preview-orientation')).toHaveCount(0);
 
   const preview = panel.getByRole('img', { name: /stack preview/i });
   await expect(preview).toBeVisible();
@@ -231,12 +231,12 @@ test('builds a real three-frame Seiza stack and exposes its frame decisions', as
   expect(Number(fitsHead.headers()['content-length'])).toBeGreaterThan(10_000_000);
   const fitsResponse = await page.request.get(fitsHref!);
   const fitsHeaderText = (await fitsResponse.body()).subarray(0, 2880).toString('ascii');
-  expect(fitsHeaderText).toContain('SKYORIEN');
-  expect(fitsHeaderText).toContain('N-UP E-LEFT');
-  expect(fitsNumericValue(fitsHeaderText, 'CD1_1')).toBeLessThan(0);
-  expect(Math.abs(fitsNumericValue(fitsHeaderText, 'CD1_2'))).toBeLessThan(1e-10);
-  expect(Math.abs(fitsNumericValue(fitsHeaderText, 'CD2_1'))).toBeLessThan(1e-10);
-  expect(fitsNumericValue(fitsHeaderText, 'CD2_2')).toBeLessThan(0);
+  expect(fitsHeaderText).toContain('STACKCNT');
+  expect(fitsHeaderText).toContain('STACKREJ');
+  // The build keeps the reference frame's rotation, so it neither reprojects
+  // the pixels nor stamps the canonical sky-up WCS over them.
+  expect(fitsHeaderText).not.toContain('SKYORIEN');
+  expect(fitsHeaderText).not.toContain('N-UP E-LEFT');
 
   const defaultPreviewSrc = await preview.getAttribute('src');
   const stretchControls = panel.locator('.stack-preview-card .stack-stretch-controls');
@@ -607,8 +607,8 @@ test('composes cached channel stacks into RGB, LRGB, and selectable narrowband p
   expect(rgbHeader).toContain('COLORSPC');
   expect(rgbHeader).toContain('RGB');
   expect(rgbHeader).toContain('DISPLAY');
-  expect(rgbHeader).toContain('SKYORIEN');
-  expect(rgbHeader).toContain('N-UP E-LEFT');
+  expect(rgbHeader).not.toContain('SKYORIEN');
+  // The composite still inherits the reference channel's WCS.
   expect(fitsNumericValue(rgbHeader, 'CD1_1')).toBeLessThan(0);
   expect(fitsNumericValue(rgbHeader, 'CD2_2')).toBeLessThan(0);
 

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -662,7 +662,13 @@ export const apiClient = {
   startStackPreviews: async (
     dbId: string,
     projectId: number,
-    request: { image_ids: number[]; accepted_only: boolean; force?: boolean }
+    request: {
+      image_ids: number[];
+      accepted_only: boolean;
+      force?: boolean;
+      /** Reproject onto the shared north-up, east-left grid. Off by default. */
+      north_up?: boolean;
+    }
   ): Promise<StackPreviewJob> => {
     const apiInstance = await getApi();
     const { data } = await apiInstance.post<ApiResponse<StackPreviewJob>>(

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -376,12 +376,19 @@ export interface StackInputImage {
 /**
  * How the published stack pixels are laid out. `source_frame` keeps the
  * reference frame's own rotation and is the default; `north_up_east_left`
- * means the build was reprojected onto the shared celestial grid.
+ * means the build was reprojected onto the shared celestial grid. A
+ * `source_frame` stack whose source is `majority_half_turn` was turned half a
+ * turn so it faces the side of a meridian flip most of its exposure came from.
  */
 export interface StackSkyOrientation {
   convention: 'north_up_east_left' | 'source_frame';
   version: number;
-  source: 'cached_pixel_solve' | 'embedded_wcs' | 'stack_reference_solve' | 'source_frame';
+  source:
+    | 'cached_pixel_solve'
+    | 'embedded_wcs'
+    | 'stack_reference_solve'
+    | 'source_frame'
+    | 'majority_half_turn';
   output_width: number;
   output_height: number;
   source_to_output: unknown;

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -373,10 +373,15 @@ export interface StackInputImage {
   grading_status: number;
 }
 
+/**
+ * How the published stack pixels are laid out. `source_frame` keeps the
+ * reference frame's own rotation and is the default; `north_up_east_left`
+ * means the build was reprojected onto the shared celestial grid.
+ */
 export interface StackSkyOrientation {
-  convention: 'north_up_east_left';
+  convention: 'north_up_east_left' | 'source_frame';
   version: number;
-  source: 'cached_pixel_solve' | 'embedded_wcs' | 'stack_reference_solve';
+  source: 'cached_pixel_solve' | 'embedded_wcs' | 'stack_reference_solve' | 'source_frame';
   output_width: number;
   output_height: number;
   source_to_output: unknown;

--- a/static/src/components/StackColorPreviewPanel.tsx
+++ b/static/src/components/StackColorPreviewPanel.tsx
@@ -14,6 +14,7 @@ import StackColorProcessingControls from './StackColorProcessingControls';
 import {
   processingForColorBuild,
 } from './stackColorProcessing';
+import { isColorStackSkyOriented } from './stackOrientation';
 import { adoptableStackJob, useStackActivity } from '../hooks/useStackActivity';
 
 interface StackColorPreviewPanelProps {
@@ -239,7 +240,9 @@ function ColorCard({
             src={apiClient.getStackColorPreviewUrl(dbId, artifact.job_id, artifact.artifact_revision)}
             alt={`${target.target_name} ${label} color stack preview`}
           />
-          <span className="stack-preview-orientation">N ↑ · E ←</span>
+          {isColorStackSkyOriented(artifact) && (
+            <span className="stack-preview-orientation">N ↑ · E ←</span>
+          )}
         </div>
       ) : activeJob && !terminalStates.has(activeJob.state) ? (
         <div className="stack-preview-placeholder">
@@ -564,7 +567,7 @@ export default function StackColorPreviewPanel({
           summary={[
             `${inspector.sources.length} channel stacks`,
             `${inspector.sources.reduce((sum, source) => sum + source.accepted_frames, 0)} integrated inputs`,
-            'North up · East left',
+            ...(isColorStackSkyOriented(inspector) ? ['North up · East left'] : []),
           ]}
           imageUrl={apiClient.getStackColorPreviewUrl(
             dbId, inspector.job_id, inspector.artifact_revision, 'original'

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -13,6 +13,7 @@ import type {
 import StackPreviewInspector from './StackPreviewInspector';
 import StackColorPreviewPanel from './StackColorPreviewPanel';
 import StackStretchControls from './StackStretchControls';
+import { isSkyOriented } from './stackOrientation';
 import { useAccess } from '../auth/access';
 import { adoptableStackJob, useStackActivity } from '../hooks/useStackActivity';
 
@@ -550,7 +551,9 @@ export default function StackPreviewPanel({
                           )}
                           alt={`${targetName} ${filterName} stack preview`}
                         />
-                        <span className="stack-preview-orientation">N ↑ · E ←</span>
+                        {isSkyOriented(artifact.group.sky_orientation) && (
+                          <span className="stack-preview-orientation">N ↑ · E ←</span>
+                        )}
                       </div>
                     )}
                     {artifact && stretchKey && (
@@ -680,7 +683,9 @@ export default function StackPreviewPanel({
           summary={[
             `${inspector.group.accepted_frames} frames`,
             `${Math.round(inspector.group.total_exposure_seconds)} s`,
-            'North up · East left',
+            ...(isSkyOriented(inspector.group.sky_orientation)
+              ? ['North up · East left']
+              : []),
           ]}
           imageUrl={stretches[artifactStretchKey(inspector)]?.original_preview_url ??
             apiClient.getStackPreviewUrl(

--- a/static/src/components/__tests__/stackOrientation.test.ts
+++ b/static/src/components/__tests__/stackOrientation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { isColorStackSkyOriented, isSkyOriented } from '../stackOrientation';
+import type { StackColorJob, StackColorRole, StackSkyOrientation } from '../../api/types';
+
+function orientation(convention: StackSkyOrientation['convention']): StackSkyOrientation {
+  return {
+    convention,
+    version: 1,
+    source: convention === 'source_frame' ? 'source_frame' : 'embedded_wcs',
+    output_width: 512,
+    output_height: 384,
+    source_to_output: { matrix: [[1, 0], [0, 1]], translation_x: 0, translation_y: 0 },
+  };
+}
+
+function colorJob(conventions: StackSkyOrientation['convention'][]): StackColorJob {
+  const roles: StackColorRole[] = ['red', 'green', 'blue'];
+  return {
+    sources: conventions.map((convention, index) => ({
+      role: roles[index],
+      filter_name: roles[index],
+      job_id: `job-${index}`,
+      group_index: index,
+      artifact_revision: `rev-${index}`,
+      accepted_frames: 3,
+      reference_image_id: index + 1,
+      sky_orientation: orientation(convention),
+      registration_transform: null,
+    })),
+  } as unknown as StackColorJob;
+}
+
+describe('stack orientation', () => {
+  it('claims the sky frame only for a reprojected stack', () => {
+    expect(isSkyOriented(orientation('north_up_east_left'))).toBe(true);
+    expect(isSkyOriented(orientation('source_frame'))).toBe(false);
+    expect(isSkyOriented(null)).toBe(false);
+    expect(isSkyOriented(undefined)).toBe(false);
+  });
+
+  it('claims the sky frame for a composite only when every channel is oriented', () => {
+    expect(isColorStackSkyOriented(colorJob([
+      'north_up_east_left', 'north_up_east_left', 'north_up_east_left',
+    ]))).toBe(true);
+    expect(isColorStackSkyOriented(colorJob([
+      'north_up_east_left', 'source_frame', 'north_up_east_left',
+    ]))).toBe(false);
+    expect(isColorStackSkyOriented(colorJob(['source_frame']))).toBe(false);
+    expect(isColorStackSkyOriented(colorJob([]))).toBe(false);
+    expect(isColorStackSkyOriented(undefined)).toBe(false);
+  });
+});

--- a/static/src/components/stackOrientation.ts
+++ b/static/src/components/stackOrientation.ts
@@ -1,0 +1,19 @@
+import type { StackColorJob, StackSkyOrientation } from '../api/types';
+
+/**
+ * Whether a stack was reprojected onto the shared north-up, east-left grid.
+ * Builds keep the reference frame's own rotation by default, so only an
+ * explicitly oriented stack may claim the celestial display contract.
+ */
+export function isSkyOriented(orientation: StackSkyOrientation | null | undefined): boolean {
+  return orientation?.convention === 'north_up_east_left';
+}
+
+/**
+ * A composite only carries the celestial display contract when every channel
+ * stack it registered was built on the shared north-up grid.
+ */
+export function isColorStackSkyOriented(job: StackColorJob | undefined): boolean {
+  const sources = job?.sources ?? [];
+  return sources.length > 0 && sources.every((source) => isSkyOriented(source.sky_orientation));
+}


### PR DESCRIPTION
Stack previews were reprojected to north up, east left and marked with an `N ↑ · E ←` badge. That was more than we wanted. Registration already matches star triangles at any angle, so frames on either side of a meridian flip land on the same grid without a reprojection. The shared celestial grid only matters when several stacks must line up, as a sky mosaic needs.

A build now keeps the rotation of its reference frame, apart from one correction: it faces the side of a meridian flip most of its exposure came from. The full reprojection stays, behind a new `north_up` flag on the start request that defaults to off.

## Keeping the flip right way up

Keeping the reference frame's rotation on its own was not enough. The reference is whichever frame scored best, so for a night that flips it can sit on either side — and because frame scores are part of the cache key, a regrade or a quality rescan can move it across the flip and silently republish the stack half a turn over.

So the build weighs the integrated exposure by each frame's registered rotation, which registration already gives us. When most of those seconds sit half a turn from the reference, it turns the finished stack to match them. Reversing the pixel order is exact, so it costs no resampling and loses no accuracy, and the same half turn is composed into the recorded source-to-output mapping so artifact search and background protection follow the published pixels without special cases.

A night that never flipped is never turned, an even split keeps the reference frame's rotation, and the choice no longer moves when scores do.

## What changed

- `StackPreviewRequest` gained `north_up: bool`, default false. With it off, `run_group` skips `SkyOrientationPlan` entirely: no plate solve, no reprojection, and no `SKYORIEN` or replacement WCS stamped over the output. The FITS keeps the reference frame's own headers plus the `STACKCNT`/`STACKREJ` counters.
- Dropping the required solve is why the real three-frame e2e build went from about 200 seconds to 10.
- Every stack records a `sky_orientation` mapping under a `source_frame` convention — the identity, or the half turn with `source: "majority_half_turn"`. The convention checks go through a shared `StackSkyOrientation::is_current()`.
- Cache versions bumped (stack → 10, color → 10), so existing previews rebuild.
- The `N ↑ · E ←` badge and the "North up · East left" inspector line appear only for a stack actually built on the shared grid. A composite claims it only when every channel was.
- `docs/STACKING_PREVIEWS.md` covers the new default, the flip rule, and the north-up grid as the mosaic-facing option.

## Checks run locally

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` — 507 lib tests pass. New coverage: the request default, both conventions surviving the latest-index filter, the identity mapping, which rotations count as half a turn (including non-finite ones), the exposure-weighted majority across six cases, and that the pixel reversal is exact, keeps RGB channel order, and agrees with its recorded affine.
- `npm run lint`, `npx tsc --noEmit`, `npx vitest run` — passes apart from the 5 pre-existing `useColorPreview` localStorage failures, which fail identically on `main`.
- `npx playwright test stack-preview` — 3 passed. The real build now also asserts the published orientation record.

## Worth flagging

There is still no UI toggle for `north_up`, so the reprojection is reachable only by an API caller and has no automated coverage. That is deliberate — no user-facing workflow needs it until mosaics land — but it does mean the oriented path will have been untested for however long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)