### PR TITLE
Clamp an oversized artifact drag instead of cancelling it

### DIFF
--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -288,8 +288,9 @@ be a reflection. Low-evidence results stay unclassified. The search never
 accepts or rejects an image. It cannot isolate a defect that appears in the
 same registered place in every source because that defect becomes part of the
 peer baseline. At least three integrated frames are needed for a filter. A
-color search skips a channel that has fewer than three inputs and says why. The
-region must measure 8–512 pixels on each side.
+color search skips a channel that has fewer than three inputs and says why. A
+region must measure at least 8 pixels on each side; dragging past 512 stops the
+box at 512 rather than clearing it, keeping the corner the drag started from.
 
 ![A selected stack region ranked across three real source frames](stack-artifact-finder.png)
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -63,6 +63,9 @@ color stacks, and a Sequence view that keeps its place as you grade.
 - Closing an image detail returns to the view that opened it, at the position
   it was left, including a partly visible Sequence card.
 - Background protection follows the stack's own geometry.
+- Dragging past the largest searchable region when finding a source artifact
+  now stops the box at the limit. It used to disappear mid-drag, so the
+  selection had to be started over.
 - Flagged Sequence thumbnails stay bright.
 - Shift-click range selection keeps a stable anchor.
 

--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -349,6 +349,28 @@ test('builds a real three-frame Seiza stack and exposes its frame decisions', as
   }
 
   await inspector.getByRole('button', { name: 'Find source artifact' }).click();
+
+  // Dragging past the largest searchable region clamps the box. It used to
+  // vanish mid-drag, which read as the selection cancelling itself. The
+  // inspector is at 100%, so one screen pixel is one image pixel here.
+  const marquee = inspector.getByTestId('stack-artifact-region');
+  const longDragX = Math.min(canvasBox!.width - 20, 760);
+  const longDragY = Math.min(canvasBox!.height - 20, 660);
+  expect(longDragX, 'canvas too narrow to drag past the limit').toBeGreaterThan(560);
+  expect(longDragY, 'canvas too short to drag past the limit').toBeGreaterThan(560);
+  await page.mouse.move(canvasBox!.x + 10, canvasBox!.y + 10);
+  await page.mouse.down();
+  await page.mouse.move(canvasBox!.x + longDragX, canvasBox!.y + longDragY, { steps: 6 });
+  await expect(marquee).toBeVisible();
+  const midDrag = await marquee.boundingBox();
+  expect(Math.round(midDrag!.width)).toBe(512);
+  expect(Math.round(midDrag!.height)).toBe(512);
+  await expect(inspector.locator('.stack-inspector-hint')).toContainText('512px is as wide');
+  await page.mouse.up();
+  await expect(marquee).toBeVisible();
+  await expect(inspector.getByRole('button', { name: 'Search this region' })).toBeVisible();
+
+  await inspector.getByRole('button', { name: 'Find source artifact' }).click();
   await page.mouse.move(canvasBox!.x + 160, canvasBox!.y + 140);
   await page.mouse.down();
   await page.mouse.move(canvasBox!.x + 280, canvasBox!.y + 230, { steps: 4 });

--- a/static/src/components/StackPreviewInspector.tsx
+++ b/static/src/components/StackPreviewInspector.tsx
@@ -11,6 +11,7 @@ import { useImageZoom } from '../hooks/useImageZoom';
 import { morphologyLabel } from './artifactMorphology';
 import {
   artifactRegionFromPoints,
+  isArtifactRegionCapped,
   MAX_ARTIFACT_REGION_EDGE,
   MIN_ARTIFACT_REGION_EDGE,
 } from './stackArtifactRegion';
@@ -199,7 +200,7 @@ export default function StackPreviewInspector({
     setDragStart(null);
     if (!selected) {
       setRegion(null);
-      setRegionError(`Choose a region from ${MIN_ARTIFACT_REGION_EDGE} to ${MAX_ARTIFACT_REGION_EDGE} pixels on each side.`);
+      setRegionError(`Drag a box at least ${MIN_ARTIFACT_REGION_EDGE} pixels on each side.`);
       return;
     }
     setRegion(selected);
@@ -462,9 +463,11 @@ export default function StackPreviewInspector({
 
         <footer className="stack-inspector-toolbar">
           <div className="stack-inspector-hint">
-            {selecting
-              ? `Drag a ${MIN_ARTIFACT_REGION_EDGE}–${MAX_ARTIFACT_REGION_EDGE}px box over the artifact`
-              : 'Wheel to zoom · drag to pan · F fit · 1 actual size'}
+            {!selecting
+              ? 'Wheel to zoom · drag to pan · F fit · 1 actual size'
+              : displayedRegion && isArtifactRegionCapped(displayedRegion)
+                ? `${MAX_ARTIFACT_REGION_EDGE}px is as wide as the search looks — drag from another corner to move the box`
+                : `Drag a box over the artifact, up to ${MAX_ARTIFACT_REGION_EDGE}px a side`}
           </div>
           {regionError && <span className="stack-artifact-region-error" role="alert">{regionError}</span>}
           {artifactSource && (

--- a/static/src/components/__tests__/StackPreviewInspector.test.ts
+++ b/static/src/components/__tests__/StackPreviewInspector.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ArtifactSearchResult } from '../../api/types';
 import { morphologyLabel } from '../artifactMorphology';
-import { artifactRegionFromPoints } from '../stackArtifactRegion';
+import { artifactRegionFromPoints, isArtifactRegionCapped } from '../stackArtifactRegion';
 
 function result(
   morphology: ArtifactSearchResult['morphology'],
@@ -43,19 +43,59 @@ describe('artifactRegionFromPoints', () => {
     )).toEqual({ x: 0, y: 90, width: 20, height: 10 });
   });
 
-  it('rejects regions that are too small or too large', () => {
+  it('rejects a drag that is still too small to search', () => {
     expect(artifactRegionFromPoints(
       { x: 0, y: 0 },
       { x: 7, y: 20 },
       100,
       100
     )).toBeNull();
+  });
+
+  it('stops a long drag at the limit instead of voiding the box', () => {
+    // Dragging past the limit used to return null, so the box vanished
+    // mid-drag and the selection had to be started over.
+    expect(artifactRegionFromPoints(
+      { x: 100, y: 100 },
+      { x: 900, y: 900 },
+      2000,
+      2000
+    )).toEqual({ x: 100, y: 100, width: 512, height: 512 });
+  });
+
+  it('keeps the corner the drag began at when it clamps backwards', () => {
+    // Dragging up and left, the anchor is the bottom-right corner, so that is
+    // the edge that has to stay put.
+    expect(artifactRegionFromPoints(
+      { x: 600, y: 700 },
+      { x: 0, y: 0 },
+      2000,
+      2000
+    )).toEqual({ x: 88, y: 188, width: 512, height: 512 });
+  });
+
+  it('clamps each side on its own', () => {
     expect(artifactRegionFromPoints(
       { x: 0, y: 0 },
-      { x: 513, y: 20 },
+      { x: 900, y: 40 },
+      2000,
+      2000
+    )).toEqual({ x: 0, y: 0, width: 512, height: 40 });
+  });
+
+  it('clamps a drag that runs off the image to the limit, not the edge', () => {
+    expect(artifactRegionFromPoints(
+      { x: 50, y: 50 },
+      { x: 5000, y: 5000 },
       1000,
       1000
-    )).toBeNull();
+    )).toEqual({ x: 50, y: 50, width: 512, height: 512 });
+  });
+
+  it('reports when a region has grown to the limit', () => {
+    expect(isArtifactRegionCapped({ x: 0, y: 0, width: 512, height: 40 })).toBe(true);
+    expect(isArtifactRegionCapped({ x: 0, y: 0, width: 40, height: 512 })).toBe(true);
+    expect(isArtifactRegionCapped({ x: 0, y: 0, width: 511, height: 511 })).toBe(false);
   });
 });
 

--- a/static/src/components/stackArtifactRegion.ts
+++ b/static/src/components/stackArtifactRegion.ts
@@ -8,19 +8,60 @@ export interface ImagePoint {
 export const MIN_ARTIFACT_REGION_EDGE = 8;
 export const MAX_ARTIFACT_REGION_EDGE = 512;
 
+interface Span {
+  origin: number;
+  length: number;
+}
+
+/**
+ * One axis of the selection. The corner the drag began at stays put and the
+ * moving edge stops at the widest region the search accepts, so dragging past
+ * that grows nothing instead of voiding the box.
+ */
+function clampedSpan(anchor: number, moving: number, extent: number): Span {
+  const from = Math.min(Math.max(anchor, 0), extent);
+  const to = Math.min(Math.max(moving, 0), extent);
+  // Both edges round outward, so a box never reads as smaller than it looks.
+  if (to >= from) {
+    const origin = Math.floor(from);
+    const length = Math.min(Math.ceil(to) - origin, MAX_ARTIFACT_REGION_EDGE);
+    return { origin, length };
+  }
+  const end = Math.ceil(from);
+  const length = Math.min(end - Math.floor(to), MAX_ARTIFACT_REGION_EDGE);
+  return { origin: end - length, length };
+}
+
+/**
+ * The region a drag selects, in image pixels, or null while it is still too
+ * small to search. Oversized drags are clamped rather than rejected: the box
+ * stops growing at the limit and stays selectable.
+ */
 export function artifactRegionFromPoints(
   start: ImagePoint,
   end: ImagePoint,
   imageWidth: number,
   imageHeight: number
 ): ReferenceRegion | null {
-  const left = Math.max(0, Math.floor(Math.min(start.x, end.x)));
-  const top = Math.max(0, Math.floor(Math.min(start.y, end.y)));
-  const right = Math.min(imageWidth, Math.ceil(Math.max(start.x, end.x)));
-  const bottom = Math.min(imageHeight, Math.ceil(Math.max(start.y, end.y)));
-  const width = right - left;
-  const height = bottom - top;
-  if (width < MIN_ARTIFACT_REGION_EDGE || height < MIN_ARTIFACT_REGION_EDGE) return null;
-  if (width > MAX_ARTIFACT_REGION_EDGE || height > MAX_ARTIFACT_REGION_EDGE) return null;
-  return { x: left, y: top, width, height };
+  const horizontal = clampedSpan(start.x, end.x, imageWidth);
+  const vertical = clampedSpan(start.y, end.y, imageHeight);
+  if (
+    horizontal.length < MIN_ARTIFACT_REGION_EDGE ||
+    vertical.length < MIN_ARTIFACT_REGION_EDGE
+  ) {
+    return null;
+  }
+  return {
+    x: horizontal.origin,
+    y: vertical.origin,
+    width: horizontal.length,
+    height: vertical.length,
+  };
+}
+
+/** Whether a region has grown to the limit on either side. */
+export function isArtifactRegionCapped(region: ReferenceRegion): boolean {
+  return (
+    region.width >= MAX_ARTIFACT_REGION_EDGE || region.height >= MAX_ARTIFACT_REGION_EDGE
+  );
 }


### PR DESCRIPTION
Dragging a source-artifact box past 512 pixels returned no region at all, so the box vanished mid-drag and the selection had to be started over. `artifactRegionFromPoints` returned `null` above the limit, and that same `null` drives the live marquee — so the rubber band disappeared while the mouse was still down, and letting go left an error where a selection should have been.

## What changed

The box now stops growing at the limit instead of voiding itself.

- **The anchor stays put.** Only the moving edge is held back, so carrying a drag further slides the far edge along rather than clearing the box, and dragging back inside the limit grows normally again. Dragging up and left clamps the other way, keeping the bottom-right corner where the drag began.
- **Each side clamps on its own**, so a wide, short drag keeps its height.
- **Below the minimum is still no selection.** There is no honest way to invent area the drag never covered, so a too-small drag reports that rather than being grown to 8 pixels — which would turn a stray click into a selection. Its message no longer mentions a maximum that can't be hit.
- **The hint says the limit has been reached** while it is being held, so the box stopping reads as a limit rather than a stuck interface.

The server keeps rejecting oversized regions as a guard; the UI simply never sends one now.

## Checks run locally

- `npm run lint`, `npx tsc --noEmit`, `npm run build` clean.
- `npx vitest run` — 257 pass. Six new cases on the region helper: clamping forward, clamping backward while keeping the anchor corner, each axis independently, a drag running off the image clamping to the limit rather than the edge, the too-small case still rejected, and the cap report.
- `npx playwright test` — full suite, 93 passed.
- The e2e now drives the real interaction: at 100% zoom it drags 750 × 650 image pixels, asserts **mid-drag** that the marquee is still visible and measures exactly 512 × 512, and that the hint names the limit. **Reverting just `stackArtifactRegion.ts` to its previous version fails that assertion** — the marquee is gone at the mid-drag check — so the test pins the bug rather than the fix's shape.

Frontend only; no Rust source is touched, so I did not run the Rust layers beyond `cargo test` to confirm nothing moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)