### PR TITLE
Make catalog background protection optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4906,9 +4906,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0e19c1983f135a319ae46fa8a51cb6392eff58fe8f4bf5dc1c795161d8458b"
+checksum = "b9eb8fe848b31588a4533a8195c0aa202a1c5398b4dd59bc614276621460282b"
 dependencies = [
  "directories",
  "image",
@@ -4928,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-background"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce27c654312993dceef01e654de2fdce5d3adeddbac19ea0c45c0b94a91b271b"
+checksum = "7de02ad32155f0110b8643ee35e3c2b8259a37c6492230f0a9a10873c902b87a"
 dependencies = [
  "rayon",
  "seiza-stats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,14 +33,14 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.15.0"
+seiza = "0.15.1"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.1", features = ["parallel"] }
 seiza-fits = "=0.2.1"
 seiza-satellites = { version = "0.4.5", features = ["serde"] }
 seiza-stacking = "0.3.0"
 seiza-stretch = "0.2.0"
-seiza-background = "0.2.0"
+seiza-background = "0.2.1"
 seiza-deconvolution = "0.1.0"
 sha2 = "0.11"
 base64 = "0.23"

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -55,6 +55,8 @@ color stacks, and a Sequence view that keeps its place as you grade.
 ## Fixed
 
 - Opening the Overview no longer loses the project you were working in.
+- Color background extraction retries without catalog protection when a
+  protected fit fails. The processing stack also lets you turn protection off.
 - Closing an image detail returns to the view that opened it, at the position
   it was left, including a partly visible Sequence card.
 - Background protection follows the stack's own geometry.

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -279,10 +279,18 @@ pub struct StackBackgroundExtraction {
     /// Fraction of the fitted correction applied to each channel.
     #[serde(default = "full_background_strength")]
     pub strength: f64,
+    /// Keep solved catalog emission out of the background samples. Older
+    /// requests retain the protected behavior.
+    #[serde(default = "catalog_background_protection_enabled")]
+    pub protect_catalog_emission: bool,
 }
 
 const fn full_background_strength() -> f64 {
     1.0
+}
+
+const fn catalog_background_protection_enabled() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -417,6 +425,9 @@ pub struct StackColorJob {
     /// out of the background samples. These are part of the cache identity.
     #[serde(default)]
     pub resolved_background_protection: BTreeMap<StackColorRole, StackBackgroundProtection>,
+    /// Protected fits that failed and were retried without catalog regions.
+    #[serde(default)]
+    pub background_protection_fallbacks: BTreeMap<StackColorRole, String>,
     pub preview_url: String,
     pub fits_url: String,
     pub error: Option<String>,
@@ -461,6 +472,8 @@ struct CachedColorInputs {
     #[serde(default)]
     registered_transforms: BTreeMap<StackColorRole, seiza_stacking::SimilarityTransform>,
     resolved_backgrounds: BTreeMap<StackColorRole, BackgroundFit>,
+    #[serde(default)]
+    background_protection_fallbacks: BTreeMap<StackColorRole, String>,
     resolved_deconvolutions: BTreeMap<StackColorRole, super::stretch::StackDeconvolutionResult>,
 }
 
@@ -1063,11 +1076,12 @@ fn prepare_color_job(
         }
     }
 
-    let resolved_background_protection = if request
-        .processing
-        .as_ref()
-        .is_some_and(|processing| processing.background_extraction.is_some())
-    {
+    let resolved_background_protection = if request.processing.as_ref().is_some_and(|processing| {
+        processing
+            .background_extraction
+            .as_ref()
+            .is_some_and(|extraction| extraction.protect_catalog_emission)
+    }) {
         resolve_background_protection(ctx, &sources)?
     } else {
         BTreeMap::new()
@@ -1172,6 +1186,7 @@ fn prepare_color_job(
             resolved_output_stretches: Vec::new(),
             resolved_backgrounds: BTreeMap::new(),
             resolved_background_protection: background_protection_summary,
+            background_protection_fallbacks: BTreeMap::new(),
             preview_url: format!(
                 "/api/db/{}/stack-previews/color/{job_id}/preview?v={artifact_revision}",
                 ctx.id
@@ -1513,6 +1528,44 @@ fn finish_color_job(job: &mut StackColorJob) {
     job.progress.stage_count = None;
 }
 
+fn fit_channel_background(
+    image: &LinearImage,
+    extraction: &StackBackgroundExtraction,
+    protected_regions: Vec<ProtectedRegion>,
+    mut on_fallback: impl FnMut(&str),
+) -> Result<(BackgroundFit, Option<String>), seiza_background::Error> {
+    let mut config = extraction.config.clone();
+    if extraction.protect_catalog_emission {
+        config.protected_regions = protected_regions;
+    } else {
+        config.protected_regions.clear();
+    }
+    let protected_fit = !config.protected_regions.is_empty();
+    match seiza_background::fit_background(
+        &image.data,
+        image.width,
+        image.height,
+        image.channels,
+        &config,
+    ) {
+        Ok(fit) => Ok((fit, None)),
+        Err(error) if protected_fit => {
+            let reason = error.to_string();
+            on_fallback(&reason);
+            config.protected_regions.clear();
+            seiza_background::fit_background(
+                &image.data,
+                image.width,
+                image.height,
+                image.channels,
+                &config,
+            )
+            .map(|fit| (fit, Some(reason)))
+        }
+        Err(error) => Err(error),
+    }
+}
+
 fn compose_color(
     state: &Arc<AppState>,
     job: &StackColorJob,
@@ -1540,12 +1593,15 @@ fn compose_color(
     let (
         mut reference,
         mut resolved_backgrounds,
+        mut background_protection_fallbacks,
         mut resolved_deconvolutions,
         mut registered_transforms,
     ) = if let Some((manifest, reference)) = cached_inputs {
         state.stack_previews.update_color(&job.job_id, |current| {
             current.processed_channels = current.total_channels;
             current.resolved_backgrounds = manifest.resolved_backgrounds.clone();
+            current.background_protection_fallbacks =
+                manifest.background_protection_fallbacks.clone();
             current.resolved_input_deconvolutions = manifest.resolved_deconvolutions.clone();
             for source in &mut current.sources {
                 source.registration_transform =
@@ -1555,6 +1611,7 @@ fn compose_color(
         (
             reference,
             manifest.resolved_backgrounds,
+            manifest.background_protection_fallbacks,
             manifest.resolved_deconvolutions,
             manifest.registered_transforms,
         )
@@ -1573,7 +1630,13 @@ fn compose_color(
         );
         let reference = load_source_frame(cache_root, reference_source)?;
         progress.advance(StackColorProgressPhase::LoadingSources, 1);
-        (reference, BTreeMap::new(), BTreeMap::new(), BTreeMap::new())
+        (
+            reference,
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
     };
     registered_transforms
         .entry(reference_role)
@@ -1690,17 +1753,28 @@ fn compose_color(
                     Some(source.role),
                     None,
                 );
-                let mut config = extraction.config.clone();
-                config.protected_regions = background_regions
-                    .get(&source.role)
-                    .cloned()
-                    .unwrap_or_default();
-                let fit = seiza_background::fit_background(
-                    &frame.image.data,
-                    frame.image.width,
-                    frame.image.height,
-                    frame.image.channels,
-                    &config,
+                let (fit, fallback) = fit_channel_background(
+                    &frame.image,
+                    extraction,
+                    background_regions
+                        .get(&source.role)
+                        .cloned()
+                        .unwrap_or_default(),
+                    |error| {
+                        tracing::warn!(
+                            "Protected {} background fit failed; retrying without catalog protection: {error}",
+                            source.role.label()
+                        );
+                        progress.begin(
+                            StackColorProgressPhase::BackgroundPreparation,
+                            format!(
+                                "Retrying {} background without catalog protection",
+                                source.role.label()
+                            ),
+                            Some(source.role),
+                            None,
+                        );
+                    },
                 )
                 .map_err(|error| {
                     format!("Failed to fit {} background: {error}", source.role.label())
@@ -1728,7 +1802,15 @@ fn compose_color(
                     current
                         .resolved_backgrounds
                         .insert(source.role, fit.clone());
+                    if let Some(reason) = fallback.as_ref() {
+                        current
+                            .background_protection_fallbacks
+                            .insert(source.role, reason.clone());
+                    }
                 });
+                if let Some(reason) = fallback {
+                    background_protection_fallbacks.insert(source.role, reason);
+                }
                 resolved_backgrounds.insert(source.role, fit);
             }
             Ok::<(), String>(())
@@ -1913,6 +1995,7 @@ fn compose_color(
                         roles: job.sources.iter().map(|source| source.role).collect(),
                         registered_transforms: registered_transforms.clone(),
                         resolved_backgrounds: resolved_backgrounds.clone(),
+                        background_protection_fallbacks: background_protection_fallbacks.clone(),
                         resolved_deconvolutions: resolved_deconvolutions.clone(),
                     };
                     store_cached_color_inputs(
@@ -2573,11 +2656,12 @@ fn color_job_outdated_reason(
     }) {
         return Ok(Some("one or more source channel stacks changed".into()));
     }
-    if job
-        .processing
-        .as_ref()
-        .is_some_and(|processing| processing.background_extraction.is_some())
-    {
+    if job.processing.as_ref().is_some_and(|processing| {
+        processing
+            .background_extraction
+            .as_ref()
+            .is_some_and(|extraction| extraction.protect_catalog_emission)
+    }) {
         let current = resolve_background_protection(ctx, &job.sources)?
             .into_iter()
             .map(|(role, protection)| (role, protection.summary))
@@ -2854,6 +2938,7 @@ mod tests {
             resolved_output_stretches: Vec::new(),
             resolved_backgrounds: BTreeMap::new(),
             resolved_background_protection: BTreeMap::new(),
+            background_protection_fallbacks: BTreeMap::new(),
             preview_url: String::new(),
             fits_url: String::new(),
             error: None,
@@ -3229,6 +3314,7 @@ mod tests {
             config: BackgroundConfig::default(),
             correction_mode: CorrectionMode::Subtract,
             strength: 1.1,
+            protect_catalog_emission: true,
         };
         assert!(validate_request(&request(invalid_strength.clone())).is_err());
 
@@ -3245,12 +3331,70 @@ mod tests {
     }
 
     #[test]
+    fn older_background_requests_keep_catalog_protection_enabled() {
+        let extraction: StackBackgroundExtraction = serde_json::from_value(serde_json::json!({
+            "config": BackgroundConfig::default(),
+            "correction_mode": "subtract",
+            "strength": 1.0
+        }))
+        .unwrap();
+
+        assert!(extraction.protect_catalog_emission);
+    }
+
+    #[test]
+    fn protected_background_fit_retries_without_regions_after_any_error() {
+        let values = (0..64 * 64)
+            .map(|index| {
+                let x = (index % 64) as f32 / 63.0;
+                let y = (index / 64) as f32 / 63.0;
+                0.1 + x * 0.02 + y * 0.03
+            })
+            .collect();
+        let image = LinearImage::new(64, 64, 1, values).unwrap();
+        let whole_image = ProtectedRegion::Polygon {
+            points: vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+        };
+        let mut fallback_messages = Vec::new();
+        let extraction = StackBackgroundExtraction {
+            config: BackgroundConfig::default(),
+            correction_mode: CorrectionMode::Subtract,
+            strength: 1.0,
+            protect_catalog_emission: true,
+        };
+
+        let (fit, fallback) =
+            fit_channel_background(&image, &extraction, vec![whole_image.clone()], |error| {
+                fallback_messages.push(error.to_string())
+            })
+            .unwrap();
+
+        assert!(fallback.is_some());
+        assert_eq!(fallback_messages, fallback.into_iter().collect::<Vec<_>>());
+        assert_eq!(fit.diagnostics.protected_regions, 0);
+
+        let (unprotected_fit, fallback) = fit_channel_background(
+            &image,
+            &StackBackgroundExtraction {
+                protect_catalog_emission: false,
+                ..extraction
+            },
+            vec![whole_image],
+            |_| panic!("disabled protection must not need a fallback"),
+        )
+        .unwrap();
+        assert!(fallback.is_none());
+        assert_eq!(unprotected_fit.diagnostics.protected_regions, 0);
+    }
+
+    #[test]
     fn progress_ledger_accounts_for_every_pipeline_phase() {
         let processing = StackColorProcessing {
             background_extraction: Some(StackBackgroundExtraction {
                 config: BackgroundConfig::default(),
                 correction_mode: CorrectionMode::Subtract,
                 strength: 1.0,
+                protect_catalog_emission: true,
             }),
             input_deconvolutions: BTreeMap::from([(
                 StackColorRole::Red,
@@ -3420,6 +3564,7 @@ mod tests {
                 (StackColorRole::Green, transform),
             ]),
             resolved_backgrounds: BTreeMap::new(),
+            background_protection_fallbacks: BTreeMap::new(),
             resolved_deconvolutions: BTreeMap::new(),
         };
 

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -4242,7 +4242,7 @@
   margin-top: 0.5rem;
 }
 
-.stack-background-rbf-toggle input[type='checkbox'] {
+.stack-background-toggle input[type='checkbox'] {
   width: 18px;
   min-height: 18px;
   justify-self: start;

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -638,6 +638,7 @@ export interface StackBackgroundExtraction {
   config: StackBackgroundConfig;
   correction_mode: 'subtract' | 'divide';
   strength: number;
+  protect_catalog_emission: boolean;
 }
 
 export interface StackBackgroundFit {
@@ -776,6 +777,7 @@ export interface StackColorJob {
   resolved_output_stretches: unknown[];
   resolved_backgrounds: Partial<Record<StackColorRole, StackBackgroundFit>>;
   resolved_background_protection: Partial<Record<StackColorRole, StackBackgroundProtection>>;
+  background_protection_fallbacks: Partial<Record<StackColorRole, string>>;
   preview_url: string;
   fits_url: string;
   error: string | null;

--- a/static/src/components/StackColorPreviewPanel.tsx
+++ b/static/src/components/StackColorPreviewPanel.tsx
@@ -339,6 +339,7 @@ function ColorCard({
         applied={artifact?.processing ?? null}
         backgrounds={artifact?.resolved_backgrounds ?? {}}
         protections={artifact?.resolved_background_protection ?? {}}
+        fallbacks={artifact?.background_protection_fallbacks ?? {}}
         deconvolutions={artifact?.resolved_input_deconvolutions ?? {}}
         disabled={!canCompute || busy || unavailable}
         onApply={onProcessingApply}

--- a/static/src/components/StackColorProcessingControls.tsx
+++ b/static/src/components/StackColorProcessingControls.tsx
@@ -139,11 +139,12 @@ function BackgroundNumberField({
 }
 
 function BackgroundControls({
-  extraction, backgrounds, protections, disabled, onChange,
+  extraction, backgrounds, protections, fallbacks, disabled, onChange,
 }: {
   extraction: StackBackgroundExtraction | null;
   backgrounds: Partial<Record<StackColorRole, StackBackgroundFit>>;
   protections: Partial<Record<StackColorRole, StackBackgroundProtection>>;
+  fallbacks: Partial<Record<StackColorRole, string>>;
   disabled: boolean;
   onChange: (extraction: StackBackgroundExtraction | null) => void;
 }) {
@@ -212,6 +213,15 @@ function BackgroundControls({
           <BackgroundNumberField label="Strength" value={extraction.strength}
             min={0} max={1} step={0.05} disabled={disabled}
             onChange={(strength) => onChange({ ...extraction, strength: strength ?? 0 })} />
+          <label className="stack-stretch-field stack-background-toggle">
+            <span>Protect catalog emission</span>
+            <input type="checkbox" aria-label="Protect catalog emission from background fitting"
+              checked={extraction.protect_catalog_emission ?? true} disabled={disabled}
+              onChange={(event) => onChange({
+                ...extraction,
+                protect_catalog_emission: event.target.checked,
+              })} />
+          </label>
           <label className="stack-stretch-field">
             <span>Surface model</span>
             <select
@@ -239,7 +249,7 @@ function BackgroundControls({
                 onChange={(minimum_improvement) => updateAutomaticModel({
                   minimum_improvement: minimum_improvement ?? 0,
                 })} />
-              <label className="stack-stretch-field stack-background-rbf-toggle">
+              <label className="stack-stretch-field stack-background-toggle">
                 <span>Flexible surface</span>
                 <input type="checkbox" aria-label="Allow radial-basis background model"
                   checked={extraction.config.model.allow_radial_basis} disabled={disabled}
@@ -341,7 +351,11 @@ function BackgroundControls({
                 {' · '}radius {fit.diagnostics.sample_radius}
                 {' · '}{fit.diagnostics.protected_regions ?? 0} protected
               </small>
-              {!!protections[role]?.object_names.length && (
+              {fallbacks[role] ? (
+                <small title={`Protected fit failed: ${fallbacks[role]}`}>
+                  Catalog protection skipped after the protected fit failed
+                </small>
+              ) : !!protections[role]?.object_names.length && (
                 <small title={protections[role]?.object_names.join(', ')}>
                   Protected: {protections[role]?.object_names.join(', ')}
                 </small>
@@ -436,13 +450,14 @@ function StageLane({
 }
 
 export default function StackColorProcessingControls({
-  label, roles, applied, backgrounds, protections, deconvolutions, disabled, onApply,
+  label, roles, applied, backgrounds, protections, fallbacks, deconvolutions, disabled, onApply,
 }: {
   label: string;
   roles: StackColorRole[];
   applied: StackColorProcessing | null;
   backgrounds: Partial<Record<StackColorRole, StackBackgroundFit>>;
   protections: Partial<Record<StackColorRole, StackBackgroundProtection>>;
+  fallbacks: Partial<Record<StackColorRole, string>>;
   deconvolutions: Partial<Record<StackColorRole, StackDeconvolutionResult>>;
   disabled: boolean;
   onApply: (processing: StackColorProcessing) => void;
@@ -509,6 +524,7 @@ export default function StackColorProcessingControls({
           extraction={draft.background_extraction}
           backgrounds={backgrounds}
           protections={protections}
+          fallbacks={fallbacks}
           disabled={disabled}
           onChange={(background_extraction) => setDraft((current) => ({
             ...current, background_extraction,

--- a/static/src/components/__tests__/StackColorProcessingControls.test.tsx
+++ b/static/src/components/__tests__/StackColorProcessingControls.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import StackColorProcessingControls from '../StackColorProcessingControls';
+import { defaultColorProcessing } from '../stackColorProcessing';
+
+describe('StackColorProcessingControls', () => {
+  it('lets the user disable catalog background protection', async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    render(
+      <StackColorProcessingControls
+        label="Test RGB"
+        roles={['red', 'green', 'blue']}
+        applied={defaultColorProcessing(['red', 'green', 'blue'])}
+        backgrounds={{}}
+        protections={{}}
+        fallbacks={{}}
+        deconvolutions={{}}
+        disabled={false}
+        onApply={onApply}
+      />
+    );
+
+    await user.click(screen.getByText('Processing stack'));
+    const protection = screen.getByRole('checkbox', {
+      name: 'Protect catalog emission from background fitting',
+    });
+    expect(protection).toBeChecked();
+
+    await user.click(protection);
+    await user.click(screen.getByRole('button', { name: 'Apply processing stack' }));
+
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({
+      background_extraction: expect.objectContaining({
+        protect_catalog_emission: false,
+      }),
+    }));
+  });
+});

--- a/static/src/components/__tests__/stackColorProcessing.test.ts
+++ b/static/src/components/__tests__/stackColorProcessing.test.ts
@@ -27,6 +27,7 @@ describe('stack color processing defaults', () => {
     expect(processing.input_deconvolutions).toEqual({});
     expect(processing.background_extraction?.correction_mode).toBe('subtract');
     expect(processing.background_extraction?.strength).toBe(1);
+    expect(processing.background_extraction?.protect_catalog_emission).toBe(true);
     expect(processing.background_extraction?.config.model).toMatchObject({
       kind: 'automatic',
       max_degree: 2,
@@ -86,6 +87,28 @@ describe('stack color processing defaults', () => {
       cache_version: BACKGROUND_COLOR_CACHE_VERSION,
       processing,
     }, ['red', 'green', 'blue']).background_extraction?.strength).toBe(1);
+  });
+
+  it('enables catalog protection for older background requests', () => {
+    const processing = defaultColorProcessing(['red', 'green', 'blue']);
+    delete (processing.background_extraction as Partial<
+      NonNullable<typeof processing.background_extraction>
+    >).protect_catalog_emission;
+
+    expect(processingForColorBuild({
+      cache_version: BACKGROUND_COLOR_CACHE_VERSION,
+      processing,
+    }, ['red', 'green', 'blue']).background_extraction?.protect_catalog_emission).toBe(true);
+  });
+
+  it('keeps an explicit catalog protection opt-out', () => {
+    const processing = defaultColorProcessing(['red', 'green', 'blue']);
+    processing.background_extraction!.protect_catalog_emission = false;
+
+    expect(processingForColorBuild({
+      cache_version: BACKGROUND_COLOR_CACHE_VERSION,
+      processing,
+    }, ['red', 'green', 'blue']).background_extraction?.protect_catalog_emission).toBe(false);
   });
 
   it('uses conservative upstream defaults only after deconvolution is enabled', () => {

--- a/static/src/components/stackColorProcessing.ts
+++ b/static/src/components/stackColorProcessing.ts
@@ -39,6 +39,7 @@ export function defaultBackgroundExtraction(): StackBackgroundExtraction {
     },
     correction_mode: 'subtract',
     strength: 1,
+    protect_catalog_emission: true,
   };
 }
 
@@ -67,6 +68,8 @@ export function processingForColorBuild(
       ? {
           ...processing.background_extraction,
           strength: processing.background_extraction.strength ?? 1,
+          protect_catalog_emission:
+            processing.background_extraction.protect_catalog_emission ?? true,
         }
       : null,
     input_deconvolutions: processing.input_deconvolutions ?? {},


### PR DESCRIPTION
## Summary

- add an on/off control for catalog emission protection in color background extraction
- retry a failed protected background fit once with no protected regions
- retain and show the fallback result when prepared color inputs are reused
- keep protection on for older saved requests and record the change in the release notes
- use released `seiza` 0.15.1 and `seiza-background` 0.2.1, including the repeated catalog polygon point fix from Seiza #110

## Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `npm run lint`
- `npx vitest run`
- `npm run build`

All 257 frontend tests passed. Node 26 needed `NODE_OPTIONS=--localstorage-file=/tmp/psf-guard-vitest-localstorage.json` for Vitest. Cache invalidation changes are outside this PR.
