### PR TITLE
Let a narrowband colour card show which target it is

### DIFF
--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -780,6 +780,40 @@ test('composes cached channel stacks into RGB, LRGB, and selectable narrowband p
   expect(foraxxHeader).toContain('FORAXX-HOO');
   expect(foraxxHeader).toContain('DISPLAY');
 
+  // The narrowband header's worst case: a built card carries a status badge
+  // and three buttons, and SHO is the widest palette label. The colour grid is
+  // two fixed columns, so a laptop-width window is what users actually get.
+  await palette.selectOption('sho');
+  await section.getByRole('button', { name: 'Build SHO color preview' }).click();
+  await expect(narrowbandCard.locator('.stack-preview-progress')).toHaveAttribute(
+    'data-stack-color-state', 'completed', { timeout: 90_000 }
+  );
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.waitForTimeout(300);
+  const header = await narrowbandCard.evaluate((card) => {
+    const row = card.querySelector('header')!;
+    const left = row.querySelector(':scope > div:first-child')!.getBoundingClientRect();
+    const actions = row.querySelector('.stack-preview-card-actions')!.getBoundingClientRect();
+    const title = card.querySelector('h3')!.getBoundingClientRect();
+    return {
+      overlap: Math.round(left.right - actions.left),
+      sameRow: Math.abs(left.top - actions.top) < 4,
+      overflow: row.scrollWidth - row.clientWidth,
+      titleWidth: Math.round(title.width),
+      actionItems: row.querySelectorAll('.stack-preview-card-actions > *').length,
+    };
+  });
+  expect(header.actionItems, 'expected a built card with its full actions').toBeGreaterThan(3);
+  // Either the two groups share a row without touching, or the actions wrapped
+  // onto their own. Neither may push the row wider than the card.
+  if (header.sameRow) {
+    expect(header.overlap, 'header groups overlap').toBeLessThanOrEqual(1);
+  }
+  expect(header.overflow, 'narrowband header overflows its card').toBeLessThanOrEqual(1);
+  // The card has to say which target it belongs to. A longer target name than
+  // this fixture's squeezes the title to nothing when the row cannot wrap.
+  expect(header.titleWidth, 'target name squeezed out of the header').toBeGreaterThan(0);
+
   if (process.env.PSF_GUARD_CAPTURE_DOCS === '1') {
     const docs = path.resolve(process.cwd(), '..', 'docs');
     fs.mkdirSync(docs, { recursive: true });

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3882,13 +3882,19 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.65rem;
+  gap: 0.4rem 0.65rem;
   padding: 0.48rem 0.7rem;
+  /* A narrowband card carries a palette picker the RGB one does not. Two
+     columns of cards leave the row too narrow for both selects, the status
+     badge and three buttons, so let the actions drop to their own line
+     instead of sliding underneath them. */
+  flex-wrap: wrap;
 }
 
 .stack-color-card > header > div:first-child {
   min-width: 0;
   display: flex;
+  flex: 1 1 auto;
   align-items: center;
   gap: 0.45rem;
 }
@@ -3902,6 +3908,7 @@
 }
 
 .stack-color-palette {
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 0.35rem;
@@ -3916,6 +3923,7 @@
 }
 
 .stack-color-palette select {
+  min-width: 0;
   max-width: 210px;
   min-height: 27px;
   padding: 0.2rem 1.6rem 0.2rem 0.45rem;
@@ -3933,10 +3941,10 @@
 }
 
 .stack-color-crop {
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  margin-top: 0.3rem;
 }
 
 .stack-color-crop > span {
@@ -3947,6 +3955,7 @@
 }
 
 .stack-color-crop select {
+  min-width: 0;
   max-width: 210px;
   min-height: 27px;
   padding: 0.2rem 1.6rem 0.2rem 0.45rem;


### PR DESCRIPTION
## I had this wrong, and the measurement corrected me

I reported this as the status badge overlapping the Edges picker. It is not. Measuring the real card's DOM:

```
overlap: -10    overflow: 0    cardWidth: 552    actionItems: 4
title: "Golf of Mexico"    titleWidth: 0
```

Nothing overlaps and nothing overflows. What I read off a screenshot as an overlap was the `<select>` clipping its own text — "Keep blank…" — with the badge sitting next to it, which is ordinary select behaviour.

The same measurement showed a real defect I had described wrongly: **`titleWidth: 0`**. At the colour grid's two fixed columns a narrowband card carries a palette picker the RGB card does not, plus an Edges picker, a status badge and three buttons. The row cannot hold all of it, and the only thing able to give is the target name — so it collapses to nothing and the card never says which target it belongs to.

## The change

`.stack-color-card > header` now wraps, so the actions drop to their own line instead of squeezing the title away, and both pickers get `min-width: 0` so they can give ground before it comes to that. Flex only wraps once a row overflows, so a card with room to spare is untouched.

Measured on the same real card afterwards: **`titleWidth: 101`**, "Golf of Mexico" legible, `overflow: 0`.

Also dropped a stray `margin-top` on the crop label — it sits in a flex row here and never stacked under anything.

## About the test

`static/e2e/stack-preview.spec.ts` now builds the SHO palette (the widest label) so the card carries its full four actions, sizes the window to a laptop width, and asserts the header neither overlaps nor overflows and that the title keeps a non-zero width.

**Being straight about its limits:** this assertion passes both with and without the CSS change. The fixture's target is "Beta Field", which is short enough to survive where "Golf of Mexico" did not — measured slack was 10px at every width I probed from 552 down to 424. Reproducing the collapse in the suite would mean renaming the fixture target, which several other assertions key off. So the test guards the invariant going forward; the defect itself was verified against real data, 0px → 101px.

## Checks

- `npx playwright test` — full suite, 93 passed.
- `npm run lint`, `npx tsc --noEmit`, `npm run build` clean. `npx vitest run` — 257 pass, with the 5 pre-existing `useColorPreview` localStorage failures that also fail on `main`.
- `cargo fmt --all -- --check` clean; no Rust source touched.
- Measured before and after against a real 294-frame Golf of Mexico narrowband card served from a local copy of the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)