### PR TITLE
Collect release notes as changes merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,10 @@ Current behavior: [importing](docs/IMPORTING.md) and
    browser layers before handoff.
 5. Run `git diff --check` and review the final diff for stale links, generated
    files, and unrelated changes.
-6. For a PR, state exactly which checks ran. Do not treat hosted CI as a local
+6. Add a line to `docs/releases/unreleased.md` when the change is visible to a
+   user. Describe the behavior they get, not the commit. Skip it for internal
+   refactors, test-only work, and dependency bumps.
+7. For a PR, state exactly which checks ran. Do not treat hosted CI as a local
    test result.
 
 ## Documentation

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -32,6 +32,12 @@ Create an isolated worktree from current `origin/main`. Update:
 - `packaging/rpm/psf-guard.spec` version and changelog; and
 - `docs/releases/vVERSION.md` release highlights.
 
+Write the highlights by renaming `docs/releases/unreleased.md`, which collects
+each user-visible change as it merges. Read it against
+`git log vPREVIOUS..origin/main` and fill in anything that landed without an
+entry. Then rewrite the opening sentence for this version, drop the note about
+renaming the file, and start a fresh `unreleased.md` for the next release.
+
 Search for the old version after the edit. Test fixtures and dependency versions
 may still use the same number; inspect each match instead of replacing all of
 them.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,72 @@
+# Unreleased
+
+> Add a line here as each user-visible change merges. At release time this
+> file becomes `vVERSION.md`; rewrite the opening sentence for the version
+> being shipped and delete this note. See [the release guide](../RELEASING.md).
+
+This release adds optional server accounts, cropped and gradient-corrected
+color stacks, and a Sequence view that keeps its place as you grade.
+
+## Added
+
+- Optional server user accounts, with roles, a browser management UI, and a
+  login page. See [authentication](../AUTHENTICATION.md).
+- A **Stop** button on a queued or running stack build. The stop lands between
+  frames, between channels, and between calibration masters. Nothing partial is
+  published, and channels that already finished keep their previews.
+- A **Stacking** indicator in the header for as long as any mono or color
+  build is queued or running, in every view and across databases. Stack panels
+  re-attach to a running job when they mount, so leaving the grid or reloading
+  no longer hides work in flight.
+- Source-frame artifact search: select a region of a stack and see the frames
+  that contributed it, with the shape classified and localized quality findings
+  highlighted.
+- Automatic gradient correction for stack previews.
+- An **Edges** picker on each color card: keep the blank edges left by
+  registration, trim to the box the covered pixels span, or trim to the largest
+  rectangle every channel covers in full. The default is unchanged. A completed
+  card reports the kept size and, when one channel bounded the crop, names it.
+- A thumbnail zoom control in Sequence, remembered across reloads.
+- Quality analysis can be started from the image grid, and now appears only
+  where it is needed.
+
+## Changed
+
+- Stack previews keep the rotation of their reference frame instead of being
+  reprojected. A build that spans a meridian flip is turned to face the side
+  most of its exposure came from. The shared north-up, east-left grid is still
+  available to an API caller through `north_up: true`, which is what a mosaic
+  needs. Dropping the required plate solve also made a three-frame build about
+  twenty times faster.
+- A color composite crops before normalization, so every channel is scaled
+  from the same patch of sky, and its FITS keeps the reference plate solution.
+- Sequence navigation matches the image grid: the same arrow keys, the same
+  Space selection, and a grid selection carried into Sequence.
+- Sequence tabs wrap instead of scrolling sideways.
+- Sequence quality scores renormalize when evidence is missing, so a session
+  is not punished for a scan that has not run, and scores stay consistent
+  across sessions and projects.
+- A satellite trail warning needs pixel evidence, not just a predicted pass.
+- Background grading uses the solved nebulosity of a field.
+- The Overview states its grading progress and status more plainly, and the
+  selection marker no longer sits over the quality score.
+- The closed project picker names its database under the project name.
+
+## Fixed
+
+- Opening the Overview no longer loses the project you were working in.
+- Closing an image detail returns to the view that opened it, at the position
+  it was left, including a partly visible Sequence card.
+- Background protection follows the stack's own geometry.
+- Flagged Sequence thumbnails stay bright.
+- Shift-click range selection keeps a stable anchor.
+
+## Security
+
+- A server bound to anything other than loopback now answers `401` to every
+  API request until an operator adds a user, and refuses to start if it was
+  also asked for database management. Previously a server with no accounts
+  treated every caller as a full editor, and the default bind is `0.0.0.0`.
+  Remote sync and image upload are unaffected — their bearer keys carry their
+  own proof. `--allow-anonymous-access` restores the old behavior for a
+  trusted network, and logs what it gives away.


### PR DESCRIPTION
Release notes are written at release time from `git log`. There are 26 unreleased commits since v0.6.6, so whoever cuts the next release has to reconstruct the user-visible behavior from commit subjects — and anything that landed under an internal-sounding subject is easy to miss.

`docs/releases/unreleased.md` now collects a line per user-visible change as it merges. At release time it is renamed to `vVERSION.md`, which is the file the release workflow already prepends to GitHub's generated change list.

## What changed

- **`docs/releases/unreleased.md`** — seeded with everything since v0.6.6, grouped Added / Changed / Fixed / Security.
- **`docs/RELEASING.md`** — step 2 now says to write the highlights by renaming `unreleased.md`, check it against `git log vPREVIOUS..origin/main` for anything that landed without an entry, and start a fresh file.
- **`CLAUDE.md`** — a step in the change workflow to add a line when a change is visible to a user, and to skip it for refactors, test-only work, and dependency bumps. `AGENTS.md` is a symlink, so it follows.

## Notes on the seeded content

Entries came from reading the commit bodies, not the subjects.

Where a change was superseded before shipping, the notes describe the behavior that will actually ship rather than the round trip. The sky-up stack default (#285) landed and was then replaced by keeping the source rotation (#291), so there is one entry saying stacks keep their reference frame's rotation — a reader of the release notes never saw the intermediate state.

Dependency bumps (#265, #293) are not listed. GitHub's generated change list already names every merged PR; this file is the highlights that sit above it.

## Two things worth knowing about the format

The editing note at the top is a **blockquote**, not a paragraph or an HTML comment. `summaryFromNotes` in `scripts/release-feeds.mjs` takes the first prose paragraph as the update-banner summary and explicitly skips `>` lines, but it does not skip HTML comments — a comment there would have shipped as the banner text of the next release.

Nothing globs `docs/releases/`. `check-release-version.mjs` and `release-feeds.mjs` both read `docs/releases/<tag>.md` by exact name, so the extra file is inert until it is renamed.

## Checks run locally

- `npm run test:release` — 14 pass, with the new file present.
- Ran `summaryFromNotes` against the seeded file: it returns the intended sentence, `"This release adds optional server accounts, cropped and gradient-corrected color stacks, and a Sequence view that keeps its place as you grade."`, confirming the blockquote is skipped.
- `git diff --check` clean; prose wrapped at 80 columns and spelled to match the repo (`color`, `behavior`).

Docs only — no Rust or frontend source is touched, so I did not run the Rust or browser layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)