### PR TITLE
Read XISF frames wherever PSF Guard reads FITS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,10 @@ Design records: [multi-database](docs/design/multi-database.md),
 - A lone no-solve is advisory. Automatic rejection needs corroborating
   pointing, cloud, obstruction, or tracking evidence.
 - Cross-frame background and flux comparisons must use physical ADU, not the
-  per-frame normalized storage values.
+  per-frame normalized storage values. A PixInsight XISF frame declaring
+  `bounds="0:1"` has no ADU of its own; `src/image_io.rs` puts it on a 16-bit
+  scale on the way in, so read every frame through there rather than reaching
+  for `seiza_xisf` or `seiza_stacking::FitsFrame::open` directly.
 - N.I.N.A. Fast supplies comparable star count and HFR values for imported
   catalogs. HocusFocus remains available for deeper analysis.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,10 @@ Current behavior: [satellites](docs/SATELLITES.md) and
 
 ### Imports, files, and calibration
 
-- Initial FITS import is header-first. Expensive star, photometry, spatial, and
+- A frame is a FITS or an XISF file. Detect one with `src/image_io.rs` and read
+  one through it; do not test extensions or call `seiza_fits` directly at a new
+  site. Both containers decode to the same `seiza_fits::FitsImage`.
+- Initial import is header-first. Expensive star, photometry, spatial, and
   astrometry work belongs to the background quality job.
 - Import creates Target Scheduler-compatible lights and PSF Guard-owned
   calibration records. Never put calibration frames in `acquiredimage`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,9 +2776,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -3821,7 +3821,7 @@ checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.38.3",
  "serde",
  "time",
 ]
@@ -4100,6 +4100,15 @@ name = "quick-xml"
 version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4907,9 +4916,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9eb8fe848b31588a4533a8195c0aa202a1c5398b4dd59bc614276621460282b"
+checksum = "c99cbbe8e89620716d4f0423c74221f933db2c00f867023cd25aa5664ed487b6"
 dependencies = [
  "directories",
  "image",
@@ -5022,9 +5031,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e71d0811c7ff22bc80f26bdee54a9832ddab11c1825bd708cdcfa5dee23c945"
+checksum = "56b4c3a2cd7f24f06f2d5ee51f08851687241ce390c85646dd3e62fa5116df67"
 dependencies = [
  "rayon",
  "seiza",
@@ -5061,13 +5070,13 @@ dependencies = [
 
 [[package]]
 name = "seiza-xisf"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c58629034c4197cf415a86ad91fc044dbf9f1ea892ec5617d611e530af990c"
+checksum = "8d972a8c14605b1ddd171c964f07522350c30efbe0a917f21f0e357844c6099c"
 dependencies = [
  "flate2",
  "lz4_flex",
- "quick-xml",
+ "quick-xml 0.41.0",
  "seiza-fits",
  "sha1",
  "sha2 0.11.0",
@@ -5314,13 +5323,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,6 +4049,7 @@ dependencies = [
  "seiza-satellites",
  "seiza-stacking",
  "seiza-stretch",
+ "seiza-xisf",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,16 +33,16 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.15.1"
+seiza = "0.15.2"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.1", features = ["parallel"] }
 seiza-fits = "=0.2.1"
 seiza-satellites = { version = "0.4.5", features = ["serde"] }
-seiza-stacking = "0.3.0"
+seiza-stacking = "0.4.0"
 seiza-stretch = "0.2.0"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.
-seiza-xisf = "0.1.0"
+seiza-xisf = "0.2.0"
 seiza-background = "0.2.1"
 seiza-deconvolution = "0.1.0"
 sha2 = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ seiza-fits = "=0.2.1"
 seiza-satellites = { version = "0.4.5", features = ["serde"] }
 seiza-stacking = "0.3.0"
 seiza-stretch = "0.2.0"
+# XISF reading. Already in the tree through seiza-stacking, which decodes both
+# containers into the same `seiza_fits::FitsImage`.
+seiza-xisf = "0.1.0"
 seiza-background = "0.2.1"
 seiza-deconvolution = "0.1.0"
 sha2 = "0.11"

--- a/README.md
+++ b/README.md
@@ -120,17 +120,19 @@ exposure value, which means “use the template default.” Both the desktop app
 and the web server can edit these fields: they change rows inside a database
 you already configured, so they need no extra flag.
 
-### Build an image catalog from FITS folders
+### Build an image catalog from image folders
 
 Use this path when no catalog exists or when frames are missing from one you
 already use.
 
 ![New Database from Images with separate background quality analysis](docs/import-from-images.png)
 
-Open **Settings → New Database from Images** to build a catalog from plain FITS
-folders. PSF Guard uses the Target Scheduler database structure, but does not
-require Target Scheduler. The first pass reads headers only. It creates one
-project per target by default, joins only strong same-rig mosaic panel matches,
+Open **Settings → New Database from Images** to build a catalog from plain
+image folders. A scan picks up `.fits`, `.fit`, `.fts`, and `.xisf`, so
+PixInsight-written frames come in beside camera-written ones. PSF Guard uses
+the Target Scheduler database structure, but does not require Target
+Scheduler. The first pass reads headers only. It creates one project per
+target by default, joins only strong same-rig mosaic panel matches,
 derives target coordinates, and builds shared exposure templates and plans from
 filter, gain, offset, binning, readout mode, and exposure time. Pixel work stays
 off by default, so a large import does not wait for star detection or plate
@@ -148,7 +150,7 @@ photometric, spatial, and pointing evidence in a low-priority job;
 a dry preview, skips basenames already present, and attaches new frames to an
 existing target by name or nearby coordinates before it creates new structure.
 
-Remote acquisition clients can send one FITS light at a time without sharing
+Remote acquisition clients can send one light frame at a time without sharing
 the image folder or running Target Scheduler. Edit a database in Settings,
 generate its per-database **Remote API key**, enable **Accept remote image
 uploads**, and select its receive directory. The authenticated

--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -14,6 +14,13 @@ so they group, grade, preview, and stack exactly like FITS frames. Everything
 else in the folder, including plate-solve `.json` and other sidecars, is left
 alone.
 
+PixInsight normalizes float images, writing samples between 0 and 1 where a
+camera writes thousands of ADU. A frame that says so — `bounds="0:1"` — is put
+on a 16-bit scale as PSF Guard reads it, so its background and star flux can be
+compared against camera frames in the same sequence. A frame declaring any
+other range is left exactly as stored, because writers disagree about what that
+range means.
+
 ## Create a catalog in the UI
 
 The desktop app always allows database management. For the web server, bind to

--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -1,10 +1,18 @@
-# Adding FITS folders
+# Adding image folders
 
 PSF Guard can start from an existing N.I.N.A. Target Scheduler database or
-build a compatible image catalog from folders of FITS frames. The first
-import reads FITS headers only. It does not decode every image or run quality
+build a compatible image catalog from folders of image frames. The first
+import reads headers only. It does not decode every image or run quality
 analysis, so a large library becomes usable without waiting for star
 detection, photometry, or plate solving.
+
+## What counts as a frame
+
+A scan picks up `.fits`, `.fit`, `.fts`, and `.xisf`, in any letter case.
+Monolithic XISF files — what PixInsight writes — carry the same FITS keywords,
+so they group, grade, preview, and stack exactly like FITS frames. Everything
+else in the folder, including plate-solve `.json` and other sidecars, is left
+alone.
 
 ## Create a catalog in the UI
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Use this index for detailed behavior and engineering records.
 
 ## Catalog and review workflows
 
-- [Adding FITS folders](IMPORTING.md)
+- [Adding image folders](IMPORTING.md)
 - [Calibration libraries](CALIBRATION_LIBRARY.md)
 - [Project stack previews](STACKING_PREVIEWS.md)
 - [Statistical grading](STATISTICAL_GRADING.md)

--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -405,8 +405,9 @@ image=@capture.fits
 The database settings select one of that database's registered image roots as
 the receive directory. The server requires the URL slug and echoed database ID
 to agree, authenticates with the selected database's salted token hash, streams
-at most 512 MiB to a sibling temporary file, verifies SHA-256 and FITS headers,
-and publishes without overwriting an existing basename.
+at most 512 MiB to a sibling temporary file, verifies SHA-256 and the frame
+headers, and publishes without overwriting an existing basename. The filename
+must carry a frame extension: `.fits`, `.fit`, `.fts`, or `.xisf`.
 
 The normal one-frame importer then resolves an existing target by object name
 or coordinates and reuses its exposure plan. If no target matches, it builds

--- a/docs/design/reject-archive.md
+++ b/docs/design/reject-archive.md
@@ -48,7 +48,7 @@ discoverable per-project, configurable per-rig, and reversible.
 - **Core**: `src/commands/filter_rejected.rs` — queries DB for `gradingStatus = 2`, generates ~28 candidate paths per image via `get_possible_paths` (date ±1 day, several reject-folder naming conventions), falls back to `DirectoryTree::find_file_first`.
 - **Move action**: `process_file_movement:258-266` — string-substitutes `/LIGHT/` → `/LIGHT_REJECT/` in the source path, `fs::rename` to that. Sibling folder, same tree.
 - **No state tracking**: `gradingStatus = 2` means "user rejected"; no flag for "file has been physically moved." Re-runs hit not-found errors silently.
-- **No sidecar handling**: only the primary FITS file moves. `.xisf`, plate-solve `.json`, mask files stay.
+- **No sidecar handling**: only the primary frame moves. Plate-solve `.json`, mask files stay.
 - **No undo**.
 - **Zero integration tests**.
 - **UI never invokes it**: web UI's reject button only sets `gradingStatus = 2`; users drop to a terminal afterward.
@@ -117,7 +117,8 @@ Example with depth=1, segment="REJECT":
 
 CLI flag > per-DB registry override > global default.
 
-- Global default: `{ segment_name: "REJECT", depth: 1, sidecar_exts: [".xisf", ".json", ".txt"] }`. Hardcoded in source.
+- Global default: `{ segment_name: "REJECT", depth: 1, sidecar_exts: [".json", ".txt"] }`. Hardcoded in source.
+- A sidecar extension may not name a frame container (`.fits`, `.fit`, `.fts`, `.xisf`). PSF Guard catalogs those as images with their own grade, so archiving one as a sibling's companion would move a file the catalog still calls accepted. Such a list is refused with an error.
 - Per-DB registry override: optional `reject_archive` block in each `DbEntry`. New fields on the JSON shape (additive — old configs keep working):
   ```jsonc
   {
@@ -128,11 +129,11 @@ CLI flag > per-DB registry override > global default.
     "reject_archive": {            // optional
       "segment_name": "REJECT",    // optional
       "depth": 1,                  // optional
-      "sidecar_exts": [".xisf", ".json"]  // optional
+      "sidecar_exts": [".wcs", ".json"]  // optional
     }
   }
   ```
-- CLI: `--reject-segment NAME`, `--reject-depth N`, `--sidecar-exts ".xisf,.json"` override the per-DB / global values for this invocation only.
+- CLI: `--reject-segment NAME`, `--reject-depth N`, `--sidecar-exts ".wcs,.json"` override the per-DB / global values for this invocation only.
 
 ### 4.3 Sidecar handling
 
@@ -191,7 +192,7 @@ A redundant JSON file lives at `<image_dir>/<P>/REJECT/.psf-guard-manifest.json`
       "moved_at": 1776470400,
       "original_path": "...",
       "archive_path": "...",
-      "sidecar_files": ["img.xisf", "img.json"],
+      "sidecar_files": ["img.wcs", "img.json"],
       "segment_name": "REJECT",
       "archive_depth": 1
     }
@@ -210,7 +211,7 @@ alias):
 ```
 psf-guard move-rejects --db <slug> [--dry-run]
                        [--reject-segment NAME] [--reject-depth N]
-                       [--sidecar-exts ".xisf,.json,.txt"]
+                       [--sidecar-exts ".json,.txt"]
                        [--registry <path>]
                        [--project NAME] [--target NAME]
 ```

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -20,3 +20,11 @@
 - The Stack previews panel collapses from its title and stays collapsed
   across reloads, and its result cards follow the grid's thumbnail-size
   slider up to one full-width column.
+
+## Changed
+
+- The reject archive no longer treats `.xisf` as a companion file. A frame
+  carries its own grade, so archiving one alongside a rejected sibling would
+  move a file the catalog still calls accepted. The default companion list is
+  now `.json` and `.txt`, and a list naming any frame container — `.fits`,
+  `.fit`, `.fts`, `.xisf` — is refused with an error that says why.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,11 @@
 
 ## Added
 
+- XISF frames count as images everywhere FITS frames do. Folder scans,
+  imports, screening, and remote uploads now pick up `.xisf` next to `.fits`,
+  `.fit`, and `.fts`, and a PixInsight-written frame grades, previews, and
+  stacks like any other. See [adding image
+  folders](https://github.com/theatrus/psf-guard/blob/main/docs/IMPORTING.md).
 - Named processing setups. Save the parameters of the mono view-processing or
   color processing editor under a name and apply them to any card in any
   database; manage, import, and export them — singly or as one file — in

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,7 +9,10 @@
 - XISF frames count as images everywhere FITS frames do. Folder scans,
   imports, screening, and remote uploads now pick up `.xisf` next to `.fits`,
   `.fit`, and `.fts`, and a PixInsight-written frame grades, previews, and
-  stacks like any other. See [adding image
+  stacks like any other. A frame that says it is normalized is put on a 16-bit
+  scale as it is read, so its background and star flux can be compared with
+  camera frames in the same sequence instead of reading as a near-black
+  outlier. See [adding image
   folders](https://github.com/theatrus/psf-guard/blob/main/docs/IMPORTING.md).
 - Named processing setups. Save the parameters of the mono view-processing or
   color processing editor under a name and apply them to any card in any

--- a/src/astrometry.rs
+++ b/src/astrometry.rs
@@ -1589,8 +1589,8 @@ fn detect_fits_stars(
     path: &Path,
     pass: DetectionPass,
 ) -> Result<(Vec<seiza::DetectedStar>, (u32, u32)), String> {
-    let fits = seiza_fits::FitsImage::open(path)
-        .map_err(|error| format!("failed to decode FITS pixels: {error}"))?;
+    let fits = crate::image_io::open(path)
+        .map_err(|error| format!("failed to decode image pixels: {error}"))?;
     let width = u32::try_from(fits.width)
         .map_err(|_| "FITS width exceeds supported dimensions".to_string())?;
     let height = u32::try_from(fits.height)

--- a/src/astrometry_headers.rs
+++ b/src/astrometry_headers.rs
@@ -89,9 +89,9 @@ pub struct FitsWcsHeaders {
 }
 
 impl FitsAstrometryHeaders {
-    /// Read only the FITS header blocks, without touching the pixel payload.
-    pub fn from_path(path: &Path) -> Result<Self, seiza_fits::FitsError> {
-        seiza_fits::read_header(path).map(|headers| Self::from_headers(&headers))
+    /// Read only the header cards, without touching the pixel payload.
+    pub fn from_path(path: &Path) -> Result<Self, crate::image_io::ImageError> {
+        crate::image_io::read_header(path).map(|headers| Self::from_headers(&headers))
     }
 
     /// Normalize an already-parsed FITS header.

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -953,7 +953,7 @@ pub fn resolve_or_build_masters(
 
     let bias_image = bias
         .as_ref()
-        .map(|master| seiza_stacking::FitsFrame::open(&master.path).map(|frame| frame.image))
+        .map(|master| crate::image_io::open_linear_frame(&master.path).map(|frame| frame.image))
         .transpose()
         .context("loading the cached master bias")?;
     stop_requested(cancel)?;
@@ -972,7 +972,7 @@ pub fn resolve_or_build_masters(
     let flat_dark = dark_flat
         .as_ref()
         .map(|master| {
-            seiza_stacking::FitsFrame::open(&master.path).and_then(|frame| {
+            crate::image_io::open_linear_frame(&master.path).and_then(|frame| {
                 seiza_stacking::MasterDark::from_fits_frame(
                     frame,
                     selected
@@ -1144,7 +1144,7 @@ fn build_master(
             )
             .optional()?
             .is_some();
-        let file_valid = seiza_stacking::FitsFrame::open(&path)
+        let file_valid = crate::image_io::open_linear_frame(&path)
             .and_then(|frame| frame.validate_master_kind(expected_kind))
             .is_ok();
         if row_exists && file_valid {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -236,7 +236,8 @@ pub enum Commands {
         reject_depth: Option<u32>,
 
         /// Override the sidecar extension list (comma-separated, e.g.
-        /// `.xisf,.json,.txt`).
+        /// `.json,.txt`). Frame containers are refused: they have their own
+        /// grade and never travel as another frame's companion.
         #[arg(long, value_delimiter = ',')]
         sidecar_exts: Option<Vec<String>>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,7 +35,7 @@ pub enum Commands {
         format: String,
     },
 
-    /// Create a new Target Scheduler database and import FITS folders into it.
+    /// Create a new Target Scheduler database and import image folders into it.
     ///
     /// Bootstraps a fully-faithful scheduler database (vendored upstream
     /// schema, user_version 23) at the given path, then scans the supplied
@@ -48,7 +48,7 @@ pub enum Commands {
         /// Path of the new .sqlite database file to create.
         database: String,
 
-        /// Directories (or single FITS files) to import.
+        /// Directories (or single FITS or XISF files) to import.
         #[arg(required = true)]
         directories: Vec<String>,
 
@@ -80,7 +80,7 @@ pub enum Commands {
         registry: Option<String>,
     },
 
-    /// Import FITS folders into an existing Target Scheduler database.
+    /// Import image folders into an existing Target Scheduler database.
     ///
     /// Accepts a registry slug or a path to a .sqlite file. Frames whose
     /// basename is already recorded are skipped; remaining frames attach to
@@ -91,7 +91,7 @@ pub enum Commands {
         /// Registry slug or path of the target database.
         db: String,
 
-        /// Directories (or single FITS files) to import.
+        /// Directories (or single FITS or XISF files) to import.
         #[arg(required = true)]
         directories: Vec<String>,
 

--- a/src/commands/annotate_stars.rs
+++ b/src/commands/annotate_stars.rs
@@ -196,8 +196,10 @@ pub fn annotate_stars(
 
     // Generate output filename
     let output_path = output.unwrap_or_else(|| {
-        let base = fits_path.trim_end_matches(".fits").trim_end_matches(".fit");
-        format!("{}_annotated.png", base)
+        format!(
+            "{}_annotated.png",
+            crate::image_io::strip_image_extension(fits_path)
+        )
     });
 
     // Save the annotated image with compression

--- a/src/commands/import/headers.rs
+++ b/src/commands/import/headers.rs
@@ -73,11 +73,18 @@ impl FrameMeta {
 /// Read one frame's headers. Unreadable files yield a `FrameMeta` with only
 /// `path` set (the caller decides whether to skip or report them).
 pub fn read_frame_meta(path: &Path) -> FrameMeta {
+    read_frame_meta_named(path, path)
+}
+
+/// [`read_frame_meta`] for a file whose own path does not name its container,
+/// such as the temporary a remote upload streams into. `declared` picks the
+/// decoder; `path` supplies the bytes.
+pub fn read_frame_meta_named(path: &Path, declared: &Path) -> FrameMeta {
     let mut meta = FrameMeta {
         path: path.to_path_buf(),
         ..Default::default()
     };
-    let Ok(headers) = crate::image_io::read_header(path) else {
+    let Ok(headers) = crate::image_io::read_header_named(path, declared) else {
         return meta;
     };
     meta.readable = true;

--- a/src/commands/import/headers.rs
+++ b/src/commands/import/headers.rs
@@ -77,7 +77,7 @@ pub fn read_frame_meta(path: &Path) -> FrameMeta {
         path: path.to_path_buf(),
         ..Default::default()
     };
-    let Ok(headers) = seiza_fits::read_header(path) else {
+    let Ok(headers) = crate::image_io::read_header(path) else {
         return meta;
     };
     meta.readable = true;

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -107,7 +107,7 @@ pub struct ImportOutcome {
     pub attached_target_ids: Vec<i32>,
 }
 
-/// Recursively collect `.fits` / `.fit` files (a bare file argument is
+/// Recursively collect image files — FITS or XISF (a bare file argument is
 /// accepted too). Sorted for deterministic plans.
 pub fn collect_fits_files(dirs: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
@@ -130,9 +130,7 @@ pub fn collect_fits_files(dirs: &[PathBuf]) -> Result<Vec<PathBuf>> {
                 let p = entry?.path();
                 if p.is_dir() {
                     stack.push(p);
-                } else if p.extension().and_then(|e| e.to_str()).is_some_and(|e| {
-                    e.eq_ignore_ascii_case("fits") || e.eq_ignore_ascii_case("fit")
-                }) {
+                } else if crate::image_io::is_image_path(&p) {
                     files.push(p);
                 }
             }

--- a/src/commands/read_fits.rs
+++ b/src/commands/read_fits.rs
@@ -151,8 +151,8 @@ pub struct ImageInfo {
 
 /// Read metadata from a FITS file
 pub fn read_fits_metadata(path: &Path) -> Result<FitsMetadata> {
-    let fits = seiza_fits::FitsImage::open(path)
-        .map_err(|e| anyhow::anyhow!("Failed to open FITS file {}: {:?}", path.display(), e))?;
+    let fits = crate::image_io::open(path)
+        .map_err(|e| anyhow::anyhow!("Failed to open image file {}: {:?}", path.display(), e))?;
 
     let filename = path
         .file_name()

--- a/src/commands/reject_archive.rs
+++ b/src/commands/reject_archive.rs
@@ -25,7 +25,10 @@ use crate::models::GradingStatus;
 /// rules.
 pub const DEFAULT_SEGMENT_NAME: &str = "REJECT";
 pub const DEFAULT_DEPTH: u32 = 1;
-pub const DEFAULT_SIDECAR_EXTS: &[&str] = &[".xisf", ".json", ".txt"];
+/// A sidecar is a companion file, never a frame: PSF Guard catalogs `.xisf`
+/// as an image in its own right, so archiving one as a sibling's sidecar
+/// would move a frame that has its own grade.
+pub const DEFAULT_SIDECAR_EXTS: &[&str] = &[".json", ".txt"];
 
 /// Resolved (CLI ∪ per-DB ∪ defaults) configuration used at command time.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -305,7 +308,16 @@ fn validate_sidecar_ext(ext: &str) -> Result<()> {
     if !ext.starts_with('.') {
         return Err(anyhow::anyhow!(
             "reject_archive.sidecar_exts entry '{}' must start with a dot \
-             (e.g. \".xisf\")",
+             (e.g. \".json\")",
+            ext
+        ));
+    }
+    if crate::image_io::is_image_extension(ext) {
+        return Err(anyhow::anyhow!(
+            "reject_archive.sidecar_exts entry '{}' names an image container. \
+             PSF Guard catalogs those as frames with their own grade, so \
+             archiving one as another frame's sidecar would move a file the \
+             catalog still calls accepted",
             ext
         ));
     }
@@ -1339,7 +1351,7 @@ mod tests {
               sidecar_files, source_db_slug)
              VALUES ('abc', 42, 1700000000,
                      '/src/img.fits', '/src/REJECT/img.fits',
-                     'REJECT', 1, '[\"img.xisf\"]', 'imaging-rig')",
+                     'REJECT', 1, '[\"img.json\"]', 'imaging-rig')",
             [],
         )
         .unwrap();
@@ -1351,7 +1363,7 @@ mod tests {
         assert_eq!(by_guid.archive_path, "/src/REJECT/img.fits");
         assert_eq!(by_guid.segment_name, "REJECT");
         assert_eq!(by_guid.archive_depth, 1);
-        assert_eq!(by_guid.sidecar_files, vec!["img.xisf"]);
+        assert_eq!(by_guid.sidecar_files, vec!["img.json"]);
         assert_eq!(by_guid.source_db_slug.as_deref(), Some("imaging-rig"));
 
         let by_id = get_archive_record_by_image_id(&conn, 42).unwrap().unwrap();
@@ -1363,7 +1375,7 @@ mod tests {
         let cfg = resolve_config(None, None, None, None).unwrap();
         assert_eq!(cfg.segment_name, "REJECT");
         assert_eq!(cfg.depth, 1);
-        assert_eq!(cfg.sidecar_exts, vec![".xisf", ".json", ".txt"]);
+        assert_eq!(cfg.sidecar_exts, vec![".json", ".txt"]);
     }
 
     #[test]
@@ -1371,12 +1383,12 @@ mod tests {
         let per_db = RejectArchiveOverrides {
             segment_name: Some("BAD".into()),
             depth: Some(2),
-            sidecar_exts: Some(vec![".xisf".into()]),
+            sidecar_exts: Some(vec![".wcs".into()]),
         };
         let cfg = resolve_config(Some(&per_db), None, None, None).unwrap();
         assert_eq!(cfg.segment_name, "BAD");
         assert_eq!(cfg.depth, 2);
-        assert_eq!(cfg.sidecar_exts, vec![".xisf"]);
+        assert_eq!(cfg.sidecar_exts, vec![".wcs"]);
     }
 
     #[test]
@@ -1385,7 +1397,7 @@ mod tests {
         let per_db = RejectArchiveOverrides {
             segment_name: Some("BAD".into()),
             depth: Some(2),
-            sidecar_exts: Some(vec![".xisf".into()]),
+            sidecar_exts: Some(vec![".wcs".into()]),
         };
         let cli_exts: Option<&[String]> = None;
         let cfg = resolve_config(Some(&per_db), Some("KEPT-AWAY"), None, cli_exts).unwrap();
@@ -1396,7 +1408,7 @@ mod tests {
         );
         assert_eq!(
             cfg.sidecar_exts,
-            vec![".xisf"],
+            vec![".wcs"],
             "per-DB exts win when CLI doesn't supply"
         );
     }
@@ -1416,9 +1428,24 @@ mod tests {
 
     #[test]
     fn resolve_config_rejects_invalid_sidecar_exts() {
-        let bad_exts: Vec<String> = vec!["xisf".into()]; // missing dot
+        let bad_exts: Vec<String> = vec!["json".into()]; // missing dot
         let err = resolve_config(None, None, None, Some(&bad_exts)).unwrap_err();
         assert!(format!("{err}").contains("sidecar_exts"));
+    }
+
+    /// A frame has its own grade, so it must never be archived as another
+    /// frame's companion.
+    #[test]
+    fn resolve_config_refuses_a_frame_container_as_a_sidecar() {
+        for bad in [".xisf", ".XISF", ".fits", ".fit", ".fts"] {
+            let exts: Vec<String> = vec![bad.into()];
+            let err = resolve_config(None, None, None, Some(&exts)).unwrap_err();
+            let message = format!("{err}");
+            assert!(
+                message.contains("image container"),
+                "error for {bad:?} should explain why: {message}"
+            );
+        }
     }
 
     fn p(s: &str) -> std::path::PathBuf {
@@ -1622,23 +1649,23 @@ mod tests {
         fs::write(&primary, b"").unwrap();
 
         // Sidecars (should be picked up):
-        fs::write(dir.path().join("img_0028.xisf"), b"").unwrap();
-        fs::write(dir.path().join("img_0028.json"), b"").unwrap();
         fs::write(dir.path().join("img_0028.txt"), b"").unwrap();
+        fs::write(dir.path().join("img_0028.json"), b"").unwrap();
+        fs::write(dir.path().join("img_0028.wcs"), b"").unwrap();
 
         // Same stem but extension not in the list:
         fs::write(dir.path().join("img_0028.log"), b"").unwrap();
 
         // Different stem — typical calibration-master shape:
         fs::write(dir.path().join("Bias_master.fits"), b"").unwrap();
-        fs::write(dir.path().join("Dark_60s.xisf"), b"").unwrap();
+        fs::write(dir.path().join("Dark_60s.txt"), b"").unwrap();
 
         // Subdirectory should not be descended into:
         let sub = dir.path().join("nested");
         fs::create_dir(&sub).unwrap();
-        fs::write(sub.join("img_0028.xisf"), b"").unwrap();
+        fs::write(sub.join("img_0028.txt"), b"").unwrap();
 
-        let exts: Vec<String> = [".xisf", ".json", ".txt"]
+        let exts: Vec<String> = [".json", ".txt", ".wcs"]
             .iter()
             .map(|s| s.to_string())
             .collect();
@@ -1647,7 +1674,7 @@ mod tests {
         let expected = vec![
             dir.path().join("img_0028.json"),
             dir.path().join("img_0028.txt"),
-            dir.path().join("img_0028.xisf"),
+            dir.path().join("img_0028.wcs"),
         ];
         assert_eq!(found, expected);
     }
@@ -1658,14 +1685,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let primary = dir.path().join("img.fits");
         fs::write(&primary, b"").unwrap();
-        fs::write(dir.path().join("img.XISF"), b"").unwrap();
+        fs::write(dir.path().join("img.TXT"), b"").unwrap();
         fs::write(dir.path().join("img.Json"), b"").unwrap();
 
-        let exts: Vec<String> = [".xisf", ".json"].iter().map(|s| s.to_string()).collect();
+        let exts: Vec<String> = [".txt", ".json"].iter().map(|s| s.to_string()).collect();
         let mut found = find_sidecars(&primary, &exts);
         found.sort();
         assert_eq!(found.len(), 2);
-        assert!(found.iter().any(|p| p.file_name().unwrap() == "img.XISF"));
+        assert!(found.iter().any(|p| p.file_name().unwrap() == "img.TXT"));
         assert!(found.iter().any(|p| p.file_name().unwrap() == "img.Json"));
     }
 
@@ -1673,15 +1700,16 @@ mod tests {
     fn find_sidecars_returns_empty_when_parent_missing() {
         let found = find_sidecars(
             std::path::Path::new("/no/such/dir/img.fits"),
-            &[".xisf".to_string()],
+            &[".txt".to_string()],
         );
         assert!(found.is_empty());
     }
 
     #[test]
     fn find_sidecars_excludes_the_primary_itself() {
-        // If exts somehow listed `.fits` (caller bug), the primary file
-        // itself should still not be returned as its own sidecar.
+        // `validate_sidecar_ext` refuses a frame container, so this list
+        // cannot come from config. Kept as a second line of defence: even
+        // then the primary must not be returned as its own sidecar.
         use std::fs;
         let dir = tempfile::tempdir().unwrap();
         let primary = dir.path().join("img.fits");

--- a/src/commands/screen_fits.rs
+++ b/src/commands/screen_fits.rs
@@ -137,7 +137,7 @@ struct ScreenResult {
 
 pub fn screen_fits(path: &str, options: &ScreenOptions) -> Result<()> {
     let dir = Path::new(path);
-    let files = collect_fits_files(dir)?;
+    let files = crate::commands::import::collect_fits_files(&[dir.to_path_buf()])?;
     if files.is_empty() {
         return Err(anyhow::anyhow!(
             "No FITS files found under: {}",
@@ -575,33 +575,6 @@ fn apply_regrade(results: &[ScreenResult], db_arg: &str, options: &ScreenOptions
     db.batch_update_grading_status(&updates)?;
     println!("Applied {} rejections.", updates.len());
     Ok(())
-}
-
-fn collect_fits_files(dir: &Path) -> Result<Vec<PathBuf>> {
-    if dir.is_file() {
-        return Ok(vec![dir.to_path_buf()]);
-    }
-    if !dir.is_dir() {
-        return Err(anyhow::anyhow!(
-            "Path does not exist or is not accessible: {}",
-            dir.display()
-        ));
-    }
-    let mut files = Vec::new();
-    let mut stack = vec![dir.to_path_buf()];
-    while let Some(d) = stack.pop() {
-        for entry in std::fs::read_dir(&d)? {
-            let entry = entry?;
-            let p = entry.path();
-            if p.is_dir() {
-                stack.push(p);
-            } else if crate::image_io::is_image_path(&p) {
-                files.push(p);
-            }
-        }
-    }
-    files.sort();
-    Ok(files)
 }
 
 /// Analyze all frames, in parallel worker threads.

--- a/src/commands/screen_fits.rs
+++ b/src/commands/screen_fits.rs
@@ -595,11 +595,7 @@ fn collect_fits_files(dir: &Path) -> Result<Vec<PathBuf>> {
             let p = entry.path();
             if p.is_dir() {
                 stack.push(p);
-            } else if p
-                .extension()
-                .and_then(|e| e.to_str())
-                .is_some_and(|e| e.eq_ignore_ascii_case("fits") || e.eq_ignore_ascii_case("fit"))
-            {
+            } else if crate::image_io::is_image_path(&p) {
                 files.push(p);
             }
         }
@@ -785,7 +781,7 @@ pub(crate) struct FrameHeaders {
 /// Extract filter, exposure and observation time from the FITS header.
 pub(crate) fn extract_headers(path: &Path) -> FrameHeaders {
     let mut out = FrameHeaders::default();
-    let Ok(headers) = seiza_fits::read_header(path) else {
+    let Ok(headers) = crate::image_io::read_header(path) else {
         return out;
     };
 

--- a/src/commands/visualize_psf/visualize_psf_multi.rs
+++ b/src/commands/visualize_psf/visualize_psf_multi.rs
@@ -54,8 +54,10 @@ pub fn visualize_psf_multi(
 
     // Generate output filename
     let output_path = output.unwrap_or_else(|| {
-        let base = fits_path.trim_end_matches(".fits").trim_end_matches(".fit");
-        format!("{}_psf_multi.png", base)
+        format!(
+            "{}_psf_multi.png",
+            crate::image_io::strip_image_extension(fits_path)
+        )
     });
 
     // Save the image with compression

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -345,7 +345,7 @@ fn parse_meminfo_kb(rest: &str) -> Option<u64> {
 /// data, so a scan can size its worker pool to the sensor. `None` if the file
 /// or the axes can't be read.
 pub fn probe_frame_pixels(path: &Path) -> Option<usize> {
-    let headers = seiza_fits::read_header(path).ok()?;
+    let headers = crate::image_io::read_header(path).ok()?;
     let axis = |key: &str| -> Option<usize> {
         headers
             .iter()

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -34,7 +34,7 @@ pub struct DbEntry {
     /// `docs/design/reject-archive.md`). All fields optional; absent values fall
     /// back to the CLI flag, then the compiled-in defaults
     /// (`segment_name = "REJECT"`, `depth = 1`,
-    /// `sidecar_exts = [".xisf", ".json", ".txt"]`).
+    /// `sidecar_exts = [".json", ".txt"]`).
     ///
     /// The block itself is also optional; absent in older configs means
     /// "no per-DB overrides — use CLI flags or defaults entirely."
@@ -178,9 +178,9 @@ pub struct RejectArchiveOverrides {
     /// REJECT bucket.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub depth: Option<u32>,
-    /// Extensions of sibling files that move alongside the primary FITS.
-    /// Defaults to `.xisf`, `.json`, `.txt` (set via the resolver in the
-    /// CLI command — this slot is only the override).
+    /// Extensions of sibling files that move alongside the primary frame.
+    /// Defaults to `.json`, `.txt` (set via the resolver in the CLI command —
+    /// this slot is only the override). A frame container is refused here.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sidecar_exts: Option<Vec<String>>,
 }
@@ -614,7 +614,7 @@ mod tests {
         reg.databases[0].reject_archive = Some(RejectArchiveOverrides {
             segment_name: Some("BAD".into()),
             depth: Some(2),
-            sidecar_exts: Some(vec![".xisf".into(), ".json".into()]),
+            sidecar_exts: Some(vec![".wcs".into(), ".json".into()]),
         });
         reg.save(&path).unwrap();
         let reloaded = DbRegistry::load_or_init(&path).unwrap();

--- a/src/directory_tree.rs
+++ b/src/directory_tree.rs
@@ -209,15 +209,9 @@ impl DirectoryTree {
             .collect()
     }
 
-    /// Get all FITS files in the tree
+    /// Get all image files in the tree (FITS and XISF)
     pub fn get_fits_files(&self) -> Vec<&PathBuf> {
-        self.find_files_matching(|filename| {
-            filename.ends_with(".fits")
-                || filename.ends_with(".fit")
-                || filename.ends_with(".FIT")
-                || filename.ends_with(".FITS")
-                || filename.ends_with(".fts")
-        })
+        self.find_files_matching(crate::image_io::has_image_extension)
     }
 
     /// Get contents of a specific directory
@@ -306,6 +300,34 @@ mod tests {
         let stats = tree.stats();
         assert_eq!(stats.total_files, 3);
         assert_eq!(stats.unique_filenames, 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn scan_picks_up_xisf_alongside_fits() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let root = temp_dir.path();
+
+        fs::create_dir_all(root.join("LIGHT"))?;
+        fs::write(root.join("LIGHT/frame1.fits"), "test")?;
+        fs::write(root.join("LIGHT/frame2.xisf"), "test")?;
+        fs::write(root.join("LIGHT/frame3.XISF"), "test")?;
+        fs::write(root.join("LIGHT/frame4.fts"), "test")?;
+        // A plate-solve sidecar is not a frame.
+        fs::write(root.join("LIGHT/frame1.json"), "test")?;
+
+        let tree = DirectoryTree::build(root)?;
+        let mut names: Vec<String> = tree
+            .get_fits_files()
+            .into_iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            ["frame1.fits", "frame2.xisf", "frame3.XISF", "frame4.fts"]
+        );
 
         Ok(())
     }

--- a/src/image_analysis.rs
+++ b/src/image_analysis.rs
@@ -70,8 +70,8 @@ impl ColorFrame {
     /// fall back to the ordinary greyscale rendition rather than inventing
     /// one.
     pub fn from_file(path: &Path) -> Result<Option<Self>> {
-        let fits = seiza_fits::FitsImage::open(path)
-            .map_err(|e| anyhow::anyhow!("Failed to open FITS file {}: {e:?}", path.display()))?;
+        let fits = crate::image_io::open(path)
+            .map_err(|e| anyhow::anyhow!("Failed to open image file {}: {e:?}", path.display()))?;
         Ok(fits.debayer().map(|rgb| Self {
             width: rgb.width,
             height: rgb.height,
@@ -108,7 +108,7 @@ impl ColorFrame {
 impl FitsImage {
     /// Extract temperature from FITS headers
     pub fn extract_temperature(path: &Path) -> Option<f64> {
-        let headers = seiza_fits::read_header(path).ok()?;
+        let headers = crate::image_io::read_header(path).ok()?;
         let temp_keywords = [
             "CCD-TEMP", "TEMP", "SET-TEMP", "CCD_TEMP", "TEMPERAT", "CCDTEMP",
         ];
@@ -122,7 +122,7 @@ impl FitsImage {
 
     /// Extract camera model from FITS headers
     pub fn extract_camera_model(path: &Path) -> Option<String> {
-        let headers = seiza_fits::read_header(path).ok()?;
+        let headers = crate::image_io::read_header(path).ok()?;
         let camera_keywords = ["INSTRUME", "CAMERA", "DETECTOR", "CCD_NAME", "CCDNAME"];
         camera_keywords.iter().find_map(|keyword| {
             headers
@@ -141,8 +141,8 @@ impl FitsImage {
     /// the per-channel sampling, and N.I.N.A. itself measures the
     /// debayered image, so this keeps numbers comparable.
     pub fn from_file(path: &Path) -> Result<Self> {
-        let fits = seiza_fits::FitsImage::open(path)
-            .map_err(|e| anyhow::anyhow!("Failed to open FITS file {}: {e:?}", path.display()))?;
+        let fits = crate::image_io::open(path)
+            .map_err(|e| anyhow::anyhow!("Failed to open image file {}: {e:?}", path.display()))?;
 
         if let Some(rgb) = fits.debayer() {
             // Luminance of the debayered mosaic, already in physical ADU

--- a/src/image_io.rs
+++ b/src/image_io.rs
@@ -109,13 +109,53 @@ pub fn read_header_named(
     }
 }
 
+/// The scale a normalized frame is placed on: full-well for 16-bit data.
+///
+/// PSF Guard compares background and flux across frames in physical ADU, and
+/// almost every frame it meets is 16-bit camera data. A PixInsight float
+/// frame that declares itself normalized has no ADU of its own, so the
+/// nearest honest thing is to put it on the same scale as its neighbours.
+const NORMALIZED_FULL_SCALE: f32 = 65535.0;
+
 /// Decode a frame's pixels and headers.
+///
+/// A float XISF frame that declares `bounds="0:1"` is placed on a 16-bit
+/// scale on the way through. PixInsight normalizes float images, so such a
+/// frame's samples run 0..1 where a camera frame's run in the thousands, and
+/// leaving them alone would make every cross-frame background and flux
+/// comparison meaningless — quality screening would read the normalized frame
+/// as a near-black outlier and its neighbours as blown. Only an exact `0:1`
+/// is converted; seiza declines any other declared range, because writers
+/// disagree about what it means.
 pub fn open(path: &Path) -> Result<FitsImage, ImageError> {
     if seiza_xisf::is_xisf_path(path) {
-        Ok(seiza_xisf::open(path)?)
+        let mut read = seiza_xisf::read_image(path)?;
+        read.rescale_normalized_to(NORMALIZED_FULL_SCALE);
+        Ok(read.image)
     } else {
         Ok(FitsImage::open(path)?)
     }
+}
+
+/// Open a frame as linear samples for calibration and stacking, with the same
+/// normalization [`open`] applies.
+///
+/// Stacking compares frames against a reference, so one normalized frame
+/// among camera frames skews normalization and rejection for the whole group.
+/// A no-op for FITS and for any XISF that does not declare itself normalized,
+/// which is why every stacking read goes through here rather than picking and
+/// choosing.
+pub fn open_linear_frame(
+    path: impl AsRef<Path>,
+) -> Result<seiza_stacking::FitsFrame, seiza_stacking::Error> {
+    let mut frame = seiza_stacking::FitsFrame::open(path)?;
+    if frame.bounds == Some((0.0, 1.0)) {
+        for sample in &mut frame.image.data {
+            *sample *= NORMALIZED_FULL_SCALE;
+        }
+        frame.bounds = Some((0.0, f64::from(NORMALIZED_FULL_SCALE)));
+    }
+    Ok(frame)
 }
 
 #[cfg(test)]
@@ -160,8 +200,18 @@ mod tests {
     /// A sample 4x3 mono XISF light frame, written by the same XISF writer a
     /// reader in the wild would meet. Generating it beats checking in a blob:
     /// the fixture cannot drift away from the format the crate speaks.
+    ///
+    /// The samples span 0..1, so the writer declares `bounds="0:1"` and the
+    /// frame reads back as a normalized one.
     fn write_sample_xisf(directory: &Path, name: &str) -> PathBuf {
-        let pixels: Vec<f32> = (0..12).map(|index| index as f32 / 11.0).collect();
+        write_xisf_spanning(directory, name, 0.0, 1.0)
+    }
+
+    /// The same frame with its samples spread evenly over `low..=high`.
+    fn write_xisf_spanning(directory: &Path, name: &str, low: f32, high: f32) -> PathBuf {
+        let pixels: Vec<f32> = (0..12)
+            .map(|index| low + (high - low) * index as f32 / 11.0)
+            .collect();
         let path = directory.join(name);
         seiza_xisf::write_f32_image(
             &path,
@@ -263,6 +313,69 @@ mod tests {
                 .and_then(|(_, value)| value.as_str()),
             Some("M31")
         );
+    }
+
+    /// The finding this exists for: PixInsight normalizes float images, so a
+    /// frame declaring `0:1` has samples four orders of magnitude below a
+    /// camera frame's, and every cross-frame ADU comparison built on it is
+    /// meaningless.
+    #[test]
+    fn a_normalized_xisf_frame_lands_on_a_sixteen_bit_scale() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_sample_xisf(directory.path(), "light.xisf");
+
+        let seiza_fits::Pixels::F32(samples) = open(&path).unwrap().pixels else {
+            panic!("expected float samples");
+        };
+        assert_eq!(samples.first().copied(), Some(0.0));
+        assert_eq!(samples.last().copied(), Some(65535.0));
+    }
+
+    /// Only an exact `0:1` is treated as normalized. Any other declared range
+    /// is ambiguous — this crate's own stack output declares the observed
+    /// minimum and maximum — so the samples must survive untouched.
+    #[test]
+    fn a_physical_xisf_frame_passes_through_untouched() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_xisf_spanning(directory.path(), "light.xisf", 100.0, 30000.0);
+
+        let seiza_fits::Pixels::F32(samples) = open(&path).unwrap().pixels else {
+            panic!("expected float samples");
+        };
+        assert_eq!(samples.first().copied(), Some(100.0));
+        assert_eq!(samples.last().copied(), Some(30000.0));
+    }
+
+    /// The measured value the grader actually compares across frames. Before
+    /// the conversion this read about 0.01 against a camera frame's thousands.
+    #[test]
+    fn a_normalized_frame_reports_adu_a_camera_frame_can_be_compared_with() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_sample_xisf(directory.path(), "light.xisf");
+
+        let frame = crate::image_analysis::FitsImage::from_file(&path).unwrap();
+        let statistics = frame.calculate_basic_statistics();
+        let median_adu = frame.stored_to_adu(statistics.median);
+        assert!(
+            (1000.0..65536.0).contains(&median_adu),
+            "median should read as 16-bit ADU, got {median_adu}"
+        );
+    }
+
+    /// Stacking normalizes every frame against a reference, so one normalized
+    /// frame among camera frames would skew the whole group.
+    #[test]
+    fn the_stacking_reader_applies_the_same_conversion() {
+        let directory = tempfile::tempdir().unwrap();
+        let normalized = write_sample_xisf(directory.path(), "normalized.xisf");
+        let frame = open_linear_frame(&normalized).unwrap();
+        assert_eq!(frame.image.data.first().copied(), Some(0.0));
+        assert_eq!(frame.image.data.last().copied(), Some(65535.0));
+
+        let physical = write_xisf_spanning(directory.path(), "physical.xisf", 100.0, 30000.0);
+        let frame = open_linear_frame(&physical).unwrap();
+        assert_eq!(frame.image.data.first().copied(), Some(100.0));
+        assert_eq!(frame.image.data.last().copied(), Some(30000.0));
     }
 
     #[test]

--- a/src/image_io.rs
+++ b/src/image_io.rs
@@ -1,0 +1,227 @@
+//! One door for reading an image frame, whichever container holds it.
+//!
+//! PSF Guard reads FITS and XISF. Seiza decodes both into the same
+//! [`seiza_fits::FitsImage`] with the same FITS-style header cards, so nothing
+//! downstream — statistics, star detection, stretching, solving, stacking —
+//! needs to know which one it opened. Route every read and every "is this a
+//! frame?" test through here so a new container only has to be added once.
+
+#[cfg(test)]
+use seiza_fits::WriteHeaderCard;
+use seiza_fits::{FitsImage, HeaderValue};
+use std::path::Path;
+
+/// File extensions PSF Guard treats as image frames, matched case-insensitively.
+///
+/// `fts` is the old 8.3-era spelling of `fits`; N.I.N.A. and PixInsight both
+/// still read it, so a catalog that contains one should not silently lose it.
+pub const IMAGE_EXTENSIONS: &[&str] = &["fits", "fit", "fts", "xisf"];
+
+/// Failure to read an image, whatever container it came from.
+#[derive(Debug)]
+pub enum ImageError {
+    Fits(seiza_fits::FitsError),
+    Xisf(seiza_xisf::XisfError),
+}
+
+impl std::fmt::Display for ImageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fits(error) => write!(f, "{error}"),
+            Self::Xisf(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for ImageError {}
+
+impl From<seiza_fits::FitsError> for ImageError {
+    fn from(error: seiza_fits::FitsError) -> Self {
+        Self::Fits(error)
+    }
+}
+
+impl From<seiza_xisf::XisfError> for ImageError {
+    fn from(error: seiza_xisf::XisfError) -> Self {
+        Self::Xisf(error)
+    }
+}
+
+/// Whether this filename carries an image extension.
+pub fn has_image_extension(filename: &str) -> bool {
+    is_image_path(Path::new(filename))
+}
+
+/// Whether this path carries an image extension.
+///
+/// Extension only: a scan reads thousands of names and cannot afford to open
+/// each one to sniff its signature.
+pub fn is_image_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            IMAGE_EXTENSIONS
+                .iter()
+                .any(|known| extension.eq_ignore_ascii_case(known))
+        })
+}
+
+/// The filename without its image extension, for naming derived output.
+///
+/// A name that is not an image comes back whole.
+pub fn strip_image_extension(filename: &str) -> &str {
+    if !has_image_extension(filename) {
+        return filename;
+    }
+    match filename.rfind('.') {
+        Some(dot) => &filename[..dot],
+        None => filename,
+    }
+}
+
+/// Read the header cards without decoding pixels.
+pub fn read_header(path: &Path) -> Result<Vec<(String, HeaderValue)>, ImageError> {
+    if seiza_xisf::is_xisf_path(path) {
+        Ok(seiza_xisf::read_header(path)?)
+    } else {
+        Ok(seiza_fits::read_header(path)?)
+    }
+}
+
+/// Decode a frame's pixels and headers.
+pub fn open(path: &Path) -> Result<FitsImage, ImageError> {
+    if seiza_xisf::is_xisf_path(path) {
+        Ok(seiza_xisf::open(path)?)
+    } else {
+        Ok(FitsImage::open(path)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn recognizes_every_image_extension_in_any_case() {
+        for name in [
+            "frame.fits",
+            "frame.FITS",
+            "frame.fit",
+            "frame.FIT",
+            "frame.fts",
+            "frame.xisf",
+            "frame.XISF",
+            "frame.Xisf",
+        ] {
+            assert!(has_image_extension(name), "{name} should be an image");
+        }
+    }
+
+    #[test]
+    fn rejects_sidecars_and_extensionless_names() {
+        for name in ["frame.json", "frame.txt", "frame.png", "frame", "frame."] {
+            assert!(!has_image_extension(name), "{name} should not be an image");
+        }
+    }
+
+    #[test]
+    fn strips_only_image_extensions() {
+        assert_eq!(strip_image_extension("frame.fits"), "frame");
+        assert_eq!(strip_image_extension("frame.XISF"), "frame");
+        assert_eq!(
+            strip_image_extension("m31.2026-01-01.fit"),
+            "m31.2026-01-01"
+        );
+        assert_eq!(strip_image_extension("notes.json"), "notes.json");
+    }
+
+    /// A sample 4x3 mono XISF light frame, written by the same XISF writer a
+    /// reader in the wild would meet. Generating it beats checking in a blob:
+    /// the fixture cannot drift away from the format the crate speaks.
+    fn write_sample_xisf(directory: &Path, name: &str) -> PathBuf {
+        let pixels: Vec<f32> = (0..12).map(|index| index as f32 / 11.0).collect();
+        let path = directory.join(name);
+        seiza_xisf::write_f32_image(
+            &path,
+            4,
+            3,
+            seiza_fits::F32ImageData::Mono(&pixels),
+            &[
+                WriteHeaderCard::new("IMAGETYP", HeaderValue::String("LIGHT".into())),
+                WriteHeaderCard::new("OBJECT", HeaderValue::String("M31".into())),
+                WriteHeaderCard::new("FILTER", HeaderValue::String("Ha".into())),
+                WriteHeaderCard::new("EXPTIME", HeaderValue::Float(300.0)),
+            ],
+        )
+        .expect("sample XISF should write");
+        path
+    }
+
+    fn write_temp(name: &str, bytes: &[u8]) -> (tempfile::TempDir, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join(name);
+        std::fs::write(&path, bytes).unwrap();
+        (directory, path)
+    }
+
+    #[test]
+    fn opens_an_xisf_frame_through_the_shared_reader() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_sample_xisf(directory.path(), "light.xisf");
+        let image = open(&path).expect("XISF should decode");
+        assert_eq!((image.width, image.height, image.planes), (4, 3, 1));
+        assert!(
+            matches!(image.pixels, seiza_fits::Pixels::F32(ref samples) if samples.len() == 12)
+        );
+    }
+
+    #[test]
+    fn reads_xisf_headers_without_decoding_pixels() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_sample_xisf(directory.path(), "light.xisf");
+        let headers = read_header(&path).expect("XISF headers should parse");
+        let text = |keyword: &str| {
+            headers
+                .iter()
+                .find(|(name, _)| name == keyword)
+                .and_then(|(_, value)| value.as_str())
+                .map(str::to_string)
+        };
+        assert_eq!(text("OBJECT").as_deref(), Some("M31"));
+        assert_eq!(text("FILTER").as_deref(), Some("Ha"));
+        assert_eq!(text("IMAGETYP").as_deref(), Some("LIGHT"));
+        assert_eq!(
+            headers
+                .iter()
+                .find(|(name, _)| name == "EXPTIME")
+                .and_then(|(_, value)| value.as_f64()),
+            Some(300.0)
+        );
+    }
+
+    #[test]
+    fn xisf_frames_reach_the_shared_astrometry_header_reader() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_sample_xisf(directory.path(), "light.xisf");
+        let headers = crate::astrometry_headers::FitsAstrometryHeaders::from_path(&path)
+            .expect("XISF headers should normalize");
+        assert_eq!(
+            headers.object_name.map(|value| value.value),
+            Some("M31".into())
+        );
+        assert_eq!(headers.width.map(|value| value.value), Some(4));
+        assert_eq!(headers.height.map(|value| value.value), Some(3));
+    }
+
+    #[test]
+    fn reports_which_container_failed() {
+        let (_directory, path) = write_temp("broken.xisf", b"not an xisf file at all");
+        let error = open(&path).expect_err("a non-XISF body must fail");
+        assert!(matches!(error, ImageError::Xisf(_)), "{error}");
+
+        let (_directory, path) = write_temp("broken.fits", b"not a fits file at all");
+        let error = open(&path).expect_err("a non-FITS body must fail");
+        assert!(matches!(error, ImageError::Fits(_)), "{error}");
+    }
+}

--- a/src/image_io.rs
+++ b/src/image_io.rs
@@ -47,6 +47,18 @@ impl From<seiza_xisf::XisfError> for ImageError {
     }
 }
 
+/// Whether this extension names a frame container, with or without its
+/// leading dot (`xisf` and `.xisf` both answer yes).
+///
+/// Config lists extensions dotted, so take both spellings rather than make
+/// every caller remember which one it holds.
+pub fn is_image_extension(extension: &str) -> bool {
+    let extension = extension.strip_prefix('.').unwrap_or(extension);
+    IMAGE_EXTENSIONS
+        .iter()
+        .any(|known| extension.eq_ignore_ascii_case(known))
+}
+
 /// Whether this filename carries an image extension.
 pub fn has_image_extension(filename: &str) -> bool {
     is_image_path(Path::new(filename))
@@ -59,11 +71,7 @@ pub fn has_image_extension(filename: &str) -> bool {
 pub fn is_image_path(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| {
-            IMAGE_EXTENSIONS
-                .iter()
-                .any(|known| extension.eq_ignore_ascii_case(known))
-        })
+        .is_some_and(is_image_extension)
 }
 
 /// The filename without its image extension, for naming derived output.
@@ -73,15 +81,28 @@ pub fn strip_image_extension(filename: &str) -> &str {
     if !has_image_extension(filename) {
         return filename;
     }
-    match filename.rfind('.') {
-        Some(dot) => &filename[..dot],
-        None => filename,
-    }
+    filename
+        .rsplit_once('.')
+        .map(|(base, _)| base)
+        .unwrap_or(filename)
 }
 
 /// Read the header cards without decoding pixels.
 pub fn read_header(path: &Path) -> Result<Vec<(String, HeaderValue)>, ImageError> {
-    if seiza_xisf::is_xisf_path(path) {
+    read_header_named(path, path)
+}
+
+/// [`read_header`] for a file whose own path does not name its container.
+///
+/// A remote upload streams into a temporary file inside a scanned image root.
+/// That file must not carry a frame extension — a scan would pick it up
+/// mid-write — so the decoder is chosen from the name the client declared
+/// while the bytes are read from `path`.
+pub fn read_header_named(
+    path: &Path,
+    declared: impl AsRef<Path>,
+) -> Result<Vec<(String, HeaderValue)>, ImageError> {
+    if seiza_xisf::is_xisf_path(declared.as_ref()) {
         Ok(seiza_xisf::read_header(path)?)
     } else {
         Ok(seiza_fits::read_header(path)?)
@@ -212,6 +233,36 @@ mod tests {
         );
         assert_eq!(headers.width.map(|value| value.value), Some(4));
         assert_eq!(headers.height.map(|value| value.value), Some(3));
+    }
+
+    /// A remote upload streams into an extensionless temporary inside a
+    /// scanned image root. The decoder has to come from the declared name, or
+    /// the temporary would need a frame extension and a concurrent scan would
+    /// pick it up mid-write.
+    #[test]
+    fn a_declared_name_picks_the_decoder_for_an_extensionless_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let written = write_sample_xisf(directory.path(), "light.xisf");
+        let bare = directory.path().join(".tmpAbC123");
+        std::fs::rename(&written, &bare).unwrap();
+
+        assert!(
+            !is_image_path(&bare),
+            "the temporary must stay invisible to scans"
+        );
+        assert!(
+            read_header(&bare).is_err(),
+            "without the declared name this is read as FITS"
+        );
+
+        let headers = read_header_named(&bare, "light.xisf").expect("declared name should decode");
+        assert_eq!(
+            headers
+                .iter()
+                .find(|(name, _)| name == "OBJECT")
+                .and_then(|(_, value)| value.as_str()),
+            Some("M31")
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod directory_tree;
 pub mod grading;
 pub mod hocus_focus_star_detection;
 pub mod image_analysis;
+pub mod image_io;
 pub mod models;
 pub mod nina_star_detection;
 pub mod photometry;

--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -69,12 +69,23 @@ pub async fn upload_image(
             .ok_or_else(|| AppError::BadRequest("image field has no filename".into()))?;
         validate_filename(&filename)?;
 
-        let temporary = tempfile::NamedTempFile::new_in(&upload_dir).map_err(|error| {
-            AppError::InternalError(format!(
-                "creating upload temporary file in {}: {error}",
-                upload_dir.display()
-            ))
-        })?;
+        // Keep the uploaded extension on the temporary file: the header read
+        // below picks its decoder from it, so a `.xisf` body landing under a
+        // bare temporary name would be read as FITS and rejected.
+        let suffix = Path::new(&filename)
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(|extension| format!(".{extension}"))
+            .unwrap_or_default();
+        let temporary = tempfile::Builder::new()
+            .suffix(&suffix)
+            .tempfile_in(&upload_dir)
+            .map_err(|error| {
+                AppError::InternalError(format!(
+                    "creating upload temporary file in {}: {error}",
+                    upload_dir.display()
+                ))
+            })?;
         let reopened = temporary.reopen().map_err(|error| {
             AppError::InternalError(format!("opening upload temporary file: {error}"))
         })?;
@@ -127,11 +138,11 @@ pub async fn upload_image(
         tokio::task::spawn_blocking(move || import::headers::read_frame_meta(&temporary_path))
             .await
             .map_err(|error| {
-                AppError::InternalError(format!("FITS header validation task failed: {error}"))
+                AppError::InternalError(format!("image header validation task failed: {error}"))
             })?;
     if !frame.readable {
         return Err(AppError::BadRequest(
-            "uploaded image is not a readable FITS file".into(),
+            "uploaded image is not a readable FITS or XISF file".into(),
         ));
     }
     if !frame.is_light() {
@@ -422,15 +433,15 @@ fn validate_filename(filename: &str) -> Result<(), AppError> {
             "image filename is not filesystem-safe".into(),
         ));
     }
-    let extension = Path::new(filename)
-        .extension()
-        .and_then(|extension| extension.to_str());
-    if !extension.is_some_and(|extension| {
-        extension.eq_ignore_ascii_case("fit") || extension.eq_ignore_ascii_case("fits")
-    }) {
-        return Err(AppError::BadRequest(
-            "remote image upload currently accepts only .fit and .fits files".into(),
-        ));
+    if !crate::image_io::is_image_path(Path::new(filename)) {
+        return Err(AppError::BadRequest(format!(
+            "remote image upload accepts only {} files",
+            crate::image_io::IMAGE_EXTENSIONS
+                .iter()
+                .map(|extension| format!(".{extension}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
     }
     Ok(())
 }

--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -69,23 +69,16 @@ pub async fn upload_image(
             .ok_or_else(|| AppError::BadRequest("image field has no filename".into()))?;
         validate_filename(&filename)?;
 
-        // Keep the uploaded extension on the temporary file: the header read
-        // below picks its decoder from it, so a `.xisf` body landing under a
-        // bare temporary name would be read as FITS and rejected.
-        let suffix = Path::new(&filename)
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .map(|extension| format!(".{extension}"))
-            .unwrap_or_default();
-        let temporary = tempfile::Builder::new()
-            .suffix(&suffix)
-            .tempfile_in(&upload_dir)
-            .map_err(|error| {
-                AppError::InternalError(format!(
-                    "creating upload temporary file in {}: {error}",
-                    upload_dir.display()
-                ))
-            })?;
+        // The temporary lands in one of this database's scanned image roots,
+        // so it must not carry a frame extension: a folder scan running
+        // alongside the upload would pick up the half-written file as a
+        // frame. The header read below is told the declared name instead.
+        let temporary = tempfile::NamedTempFile::new_in(&upload_dir).map_err(|error| {
+            AppError::InternalError(format!(
+                "creating upload temporary file in {}: {error}",
+                upload_dir.display()
+            ))
+        })?;
         let reopened = temporary.reopen().map_err(|error| {
             AppError::InternalError(format!("opening upload temporary file: {error}"))
         })?;
@@ -134,12 +127,14 @@ pub async fn upload_image(
         AppError::BadRequest("multipart request must contain one image field".into())
     })?;
     let temporary_path = temporary.path().to_path_buf();
-    let frame =
-        tokio::task::spawn_blocking(move || import::headers::read_frame_meta(&temporary_path))
-            .await
-            .map_err(|error| {
-                AppError::InternalError(format!("image header validation task failed: {error}"))
-            })?;
+    let declared_name = PathBuf::from(&filename);
+    let frame = tokio::task::spawn_blocking(move || {
+        import::headers::read_frame_meta_named(&temporary_path, &declared_name)
+    })
+    .await
+    .map_err(|error| {
+        AppError::InternalError(format!("image header validation task failed: {error}"))
+    })?;
     if !frame.readable {
         return Err(AppError::BadRequest(
             "uploaded image is not a readable FITS or XISF file".into(),

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -1740,9 +1740,7 @@ fn run_group(
     group: PreparedGroup,
     anchor: Option<(bool, &'static str)>,
 ) -> Result<GroupOutcome, String> {
-    use seiza_stacking::{
-        FitsFrame, FrameDisposition, LiveStacker, NormalizationMode, StackOptions,
-    };
+    use seiza_stacking::{FrameDisposition, LiveStacker, NormalizationMode, StackOptions};
 
     let &GroupJob {
         database_id,
@@ -1822,8 +1820,8 @@ fn run_group(
         });
     }
     let checkpoint = decision.state();
-    let reference_frame =
-        FitsFrame::open(&group.frames[0].path).map_err(|error| error.to_string())?;
+    let reference_frame = crate::image_io::open_linear_frame(&group.frames[0].path)
+        .map_err(|error| error.to_string())?;
     let output_channels = if reference_frame.bayer.is_some() {
         3_u64
     } else {
@@ -2019,7 +2017,7 @@ fn run_group(
                 save_checkpoint(&stacker, &ledger);
                 return Ok(GroupOutcome::Cancelled);
             }
-            let opened = FitsFrame::open(&frame.path);
+            let opened = crate::image_io::open_linear_frame(&frame.path);
             let exposure = opened
                 .as_ref()
                 .ok()

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -1602,7 +1602,7 @@ fn reference_anchors(
         if group.frames.len() < 2 {
             continue;
         }
-        let headers = seiza_fits::read_header(&reference.path).unwrap_or_default();
+        let headers = crate::image_io::read_header(&reference.path).unwrap_or_default();
         let orientation = ReferenceOrientation {
             north_up: cached_or_embedded_wcs(&ctx, reference, &headers)
                 .and_then(|(wcs, _)| faces_north_up(wcs.cd)),

--- a/src/server/stack_preview/artifact.rs
+++ b/src/server/stack_preview/artifact.rs
@@ -17,7 +17,7 @@ use axum::{
 };
 use seiza_imgproc::components::{largest_connected_component, BinaryComponent, Connectivity};
 use seiza_stacking::{
-    AffineTransform, CalibrationMasters, FitsFrame, ReferenceRegion, RegisteredFrameMapping,
+    AffineTransform, CalibrationMasters, ReferenceRegion, RegisteredFrameMapping,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -824,7 +824,8 @@ fn extract_source_crop(
     masters: &CalibrationMasters,
     prepared: &PreparedSearch,
 ) -> Result<seiza_stacking::LinearImage, String> {
-    let mut frame = FitsFrame::open(&source.path).map_err(|error| error.to_string())?;
+    let mut frame =
+        crate::image_io::open_linear_frame(&source.path).map_err(|error| error.to_string())?;
     masters
         .apply(&mut frame.image, frame.exposure_seconds, frame.bayer)
         .map_err(|error| error.to_string())?;

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -1742,8 +1742,12 @@ fn compose_color(
                 .linear_input_id
                 .as_deref()
                 .expect("cached inputs have an identity");
-            let frame = FitsFrame::open(color_input_fits_path(cache_root, input_id, source.role))
-                .map_err(|error| error.to_string())?;
+            let frame = crate::image_io::open_linear_frame(color_input_fits_path(
+                cache_root,
+                input_id,
+                source.role,
+            ))
+            .map_err(|error| error.to_string())?;
             validate_mono(&frame.image, source.role)?;
             frame
         } else {
@@ -2334,7 +2338,7 @@ fn compose_color(
 }
 
 fn load_source_frame(cache_root: &FsPath, source: &StackColorSource) -> Result<FitsFrame, String> {
-    let frame = FitsFrame::open(super::fits_path(
+    let frame = crate::image_io::open_linear_frame(super::fits_path(
         cache_root,
         &source.job_id,
         source.group_index,
@@ -2370,8 +2374,12 @@ fn load_cached_color_input_manifest(
     {
         return None;
     }
-    let reference =
-        FitsFrame::open(color_input_fits_path(cache_root, input_id, reference_role)).ok()?;
+    let reference = crate::image_io::open_linear_frame(color_input_fits_path(
+        cache_root,
+        input_id,
+        reference_role,
+    ))
+    .ok()?;
     validate_mono(&reference.image, reference_role).ok()?;
     Some((manifest, reference))
 }

--- a/src/server/stack_preview/stretch.rs
+++ b/src/server/stack_preview/stretch.rs
@@ -20,7 +20,7 @@ use seiza_deconvolution::{
     deconvolve_masked, ChannelDiagnostics, DeconvolutionConfig, ALGORITHM_VERSION,
 };
 use seiza_fits::{HeaderValue, WriteHeaderCard};
-use seiza_stacking::{write_processed_image_fits_f32, FitsFrame, LinearImage};
+use seiza_stacking::{write_processed_image_fits_f32, LinearImage};
 use seiza_stretch::{
     ColorStrategy, RobustStatistics, StretchAnalysis, StretchConfig, StretchModel, StretchParams,
     StretchPlan,
@@ -473,7 +473,8 @@ fn render_fits_variant(
     deconvolution_request: Option<DeconvolutionConfig>,
     deconvolution_id: Option<&str>,
 ) -> Result<RenderedVariant, String> {
-    let frame = FitsFrame::open(source_path).map_err(|error| error.to_string())?;
+    let frame =
+        crate::image_io::open_linear_frame(source_path).map_err(|error| error.to_string())?;
     let samples = frame.image.data.len();
     let bytes_per_sample = if deconvolution_request.is_some() {
         DECONVOLUTION_BYTES_PER_SAMPLE
@@ -543,7 +544,8 @@ fn render_fits_variant(
                     && fits.is_file()
             });
         if let Some(cached) = cached {
-            cached_processed = Some(FitsFrame::open(&fits).map_err(|error| error.to_string())?);
+            cached_processed =
+                Some(crate::image_io::open_linear_frame(&fits).map_err(|error| error.to_string())?);
             Some(StackDeconvolutionResult {
                 config: cached.config,
                 channels: cached.channels,

--- a/static/src/components/Overview.tsx
+++ b/static/src/components/Overview.tsx
@@ -391,8 +391,8 @@ export default function Overview() {
         {managementAllowed ? (
           <>
             <p>
-              Build a catalog from folders of FITS images, or open a N.I.N.A.
-              scheduler database you already have.
+              Build a catalog from folders of FITS or XISF images, or open a
+              N.I.N.A. scheduler database you already have.
             </p>
             <div className="overview-empty-actions">
               <button

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -660,8 +660,9 @@ export default function TauriSettings({
             <div className="welcome-message">
               <h3>🚀 Welcome to PSF Guard!</h3>
               <p>
-                Start from folders of FITS images, or from a N.I.N.A. scheduler
-                database you already have. You can add more catalogs later.
+                Start from folders of FITS or XISF images, or from a N.I.N.A.
+                scheduler database you already have. You can add more catalogs
+                later.
               </p>
               {!showAddForm && (
                 <div className="welcome-choices">
@@ -674,8 +675,8 @@ export default function TauriSettings({
                       ✨ New Database from Images
                     </span>
                     <span className="welcome-choice-detail">
-                      Pick folders of FITS files. PSF Guard builds a Target
-                      Scheduler database and imports them.
+                      Pick folders of FITS or XISF files. PSF Guard builds a
+                      Target Scheduler database and imports them.
                     </span>
                   </button>
                   <button
@@ -756,7 +757,7 @@ export default function TauriSettings({
                       className="browse-button"
                       onClick={() => handleImport(entry)}
                       disabled={isApplying || (importRunning && importDbId === entry.id)}
-                      title="Scan this database's image directories and import new FITS frames"
+                      title="Scan this database's image directories and import new frames"
                     >
                       {importRunning && importDbId === entry.id ? 'Importing…' : 'Import'}
                     </button>
@@ -795,7 +796,7 @@ export default function TauriSettings({
                   className="add-directory-button"
                   onClick={startCreate}
                   disabled={isApplying}
-                  title="Create a brand-new Target Scheduler database and import folders of FITS images into it"
+                  title="Create a brand-new Target Scheduler database and import folders of images into it"
                 >
                   ✨ New Database from Images
                 </button>

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -45,7 +45,7 @@ export const initializeApiBaseUrl = async (): Promise<string> => {
 // Per-DB overrides for the reject-archive feature (mirrors
 // `RejectArchiveOverrides` in src/db_registry.rs). All fields optional;
 // missing keys fall through to the CLI flag, then the compiled-in defaults
-// (`REJECT`, depth 1, `.xisf` / `.json` / `.txt`).
+// (`REJECT`, depth 1, `.json` / `.txt`).
 export interface RejectArchiveOverrides {
   segment_name?: string;
   depth?: number;

--- a/tests/integration_import.rs
+++ b/tests/integration_import.rs
@@ -105,6 +105,38 @@ fn write_fits(path: &std::path::Path, object: &str, filter: &str, date_obs: &str
     file.write_all(&[0u8; 2880]).unwrap(); // 10*10*2 bytes, padded
 }
 
+/// The same light frame in a monolithic XISF container. Written by the XISF
+/// writer rather than hand-assembled, so the sample stays a real file.
+fn write_xisf(path: &std::path::Path, object: &str, filter: &str, date_obs: &str, ra: f64) {
+    use seiza_fits::{F32ImageData, HeaderValue, WriteHeaderCard};
+
+    let pixels = vec![0.0f32; 100];
+    seiza_xisf::write_f32_image(
+        path,
+        10,
+        10,
+        F32ImageData::Mono(&pixels),
+        &[
+            WriteHeaderCard::new("IMAGETYP", HeaderValue::String("LIGHT".into())),
+            WriteHeaderCard::new("OBJECT", HeaderValue::String(object.into())),
+            WriteHeaderCard::new("FILTER", HeaderValue::String(filter.into())),
+            WriteHeaderCard::new("DATE-OBS", HeaderValue::String(date_obs.into())),
+            WriteHeaderCard::new("EXPTIME", HeaderValue::Float(300.0)),
+            WriteHeaderCard::new("GAIN", HeaderValue::Integer(100)),
+            WriteHeaderCard::new("OFFSET", HeaderValue::Integer(30)),
+            WriteHeaderCard::new("XBINNING", HeaderValue::Integer(1)),
+            WriteHeaderCard::new("YBINNING", HeaderValue::Integer(1)),
+            WriteHeaderCard::new("READOUTM", HeaderValue::Integer(2)),
+            WriteHeaderCard::new("RA", HeaderValue::Float(ra)),
+            WriteHeaderCard::new("DEC", HeaderValue::Float(41.2687)),
+            WriteHeaderCard::new("TELESCOP", HeaderValue::String("TestScope".into())),
+            WriteHeaderCard::new("INSTRUME", HeaderValue::String("TestCam".into())),
+            WriteHeaderCard::new("FOCALLEN", HeaderValue::Float(518.0)),
+        ],
+    )
+    .unwrap();
+}
+
 async fn json_request(
     app: Router,
     method: &str,
@@ -1108,5 +1140,75 @@ async fn reimport_attaches_to_existing_targets_after_preview() {
         (projects, targets, images_n, distinct_targets),
         (1, 1, 2, 1),
         "both frames on the one existing target"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn import_scans_xisf_frames_alongside_fits() {
+    let dir = tempdir().unwrap();
+    let images = dir.path().join("lights");
+    std::fs::create_dir_all(&images).unwrap();
+    write_fits(
+        &images.join("m31_ha_0001.fits"),
+        "M31",
+        "Ha",
+        "2026-01-15T04:00:00.000",
+        10.6847,
+    );
+    write_xisf(
+        &images.join("m31_ha_0002.xisf"),
+        "M31",
+        "Ha",
+        "2026-01-15T04:05:10.000",
+        10.6851,
+    );
+    // PixInsight leaves these next to the frames; they are not frames.
+    std::fs::write(images.join("m31_ha_0001.json"), "{}").unwrap();
+
+    let state = state_with_management(dir.path());
+    let (status, body) = json_request(
+        build_app(state.clone()),
+        "POST",
+        "/api/databases/create",
+        Some(serde_json::json!({
+            "name": "XISF Rig",
+            "image_dirs": [images.to_string_lossy()],
+            "backfill": false,
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "create failed: {body}");
+    let slug = body["data"]["database"]["id"].as_str().unwrap().to_string();
+
+    let progress = wait_for_import(&state, &slug).await;
+    assert_eq!(progress["stage"], "complete", "progress: {progress}");
+    let outcome = &progress["outcome"];
+    assert_eq!(outcome["scanned"], 2, "the sidecar must not be scanned");
+    assert_eq!(outcome["unreadable"], 0);
+    assert_eq!(outcome["imported"], 2);
+    // Both frames carry the same target, filter, and equipment, so they land
+    // on one target rather than splitting on container format.
+    assert_eq!(outcome["targets_created"], 1);
+
+    let db_path = body["data"]["database"]["database_path"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let mut statement = conn
+        .prepare("SELECT metadata FROM acquiredimage ORDER BY acquireddate")
+        .unwrap();
+    let filenames: Vec<String> = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .map(|metadata| {
+            let value: Value = serde_json::from_str(&metadata.unwrap()).unwrap();
+            value["FileName"].as_str().unwrap().to_string()
+        })
+        .collect();
+    assert_eq!(filenames.len(), 2, "{filenames:?}");
+    assert!(
+        filenames.iter().any(|name| name.ends_with(".xisf")),
+        "the XISF frame should be recorded with its own path: {filenames:?}"
     );
 }

--- a/tests/integration_reject_archive.rs
+++ b/tests/integration_reject_archive.rs
@@ -34,7 +34,7 @@ struct Fixture {
 ///   M31/
 ///     2026-04-16/
 ///       LIGHT/
-///         img_0028.fits          (rejected) + .xisf + .json sidecars
+///         img_0028.fits          (rejected) + .txt + .json sidecars
 ///         img_0029.fits          (rejected, no sidecars)
 ///         img_0030.fits          (accepted)
 ///   M42/
@@ -54,7 +54,7 @@ fn build_fixture() -> Fixture {
 
     let img1_src = m31_light.join("img_0028.fits");
     fs::write(&img1_src, b"primary 28").unwrap();
-    fs::write(m31_light.join("img_0028.xisf"), b"xisf 28").unwrap();
+    fs::write(m31_light.join("img_0028.txt"), b"notes 28").unwrap();
     fs::write(m31_light.join("img_0028.json"), b"json 28").unwrap();
     // Non-matching extension; should NOT move.
     fs::write(m31_light.join("img_0028.log"), b"log 28").unwrap();
@@ -251,8 +251,8 @@ fn live_run_moves_primary_plus_matching_sidecars_only() {
         "primary 28 should have moved"
     );
     assert!(
-        archive_dir.join("img_0028.xisf").exists(),
-        "matching .xisf sidecar should have moved"
+        archive_dir.join("img_0028.txt").exists(),
+        "matching .txt sidecar should have moved"
     );
     assert!(
         archive_dir.join("img_0028.json").exists(),
@@ -298,7 +298,7 @@ fn live_run_moves_primary_plus_matching_sidecars_only() {
     let sidecars: Vec<String> = serde_json::from_str(&sidecar_json).unwrap();
     let mut sidecars_sorted = sidecars.clone();
     sidecars_sorted.sort();
-    assert_eq!(sidecars_sorted, vec!["img_0028.json", "img_0028.xisf"]);
+    assert_eq!(sidecars_sorted, vec!["img_0028.json", "img_0028.txt"]);
 
     // Manifest lives at the REJECT root (<image_dir>/M31/REJECT), not in the
     // leaf archive directory — one manifest per archive tree.
@@ -384,7 +384,7 @@ fn restore_default_only_moves_un_rejected() {
     // img1 primary + sidecars are back at their original paths.
     assert!(fixture.img1_src.exists(), "primary 28 restored");
     let orig_dir = fixture.img1_src.parent().unwrap();
-    assert!(orig_dir.join("img_0028.xisf").exists());
+    assert!(orig_dir.join("img_0028.txt").exists());
     assert!(orig_dir.join("img_0028.json").exists());
 
     // img2 is still archived (still Rejected); its row remains.

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -398,6 +398,18 @@ async fn upload_accepts_an_xisf_frame_and_imports_it_like_a_fits_one() {
     assert_eq!(body["data"]["import"]["unreadable"], 0);
     assert!(fixture.images_a.join("m81-001.xisf").is_file());
     assert_eq!(image_count(&fixture.database_a), 1);
+
+    // The receive directory is one of this database's scanned image roots, so
+    // the upload must leave nothing behind that a folder scan would read as a
+    // frame.
+    let scannable =
+        psf_guard::commands::import::collect_fits_files(std::slice::from_ref(&fixture.images_a))
+            .expect("scanning the receive directory");
+    assert_eq!(
+        scannable,
+        vec![fixture.images_a.join("m81-001.xisf")],
+        "only the published frame should be scannable"
+    );
 }
 
 #[tokio::test]

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -135,6 +135,36 @@ fn fits_bytes(object: &str, date_obs: &str) -> Vec<u8> {
     bytes
 }
 
+/// The same light frame in a monolithic XISF container, written by the XISF
+/// writer rather than hand-assembled, so the sample stays a real file.
+fn xisf_bytes(object: &str, date_obs: &str) -> Vec<u8> {
+    use seiza_fits::{F32ImageData, HeaderValue, WriteHeaderCard};
+
+    let pixels = vec![0.0f32; 100];
+    let mut bytes = Vec::new();
+    seiza_xisf::write_f32_image_to(
+        &mut bytes,
+        10,
+        10,
+        F32ImageData::Mono(&pixels),
+        &[
+            WriteHeaderCard::new("IMAGETYP", HeaderValue::String("LIGHT".into())),
+            WriteHeaderCard::new("OBJECT", HeaderValue::String(object.into())),
+            WriteHeaderCard::new("FILTER", HeaderValue::String("Ha".into())),
+            WriteHeaderCard::new("DATE-OBS", HeaderValue::String(date_obs.into())),
+            WriteHeaderCard::new("EXPTIME", HeaderValue::Float(300.0)),
+            WriteHeaderCard::new("GAIN", HeaderValue::Integer(100)),
+            WriteHeaderCard::new("OFFSET", HeaderValue::Integer(30)),
+            WriteHeaderCard::new("XBINNING", HeaderValue::Integer(1)),
+            WriteHeaderCard::new("YBINNING", HeaderValue::Integer(1)),
+            WriteHeaderCard::new("RA", HeaderValue::Float(10.68)),
+            WriteHeaderCard::new("DEC", HeaderValue::Float(41.2687)),
+        ],
+    )
+    .unwrap();
+    bytes
+}
+
 fn sha256(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
     let mut encoded = String::with_capacity(64);
@@ -345,4 +375,50 @@ async fn database_echo_token_and_checksum_are_required_before_publish() {
     assert!(!fixture.images_a.join("m33-001.fits").exists());
     assert_eq!(image_count(&fixture.database_a), 0);
     assert_eq!(image_count(&fixture.database_b), 0);
+}
+
+#[tokio::test]
+async fn upload_accepts_an_xisf_frame_and_imports_it_like_a_fits_one() {
+    let fixture = Fixture::new();
+    let image = xisf_bytes("M 81", "2026-07-24T06:00:00");
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "m81-001.xisf",
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["resolution"]["target_name"], "M 81");
+    assert_eq!(body["data"]["import"]["imported"], 1);
+    assert_eq!(body["data"]["import"]["unreadable"], 0);
+    assert!(fixture.images_a.join("m81-001.xisf").is_file());
+    assert_eq!(image_count(&fixture.database_a), 1);
+}
+
+#[tokio::test]
+async fn upload_still_rejects_a_non_image_extension() {
+    let fixture = Fixture::new();
+    let image = fits_bytes("M 81", "2026-07-24T06:00:00");
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "m81-001.png",
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains(".xisf"),
+        "the error should list what is accepted: {body}"
+    );
+    assert_eq!(image_count(&fixture.database_a), 0);
 }


### PR DESCRIPTION
Seiza decodes FITS and XISF into the same `FitsImage` with the same header
cards, so a PixInsight-written frame can be catalogued, graded, previewed, and
stacked like any other. Two things stood in the way: every folder walk tested
for `.fits` or `.fit` by hand, and every read called `seiza_fits` directly.

## What changed

- **New `src/image_io.rs`** — one door for "is this a frame?" and for reading
  one. It owns the extension list (`.fits`, `.fit`, `.fts`, `.xisf`, any letter
  case) and picks the decoder from the extension.
- **Scans route through it**: the server's cached directory tree, the importer's
  collector (CLI and server), `screen-fits`, and remote upload. Reads route
  through it too: import headers, screening headers, astrometry headers,
  star detection, image statistics, colour frames, `read-fits`, stack-preview
  reference headers, and the worker-pool sizing probe.
- **A normalized frame is put on a 16-bit scale as it is read.** PixInsight
  normalizes float images, so such a frame's samples run 0..1 where a camera's
  run in the thousands — `median_adu` read about 0.01 against a camera frame's
  1200, making the cross-frame background and flux comparison the grader
  depends on meaningless. A frame declaring exactly `bounds="0:1"` is converted;
  any other declared range passes through untouched, because writers disagree
  about what it means (seiza's own writer reports the observed sample minimum
  and maximum). Stacking reads the same way through `open_linear_frame`, since
  it normalizes each frame against a reference and one normalized frame among
  camera frames would skew the whole group.
- **`.xisf` stops being a reject-archive companion extension.** A frame carries
  its own grade, so archiving one alongside a rejected sibling would move a file
  the catalog still calls accepted. The default companion list is now `.json`
  and `.txt`, and a list naming any frame container is refused with an error
  that says why.
- **A side effect worth naming**: the importer and screener now also accept
  `.fts`, which the server's directory scan already accepted. That
  inconsistency meant a `.fts` frame was visible but not importable.
- **Remote upload**: an upload streams to a temporary file inside a scanned
  image root, so that file must not carry a frame extension — a concurrent scan
  would pick it up mid-write. It stays extensionless, and the header read takes
  the client's declared filename for the decoder while reading bytes from the
  temporary.
- Requires the just-released **seiza-xisf 0.2.0** (`bounds`, `read_image`,
  `rescale_normalized_to`), and picks up **seiza 0.15.2** and
  **seiza-stacking 0.4.0** with it.

## Review

Two rounds of `/code-review` at high effort ran against this branch; 13 of the
15 findings are fixed here and 2 were dismissed with reasons (a same-stem
FITS/XISF pair is two frames rather than a duplicate, and stem-based output
naming for `annotate-stars` is intended). The normalization work above closes
the last one, which the first round had deferred pending an upstream API —
that API is now released as part of seiza 0.15.2.

## Tests

XISF samples are written by the XISF writer rather than checked in as a blob,
so the fixture cannot drift away from the format the crate speaks.

- `image_io`: extension matching in every case; sidecars rejected; an XISF frame
  decoded and its headers read without pixels; headers normalised through the
  shared astrometry reader; an extensionless file decoded by declared name; the
  error naming which container failed; a normalized frame landing on a 16-bit
  scale; a physical frame passing through untouched; the measured `median_adu`
  reading as 16-bit ADU; and the stacking reader applying the same conversion.
- `directory_tree`: a scan picks up `.xisf` and `.fts` beside `.fits` and leaves
  a `.json` sidecar alone.
- `reject_archive`: a frame container is refused as a companion extension.
- `integration_import`: a mixed FITS/XISF folder imports end to end.
- `integration_remote_upload`: an XISF upload is accepted and imported, the
  receive directory holds nothing scannable but the published frame, and a
  `.png` is still refused.

## Checks run locally

`cargo fmt -- --check`, `cargo build`, `cargo clippy --all-targets
--all-features -- -D warnings`, `cargo test` — 661 passed, 0 failed.
`npm run lint`, `npx vitest run` — 269 passed. `npm run build`.
`git diff --check`.

Playwright was not run: it downloads ~117 MB of real FITS fixtures and asserts
on no copy or route this change touches.

## Still worth a real frame

The conversion is exercised by generated fixtures only. A genuine
PixInsight-exported light would be worth passing through import and screening
before this is relied on for grading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)