### PR TITLE
Use the published Seiza 0.15 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,9 +2776,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.14.0"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
 ]
@@ -3821,7 +3821,7 @@ checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.3",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -4098,15 +4098,6 @@ name = "quick-xml"
 version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4915,7 +4906,8 @@ dependencies = [
 [[package]]
 name = "seiza"
 version = "0.15.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0e19c1983f135a319ae46fa8a51cb6392eff58fe8f4bf5dc1c795161d8458b"
 dependencies = [
  "directories",
  "image",
@@ -4936,7 +4928,8 @@ dependencies = [
 [[package]]
 name = "seiza-background"
 version = "0.2.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce27c654312993dceef01e654de2fdce5d3adeddbac19ea0c45c0b94a91b271b"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -4947,7 +4940,8 @@ dependencies = [
 [[package]]
 name = "seiza-calibration"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3efb42a2d6f61b63a95de257e1b8b30495b6347c466ed9bd5982df333d30d9"
 dependencies = [
  "seiza-imgproc",
  "seiza-stats",
@@ -4958,7 +4952,8 @@ dependencies = [
 [[package]]
 name = "seiza-deconvolution"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaceca0f83c0e33737d4180166c0a50ac0af4b17c3621f44346872f134871cd0"
 dependencies = [
  "rayon",
  "serde",
@@ -4968,7 +4963,8 @@ dependencies = [
 [[package]]
 name = "seiza-download"
 version = "0.6.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef1b97548079179df46c445b19056a4e0d9e332899b1980ba505ad479095ab0"
 dependencies = [
  "async-compression",
  "directories",
@@ -4986,7 +4982,8 @@ dependencies = [
 [[package]]
 name = "seiza-fits"
 version = "0.2.1"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b956875bf6b87e92eb0aab29b9fe36ffb0575cbab0f802e386bbab0d88b022e"
 dependencies = [
  "multiversion",
  "seiza-stretch",
@@ -4996,7 +4993,8 @@ dependencies = [
 [[package]]
 name = "seiza-imgproc"
 version = "0.3.1"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7838c64e51a8b068a684c25cea2d5333b38d5945c236f89d836408596dea6f1e"
 dependencies = [
  "rayon",
 ]
@@ -5004,7 +5002,8 @@ dependencies = [
 [[package]]
 name = "seiza-satellites"
 version = "0.4.5"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b530ea0708671c04c346f857699c6366d06441043c743d5492b1731b905b566"
 dependencies = [
  "directories",
  "fs2",
@@ -5022,7 +5021,8 @@ dependencies = [
 [[package]]
 name = "seiza-stacking"
 version = "0.3.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e71d0811c7ff22bc80f26bdee54a9832ddab11c1825bd708cdcfa5dee23c945"
 dependencies = [
  "rayon",
  "seiza",
@@ -5042,12 +5042,14 @@ dependencies = [
 [[package]]
 name = "seiza-stats"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02427eea0eebef160eba79502519b73272924ccea855462292006af2320ef9e2"
 
 [[package]]
 name = "seiza-stretch"
 version = "0.2.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e449c39ffe12c989a715479ce8e60990d0c9e8108d18d4f272a4631abbac27"
 dependencies = [
  "rayon",
  "seiza-stats",
@@ -5058,11 +5060,12 @@ dependencies = [
 [[package]]
 name = "seiza-xisf"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza.git?rev=f514751f5f11b578dcdc077f63c5cf506dc0c456#f514751f5f11b578dcdc077f63c5cf506dc0c456"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c58629034c4197cf415a86ad91fc044dbf9f1ea892ec5617d611e530af990c"
 dependencies = [
  "flate2",
  "lz4_flex",
- "quick-xml 0.41.0",
+ "quick-xml",
  "seiza-fits",
  "sha1",
  "sha2 0.11.0",
@@ -5309,13 +5312,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.11.0"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = { git = "https://github.com/theatrus/seiza.git", rev = "f514751f5f11b578dcdc077f63c5cf506dc0c456", version = "0.15.0" }
-seiza-download = { git = "https://github.com/theatrus/seiza.git", rev = "f514751f5f11b578dcdc077f63c5cf506dc0c456", version = "0.6.0" }
-seiza-imgproc = { git = "https://github.com/theatrus/seiza.git", rev = "f514751f5f11b578dcdc077f63c5cf506dc0c456", version = "0.3.1", features = ["parallel"] }
-seiza-fits = { git = "https://github.com/theatrus/seiza.git", rev = "f514751f5f11b578dcdc077f63c5cf506dc0c456", version = "=0.2.1" }
-seiza-satellites = { git = "https://github.com/theatrus/seiza.git", rev = "f514751f5f11b578dcdc077f63c5cf506dc0c456", version = "0.4.5", features = ["serde"] }
-seiza-stacking = { git = "https://github.com/theatrus/seiza.git", rev = "f514751f5f11b578dcdc077f63c5cf506dc0c456", version = "0.3.0" }
-seiza-stretch = { git = "https://github.com/theatrus/seiza.git", rev = "f514751f5f11b578dcdc077f63c5cf506dc0c456", version = "0.2.0" }
-seiza-background = { git = "https://github.com/theatrus/seiza.git", rev = "f514751f5f11b578dcdc077f63c5cf506dc0c456", version = "0.2.0" }
-seiza-deconvolution = { git = "https://github.com/theatrus/seiza.git", rev = "f514751f5f11b578dcdc077f63c5cf506dc0c456", version = "0.1.0" }
+seiza = "0.15.0"
+seiza-download = "0.6.0"
+seiza-imgproc = { version = "0.3.1", features = ["parallel"] }
+seiza-fits = "=0.2.1"
+seiza-satellites = { version = "0.4.5", features = ["serde"] }
+seiza-stacking = "0.3.0"
+seiza-stretch = "0.2.0"
+seiza-background = "0.2.0"
+seiza-deconvolution = "0.1.0"
 sha2 = "0.11"
 base64 = "0.23"
 rayon = "1"


### PR DESCRIPTION
Follow-up to #292, which merged with the temporary git pins still in place.

`seiza` 0.15.0, `seiza-stacking` 0.3.0, and `seiza-satellites` 0.4.5 are published, so every seiza dependency goes back to a plain version requirement. Verified `Cargo.lock` resolves all twelve seiza crates from the registry — no `source = "git"` left.

No source changes; the crop feature itself landed in #292.

### Testing

`cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` (18 binaries) all green against the published crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)