### PR TITLE
Point the release note's auth link at a URL that resolves

### DIFF
--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -10,7 +10,8 @@ requests until an operator adds a user.
 ## Added
 
 - Optional server user accounts, with roles, a browser management UI, and a
-  login page. See [authentication](../AUTHENTICATION.md).
+  login page. See
+  [server authentication](https://github.com/theatrus/psf-guard/blob/v0.7.0/docs/AUTHENTICATION.md).
 - A queue for stack builds. Build buttons stay live while a build runs, so
   each click queues a channel behind the one working; every card shows its own
   queued or running state and the status line counts the queue. The color panel


### PR DESCRIPTION
Found while preparing to tag 0.7.0.

`.github/workflows/release.yml:285` sets `body_path: docs/releases/${{ github.ref_name }}.md`, so the notes file becomes the GitHub release body verbatim. v0.7.0 is the first notes file to contain a link, and it was relative:

```
See [authentication](../AUTHENTICATION.md).
```

On a release page that resolves against the releases URL and 404s. No earlier release notes had links, so nothing had exercised this before.

It now points at the file on the `v0.7.0` tag, so it keeps matching the release it describes instead of drifting with `main`.

This is the link a reader follows straight after the security note tells them a networked server stops serving until they add a user — the one that most needs to work.

## Checks

- `node scripts/check-release-version.mjs v0.7.0` — passes.
- Ran `summaryFromNotes` against the edited file: the update banner is unchanged, still *"This release queues stack builds, resumes them as a night grows, and closes a hole that let anyone on the network reach a server with no accounts."*
- `git diff --check` clean. The changed line runs to 100 columns because a link target cannot be wrapped.

Docs only. I have not tagged yet — the tag waits on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)