### PR TITLE
Queue stack builds by hand, resume additive rebuilds, sweep stale artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,7 @@ dependencies = [
  "clap",
  "dirs",
  "dunce",
+ "filetime",
  "http-body-util",
  "humantime",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ libc = "0.2"
 windows-sys = { version = "0.61", features = ["Win32_System_SystemInformation"] }
 
 [dev-dependencies]
+filetime = "0.2"
 http-body-util = "0.1"
 
 [features]

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -60,10 +60,25 @@ checkpoint is only reused when it is provably an ancestor of the request:
 every recorded frame must still be requested with an identical source
 fingerprint, and the calibration set, Accepted-only policy, and stacking
 pipeline version must match. Removing a frame, regrading one in place,
-changing calibration, or upgrading Seiza rebuilds from scratch. A stopped
-build checkpoints the frames it finished, so building again continues where
-the stop landed instead of starting over. Checkpoints live in the project
-cache and cost one full-frame state file per target/channel.
+changing calibration, or upgrading Seiza rebuilds from scratch — and when a
+checkpoint existed but could not be extended, the card says why (`Full
+restack: calibration changed`), so a slow rebuild is never a mystery. A
+stopped build checkpoints the frames it finished, so building again continues
+where the stop landed instead of starting over. Checkpoints live in the
+project cache and cost one full-frame state file per target/channel.
+
+### Cache housekeeping
+
+Stack artifacts are content-addressed by job, so every rebuild writes a new
+directory and old ones used to accumulate forever. After a build settles, a
+janitor sweeps the stack cache and deletes what nothing references any more:
+mono and color job directories absent from every durable latest index and
+from the in-memory job list, and cached color inputs no kept job points at.
+An unreferenced directory is only deleted once it is an hour old, so a build
+writing artifacts at that moment is never swept. Resume checkpoints are
+replaced in place on every settle and are dropped only after thirty days
+untouched, so a stopped build stays resumable for a month while an abandoned
+target cannot hold full-frame accumulator state forever.
 
 A build belongs to the server, not to the page that started it. The header
 shows a **Stacking** indicator next to the cache and quality-analysis progress

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -31,6 +31,40 @@ databases, so full-frame accumulator buffers cannot multiply unexpectedly.
 Cards are capped at two columns on wide displays so the inspection preview does
 not become excessively wide.
 
+### Queue builds by hand
+
+Build buttons stay available while a build runs. Clicking **Build channel** on
+another card — or a color build, or **Build stack previews** for the whole set
+— queues that job behind the running one on the same single-job worker, so
+memory use does not grow with the queue. Each card shows its own state:
+`queued` cards wait, the `running` card shows live progress, and the status
+line counts the builds in the queue. The header **Stacking** indicator lists
+the same queue in every view. **Stop** becomes **Stop all** when more than one
+build is pending and stops every queued and running job; channels that already
+finished keep their previews.
+
+### Additive rebuilds resume
+
+A finished or stopped channel build checkpoints its integration state — the
+running accumulator, the online rejection statistics, and the registration
+reference — beside a ledger of every frame it integrated or turned away. A
+later build of the same target and channel whose frame set only grew reopens
+that checkpoint and integrates just the new frames, so adding a night to a
+season-long target costs one night's stacking, not the whole season's. The
+card marks restored work as `resumed` in its frame counter.
+
+The resumed result is exactly the stack a from-scratch build would produce;
+Seiza's checkpoint round trip is bit-for-bit and validates the format version,
+dimensions, configuration, and payload checksum before continuing. The
+checkpoint is only reused when it is provably an ancestor of the request:
+every recorded frame must still be requested with an identical source
+fingerprint, and the calibration set, Accepted-only policy, and stacking
+pipeline version must match. Removing a frame, regrading one in place,
+changing calibration, or upgrading Seiza rebuilds from scratch. A stopped
+build checkpoints the frames it finished, so building again continues where
+the stop landed instead of starting over. Checkpoints live in the project
+cache and cost one full-frame state file per target/channel.
+
 A build belongs to the server, not to the page that started it. The header
 shows a **Stacking** indicator next to the cache and quality-analysis progress
 for as long as any mono or color build is queued or running, in every view and

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -74,11 +74,17 @@ directory and old ones used to accumulate forever. After a build settles, a
 janitor sweeps the stack cache and deletes what nothing references any more:
 mono and color job directories absent from every durable latest index and
 from the in-memory job list, and cached color inputs no kept job points at.
-An unreferenced directory is only deleted once it is an hour old, so a build
-writing artifacts at that moment is never swept. Resume checkpoints are
-replaced in place on every settle and are dropped only after thirty days
-untouched, so a stopped build stays resumable for a month while an abandoned
-target cannot hold full-frame accumulator state forever.
+Both indices replace entries per identity — mono per target/channel, color
+per target/kind/palette — so a job's output is durable until its input set
+changes and a newer build of the same identity supersedes it. A full day of
+grace on top means nothing a long build session or an open inspector still
+touches is swept out from under it.
+
+Resume checkpoints follow the same rule: each is replaced in place when its
+group's input set changes and is otherwise kept, whatever its age. The only
+checkpoints deleted outright are ones that can never resume again — written
+by another stacking pipeline version, unreadable, or an orphaned half of an
+interrupted save.
 
 A build belongs to the server, not to the page that started it. The header
 shows a **Stacking** indicator next to the cache and quality-analysis progress

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -519,7 +519,7 @@ impl StackPreviewManager {
     /// pruning never fails a build.
     pub(super) fn prune_cache(&self, cache_root: &FsPath) {
         let keep = self.cache_keep_set(cache_root);
-        janitor::prune(cache_root, &keep);
+        janitor::prune(cache_root, &keep, SEIZA_STACKING_VERSION);
     }
 
     pub(crate) async fn acquire_maintenance_permit(

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -7,6 +7,7 @@
 
 pub mod artifact;
 pub mod color;
+mod janitor;
 mod resume;
 pub mod stretch;
 
@@ -207,6 +208,10 @@ pub struct StackGroupStatus {
     /// and integrated again. Zero for a from-scratch build.
     #[serde(default)]
     pub reused_frames: usize,
+    /// Why a checkpoint that existed could not be extended, when that
+    /// happened. Absent for a resumed build and for a first build.
+    #[serde(default)]
+    pub resume_note: Option<String>,
     #[serde(default)]
     pub output_channels: usize,
     #[serde(default)]
@@ -474,6 +479,47 @@ impl StackPreviewManager {
                 .then_with(|| left.job_id.cmp(&right.job_id))
         });
         active
+    }
+
+    /// Everything on disk that is still referenced: jobs a panel may poll,
+    /// and jobs a durable latest index still names. Reads every project's
+    /// index because a cache root hosts every project of a database.
+    fn cache_keep_set(&self, cache_root: &FsPath) -> janitor::KeepSet {
+        let mut mono_job_ids: std::collections::HashSet<String> =
+            self.jobs.lock().unwrap().keys().cloned().collect();
+        let mut color_job_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut color_input_ids: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        for job in self.color_jobs.lock().unwrap().values() {
+            color_job_ids.insert(job.job_id.clone());
+            if let Some(input_id) = &job.linear_input_id {
+                color_input_ids.insert(input_id.clone());
+            }
+        }
+        for latest in read_latest_indices::<LatestStackPreviews>(&cache_root.join("stack-previews"))
+        {
+            for group in latest.groups {
+                mono_job_ids.insert(group.job_id);
+            }
+        }
+        for (job_id, input_id) in color::latest_color_references(cache_root) {
+            color_job_ids.insert(job_id);
+            if let Some(input_id) = input_id {
+                color_input_ids.insert(input_id);
+            }
+        }
+        janitor::KeepSet {
+            mono_job_ids,
+            color_job_ids,
+            color_input_ids,
+        }
+    }
+
+    /// Sweep superseded artifacts after a build settles. Failures are logged;
+    /// pruning never fails a build.
+    pub(super) fn prune_cache(&self, cache_root: &FsPath) {
+        let keep = self.cache_keep_set(cache_root);
+        janitor::prune(cache_root, &keep);
     }
 
     pub(crate) async fn acquire_maintenance_permit(
@@ -1115,6 +1161,7 @@ fn prepare_job(
             accepted_frames: 0,
             rejected_frames: 0,
             reused_frames: 0,
+            resume_note: None,
             output_channels: 0,
             sky_orientation: None,
             reference_image_id,
@@ -1476,6 +1523,7 @@ fn run_job(state: &Arc<AppState>, prepared: PreparedJob, cancel: &Arc<AtomicBool
     {
         tracing::warn!("Failed to persist latest stack preview index: {error}");
     }
+    state.stack_previews.prune_cache(&cache_root);
 }
 
 /// Whether a channel produced an artifact or stopped on request. A failure is
@@ -1563,7 +1611,7 @@ fn run_group(
         .iter()
         .map(|frame| (frame.image_id, frame.source_fingerprint.as_str()))
         .collect::<Vec<_>>();
-    let checkpoint = resume::load(
+    let decision = resume::load(
         cache_root,
         database_id,
         group_target_id,
@@ -1573,6 +1621,17 @@ fn run_group(
         &calibration_fingerprint,
         &requested,
     );
+    if let Some(reason) = decision.fresh_reason() {
+        tracing::info!(
+            target_id = group_target_id,
+            filter = %group_filter_name,
+            "Full restack: {reason}"
+        );
+        state.stack_previews.update(job_id, |job| {
+            job.groups[group.index].resume_note = Some(format!("Full restack: {reason}"));
+        });
+    }
+    let checkpoint = decision.state();
     let reference_frame =
         FitsFrame::open(&group.frames[0].path).map_err(|error| error.to_string())?;
     let output_channels = if reference_frame.bayer.is_some() {
@@ -1622,6 +1681,10 @@ fn run_group(
                         "Stack checkpoint could not be reopened ({error}); rebuilding from scratch"
                     );
                     resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
+                    state.stack_previews.update(job_id, |job| {
+                        job.groups[group.index].resume_note =
+                            Some("Full restack: the checkpoint could not be reopened".into());
+                    });
                     None
                 }
             }
@@ -2113,6 +2176,24 @@ fn manifest_path(cache_root: &FsPath, job_id: &str) -> PathBuf {
     stack_dir(cache_root, job_id).join("manifest.json")
 }
 
+/// Parse every `latest-project-*.json` directly inside a directory.
+pub(super) fn read_latest_indices<T: serde::de::DeserializeOwned>(directory: &FsPath) -> Vec<T> {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("latest-project-") && name.ends_with(".json"))
+        })
+        .filter_map(|entry| std::fs::read(entry.path()).ok())
+        .filter_map(|bytes| serde_json::from_slice(&bytes).ok())
+        .collect()
+}
+
 fn latest_path(cache_root: &FsPath, project_id: i32) -> PathBuf {
     cache_root
         .join("stack-previews")
@@ -2155,6 +2236,7 @@ mod tests {
             accepted_frames: 2,
             rejected_frames: 0,
             reused_frames: 0,
+            resume_note: None,
             output_channels: 1,
             sky_orientation: Some(sky_orientation()),
             reference_image_id: Some(image_id),

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -7,6 +7,7 @@
 
 pub mod artifact;
 pub mod color;
+mod resume;
 pub mod stretch;
 
 use axum::{
@@ -202,6 +203,10 @@ pub struct StackGroupStatus {
     pub processed_frames: usize,
     pub accepted_frames: usize,
     pub rejected_frames: usize,
+    /// Frames restored from a saved accumulator instead of being registered
+    /// and integrated again. Zero for a from-scratch build.
+    #[serde(default)]
+    pub reused_frames: usize,
     #[serde(default)]
     pub output_channels: usize,
     #[serde(default)]
@@ -1109,6 +1114,7 @@ fn prepare_job(
             processed_frames: 0,
             accepted_frames: 0,
             rejected_frames: 0,
+            reused_frames: 0,
             output_channels: 0,
             sky_orientation: None,
             reference_image_id,
@@ -1389,6 +1395,7 @@ fn cancel_unfinished_groups(job: &mut StackPreviewJob) {
 fn run_job(state: &Arc<AppState>, prepared: PreparedJob, cancel: &Arc<AtomicBool>) {
     let job_id = prepared.public.job_id.clone();
     let database_id = prepared.public.database_id.clone();
+    let accepted_only = prepared.public.accepted_only;
     let PreparedJob {
         public: _,
         groups,
@@ -1404,6 +1411,7 @@ fn run_job(state: &Arc<AppState>, prepared: PreparedJob, cancel: &Arc<AtomicBool
         job_id: &job_id,
         cache_root: &cache_root,
         north_up,
+        accepted_only,
         worker_policy: &worker_policy,
         cancel,
     };
@@ -1484,6 +1492,7 @@ struct GroupJob<'a> {
     job_id: &'a str,
     cache_root: &'a FsPath,
     north_up: bool,
+    accepted_only: bool,
     worker_policy: &'a crate::concurrency::WorkerPolicy,
     cancel: &'a Arc<AtomicBool>,
 }
@@ -1502,6 +1511,7 @@ fn run_group(
         job_id,
         cache_root,
         north_up,
+        accepted_only,
         worker_policy,
         cancel,
     } = job;
@@ -1534,11 +1544,35 @@ fn run_group(
         return Ok(GroupOutcome::Cancelled);
     }
     let (calibration_masters, applied_calibration) = masters.map_err(|error| error.to_string())?;
+    let calibration_fingerprint = applied_calibration.fingerprint.clone();
     state.stack_previews.update(job_id, |job| {
         let status = &mut job.groups[group.index];
         status.calibration = applied_calibration;
         status.phase = "stacking".into();
     });
+    let (group_target_id, group_filter_name) = state
+        .stack_previews
+        .get(job_id)
+        .map(|job| {
+            let status = &job.groups[group.index];
+            (status.target_id, status.filter_name.clone())
+        })
+        .ok_or_else(|| "Stack job disappeared while running".to_string())?;
+    let requested = group
+        .frames
+        .iter()
+        .map(|frame| (frame.image_id, frame.source_fingerprint.as_str()))
+        .collect::<Vec<_>>();
+    let checkpoint = resume::load(
+        cache_root,
+        database_id,
+        group_target_id,
+        &group_filter_name,
+        accepted_only,
+        SEIZA_STACKING_VERSION,
+        &calibration_fingerprint,
+        &requested,
+    );
     let reference_frame =
         FitsFrame::open(&group.frames[0].path).map_err(|error| error.to_string())?;
     let output_channels = if reference_frame.bayer.is_some() {
@@ -1578,44 +1612,158 @@ fn run_group(
     );
 
     pool.install(|| {
-        let reference_exposure = reference_frame.exposure_seconds.unwrap_or(0.0);
-        // The reference frame defines zero rotation, so it always votes upright.
-        let mut orientation_vote = OrientationVote::default();
-        orientation_vote.add(0.0, reference_exposure);
-        let options = StackOptions {
-            normalization: NormalizationMode::Global,
-            ..StackOptions::default()
-        };
-        let mut stacker = LiveStacker::new(reference_frame, calibration_masters, options)
-            .map_err(|error| error.to_string())?;
-        let reference_mapping = stacker.reference_mapping();
-        state.stack_previews.update(job_id, |job| {
-            let status = &mut job.groups[group.index];
-            status.processed_frames = 1;
-            status.accepted_frames = 1;
-            status.output_channels = output_channels as usize;
-            status.total_exposure_seconds = reference_exposure;
-            status.frames.push(StackFrameDecision {
-                image_id: group.frames[0].image_id,
-                disposition: "reference".into(),
-                reason: None,
-                quality_score: group.frames[0].quality_score,
-                matched_stars: None,
-                registration_rms_pixels: None,
-                registration_drift_pixels: None,
-                registered_mapping: Some(reference_mapping),
-                normalization_mean_gain: Some(1.0),
-                normalization_mean_offset: Some(0.0),
-                source_fingerprint: Some(group.frames[0].source_fingerprint.clone()),
-                overlap_fraction: Some(1.0),
-                integrated_fraction: Some(1.0),
-            });
+        // A checkpoint that fails to reopen — a Seiza version change, a
+        // truncated file — is discarded and the group builds from scratch.
+        let restored = checkpoint.and_then(|checkpoint| {
+            match LiveStacker::open_context(&checkpoint.context_path) {
+                Ok(stacker) => Some((stacker, checkpoint.manifest)),
+                Err(error) => {
+                    tracing::warn!(
+                        "Stack checkpoint could not be reopened ({error}); rebuilding from scratch"
+                    );
+                    resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
+                    None
+                }
+            }
         });
+        let mut orientation_vote = OrientationVote::default();
+        let (mut stacker, mut ledger) = match restored {
+            Some((stacker, manifest)) => {
+                // Replay the checkpointed ledger: the per-frame record, the
+                // counters, and each accepted frame's orientation vote. The
+                // reference is the ledger's first entry and votes upright.
+                let ledger = manifest.frames;
+                for frame in &ledger {
+                    if let Some(rotation) = frame.rotation_radians {
+                        orientation_vote.add(rotation, frame.exposure_seconds);
+                    }
+                }
+                tracing::info!(
+                    "Stack preview {} group {}: resuming from a checkpoint of {} frame(s)",
+                    job_id,
+                    group.index,
+                    ledger.len()
+                );
+                state.stack_previews.update(job_id, |job| {
+                    let status = &mut job.groups[group.index];
+                    status.processed_frames = ledger.len();
+                    status.accepted_frames = ledger
+                        .iter()
+                        .filter(|frame| {
+                            matches!(
+                                frame.decision.disposition.as_str(),
+                                "reference" | "accepted"
+                            )
+                        })
+                        .count();
+                    status.rejected_frames = ledger.len() - status.accepted_frames;
+                    status.reused_frames = ledger.len();
+                    status.output_channels = output_channels as usize;
+                    status.total_exposure_seconds = ledger
+                        .iter()
+                        .filter(|frame| frame.rotation_radians.is_some())
+                        .map(|frame| frame.exposure_seconds)
+                        .sum();
+                    status.frames = ledger.iter().map(|frame| frame.decision.clone()).collect();
+                });
+                (stacker, ledger)
+            }
+            None => {
+                let reference_exposure = reference_frame.exposure_seconds.unwrap_or(0.0);
+                // The reference frame defines zero rotation; it votes upright.
+                orientation_vote.add(0.0, reference_exposure);
+                let options = StackOptions {
+                    normalization: NormalizationMode::Global,
+                    ..StackOptions::default()
+                };
+                let stacker = LiveStacker::new(reference_frame, calibration_masters, options)
+                    .map_err(|error| error.to_string())?;
+                let reference_mapping = stacker.reference_mapping();
+                let reference_decision = StackFrameDecision {
+                    image_id: group.frames[0].image_id,
+                    disposition: "reference".into(),
+                    reason: None,
+                    quality_score: group.frames[0].quality_score,
+                    matched_stars: None,
+                    registration_rms_pixels: None,
+                    registration_drift_pixels: None,
+                    registered_mapping: Some(reference_mapping),
+                    normalization_mean_gain: Some(1.0),
+                    normalization_mean_offset: Some(0.0),
+                    source_fingerprint: Some(group.frames[0].source_fingerprint.clone()),
+                    overlap_fraction: Some(1.0),
+                    integrated_fraction: Some(1.0),
+                };
+                state.stack_previews.update(job_id, |job| {
+                    let status = &mut job.groups[group.index];
+                    status.processed_frames = 1;
+                    status.accepted_frames = 1;
+                    status.output_channels = output_channels as usize;
+                    status.total_exposure_seconds = reference_exposure;
+                    status.frames.push(reference_decision.clone());
+                });
+                let ledger = vec![resume::ResumeFrame {
+                    decision: reference_decision,
+                    exposure_seconds: reference_exposure,
+                    rotation_radians: Some(0.0),
+                }];
+                (stacker, ledger)
+            }
+        };
+        let already_integrated: std::collections::HashSet<i32> =
+            ledger.iter().map(|frame| frame.decision.image_id).collect();
+        let save_checkpoint = |stacker: &LiveStacker, ledger: &[resume::ResumeFrame]| {
+            let context_path =
+                resume::context_path(cache_root, database_id, group_target_id, &group_filter_name);
+            let manifest = resume::ResumeManifest {
+                schema_version: resume::RESUME_SCHEMA_VERSION,
+                stacking_version: SEIZA_STACKING_VERSION.into(),
+                target_id: group_target_id,
+                filter_name: group_filter_name.clone(),
+                accepted_only,
+                calibration_fingerprint: calibration_fingerprint.clone(),
+                frames: ledger.to_vec(),
+            };
+            let saved = context_path
+                .parent()
+                .ok_or_else(|| "checkpoint path has no parent".to_string())
+                .and_then(|parent| {
+                    std::fs::create_dir_all(parent).map_err(|error| error.to_string())
+                })
+                .and_then(|()| {
+                    stacker
+                        .save_context(&context_path)
+                        .map_err(|error| error.to_string())
+                })
+                .and_then(|()| {
+                    resume::store_manifest(
+                        &resume::manifest_path(
+                            cache_root,
+                            database_id,
+                            group_target_id,
+                            &group_filter_name,
+                        ),
+                        &manifest,
+                    )
+                });
+            if let Err(error) = saved {
+                // A checkpoint is an optimization; a build never fails over
+                // it. Discard the pair so nothing resumes from half a save.
+                tracing::warn!("Failed to save stack checkpoint: {error}");
+                resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
+            }
+        };
 
-        for frame in group.frames.iter().skip(1) {
+        for frame in group
+            .frames
+            .iter()
+            .filter(|frame| !already_integrated.contains(&frame.image_id))
+        {
             // Registering and integrating one frame is the unit of work here,
-            // so this is where a stop takes effect.
+            // so this is where a stop takes effect. The frames already pushed
+            // are checkpointed, so building again continues from them.
             if cancel.load(Ordering::Relaxed) {
+                save_checkpoint(&stacker, &ledger);
                 return Ok(GroupOutcome::Cancelled);
             }
             let opened = FitsFrame::open(&frame.path);
@@ -1677,6 +1825,18 @@ fn run_group(
                     integrated_fraction: None,
                 },
             };
+            ledger.push(resume::ResumeFrame {
+                decision: decision.clone(),
+                exposure_seconds: exposure,
+                rotation_radians: if decision.disposition == "accepted" {
+                    decision
+                        .registered_mapping
+                        .as_ref()
+                        .map(|mapping| mapping.transform().rotation_radians)
+                } else {
+                    None
+                },
+            });
             state.stack_previews.update(job_id, |job| {
                 let status = &mut job.groups[group.index];
                 status.processed_frames += 1;
@@ -1689,6 +1849,9 @@ fn run_group(
                 status.frames.push(decision);
             });
         }
+        // The accumulator is complete: checkpoint it before the snapshot
+        // consumes the stacker, so an additive rebuild can pick it up here.
+        save_checkpoint(&stacker, &ledger);
         // Last exit before the job writes anything. Orienting and rendering
         // follow, and a stop after this point would have to clean up published
         // artifacts.
@@ -1991,6 +2154,7 @@ mod tests {
             processed_frames: 2,
             accepted_frames: 2,
             rejected_frames: 0,
+            reused_frames: 0,
             output_channels: 1,
             sky_orientation: Some(sky_orientation()),
             reference_image_id: Some(image_id),

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -1456,6 +1456,7 @@ fn run_color_job(state: &Arc<AppState>, prepared: PreparedColorJob) {
                 match persisted {
                     Ok(()) => {
                         let _ = state.stack_previews.insert_color(completed);
+                        state.stack_previews.prune_cache(&prepared.cache_root);
                     }
                     Err(error) => {
                         tracing::warn!("Failed to publish color preview: {error}");
@@ -2688,6 +2689,17 @@ fn role_cache_name(role: StackColorRole) -> &'static str {
     }
 }
 
+/// Job and cached-input references from every project's durable color index.
+pub(super) fn latest_color_references(cache_root: &FsPath) -> Vec<(String, Option<String>)> {
+    super::read_latest_indices::<LatestStackColorPreviews>(
+        &cache_root.join("stack-previews").join("color"),
+    )
+    .into_iter()
+    .flat_map(|latest| latest.jobs)
+    .map(|job| (job.job_id, job.linear_input_id))
+    .collect()
+}
+
 fn latest_color_path(cache_root: &FsPath, project_id: i32) -> PathBuf {
     cache_root
         .join("stack-previews")
@@ -2739,6 +2751,7 @@ mod tests {
                 accepted_frames: 3,
                 rejected_frames: 0,
                 reused_frames: 0,
+                resume_note: None,
                 output_channels: 1,
                 sky_orientation: Some(stack_orientation(
                     100,

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -2738,6 +2738,7 @@ mod tests {
                 processed_frames: 3,
                 accepted_frames: 3,
                 rejected_frames: 0,
+                reused_frames: 0,
                 output_channels: 1,
                 sky_orientation: Some(stack_orientation(
                     100,

--- a/src/server/stack_preview/janitor.rs
+++ b/src/server/stack_preview/janitor.rs
@@ -11,23 +11,27 @@
 //! - the in-memory job map — panels may still be polling those jobs;
 //! - for color inputs, the `linear_input_id` of any kept color job.
 //!
-//! Everything else is deleted once it is older than a grace period, which
-//! protects a directory that a concurrent build is writing this moment.
-//! Resume checkpoints are superseded in place per target/channel, so they are
-//! pruned purely by age: one abandoned target should not hold full-frame
-//! accumulator state forever.
+//! Both indices replace entries per identity — mono per target/channel,
+//! color per target/kind/palette — so a directory leaves the index only when
+//! a newer build of the same identity supersedes it. Unreferenced therefore
+//! means the input set changed and a newer output exists (or the job never
+//! published one), and a job's output stays durable until then. A day-long
+//! grace on top protects directories a build or an open inspector may still
+//! be touching.
+//!
+//! Resume checkpoints are superseded in place per target/channel and are
+//! kept until then. The only checkpoints deleted outright are those that can
+//! never resume again — written by another pipeline version — and orphaned
+//! halves of an interrupted save.
 
 use std::collections::HashSet;
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
-/// Age a directory must reach before an unreferenced one is deleted. Long
-/// enough that a build writing artifacts right now is never swept.
-const UNREFERENCED_GRACE: Duration = Duration::from_secs(60 * 60);
-
-/// Age at which an untouched resume checkpoint is dropped. Additive rebuilds
-/// refresh their checkpoint on every settle, so only abandoned targets age.
-const CHECKPOINT_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+/// Age a directory must reach before an unreferenced one is deleted. A full
+/// day, so nothing a long build session or an open inspector still touches is
+/// swept out from under it.
+const UNREFERENCED_GRACE: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Everything the janitor must not delete, gathered by the caller from the
 /// latest indices and the in-memory job maps.
@@ -81,22 +85,63 @@ fn prune_directories(root: &Path, keep: &HashSet<String>, now: SystemTime) -> us
     removed
 }
 
-fn prune_checkpoints(resume_root: &Path, now: SystemTime) -> usize {
+/// A checkpoint is durable until its input set changes, which replaces it in
+/// place. Deletion is reserved for pairs that can never resume again: a
+/// manifest from another pipeline version, an unreadable manifest, or an
+/// orphaned half left by an interrupted save.
+fn prune_checkpoints(resume_root: &Path, stacking_version: &str, now: SystemTime) -> usize {
     let Ok(entries) = std::fs::read_dir(resume_root) else {
         return 0;
     };
-    let mut removed = 0;
+    let mut stems: std::collections::HashMap<String, (bool, bool)> =
+        std::collections::HashMap::new();
     for entry in entries.flatten() {
         let path = entry.path();
-        if !path.is_file() || !old_enough(&path, now, CHECKPOINT_MAX_AGE) {
+        let (Some(stem), Some(extension)) = (
+            path.file_stem().and_then(|value| value.to_str()),
+            path.extension().and_then(|value| value.to_str()),
+        ) else {
             continue;
+        };
+        let record = stems.entry(stem.to_string()).or_default();
+        match extension {
+            "seiza-stack" => record.0 = true,
+            "json" => record.1 = true,
+            _ => {}
         }
-        match std::fs::remove_file(&path) {
-            Ok(()) => removed += 1,
-            Err(error) => tracing::warn!(
-                "Failed to prune stale stack checkpoint {}: {error}",
-                path.display()
-            ),
+    }
+    let mut removed = 0;
+    let mut remove = |path: std::path::PathBuf| match std::fs::remove_file(&path) {
+        Ok(()) => removed += 1,
+        Err(error) => tracing::warn!(
+            "Failed to prune stack checkpoint {}: {error}",
+            path.display()
+        ),
+    };
+    for (stem, (has_context, has_manifest)) in stems {
+        let context = resume_root.join(format!("{stem}.seiza-stack"));
+        let manifest = resume_root.join(format!("{stem}.json"));
+        if has_context && has_manifest {
+            let resumable = std::fs::read(&manifest)
+                .ok()
+                .and_then(|bytes| {
+                    serde_json::from_slice::<super::resume::ResumeManifest>(&bytes).ok()
+                })
+                .is_some_and(|parsed| {
+                    parsed.schema_version == super::resume::RESUME_SCHEMA_VERSION
+                        && parsed.stacking_version == stacking_version
+                });
+            if !resumable {
+                remove(context);
+                remove(manifest);
+            }
+        } else {
+            // Half a checkpoint resumes nothing. The grace covers the moment
+            // between Seiza writing the context and the manifest landing.
+            let orphan = if has_context { context } else { manifest };
+            if old_enough(&orphan, now, UNREFERENCED_GRACE) {
+                remove(orphan);
+            }
         }
     }
     removed
@@ -105,14 +150,14 @@ fn prune_checkpoints(resume_root: &Path, now: SystemTime) -> usize {
 /// Delete every stack artifact nothing references, and every checkpoint no
 /// build has refreshed within its age limit. Errors are logged per entry; one
 /// undeletable directory never stops the sweep.
-pub(super) fn prune(cache_root: &Path, keep: &KeepSet) {
+pub(super) fn prune(cache_root: &Path, keep: &KeepSet, stacking_version: &str) {
     let now = SystemTime::now();
     let stack_root = cache_root.join("stack-previews");
     let removed_mono = prune_directories(&stack_root, &keep.mono_job_ids, now);
     let removed_color = prune_directories(&stack_root.join("color"), &keep.color_job_ids, now);
     let removed_inputs =
         prune_directories(&stack_root.join("color-inputs"), &keep.color_input_ids, now);
-    let removed_checkpoints = prune_checkpoints(&stack_root.join("resume"), now);
+    let removed_checkpoints = prune_checkpoints(&stack_root.join("resume"), stacking_version, now);
     if removed_mono + removed_color + removed_inputs + removed_checkpoints > 0 {
         tracing::info!(
             removed_mono,
@@ -155,26 +200,27 @@ mod tests {
         let kept = cache.path().join("stack-previews").join(hex_name('b'));
         fs::create_dir_all(&stale).unwrap();
         fs::create_dir_all(&kept).unwrap();
-        age(&stale, 2 * 60 * 60);
-        age(&kept, 2 * 60 * 60);
+        age(&stale, 25 * 60 * 60);
+        age(&kept, 25 * 60 * 60);
 
-        prune(cache.path(), &keep(&[&hex_name('b')]));
+        prune(cache.path(), &keep(&[&hex_name('b')]), "test");
 
         assert!(!stale.exists(), "unreferenced directory must be swept");
         assert!(kept.exists(), "the latest index still points here");
     }
 
     #[test]
-    fn a_fresh_directory_survives_even_when_unreferenced() {
+    fn a_directory_inside_the_day_long_grace_survives_even_when_unreferenced() {
         let cache = tempfile::tempdir().unwrap();
         let racing = cache.path().join("stack-previews").join(hex_name('c'));
         fs::create_dir_all(&racing).unwrap();
+        age(&racing, 20 * 60 * 60);
 
-        prune(cache.path(), &keep(&[]));
+        prune(cache.path(), &keep(&[]), "test");
 
         assert!(
             racing.exists(),
-            "a directory inside the grace period may belong to a build in flight"
+            "a directory inside the grace period may still be in use"
         );
     }
 
@@ -188,10 +234,10 @@ mod tests {
         fs::create_dir_all(&color).unwrap();
         fs::create_dir_all(&resume).unwrap();
         fs::write(&latest, b"{}").unwrap();
-        age(&color, 3 * 60 * 60);
-        age(&resume, 3 * 60 * 60);
+        age(&color, 30 * 60 * 60);
+        age(&resume, 30 * 60 * 60);
 
-        prune(cache.path(), &keep(&[]));
+        prune(cache.path(), &keep(&[]), "test");
 
         assert!(color.exists());
         assert!(resume.exists());
@@ -213,8 +259,8 @@ mod tests {
             .join(hex_name('e'));
         fs::create_dir_all(&stale_color).unwrap();
         fs::create_dir_all(&kept_input).unwrap();
-        age(&stale_color, 2 * 60 * 60);
-        age(&kept_input, 2 * 60 * 60);
+        age(&stale_color, 25 * 60 * 60);
+        age(&kept_input, 25 * 60 * 60);
 
         prune(
             cache.path(),
@@ -223,27 +269,74 @@ mod tests {
                 color_job_ids: HashSet::new(),
                 color_input_ids: [hex_name('e')].into_iter().collect(),
             },
+            "test",
         );
 
         assert!(!stale_color.exists());
         assert!(kept_input.exists());
     }
 
+    fn checkpoint_manifest(stacking_version: &str) -> String {
+        serde_json::json!({
+            "schema_version": super::super::resume::RESUME_SCHEMA_VERSION,
+            "stacking_version": stacking_version,
+            "target_id": 7,
+            "filter_name": "Ha",
+            "accepted_only": false,
+            "calibration_fingerprint": "cal-1",
+            "frames": [],
+        })
+        .to_string()
+    }
+
     #[test]
-    fn only_ancient_checkpoints_are_dropped() {
+    fn a_current_checkpoint_is_durable_regardless_of_age() {
         let cache = tempfile::tempdir().unwrap();
         let resume = cache.path().join("stack-previews").join("resume");
         fs::create_dir_all(&resume).unwrap();
-        let ancient = resume.join("old.seiza-stack");
-        let recent = resume.join("new.seiza-stack");
-        fs::write(&ancient, b"x").unwrap();
-        fs::write(&recent, b"x").unwrap();
-        age(&ancient, 40 * 24 * 60 * 60);
-        age(&recent, 2 * 24 * 60 * 60);
+        let context = resume.join("group.seiza-stack");
+        let manifest = resume.join("group.json");
+        fs::write(&context, b"x").unwrap();
+        fs::write(&manifest, checkpoint_manifest("test")).unwrap();
+        age(&context, 90 * 24 * 60 * 60);
+        age(&manifest, 90 * 24 * 60 * 60);
 
-        prune(cache.path(), &keep(&[]));
+        prune(cache.path(), &keep(&[]), "test");
 
-        assert!(!ancient.exists(), "an abandoned checkpoint must not linger");
-        assert!(recent.exists(), "a stop from this week must stay resumable");
+        assert!(context.exists(), "durable until its input set changes");
+        assert!(manifest.exists());
+    }
+
+    #[test]
+    fn a_checkpoint_from_another_pipeline_version_is_dropped_at_once() {
+        let cache = tempfile::tempdir().unwrap();
+        let resume = cache.path().join("stack-previews").join("resume");
+        fs::create_dir_all(&resume).unwrap();
+        let context = resume.join("group.seiza-stack");
+        let manifest = resume.join("group.json");
+        fs::write(&context, b"x").unwrap();
+        fs::write(&manifest, checkpoint_manifest("older")).unwrap();
+
+        prune(cache.path(), &keep(&[]), "test");
+
+        assert!(!context.exists(), "this checkpoint can never resume again");
+        assert!(!manifest.exists());
+    }
+
+    #[test]
+    fn an_orphaned_context_is_dropped_only_after_the_grace() {
+        let cache = tempfile::tempdir().unwrap();
+        let resume = cache.path().join("stack-previews").join("resume");
+        fs::create_dir_all(&resume).unwrap();
+        let fresh_orphan = resume.join("saving.seiza-stack");
+        let old_orphan = resume.join("stranded.seiza-stack");
+        fs::write(&fresh_orphan, b"x").unwrap();
+        fs::write(&old_orphan, b"x").unwrap();
+        age(&old_orphan, 25 * 60 * 60);
+
+        prune(cache.path(), &keep(&[]), "test");
+
+        assert!(fresh_orphan.exists(), "a save may be mid-flight");
+        assert!(!old_orphan.exists(), "half a checkpoint resumes nothing");
     }
 }

--- a/src/server/stack_preview/janitor.rs
+++ b/src/server/stack_preview/janitor.rs
@@ -1,0 +1,249 @@
+//! Stack cache pruning.
+//!
+//! Stack artifacts are content-addressed by job id, so every rebuild writes a
+//! new directory and nothing ever overwrote the old ones. The in-memory job
+//! map is capped, but the disk was not: superseded FITS and preview
+//! directories accumulated forever. This janitor runs after a build settles
+//! and deletes what nothing references any more.
+//!
+//! A directory is kept when any of these still points at it:
+//! - a `latest-project-*.json` index — the durable last-successful results;
+//! - the in-memory job map — panels may still be polling those jobs;
+//! - for color inputs, the `linear_input_id` of any kept color job.
+//!
+//! Everything else is deleted once it is older than a grace period, which
+//! protects a directory that a concurrent build is writing this moment.
+//! Resume checkpoints are superseded in place per target/channel, so they are
+//! pruned purely by age: one abandoned target should not hold full-frame
+//! accumulator state forever.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+/// Age a directory must reach before an unreferenced one is deleted. Long
+/// enough that a build writing artifacts right now is never swept.
+const UNREFERENCED_GRACE: Duration = Duration::from_secs(60 * 60);
+
+/// Age at which an untouched resume checkpoint is dropped. Additive rebuilds
+/// refresh their checkpoint on every settle, so only abandoned targets age.
+const CHECKPOINT_MAX_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// Everything the janitor must not delete, gathered by the caller from the
+/// latest indices and the in-memory job maps.
+pub(super) struct KeepSet {
+    pub mono_job_ids: HashSet<String>,
+    pub color_job_ids: HashSet<String>,
+    pub color_input_ids: HashSet<String>,
+}
+
+/// A stack job directory name: the lowercase hex SHA-256 the job hash writes.
+/// Anything else under `stack-previews/` — `color`, `resume`, the latest
+/// indices — is infrastructure, never a candidate.
+fn is_job_directory_name(name: &str) -> bool {
+    name.len() == 64
+        && name
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
+
+fn old_enough(path: &Path, now: SystemTime, age: Duration) -> bool {
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| now.duration_since(modified).ok())
+        .is_some_and(|elapsed| elapsed >= age)
+}
+
+fn prune_directories(root: &Path, keep: &HashSet<String>, now: SystemTime) -> usize {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return 0;
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !is_job_directory_name(name) || keep.contains(name) {
+            continue;
+        }
+        let path = entry.path();
+        if !path.is_dir() || !old_enough(&path, now, UNREFERENCED_GRACE) {
+            continue;
+        }
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => removed += 1,
+            Err(error) => tracing::warn!(
+                "Failed to prune stale stack cache directory {}: {error}",
+                path.display()
+            ),
+        }
+    }
+    removed
+}
+
+fn prune_checkpoints(resume_root: &Path, now: SystemTime) -> usize {
+    let Ok(entries) = std::fs::read_dir(resume_root) else {
+        return 0;
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() || !old_enough(&path, now, CHECKPOINT_MAX_AGE) {
+            continue;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => removed += 1,
+            Err(error) => tracing::warn!(
+                "Failed to prune stale stack checkpoint {}: {error}",
+                path.display()
+            ),
+        }
+    }
+    removed
+}
+
+/// Delete every stack artifact nothing references, and every checkpoint no
+/// build has refreshed within its age limit. Errors are logged per entry; one
+/// undeletable directory never stops the sweep.
+pub(super) fn prune(cache_root: &Path, keep: &KeepSet) {
+    let now = SystemTime::now();
+    let stack_root = cache_root.join("stack-previews");
+    let removed_mono = prune_directories(&stack_root, &keep.mono_job_ids, now);
+    let removed_color = prune_directories(&stack_root.join("color"), &keep.color_job_ids, now);
+    let removed_inputs =
+        prune_directories(&stack_root.join("color-inputs"), &keep.color_input_ids, now);
+    let removed_checkpoints = prune_checkpoints(&stack_root.join("resume"), now);
+    if removed_mono + removed_color + removed_inputs + removed_checkpoints > 0 {
+        tracing::info!(
+            removed_mono,
+            removed_color,
+            removed_inputs,
+            removed_checkpoints,
+            "Pruned superseded stack cache entries"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn hex_name(fill: char) -> String {
+        std::iter::repeat_n(fill, 64).collect()
+    }
+
+    fn age(path: &Path, seconds_ago: u64) {
+        let stamp = filetime::FileTime::from_system_time(
+            SystemTime::now() - Duration::from_secs(seconds_ago),
+        );
+        filetime::set_file_mtime(path, stamp).unwrap();
+    }
+
+    fn keep(mono: &[&str]) -> KeepSet {
+        KeepSet {
+            mono_job_ids: mono.iter().map(|id| (*id).to_string()).collect(),
+            color_job_ids: HashSet::new(),
+            color_input_ids: HashSet::new(),
+        }
+    }
+
+    #[test]
+    fn an_unreferenced_old_job_directory_is_removed() {
+        let cache = tempfile::tempdir().unwrap();
+        let stale = cache.path().join("stack-previews").join(hex_name('a'));
+        let kept = cache.path().join("stack-previews").join(hex_name('b'));
+        fs::create_dir_all(&stale).unwrap();
+        fs::create_dir_all(&kept).unwrap();
+        age(&stale, 2 * 60 * 60);
+        age(&kept, 2 * 60 * 60);
+
+        prune(cache.path(), &keep(&[&hex_name('b')]));
+
+        assert!(!stale.exists(), "unreferenced directory must be swept");
+        assert!(kept.exists(), "the latest index still points here");
+    }
+
+    #[test]
+    fn a_fresh_directory_survives_even_when_unreferenced() {
+        let cache = tempfile::tempdir().unwrap();
+        let racing = cache.path().join("stack-previews").join(hex_name('c'));
+        fs::create_dir_all(&racing).unwrap();
+
+        prune(cache.path(), &keep(&[]));
+
+        assert!(
+            racing.exists(),
+            "a directory inside the grace period may belong to a build in flight"
+        );
+    }
+
+    #[test]
+    fn infrastructure_names_are_never_candidates() {
+        let cache = tempfile::tempdir().unwrap();
+        let stack_root = cache.path().join("stack-previews");
+        let color = stack_root.join("color");
+        let resume = stack_root.join("resume");
+        let latest = stack_root.join("latest-project-7.json");
+        fs::create_dir_all(&color).unwrap();
+        fs::create_dir_all(&resume).unwrap();
+        fs::write(&latest, b"{}").unwrap();
+        age(&color, 3 * 60 * 60);
+        age(&resume, 3 * 60 * 60);
+
+        prune(cache.path(), &keep(&[]));
+
+        assert!(color.exists());
+        assert!(resume.exists());
+        assert!(latest.exists());
+    }
+
+    #[test]
+    fn color_and_input_directories_prune_by_their_own_keep_sets() {
+        let cache = tempfile::tempdir().unwrap();
+        let stale_color = cache
+            .path()
+            .join("stack-previews")
+            .join("color")
+            .join(hex_name('d'));
+        let kept_input = cache
+            .path()
+            .join("stack-previews")
+            .join("color-inputs")
+            .join(hex_name('e'));
+        fs::create_dir_all(&stale_color).unwrap();
+        fs::create_dir_all(&kept_input).unwrap();
+        age(&stale_color, 2 * 60 * 60);
+        age(&kept_input, 2 * 60 * 60);
+
+        prune(
+            cache.path(),
+            &KeepSet {
+                mono_job_ids: HashSet::new(),
+                color_job_ids: HashSet::new(),
+                color_input_ids: [hex_name('e')].into_iter().collect(),
+            },
+        );
+
+        assert!(!stale_color.exists());
+        assert!(kept_input.exists());
+    }
+
+    #[test]
+    fn only_ancient_checkpoints_are_dropped() {
+        let cache = tempfile::tempdir().unwrap();
+        let resume = cache.path().join("stack-previews").join("resume");
+        fs::create_dir_all(&resume).unwrap();
+        let ancient = resume.join("old.seiza-stack");
+        let recent = resume.join("new.seiza-stack");
+        fs::write(&ancient, b"x").unwrap();
+        fs::write(&recent, b"x").unwrap();
+        age(&ancient, 40 * 24 * 60 * 60);
+        age(&recent, 2 * 24 * 60 * 60);
+
+        prune(cache.path(), &keep(&[]));
+
+        assert!(!ancient.exists(), "an abandoned checkpoint must not linger");
+        assert!(recent.exists(), "a stop from this week must stay resumable");
+    }
+}

--- a/src/server/stack_preview/resume.rs
+++ b/src/server/stack_preview/resume.rs
@@ -1,0 +1,376 @@
+//! Resumable mono stack accumulation.
+//!
+//! A finished or stopped group build checkpoints its Seiza live-stack context
+//! beside a manifest of every frame it pushed. A later build of the same
+//! target/filter whose frame set only grew reopens that context and pushes the
+//! new frames, instead of registering and integrating the whole set again.
+//!
+//! The manifest is the proof of "only grew": every recorded frame must still
+//! be requested with an identical source fingerprint, and the calibration
+//! fingerprint must match, or the build starts fresh. Removing a frame,
+//! regrading one in place, or changing calibration therefore never reuses a
+//! stale accumulator. Seiza validates the context itself — format version,
+//! dimensions, configuration, checksum — when it reopens it.
+
+use super::StackFrameDecision;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+/// Bumped whenever the recorded shape or the stacking pipeline changes in a
+/// way that makes an old accumulator wrong to extend.
+pub(super) const RESUME_SCHEMA_VERSION: u32 = 1;
+
+/// One frame the checkpointed stack already integrated or turned away, with
+/// everything needed to replay its ledger entry and its orientation vote.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct ResumeFrame {
+    pub decision: StackFrameDecision,
+    pub exposure_seconds: f64,
+    /// Registration rotation for an accepted frame; `None` for a rejection.
+    pub rotation_radians: Option<f64>,
+}
+
+/// Everything a later build needs to prove the checkpoint extends its request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct ResumeManifest {
+    pub schema_version: u32,
+    pub stacking_version: String,
+    pub target_id: i32,
+    pub filter_name: String,
+    pub accepted_only: bool,
+    pub calibration_fingerprint: String,
+    /// Frames in push order, the reference first.
+    pub frames: Vec<ResumeFrame>,
+}
+
+/// A validated checkpoint: the reopened-context path plus the ledger to
+/// replay. Frames the new request adds are whatever the manifest lacks.
+pub(super) struct ResumeState {
+    pub context_path: PathBuf,
+    pub manifest: ResumeManifest,
+}
+
+/// One group identity has one checkpoint, replaced on every settle. The key
+/// hashes the identity so filter names never reach the filesystem.
+fn group_key(database_id: &str, target_id: i32, filter_name: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(database_id.as_bytes());
+    hasher.update(target_id.to_le_bytes());
+    hasher.update(filter_name.as_bytes());
+    let mut output = String::with_capacity(64);
+    for byte in hasher.finalize() {
+        write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    output
+}
+
+fn resume_dir(cache_root: &Path) -> PathBuf {
+    cache_root.join("stack-previews").join("resume")
+}
+
+pub(super) fn context_path(
+    cache_root: &Path,
+    database_id: &str,
+    target_id: i32,
+    filter_name: &str,
+) -> PathBuf {
+    resume_dir(cache_root).join(format!(
+        "{}.seiza-stack",
+        group_key(database_id, target_id, filter_name)
+    ))
+}
+
+pub(super) fn manifest_path(
+    cache_root: &Path,
+    database_id: &str,
+    target_id: i32,
+    filter_name: &str,
+) -> PathBuf {
+    resume_dir(cache_root).join(format!(
+        "{}.json",
+        group_key(database_id, target_id, filter_name)
+    ))
+}
+
+/// Load and validate a checkpoint for this exact request. `None` means the
+/// build starts fresh; the reasons are logged, not surfaced, because a fresh
+/// build is always a correct answer.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn load(
+    cache_root: &Path,
+    database_id: &str,
+    target_id: i32,
+    filter_name: &str,
+    accepted_only: bool,
+    stacking_version: &str,
+    calibration_fingerprint: &str,
+    requested: &[(i32, &str)],
+) -> Option<ResumeState> {
+    let manifest_path = manifest_path(cache_root, database_id, target_id, filter_name);
+    let context_path = context_path(cache_root, database_id, target_id, filter_name);
+    if !context_path.exists() {
+        return None;
+    }
+    let manifest: ResumeManifest = serde_json::from_slice(&std::fs::read(&manifest_path).ok()?)
+        .inspect_err(|error| {
+            tracing::warn!("Ignoring unreadable stack resume manifest: {error}");
+        })
+        .ok()?;
+    if manifest.schema_version != RESUME_SCHEMA_VERSION
+        || manifest.stacking_version != stacking_version
+        || manifest.target_id != target_id
+        || manifest.filter_name != filter_name
+        || manifest.accepted_only != accepted_only
+    {
+        tracing::info!(
+            target_id,
+            filter_name,
+            "Stack checkpoint predates the current pipeline; rebuilding from scratch"
+        );
+        return None;
+    }
+    if manifest.calibration_fingerprint != calibration_fingerprint {
+        tracing::info!(
+            target_id,
+            filter_name,
+            "Calibration changed since the stack checkpoint; rebuilding from scratch"
+        );
+        return None;
+    }
+    // Every checkpointed frame must still be requested, byte-identical. A
+    // fingerprint mismatch means the file changed under the same image id.
+    let requested_fingerprints: std::collections::HashMap<i32, &str> =
+        requested.iter().copied().collect();
+    let all_present = manifest.frames.iter().all(|frame| {
+        let recorded = frame.decision.source_fingerprint.as_deref();
+        matches!(
+            (requested_fingerprints.get(&frame.decision.image_id), recorded),
+            (Some(requested), Some(recorded)) if *requested == recorded
+        )
+    });
+    if !all_present {
+        tracing::info!(
+            target_id,
+            filter_name,
+            "Requested frames are not a superset of the stack checkpoint; rebuilding from scratch"
+        );
+        return None;
+    }
+    Some(ResumeState {
+        context_path,
+        manifest,
+    })
+}
+
+/// Persist a settled group's checkpoint: the manifest first to a temporary
+/// name, then into place, beside the context Seiza already wrote atomically.
+pub(super) fn store_manifest(path: &Path, manifest: &ResumeManifest) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let bytes = serde_json::to_vec_pretty(manifest).map_err(|error| error.to_string())?;
+    let temporary = path.with_extension(format!("{}.tmp.json", std::process::id()));
+    std::fs::write(&temporary, bytes).map_err(|error| error.to_string())?;
+    std::fs::rename(&temporary, path).map_err(|error| error.to_string())
+}
+
+/// Drop a group's checkpoint. Used when a fresh build replaces it and fails
+/// to save its own, so a later build cannot resume from the wrong ancestor.
+pub(super) fn discard(cache_root: &Path, database_id: &str, target_id: i32, filter_name: &str) {
+    let _ = std::fs::remove_file(manifest_path(
+        cache_root,
+        database_id,
+        target_id,
+        filter_name,
+    ));
+    let _ = std::fs::remove_file(context_path(
+        cache_root,
+        database_id,
+        target_id,
+        filter_name,
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn decision(image_id: i32, fingerprint: &str) -> StackFrameDecision {
+        StackFrameDecision {
+            image_id,
+            disposition: "accepted".into(),
+            reason: None,
+            quality_score: None,
+            matched_stars: None,
+            registration_rms_pixels: None,
+            registration_drift_pixels: None,
+            registered_mapping: None,
+            normalization_mean_gain: None,
+            normalization_mean_offset: None,
+            source_fingerprint: Some(fingerprint.into()),
+            overlap_fraction: None,
+            integrated_fraction: None,
+        }
+    }
+
+    fn manifest(frames: Vec<ResumeFrame>) -> ResumeManifest {
+        ResumeManifest {
+            schema_version: RESUME_SCHEMA_VERSION,
+            stacking_version: "test".into(),
+            target_id: 7,
+            filter_name: "Ha".into(),
+            accepted_only: false,
+            calibration_fingerprint: "cal-1".into(),
+            frames,
+        }
+    }
+
+    fn frame(image_id: i32, fingerprint: &str) -> ResumeFrame {
+        ResumeFrame {
+            decision: decision(image_id, fingerprint),
+            exposure_seconds: 300.0,
+            rotation_radians: Some(0.0),
+        }
+    }
+
+    fn store(cache_root: &Path, manifest: &ResumeManifest) {
+        store_manifest(
+            &manifest_path(cache_root, "db", manifest.target_id, &manifest.filter_name),
+            manifest,
+        )
+        .unwrap();
+        // The context itself is Seiza's; its presence is what load checks.
+        std::fs::write(
+            context_path(cache_root, "db", manifest.target_id, &manifest.filter_name),
+            b"context",
+        )
+        .unwrap();
+    }
+
+    fn try_load(cache_root: &Path, requested: &[(i32, &str)]) -> Option<ResumeState> {
+        load(cache_root, "db", 7, "Ha", false, "test", "cal-1", requested)
+    }
+
+    #[test]
+    fn a_superset_of_the_checkpoint_resumes() {
+        let cache = tempfile::tempdir().unwrap();
+        store(
+            cache.path(),
+            &manifest(vec![frame(1, "f1"), frame(2, "f2")]),
+        );
+        let resumed = try_load(cache.path(), &[(1, "f1"), (2, "f2"), (3, "f3")]).unwrap();
+        assert_eq!(resumed.manifest.frames.len(), 2);
+    }
+
+    #[test]
+    fn the_identical_set_resumes_with_nothing_to_add() {
+        let cache = tempfile::tempdir().unwrap();
+        store(
+            cache.path(),
+            &manifest(vec![frame(1, "f1"), frame(2, "f2")]),
+        );
+        assert!(try_load(cache.path(), &[(1, "f1"), (2, "f2")]).is_some());
+    }
+
+    #[test]
+    fn a_removed_frame_rebuilds_from_scratch() {
+        let cache = tempfile::tempdir().unwrap();
+        store(
+            cache.path(),
+            &manifest(vec![frame(1, "f1"), frame(2, "f2")]),
+        );
+        assert!(try_load(cache.path(), &[(1, "f1"), (3, "f3")]).is_none());
+    }
+
+    #[test]
+    fn a_changed_file_under_the_same_id_rebuilds_from_scratch() {
+        let cache = tempfile::tempdir().unwrap();
+        store(
+            cache.path(),
+            &manifest(vec![frame(1, "f1"), frame(2, "f2")]),
+        );
+        assert!(try_load(cache.path(), &[(1, "f1"), (2, "regraded")]).is_none());
+    }
+
+    #[test]
+    fn changed_calibration_rebuilds_from_scratch() {
+        let cache = tempfile::tempdir().unwrap();
+        store(cache.path(), &manifest(vec![frame(1, "f1")]));
+        let resumed = load(
+            cache.path(),
+            "db",
+            7,
+            "Ha",
+            false,
+            "test",
+            "cal-2",
+            &[(1, "f1"), (2, "f2")],
+        );
+        assert!(resumed.is_none());
+    }
+
+    #[test]
+    fn another_pipeline_version_rebuilds_from_scratch() {
+        let cache = tempfile::tempdir().unwrap();
+        store(cache.path(), &manifest(vec![frame(1, "f1")]));
+        let resumed = load(
+            cache.path(),
+            "db",
+            7,
+            "Ha",
+            false,
+            "newer",
+            "cal-1",
+            &[(1, "f1"), (2, "f2")],
+        );
+        assert!(resumed.is_none());
+    }
+
+    #[test]
+    fn a_different_accepted_only_policy_rebuilds_from_scratch() {
+        let cache = tempfile::tempdir().unwrap();
+        store(cache.path(), &manifest(vec![frame(1, "f1")]));
+        let resumed = load(
+            cache.path(),
+            "db",
+            7,
+            "Ha",
+            true,
+            "test",
+            "cal-1",
+            &[(1, "f1"), (2, "f2")],
+        );
+        assert!(resumed.is_none());
+    }
+
+    #[test]
+    fn a_missing_context_never_resumes_even_with_a_manifest() {
+        let cache = tempfile::tempdir().unwrap();
+        let manifest_value = manifest(vec![frame(1, "f1")]);
+        store_manifest(&manifest_path(cache.path(), "db", 7, "Ha"), &manifest_value).unwrap();
+        assert!(try_load(cache.path(), &[(1, "f1"), (2, "f2")]).is_none());
+    }
+
+    #[test]
+    fn discard_removes_both_files() {
+        let cache = tempfile::tempdir().unwrap();
+        store(cache.path(), &manifest(vec![frame(1, "f1")]));
+        discard(cache.path(), "db", 7, "Ha");
+        assert!(try_load(cache.path(), &[(1, "f1"), (2, "f2")]).is_none());
+        assert!(!manifest_path(cache.path(), "db", 7, "Ha").exists());
+    }
+
+    #[test]
+    fn group_keys_separate_databases_targets_and_filters() {
+        let keys = [
+            group_key("db-a", 7, "Ha"),
+            group_key("db-b", 7, "Ha"),
+            group_key("db-a", 8, "Ha"),
+            group_key("db-a", 7, "OIII"),
+        ];
+        let unique: std::collections::HashSet<_> = keys.iter().collect();
+        assert_eq!(unique.len(), keys.len());
+    }
+}

--- a/src/server/stack_preview/resume.rs
+++ b/src/server/stack_preview/resume.rs
@@ -52,6 +52,30 @@ pub(super) struct ResumeState {
     pub manifest: ResumeManifest,
 }
 
+/// Whether a build may extend the checkpoint or must start over, and — when a
+/// checkpoint existed but could not be used — the reason, stated for the user.
+pub(super) enum ResumeDecision {
+    Resume(Box<ResumeState>),
+    /// `None` when no checkpoint existed: starting fresh is unremarkable.
+    Fresh(Option<&'static str>),
+}
+
+impl ResumeDecision {
+    pub fn state(self) -> Option<ResumeState> {
+        match self {
+            Self::Resume(state) => Some(*state),
+            Self::Fresh(_) => None,
+        }
+    }
+
+    pub fn fresh_reason(&self) -> Option<&'static str> {
+        match self {
+            Self::Resume(_) => None,
+            Self::Fresh(reason) => *reason,
+        }
+    }
+}
+
 /// One group identity has one checkpoint, replaced on every settle. The key
 /// hashes the identity so filter names never reach the filesystem.
 fn group_key(database_id: &str, target_id: i32, filter_name: &str) -> String {
@@ -94,9 +118,9 @@ pub(super) fn manifest_path(
     ))
 }
 
-/// Load and validate a checkpoint for this exact request. `None` means the
-/// build starts fresh; the reasons are logged, not surfaced, because a fresh
-/// build is always a correct answer.
+/// Load and validate a checkpoint for this exact request. A fresh decision is
+/// always a correct answer; when a checkpoint existed but was refused, the
+/// decision carries the reason so the build can say why it starts over.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn load(
     cache_root: &Path,
@@ -107,37 +131,30 @@ pub(super) fn load(
     stacking_version: &str,
     calibration_fingerprint: &str,
     requested: &[(i32, &str)],
-) -> Option<ResumeState> {
+) -> ResumeDecision {
     let manifest_path = manifest_path(cache_root, database_id, target_id, filter_name);
     let context_path = context_path(cache_root, database_id, target_id, filter_name);
     if !context_path.exists() {
-        return None;
+        return ResumeDecision::Fresh(None);
     }
-    let manifest: ResumeManifest = serde_json::from_slice(&std::fs::read(&manifest_path).ok()?)
-        .inspect_err(|error| {
-            tracing::warn!("Ignoring unreadable stack resume manifest: {error}");
-        })
-        .ok()?;
+    let manifest: Option<ResumeManifest> = std::fs::read(&manifest_path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok());
+    let Some(manifest) = manifest else {
+        return ResumeDecision::Fresh(Some("the last checkpoint was unreadable"));
+    };
     if manifest.schema_version != RESUME_SCHEMA_VERSION
         || manifest.stacking_version != stacking_version
         || manifest.target_id != target_id
         || manifest.filter_name != filter_name
-        || manifest.accepted_only != accepted_only
     {
-        tracing::info!(
-            target_id,
-            filter_name,
-            "Stack checkpoint predates the current pipeline; rebuilding from scratch"
-        );
-        return None;
+        return ResumeDecision::Fresh(Some("the stacking pipeline changed"));
+    }
+    if manifest.accepted_only != accepted_only {
+        return ResumeDecision::Fresh(Some("the Accepted-only policy changed"));
     }
     if manifest.calibration_fingerprint != calibration_fingerprint {
-        tracing::info!(
-            target_id,
-            filter_name,
-            "Calibration changed since the stack checkpoint; rebuilding from scratch"
-        );
-        return None;
+        return ResumeDecision::Fresh(Some("calibration changed"));
     }
     // Every checkpointed frame must still be requested, byte-identical. A
     // fingerprint mismatch means the file changed under the same image id.
@@ -151,17 +168,12 @@ pub(super) fn load(
         )
     });
     if !all_present {
-        tracing::info!(
-            target_id,
-            filter_name,
-            "Requested frames are not a superset of the stack checkpoint; rebuilding from scratch"
-        );
-        return None;
+        return ResumeDecision::Fresh(Some("frames were removed or changed since the last build"));
     }
-    Some(ResumeState {
+    ResumeDecision::Resume(Box::new(ResumeState {
         context_path,
         manifest,
-    })
+    }))
 }
 
 /// Persist a settled group's checkpoint: the manifest first to a temporary
@@ -250,7 +262,7 @@ mod tests {
     }
 
     fn try_load(cache_root: &Path, requested: &[(i32, &str)]) -> Option<ResumeState> {
-        load(cache_root, "db", 7, "Ha", false, "test", "cal-1", requested)
+        load(cache_root, "db", 7, "Ha", false, "test", "cal-1", requested).state()
     }
 
     #[test]
@@ -298,7 +310,7 @@ mod tests {
     fn changed_calibration_rebuilds_from_scratch() {
         let cache = tempfile::tempdir().unwrap();
         store(cache.path(), &manifest(vec![frame(1, "f1")]));
-        let resumed = load(
+        let decision = load(
             cache.path(),
             "db",
             7,
@@ -308,14 +320,14 @@ mod tests {
             "cal-2",
             &[(1, "f1"), (2, "f2")],
         );
-        assert!(resumed.is_none());
+        assert_eq!(decision.fresh_reason(), Some("calibration changed"));
     }
 
     #[test]
     fn another_pipeline_version_rebuilds_from_scratch() {
         let cache = tempfile::tempdir().unwrap();
         store(cache.path(), &manifest(vec![frame(1, "f1")]));
-        let resumed = load(
+        let decision = load(
             cache.path(),
             "db",
             7,
@@ -325,14 +337,17 @@ mod tests {
             "cal-1",
             &[(1, "f1"), (2, "f2")],
         );
-        assert!(resumed.is_none());
+        assert_eq!(
+            decision.fresh_reason(),
+            Some("the stacking pipeline changed")
+        );
     }
 
     #[test]
     fn a_different_accepted_only_policy_rebuilds_from_scratch() {
         let cache = tempfile::tempdir().unwrap();
         store(cache.path(), &manifest(vec![frame(1, "f1")]));
-        let resumed = load(
+        let decision = load(
             cache.path(),
             "db",
             7,
@@ -342,7 +357,10 @@ mod tests {
             "cal-1",
             &[(1, "f1"), (2, "f2")],
         );
-        assert!(resumed.is_none());
+        assert_eq!(
+            decision.fresh_reason(),
+            Some("the Accepted-only policy changed")
+        );
     }
 
     #[test]

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3911,6 +3911,12 @@
   font-size: 0.68rem;
 }
 
+.stack-preview-resume-note {
+  padding: 0.3rem 0.65rem;
+  color: var(--color-text-tertiary);
+  font-size: 0.68rem;
+}
+
 .stack-color-crop {
   display: flex;
   align-items: center;

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -414,6 +414,8 @@ export interface StackGroupStatus {
   processed_frames: number;
   /** Frames restored from a saved accumulator; zero for a fresh build. */
   reused_frames?: number;
+  /** Why an existing checkpoint could not be extended, when that happened. */
+  resume_note?: string | null;
   accepted_frames: number;
   rejected_frames: number;
   output_channels: number;

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -412,6 +412,8 @@ export interface StackGroupStatus {
   quality_excluded: number;
   missing_files: number;
   processed_frames: number;
+  /** Frames restored from a saved accumulator; zero for a fresh build. */
+  reused_frames?: number;
   accepted_frames: number;
   rejected_frames: number;
   output_channels: number;

--- a/static/src/components/StackColorPreviewPanel.tsx
+++ b/static/src/components/StackColorPreviewPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import type {
   StackColorCrop,
@@ -17,7 +17,7 @@ import {
 } from './stackColorProcessing';
 import { isColorStackSkyOriented } from './stackOrientation';
 import { cropLabels, cropOrder, describeCrop, offCenterChannels } from './stackColorCrop';
-import { adoptableStackJob, useStackActivity } from '../hooks/useStackActivity';
+import { useStackActivity } from '../hooks/useStackActivity';
 
 interface StackColorPreviewPanelProps {
   dbId: string;
@@ -370,7 +370,7 @@ export default function StackColorPreviewPanel({
   onOpenImage,
 }: StackColorPreviewPanelProps) {
   const queryClient = useQueryClient();
-  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [watchedJobIds, setWatchedJobIds] = useState<string[]>([]);
   const [paletteByTarget, setPaletteByTarget] = useState<Record<number, StackNarrowbandPalette>>({});
   const [cropByCard, setCropByCard] = useState<Record<string, StackColorCrop>>({});
   const [inspector, setInspector] = useState<StackColorJob | null>(null);
@@ -397,7 +397,9 @@ export default function StackColorPreviewPanel({
     }),
     onSuccess: (job) => {
       queryClient.setQueryData(jobQueryKey(dbId, projectId, job.job_id), job);
-      setActiveJobId(job.job_id);
+      setWatchedJobIds((current) =>
+        current.includes(job.job_id) ? current : [...current, job.job_id]
+      );
       if (terminalStates.has(job.state)) {
         queryClient.invalidateQueries({
           queryKey: catalogQueryKey(dbId, projectId, sourceRevision),
@@ -406,43 +408,62 @@ export default function StackColorPreviewPanel({
     },
   });
 
-  const status = useQuery({
-    queryKey: jobQueryKey(dbId, projectId, activeJobId),
-    queryFn: () => apiClient.getStackColorJob(dbId, projectId, activeJobId!),
-    enabled: activeJobId !== null,
-    refetchInterval: (query) =>
-      query.state.data && !terminalStates.has(query.state.data.state) ? 700 : false,
+  const statuses = useQueries({
+    queries: watchedJobIds.map((jobId) => ({
+      queryKey: jobQueryKey(dbId, projectId, jobId),
+      queryFn: () => apiClient.getStackColorJob(dbId, projectId, jobId),
+      refetchInterval: (query: { state: { data?: StackColorJob } }) =>
+        query.state.data && !terminalStates.has(query.state.data.state) ? 700 : false,
+    })),
   });
-  const activeJob = status.data;
-
+  const watchedJobs = useMemo(
+    () =>
+      statuses
+        .map((status) => status.data)
+        .filter((job): job is StackColorJob => job !== undefined)
+        .sort((left, right) => left.created_unix_seconds - right.created_unix_seconds),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- useQueries returns a new array each render; the join tracks content.
+    [statuses.map((status) => status.dataUpdatedAt).join('|')]
+  );
+  const statusError = statuses.find((status) => status.error)?.error;
+  const settledCount = watchedJobs.filter((job) => terminalStates.has(job.state)).length;
   useEffect(() => {
-    if (activeJob && terminalStates.has(activeJob.state)) {
+    if (settledCount > 0) {
       queryClient.invalidateQueries({
         queryKey: catalogQueryKey(dbId, projectId, sourceRevision),
       });
     }
-  }, [activeJob, dbId, projectId, queryClient, sourceRevision]);
+  }, [settledCount, dbId, projectId, queryClient, sourceRevision]);
 
   useEffect(() => {
-    setActiveJobId(null);
+    setWatchedJobIds([]);
     setPaletteByTarget({});
     setCropByCard({});
     setInspector(null);
     resetStart();
   }, [dbId, projectId, resetStart]);
 
-  // Re-attach to a color build that is still running on the server, so
-  // navigating away and back does not hide it. Declared after the reset above
-  // so a project change adopts that project's job.
+  // Re-attach to color builds still running on the server, so navigating away
+  // and back does not hide them. Declared after the reset above so a project
+  // change adopts that project's jobs.
   const { active } = useStackActivity();
-  const adoptedJobId = adoptableStackJob(active, 'color', dbId, projectId)?.job_id ?? null;
-  const shownJobFinished = activeJob ? terminalStates.has(activeJob.state) : false;
+  const adoptableIds = useMemo(
+    () =>
+      active
+        .filter(
+          (entry) =>
+            entry.kind === 'color' && entry.database_id === dbId && entry.project_id === projectId
+        )
+        .map((entry) => entry.job_id),
+    [active, dbId, projectId]
+  );
   useEffect(() => {
-    if (!adoptedJobId) return;
-    // Keep a job this panel is already watching, but never let a build we have
-    // finished with hide one that is still running.
-    setActiveJobId((current) => (current === null || shownJobFinished ? adoptedJobId : current));
-  }, [adoptedJobId, shownJobFinished]);
+    if (adoptableIds.length === 0) return;
+    setWatchedJobIds((current) => {
+      const additions = adoptableIds.filter((jobId) => !current.includes(jobId));
+      return additions.length === 0 ? current : [...current, ...additions];
+    });
+  }, [adoptableIds]);
 
   const targets = useMemo(() => {
     const byId = new Map((catalog.data?.targets ?? []).map((target) => [target.target_id, target]));
@@ -468,9 +489,20 @@ export default function StackColorPreviewPanel({
 
   if (targets.length === 0 && !catalog.error) return null;
 
-  const colorBusy = startPending || activeJob?.state === 'queued' || activeJob?.state === 'running';
-  const busy = channelBuildRunning || colorBusy;
-  const error = startError ?? status.error ?? catalog.error;
+  // Builds queue on the server, so other cards stay available while one runs.
+  // channelBuildRunning no longer locks color out; a queued color job simply
+  // waits its turn behind the mono builds on the shared permit.
+  void channelBuildRunning;
+  const error = startError ?? statusError ?? catalog.error;
+
+  const newestWatched = (
+    targetId: number,
+    kind: StackColorKind,
+    palette?: StackNarrowbandPalette
+  ) => {
+    const mine = watchedJobs.filter((job) => jobMatches(job, targetId, kind, palette));
+    return mine[mine.length - 1];
+  };
 
   return (
     <section className="stack-color-section" aria-labelledby="stack-color-title">
@@ -496,15 +528,19 @@ export default function StackColorPreviewPanel({
             { kind: 'lrgb', available: target.lrgb_available },
           ];
           for (const { kind, available } of broadbandKinds) {
-            const artifact = activeJob?.state === 'completed' &&
-              jobMatches(activeJob, target.target_id, kind)
-              ? activeJob
+            const watched = newestWatched(target.target_id, kind);
+            const artifact = watched?.state === 'completed'
+              ? watched
               : targetJobs.find((job) => jobMatches(job, target.target_id, kind));
-            const cardActive = activeJob && jobMatches(activeJob, target.target_id, kind)
-              ? activeJob : undefined;
+            const cardActive = watched;
             if (available || artifact) {
               const key = operationKey(target.target_id, kind);
               const crop = cropByCard[key] ?? artifact?.crop ?? 'none';
+              const operationPending = startPending &&
+                (startVariables?.operationKey === key ||
+                  startVariables?.operationKey === `${key}:processing`);
+              const cardBusy = operationPending ||
+                (watched !== undefined && !terminalStates.has(watched.state));
               cards.push(
                 <ColorCard
                   key={key}
@@ -515,8 +551,8 @@ export default function StackColorPreviewPanel({
                   crop={crop}
                   artifact={artifact}
                   activeJob={cardActive}
-                  busy={busy}
-                  operationPending={startPending && startVariables?.operationKey === key}
+                  busy={cardBusy}
+                  operationPending={operationPending}
                   unavailable={!available}
                   sourceStacksOutdated={outdatedTargetIds.has(target.target_id)}
                   canCompute={canCompute}
@@ -551,15 +587,18 @@ export default function StackColorPreviewPanel({
           );
           const palette = paletteByTarget[target.target_id] ?? defaultPalette(paletteChoices);
           if (palette) {
-            const artifact = activeJob?.state === 'completed' &&
-              jobMatches(activeJob, target.target_id, 'narrowband', palette)
-              ? activeJob
+            const watched = newestWatched(target.target_id, 'narrowband', palette);
+            const artifact = watched?.state === 'completed'
+              ? watched
               : targetJobs.find((job) => jobMatches(job, target.target_id, 'narrowband', palette));
-            const cardActive = activeJob &&
-              jobMatches(activeJob, target.target_id, 'narrowband', palette)
-              ? activeJob : undefined;
+            const cardActive = watched;
             const key = operationKey(target.target_id, 'narrowband', palette);
             const crop = cropByCard[key] ?? artifact?.crop ?? 'none';
+            const operationPending = startPending &&
+              (startVariables?.operationKey === key ||
+                startVariables?.operationKey === `${key}:processing`);
+            const cardBusy = operationPending ||
+              (watched !== undefined && !terminalStates.has(watched.state));
             cards.push(
               <ColorCard
                 key={`${target.target_id}:narrowband`}
@@ -571,8 +610,8 @@ export default function StackColorPreviewPanel({
                 crop={crop}
                 artifact={artifact}
                 activeJob={cardActive}
-                busy={busy}
-                operationPending={startPending && startVariables?.operationKey === key}
+                busy={cardBusy}
+                operationPending={operationPending}
                 unavailable={!target.narrowband_palettes.includes(palette)}
                 sourceStacksOutdated={outdatedTargetIds.has(target.target_id)}
                 canCompute={canCompute}

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import type {
   Image,
@@ -15,7 +15,7 @@ import StackColorPreviewPanel from './StackColorPreviewPanel';
 import StackStretchControls from './StackStretchControls';
 import { isSkyOriented } from './stackOrientation';
 import { useAccess } from '../auth/access';
-import { adoptableStackJob, useStackActivity } from '../hooks/useStackActivity';
+import { useStackActivity } from '../hooks/useStackActivity';
 
 type StackCandidateImage = Pick<
   Image,
@@ -123,7 +123,7 @@ export default function StackPreviewPanel({
   const queryClient = useQueryClient();
   const { canCompute } = useAccess();
   const [acceptedOnly, setAcceptedOnly] = useState(false);
-  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [watchedJobIds, setWatchedJobIds] = useState<string[]>([]);
   const [inspector, setInspector] = useState<StackArtifact | null>(null);
   const [stretches, setStretches] = useState<Record<string, StackStretchPreview>>({});
 
@@ -179,7 +179,9 @@ export default function StackPreviewPanel({
       }),
     onSuccess: (job) => {
       queryClient.setQueryData(stackJobQueryKey(dbId, projectId, job.job_id), job);
-      setActiveJobId(job.job_id);
+      setWatchedJobIds((current) =>
+        current.includes(job.job_id) ? current : [...current, job.job_id]
+      );
       if (terminalStates.has(job.state)) {
         queryClient.invalidateQueries({ queryKey: latestStackQueryKey(dbId, projectId) });
       }
@@ -198,42 +200,68 @@ export default function StackPreviewPanel({
     },
   });
 
-  const status = useQuery({
-    queryKey: stackJobQueryKey(dbId, projectId, activeJobId),
-    queryFn: () => apiClient.getStackPreviewJob(dbId, projectId, activeJobId!),
-    enabled: activeJobId !== null,
-    refetchInterval: (query) =>
-      query.state.data && !terminalStates.has(query.state.data.state) ? 1000 : false,
+  const statuses = useQueries({
+    queries: watchedJobIds.map((jobId) => ({
+      queryKey: stackJobQueryKey(dbId, projectId, jobId),
+      queryFn: () => apiClient.getStackPreviewJob(dbId, projectId, jobId),
+      refetchInterval: (query: { state: { data?: StackPreviewJob } }) =>
+        query.state.data && !terminalStates.has(query.state.data.state) ? 1000 : false,
+    })),
   });
-
-  const activeJob: StackPreviewJob | undefined = status.data;
+  const watchedJobs = useMemo(
+    () =>
+      statuses
+        .map((status) => status.data)
+        .filter((job): job is StackPreviewJob => job !== undefined)
+        .sort((left, right) => left.created_unix_seconds - right.created_unix_seconds),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- useQueries returns a new array each render; the join tracks content.
+    [statuses.map((status) => status.dataUpdatedAt).join('|')]
+  );
+  const unfinishedJobs = watchedJobs.filter((job) => !terminalStates.has(job.state));
+  const statusError = statuses.find((status) => status.error)?.error;
+  // The job a shared status line describes: running work first, then the
+  // newest of whatever remains.
+  const activeJob: StackPreviewJob | undefined =
+    unfinishedJobs.find((job) => job.state === 'running') ??
+    unfinishedJobs[unfinishedJobs.length - 1] ??
+    watchedJobs[watchedJobs.length - 1];
+  const settledCount = watchedJobs.filter((job) => terminalStates.has(job.state)).length;
   useEffect(() => {
-    if (activeJob && terminalStates.has(activeJob.state)) {
+    if (settledCount > 0) {
       queryClient.invalidateQueries({ queryKey: latestStackQueryKey(dbId, projectId) });
     }
-  }, [activeJob, dbId, projectId, queryClient]);
+  }, [settledCount, dbId, projectId, queryClient]);
 
   useEffect(() => {
-    setActiveJobId(null);
+    setWatchedJobIds([]);
     setInspector(null);
     setStretches({});
     resetStart();
     resetStop();
   }, [dbId, projectId, resetStart, resetStop]);
 
-  // A build started before this panel mounted — or before the last navigation
-  // — keeps running on the server. Re-attach to it so its progress is visible
-  // again. This must follow the reset above so a project change adopts the new
-  // project's job rather than the old one.
+  // Builds started before this panel mounted — or before the last navigation
+  // — keep running on the server. Re-attach to every one of them so a queue
+  // built up elsewhere stays visible. This must follow the reset above so a
+  // project change adopts the new project's jobs rather than the old ones.
   const { active } = useStackActivity();
-  const adoptedJobId = adoptableStackJob(active, 'mono', dbId, projectId)?.job_id ?? null;
-  const shownJobFinished = activeJob ? terminalStates.has(activeJob.state) : false;
+  const adoptableIds = useMemo(
+    () =>
+      active
+        .filter(
+          (entry) =>
+            entry.kind === 'mono' && entry.database_id === dbId && entry.project_id === projectId
+        )
+        .map((entry) => entry.job_id),
+    [active, dbId, projectId]
+  );
   useEffect(() => {
-    if (!adoptedJobId) return;
-    // Keep a job this panel is already watching, but never let a build we have
-    // finished with hide one that is still running.
-    setActiveJobId((current) => (current === null || shownJobFinished ? adoptedJobId : current));
-  }, [adoptedJobId, shownJobFinished]);
+    if (adoptableIds.length === 0) return;
+    setWatchedJobIds((current) => {
+      const additions = adoptableIds.filter((jobId) => !current.includes(jobId));
+      return additions.length === 0 ? current : [...current, ...additions];
+    });
+  }, [adoptableIds]);
 
   const latestByChannel = useMemo(
     () =>
@@ -245,16 +273,24 @@ export default function StackPreviewPanel({
       ),
     [latest.data]
   );
-  const activeByChannel = useMemo(
-    () =>
-      new Map(
-        (activeJob?.groups ?? []).map((group) => [
-          channelKey(group.target_id, group.filter_name),
-          group,
-        ])
-      ),
-    [activeJob]
-  );
+  const activeByChannel = useMemo(() => {
+    const merged = new Map<string, { job: StackPreviewJob; group: StackPreviewJob['groups'][number] }>();
+    for (const job of watchedJobs) {
+      for (const group of job.groups) {
+        const key = channelKey(group.target_id, group.filter_name);
+        const existing = merged.get(key);
+        // A build still holding the channel outranks a settled one; among
+        // equals the newer request wins, matching iteration order.
+        const groupBusy = group.state === 'queued' || group.state === 'running';
+        const existingBusy =
+          existing?.group.state === 'queued' || existing?.group.state === 'running';
+        if (!existing || groupBusy || !existingBusy) {
+          merged.set(key, { job, group });
+        }
+      }
+    }
+    return merged;
+  }, [watchedJobs]);
 
   const displayKeys = useMemo(() => {
     const keys = new Set([...currentChannels.keys(), ...latestByChannel.keys(), ...activeByChannel.keys()]);
@@ -273,17 +309,10 @@ export default function StackPreviewPanel({
     });
   }, [activeByChannel, currentChannels, latestByChannel]);
 
-  const running = startPending || activeJob?.state === 'queued' || activeJob?.state === 'running';
-  // A running build may have been started elsewhere, so the label falls back to
-  // the whole-set wording when this panel did not start it.
-  const buildLabel = running
-    ? startVariables && startVariables.operationKey !== 'all'
-      ? 'Building channel…'
-      : 'Building previews…'
-    : latest.data?.groups.length
-      ? 'Build current set'
-      : 'Build stack previews';
-  const error = startError ?? stopError ?? status.error ?? latest.error;
+  const running = startPending || unfinishedJobs.length > 0;
+  const queuedBuilds = unfinishedJobs.length;
+  const buildLabel = latest.data?.groups.length ? 'Build current set' : 'Build stack previews';
+  const error = startError ?? stopError ?? statusError ?? latest.error;
   const sourceText = selectionSource === 'selected' ? 'selected' : 'visible';
   // A failed stop — "that build already finished" — belongs to the build the
   // user was stopping, not to the next one they start.
@@ -301,13 +330,13 @@ export default function StackPreviewPanel({
   };
 
   const staleCount = displayKeys.filter((key) => {
-    const activeGroup = activeByChannel.get(key);
+    const activeEntry = activeByChannel.get(key);
     const latestEntry = latestByChannel.get(key);
     const artifact =
-      activeGroup?.state === 'ready' && activeJob
+      activeEntry && activeEntry.group.state === 'ready'
         ? {
-            acceptedOnly: activeJob.accepted_only,
-            group: activeGroup,
+            acceptedOnly: activeEntry.job.accepted_only,
+            group: activeEntry.group,
           }
         : latestEntry
           ? { acceptedOnly: latestEntry.accepted_only, group: latestEntry.group }
@@ -371,11 +400,11 @@ export default function StackPreviewPanel({
             <button
               className="stack-preview-build"
               type="button"
-              disabled={!canCompute || running || stableImageIds.length < 2}
+              disabled={!canCompute || startPending || stableImageIds.length < 2}
               title={canCompute ? undefined : 'This account can view cached stacks but cannot build them.'}
               onClick={() => beginAll(false)}
             >
-              {buildLabel}
+              {startPending && startVariables?.operationKey === 'all' ? 'Queueing…' : buildLabel}
             </button>
             {!!latest.data?.groups.length && !running && (
               <button
@@ -388,15 +417,19 @@ export default function StackPreviewPanel({
                 Rebuild current set
               </button>
             )}
-            {running && activeJobId && (
+            {unfinishedJobs.length > 0 && (
               <button
                 className="stack-preview-stop"
                 type="button"
-                disabled={stopPending || activeJob?.state === 'cancelled'}
-                title="Stop this build. Channels already finished keep their previews."
-                onClick={() => stopStack(activeJobId)}
+                disabled={stopPending}
+                title="Stop every queued and running build. Channels already finished keep their previews."
+                onClick={() => unfinishedJobs.forEach((job) => stopStack(job.job_id))}
               >
-                {stopPending ? 'Stopping…' : 'Stop'}
+                {stopPending
+                  ? 'Stopping…'
+                  : unfinishedJobs.length > 1
+                    ? `Stop all (${unfinishedJobs.length})`
+                    : 'Stop'}
               </button>
             )}
           </div>
@@ -435,6 +468,9 @@ export default function StackPreviewPanel({
                 {displayKeys.length} target/channel group{displayKeys.length === 1 ? '' : 's'}
               </span>
               <span>Stack preview</span>
+              {queuedBuilds > 1 && (
+                <span className="stack-preview-queue-depth">{queuedBuilds} builds in the queue</span>
+              )}
               {staleCount > 0 && (
                 <span className="stack-preview-outdated-count">{staleCount} out of date</span>
               )}
@@ -442,15 +478,16 @@ export default function StackPreviewPanel({
             <div className="stack-preview-grid">
               {displayKeys.map((key) => {
                 const current = currentChannels.get(key);
-                const activeGroup = activeByChannel.get(key);
+                const activeEntry = activeByChannel.get(key);
+                const activeGroup = activeEntry?.group;
                 const latestEntry = latestByChannel.get(key);
                 const activeArtifact: StackArtifact | undefined =
-                  activeGroup?.state === 'ready' && activeJob
+                  activeEntry && activeEntry.group.state === 'ready'
                     ? {
-                        jobId: activeJob.job_id,
-                        artifactRevision: activeJob.artifact_revision,
-                        acceptedOnly: activeJob.accepted_only,
-                        group: activeGroup,
+                        jobId: activeEntry.job.job_id,
+                        artifactRevision: activeEntry.job.artifact_revision,
+                        acceptedOnly: activeEntry.job.accepted_only,
+                        group: activeEntry.group,
                       }
                     : undefined;
                 const artifact = activeArtifact ?? artifactFromLatest(latestEntry);
@@ -506,8 +543,11 @@ export default function StackPreviewPanel({
                             : progressState === 'error'
                               ? 'Stack failed'
                               : 'Not built';
+                const reusedFrames = progressGroup?.reused_frames ?? 0;
                 const progressDetail = progressGroup
-                  ? `${processedFrames}/${eligibleFrames} frames`
+                  ? `${processedFrames}/${eligibleFrames} frames${
+                      reusedFrames > 0 ? ` · ${reusedFrames} resumed` : ''
+                    }`
                   : `${current?.images.length ?? 0} candidates`;
 
                 return (
@@ -556,7 +596,7 @@ export default function StackPreviewPanel({
                           <button
                             className="stack-preview-card-action"
                             type="button"
-                            disabled={!canCompute || running || !canBuildChannel}
+                            disabled={!canCompute || groupBusy || startPending || !canBuildChannel}
                             aria-label={artifact ? 'Rebuild channel' : 'Build channel'}
                             title={!canCompute
                               ? 'This account can view cached stacks but cannot build them.'

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -614,6 +614,9 @@ export default function StackPreviewPanel({
                     </header>
 
                     {outdated && <div className="stack-preview-outdated">{outdated}</div>}
+                    {progressGroup?.resume_note && (
+                      <div className="stack-preview-resume-note">{progressGroup.resume_note}</div>
+                    )}
 
                     {artifact && (
                       <div className="stack-preview-image">

--- a/static/src/components/__tests__/StackPreviewPanel.adopt.test.tsx
+++ b/static/src/components/__tests__/StackPreviewPanel.adopt.test.tsx
@@ -116,7 +116,10 @@ describe('StackPreviewPanel job adoption', () => {
     expect(await screen.findByText('1/2 frames')).toBeInTheDocument();
     expect(screen.getByRole('progressbar', { name: /Sh2 86 Ha stack progress/i }))
       .toHaveAttribute('aria-valuenow', '1');
-    expect(screen.getByRole('button', { name: 'Building previews…' })).toBeDisabled();
+    // The queue stays open while the adopted build runs: the header button
+    // keeps its label and stays clickable, and a Stop appears for the build.
+    expect(screen.getByRole('button', { name: 'Build stack previews' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeEnabled();
   });
 
   it('drops a finished build for one that is still running', async () => {

--- a/static/src/components/__tests__/StackPreviewPanel.queue.test.tsx
+++ b/static/src/components/__tests__/StackPreviewPanel.queue.test.tsx
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import StackPreviewPanel from '../StackPreviewPanel';
+
+const images = [
+  { id: 1, target_id: 42, target_name: 'Sh2 86', filter_name: 'Ha', grading_status: 1 },
+  { id: 2, target_id: 42, target_name: 'Sh2 86', filter_name: 'Ha', grading_status: 1 },
+  { id: 3, target_id: 42, target_name: 'Sh2 86', filter_name: 'OIII', grading_status: 1 },
+  { id: 4, target_id: 42, target_name: 'Sh2 86', filter_name: 'OIII', grading_status: 1 },
+];
+
+function wrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function ok(data: unknown) {
+  return HttpResponse.json({ success: true, data, error: null, status: 'ready' });
+}
+
+function group(index: number, filter: string, state: string, imageIds: number[]) {
+  return {
+    index,
+    target_id: 42,
+    target_name: 'Sh2 86',
+    filter_name: filter,
+    state,
+    phase: state === 'running' ? 'stacking' : state,
+    total_candidates: imageIds.length,
+    eligible_frames: imageIds.length,
+    quality_excluded: 0,
+    missing_files: 0,
+    processed_frames: state === 'running' ? 1 : 0,
+    accepted_frames: state === 'running' ? 1 : 0,
+    rejected_frames: 0,
+    output_channels: 1,
+    reference_image_id: imageIds[0],
+    total_exposure_seconds: 0,
+    preview_url: null,
+    fits_url: null,
+    error: null,
+    calibration: {
+      state: 'none',
+      bias_frames: 0,
+      dark_frames: 0,
+      dark_flat_frames: 0,
+      flat_frames: 0,
+      warning: null,
+    },
+    input_images: imageIds.map((id) => ({ image_id: id, grading_status: 1 })),
+    frames: [],
+  };
+}
+
+function job(jobId: string, created: number, state: string, groups: unknown[]) {
+  return {
+    schema_version: 2,
+    job_id: jobId,
+    database_id: 'test',
+    project_id: 1,
+    state,
+    accepted_only: false,
+    created_unix_seconds: created,
+    artifact_revision: `rev-${jobId}`,
+    cache_version: 7,
+    stacking_version: '0.3.0',
+    groups,
+    error: null,
+  };
+}
+
+describe('StackPreviewPanel manual queue', () => {
+  it('keeps other channels buildable and shows both queued builds', async () => {
+    const jobs: Record<string, unknown> = {};
+    server.use(
+      http.get('/api/stack-activity', () => ok({ schema_version: 1, active: [] })),
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/latest', () => ok({
+        schema_version: 1,
+        database_id: 'test',
+        project_id: 1,
+        updated_unix_seconds: 0,
+        groups: [],
+      })),
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/color', () => ok({
+        schema_version: 1,
+        database_id: 'test',
+        project_id: 1,
+        targets: [],
+        jobs: [],
+      })),
+      http.post(
+        '/api/db/:dbId/projects/:projectId/stack-previews',
+        async ({ request }) => {
+          const body = (await request.json()) as { image_ids: number[] };
+          if (body.image_ids.includes(1)) {
+            const started = job('job-ha', 100, 'running', [group(0, 'Ha', 'running', [1, 2])]);
+            jobs['job-ha'] = started;
+            return ok(started);
+          }
+          const queued = job('job-oiii', 200, 'queued', [group(0, 'OIII', 'queued', [3, 4])]);
+          jobs['job-oiii'] = queued;
+          return ok(queued);
+        }
+      ),
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/:jobId', ({ params }) =>
+        ok(jobs[params.jobId as string])
+      ),
+    );
+
+    render(
+      <StackPreviewPanel
+        dbId="test"
+        projectId={1}
+        images={images}
+        selectionSource="visible"
+        onOpenImage={() => undefined}
+      />,
+      { wrapper: wrapper() }
+    );
+
+    // Start the Ha channel; while it runs, OIII must stay buildable.
+    const buildButtons = await screen.findAllByRole('button', { name: 'Build channel' });
+    expect(buildButtons).toHaveLength(2);
+    await userEvent.click(buildButtons[0]);
+    await screen.findByText('1/2 frames');
+
+    // The running channel's button is held, the other stays open.
+    const afterStart = screen.getAllByRole('button', { name: 'Build channel' });
+    const enabled = afterStart.filter((button) => !(button as HTMLButtonElement).disabled);
+    expect(afterStart).toHaveLength(2);
+    expect(enabled).toHaveLength(1);
+
+    // Queue the second channel behind the first.
+    await userEvent.click(enabled[0]);
+    expect(await screen.findByText('2 builds in the queue')).toBeInTheDocument();
+    expect((await screen.findAllByText('Waiting for stacker')).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Stop all (2)' })).toBeEnabled();
+
+    // The whole-set button never greyed out either.
+    expect(screen.getByRole('button', { name: 'Build stack previews' })).toBeEnabled();
+  });
+
+  it('labels a resumed build with its restored frames', async () => {
+    const resumedGroup = {
+      ...group(0, 'Ha', 'running', [1, 2]),
+      processed_frames: 2,
+      accepted_frames: 2,
+      reused_frames: 2,
+      eligible_frames: 3,
+      total_candidates: 3,
+    };
+    server.use(
+      http.get('/api/stack-activity', () => ok({
+        schema_version: 1,
+        active: [{
+          kind: 'mono',
+          job_id: 'job-resume',
+          database_id: 'test',
+          project_id: 1,
+          state: 'running',
+          label: 'Sh2 86 · Ha',
+          detail: 'Registering frames',
+          processed_units: 2,
+          total_units: 3,
+          created_unix_seconds: 100,
+        }],
+      })),
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/latest', () => ok({
+        schema_version: 1,
+        database_id: 'test',
+        project_id: 1,
+        updated_unix_seconds: 0,
+        groups: [],
+      })),
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/color', () => ok({
+        schema_version: 1,
+        database_id: 'test',
+        project_id: 1,
+        targets: [],
+        jobs: [],
+      })),
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/job-resume', () =>
+        ok(job('job-resume', 100, 'running', [resumedGroup]))
+      ),
+    );
+
+    render(
+      <StackPreviewPanel
+        dbId="test"
+        projectId={1}
+        images={images}
+        selectionSource="visible"
+        onOpenImage={() => undefined}
+      />,
+      { wrapper: wrapper() }
+    );
+
+    expect(await screen.findByText('2/3 frames · 2 resumed')).toBeInTheDocument();
+  });
+});

--- a/tests/integration_stack_resume.rs
+++ b/tests/integration_stack_resume.rs
@@ -1,0 +1,146 @@
+//! An additive rebuild resumed from a checkpoint must equal the build that
+//! integrated everything in one pass.
+//!
+//! This is the premise the stack-preview resume path stands on: Seiza's
+//! context write/reopen round trip preserves the accumulator, its online
+//! rejection state, and the registration reference exactly. If a resumed
+//! stack ever drifted from an uninterrupted one, resuming would silently
+//! change science pixels, so this is checked bit for bit.
+
+use std::io::Write as _;
+
+const STAR_POSITIONS: [(f64, f64); 9] = [
+    (18.0, 21.0),
+    (43.0, 12.0),
+    (77.0, 26.0),
+    (108.0, 31.0),
+    (29.0, 53.0),
+    (61.0, 67.0),
+    (96.0, 58.0),
+    (25.0, 91.0),
+    (88.0, 104.0),
+];
+
+/// A registerable mono frame: sky background, deterministic noise, and a
+/// star field shifted per frame the way dithered exposures are.
+fn write_light(path: &std::path::Path, shift: (f64, f64), seed: u32) {
+    const CARD: usize = 80;
+    const BLOCK: usize = 2880;
+    let (w, h) = (128usize, 128usize);
+    let cards = [
+        "SIMPLE  =                    T".to_string(),
+        "BITPIX  =                   16".to_string(),
+        "NAXIS   =                    2".to_string(),
+        format!("NAXIS1  = {w:>20}"),
+        format!("NAXIS2  = {h:>20}"),
+        "BZERO   =                32768".to_string(),
+        "BSCALE  =                    1".to_string(),
+        "EXPTIME =                 300.".to_string(),
+        "END".to_string(),
+    ];
+    let blocks = (cards.len() * CARD).div_ceil(BLOCK);
+    let mut header = vec![b' '; blocks * BLOCK];
+    for (index, card) in cards.iter().enumerate() {
+        header[index * CARD..index * CARD + card.len()].copy_from_slice(card.as_bytes());
+    }
+    let mut data = Vec::new();
+    for y in 0..h {
+        for x in 0..w {
+            let hash = ((x as u32).wrapping_mul(73_856_093)
+                ^ (y as u32).wrapping_mul(19_349_663)
+                ^ seed.wrapping_mul(83_492_791))
+            .wrapping_mul(2_654_435_761);
+            let noise = (hash >> 20) as f64 / 4096.0 * 900.0;
+            let background = 8000.0 + noise;
+            let stars = STAR_POSITIONS
+                .iter()
+                .map(|&(sx, sy)| {
+                    let (dx, dy) = (x as f64 - (sx + shift.0), y as f64 - (sy + shift.1));
+                    22000.0 * (-(dx * dx + dy * dy) / (2.0 * 1.6 * 1.6)).exp()
+                })
+                .sum::<f64>();
+            let raw = (background + stars).clamp(0.0, 65535.0) as u16;
+            data.extend_from_slice(&((raw as i32 - 32768) as i16).to_be_bytes());
+        }
+    }
+    data.resize(data.len().div_ceil(BLOCK) * BLOCK, 0);
+    let mut file = std::fs::File::create(path).unwrap();
+    file.write_all(&header).unwrap();
+    file.write_all(&data).unwrap();
+}
+
+#[test]
+fn a_resumed_stack_is_bit_identical_to_an_uninterrupted_one() {
+    use seiza_stacking::{
+        FitsFrame, FrameDisposition, LiveStacker, NormalizationMode, StackOptions,
+    };
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let paths: Vec<_> = (0..4)
+        .map(|index| dir.path().join(format!("light-{index}.fits")))
+        .collect();
+    let shifts = [(0.0, 0.0), (2.0, -1.0), (-1.5, 2.5), (1.0, 1.0)];
+    for (index, path) in paths.iter().enumerate() {
+        write_light(path, shifts[index], index as u32 + 1);
+    }
+    let options = || StackOptions {
+        normalization: NormalizationMode::Global,
+        ..StackOptions::default()
+    };
+    let push_expecting_accept = |stacker: &mut LiveStacker, path: &std::path::Path| match stacker
+        .push(FitsFrame::open(path).unwrap())
+        .unwrap()
+    {
+        FrameDisposition::Accepted(_) => {}
+        FrameDisposition::Rejected(reason) => {
+            panic!("synthetic frame {} was rejected: {reason}", path.display())
+        }
+    };
+
+    // One uninterrupted pass over every frame.
+    let mut uninterrupted = LiveStacker::new(
+        FitsFrame::open(&paths[0]).unwrap(),
+        Default::default(),
+        options(),
+    )
+    .unwrap();
+    for path in &paths[1..] {
+        push_expecting_accept(&mut uninterrupted, path);
+    }
+    let expected = uninterrupted.into_snapshot().unwrap();
+
+    // The same frames split across a checkpoint, the way an additive rebuild
+    // sees them: two integrated, a checkpoint saved, two more added later.
+    let mut first_half = LiveStacker::new(
+        FitsFrame::open(&paths[0]).unwrap(),
+        Default::default(),
+        options(),
+    )
+    .unwrap();
+    push_expecting_accept(&mut first_half, &paths[1]);
+    let context = dir.path().join("checkpoint.seiza-stack");
+    first_half.save_context(&context).unwrap();
+    drop(first_half);
+
+    let mut resumed = LiveStacker::open_context(&context).unwrap();
+    for path in &paths[2..] {
+        push_expecting_accept(&mut resumed, path);
+    }
+    let actual = resumed.into_snapshot().unwrap();
+
+    assert_eq!(expected.accepted_frames, actual.accepted_frames);
+    assert_eq!(expected.rejected_frames, actual.rejected_frames);
+    assert_eq!(expected.image.width, actual.image.width);
+    assert_eq!(expected.image.height, actual.image.height);
+    let differing = expected
+        .image
+        .data
+        .iter()
+        .zip(&actual.image.data)
+        .filter(|(left, right)| left.to_bits() != right.to_bits())
+        .count();
+    assert_eq!(
+        differing, 0,
+        "a resumed accumulator must not drift from an uninterrupted one"
+    );
+}


### PR DESCRIPTION
Closes #244.

### Build a queue by clicking

Build buttons greyed out while any stack build ran, so filling a night's previews meant babysitting one click at a time or building everything at once. The server already ran jobs one at a time off a FIFO queue — only the panels hid it. Build buttons now stay open while builds run:

- each click queues a job behind the running one on the same single-job worker, so memory does not grow with the queue;
- every card shows its own `queued`/`running` state and the status line counts the queue;
- **Stop** becomes **Stop all (N)** and stops every queued and running build;
- the color panel follows the same rule and no longer locks while mono channels build;
- panels re-attach to *every* running job after navigation, not just one.

### Additive rebuilds resume (#244)

A queue makes rebuilds frequent, so this adopts Seiza's resumable live stacks. A finished or *stopped* channel build checkpoints its accumulator, online rejection state, and registration reference beside a ledger of every frame it pushed. A later build whose frame set only grew reopens the checkpoint and integrates just the new frames — adding a night to a season-long target costs one night's stacking. The card counts restored work as `resumed`.

**When it resumes vs. rebuilds in full.** The checkpoint is used only when it is provably an ancestor of the request: every recorded frame still requested with an identical source fingerprint, same calibration fingerprint, same Accepted-only policy, same stacking version, and Seiza's own context validation (format version, dimensions, configuration, checksum) passes. Anything else rebuilds from scratch — and when a checkpoint existed but was refused, the card says why (`Full restack: calibration changed`), so a slow rebuild is never a mystery.

An integration test proves a resumed stack is **bit-identical** to an uninterrupted one over the same frames.

### Cache housekeeping

Artifacts are content-addressed by job id, so every rebuild wrote a new directory and old ones accumulated forever — the in-memory job map was capped at 64, the disk at nothing. A janitor now runs after each settle and deletes what nothing references: mono job dirs, color job dirs, and cached color inputs absent from every durable latest index and the in-memory maps.

**Durability rule: job output lives until its input set changes.** The latest indices replace entries per identity (mono per target/channel, color per target/kind/palette), so "unreferenced" already means a newer build of the same identity superseded it — the janitor leans on that rather than on age. The grace on unreferenced directories is a full day, so nothing a long session or open inspector still touches is swept. Checkpoints follow the same rule: replaced in place when their group's input set changes, otherwise kept whatever their age. The only checkpoints deleted outright can never resume again — written by another pipeline version, unreadable, or an orphaned half of an interrupted save.

### Testing

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (19 binaries; 73 stack-preview lib tests including 10 resume-gating and 5 janitor cases)
- New `integration_stack_resume`: resumed vs. uninterrupted stack, bit-for-bit
- vitest: queue behavior (second channel buildable while the first runs, Stop all, queue counter) and the resumed-frames label; `npm run lint`, `npm run build`
- Pre-existing failures in `useColorPreview.test.tsx` (5) also fail on `main`; untouched here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
