### PR TITLE
ci: sign the Windows artifacts with Azure Artifact Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,21 @@ on:
 
 permissions:
   contents: write
+  # Required for the OIDC exchange with Entra that authenticates Windows
+  # Authenticode signing. No Azure secret is stored in this repo.
+  id-token: write
 
 jobs:
   build:
     name: Build release on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # The Entra federated credential is bound to the subject
+    # `repo:theatrus/psf-guard:environment:release`, so this job must run in the
+    # `release` environment or the OIDC token will not match and azure/login
+    # fails. Classic federated credentials require an exact subject match --
+    # `refs/tags/v*` cannot be expressed as a wildcard without the preview
+    # flexible-federation feature, hence binding to the environment instead.
+    environment: release
     strategy:
       fail-fast: false
       matrix:
@@ -147,6 +157,58 @@ jobs:
             "${{ runner.temp }}/psf-guard-updater.json"
         fi
 
+    # Authenticode signing for the Windows artifacts, via Azure Artifact Signing
+    # (the renamed Trusted Signing). The key lives in Microsoft's HSM; we only
+    # ever hold a short-lived OIDC-exchanged token, so there is no signing
+    # secret in this repo.
+    #
+    # Gated on the vars being present so a fork -- which has neither the
+    # variables nor access to the federated credential -- still builds, just
+    # unsigned, rather than failing the release job outright.
+    - name: Authenticate to Azure for code signing
+      if: matrix.os == 'windows-latest' && vars.AZURE_CLIENT_ID != ''
+      uses: azure/login@v2
+      with:
+        client-id: ${{ vars.AZURE_CLIENT_ID }}
+        tenant-id: ${{ vars.AZURE_TENANT_ID }}
+        subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Install trusted-signing-cli
+      if: matrix.os == 'windows-latest' && vars.AZURE_CLIENT_ID != ''
+      uses: taiki-e/install-action@v2
+      with:
+        tool: trusted-signing-cli
+
+    # Injected here rather than committed into tauri.bundle-windows.json on
+    # purpose: that file is used by local Windows builds too, and baking a
+    # signCommand into it would break every developer who has no Azure
+    # credentials. Patching the generated config keeps signing a CI concern.
+    #
+    # trusted-signing-cli authenticates through DefaultAzureCredential, which
+    # picks up the az CLI session established by azure/login above.
+    - name: Enable Authenticode signing in the build config
+      if: matrix.os == 'windows-latest' && vars.AZURE_CLIENT_ID != ''
+      shell: bash
+      run: |
+        node -e '
+          const fs = require("fs");
+          const p = process.argv[1];
+          const cfg = JSON.parse(fs.readFileSync(p, "utf8"));
+          cfg.bundle ??= {};
+          cfg.bundle.windows ??= {};
+          cfg.bundle.windows.signCommand =
+            `trusted-signing-cli -e ${process.env.SIGNING_ENDPOINT}`
+            + ` -a ${process.env.SIGNING_ACCOUNT}`
+            + ` -c ${process.env.SIGNING_PROFILE}`
+            + ` -d "PSF Guard" %1`;
+          fs.writeFileSync(p, JSON.stringify(cfg, null, 2) + "\n");
+          console.log(cfg.bundle.windows.signCommand);
+        ' "${{ runner.temp }}/psf-guard-updater.json"
+      env:
+        SIGNING_ENDPOINT: ${{ vars.SIGNING_ENDPOINT }}
+        SIGNING_ACCOUNT: ${{ vars.SIGNING_ACCOUNT }}
+        SIGNING_PROFILE: ${{ vars.SIGNING_PROFILE }}
+
     - name: Build CLI binary
       # Dedicated console-subsystem CLI (no tauri) — the standalone release
       # asset. The installer's bundled copy comes from Tauri auto-bundling the
@@ -169,6 +231,42 @@ jobs:
         TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
       run: cargo tauri build --verbose --config "${{ runner.temp }}/psf-guard-updater.json"
+
+    # Guards the failure mode that is otherwise invisible: the updater `.sig`
+    # must be computed over the *Authenticode-signed* installer. If Tauri ever
+    # reorders those two steps, CI stays green and the artifacts look fine --
+    # the only symptom is that every existing install fails signature
+    # verification and silently cannot auto-update. Cheap to assert, expensive
+    # to discover in the wild.
+    - name: Verify Windows signing and updater signature ordering
+      if: matrix.os == 'windows-latest' && vars.AZURE_CLIENT_ID != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        installer=$(find target/release/bundle/nsis -name "*-setup.exe" -print -quit)
+        test -n "$installer" || { echo "no NSIS installer found"; exit 1; }
+        echo "installer: $installer"
+
+        # 1. Authenticode present and chaining to a trusted root.
+        signtool=$(find "/c/Program Files (x86)/Windows Kits/10/bin" \
+                     -name signtool.exe -path "*x64*" | sort | tail -1)
+        "$signtool" verify //pa //v "$installer"
+
+        # 2. The publisher is who we expect, not a test profile.
+        "$signtool" verify //pa //v "$installer" | grep -q "StackFoundry LLC" \
+          || { echo "unexpected signing identity"; exit 1; }
+
+        # 3. Ordering: the .sig must not predate the signed installer. Tauri
+        #    signs during bundling and emits updater artifacts afterwards, so
+        #    the .sig should be at least as new. If this trips, the .sig was
+        #    taken over the pre-Authenticode bytes and updates would break.
+        test -f "$installer.sig" || { echo "no updater .sig beside installer"; exit 1; }
+        if [ "$installer" -nt "$installer.sig" ]; then
+          echo "FAIL: installer is newer than its .sig -- Authenticode ran after"
+          echo "      the updater signature, so the .sig covers unsigned bytes."
+          exit 1
+        fi
+        echo "OK: Authenticode present, publisher correct, .sig not stale"
 
     - name: Build Tauri desktop app (macOS)
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/signing-smoke-test.yml
+++ b/.github/workflows/signing-smoke-test.yml
@@ -1,0 +1,94 @@
+# On-demand check that Windows code signing still works end to end.
+#
+# The real signing path only runs on a `v*` tag, so without this the first live
+# exercise of the credential chain would be a real release. This isolates the
+# parts most likely to break -- the OIDC subject match, the Certificate Profile
+# Signer role, and the endpoint/account/profile values -- and checks them
+# against a throwaway binary in a couple of minutes rather than a 36-minute
+# Tauri build.
+#
+# Worth keeping rather than deleting after the first run: re-run it after any
+# change to the Entra app, the federated credential, the certificate profile, or
+# the signing account, and find out immediately instead of at the next release.
+#
+# Does NOT cover the Tauri updater `.sig` ordering -- that needs a real bundle,
+# and release.yml asserts it inline.
+name: Signing smoke test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  smoke:
+    name: Azure Artifact Signing smoke test
+    runs-on: windows-latest
+    # Must match the Entra federated credential subject
+    # `repo:theatrus/psf-guard:environment:release`.
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show what we are about to use
+        shell: bash
+        run: |
+          echo "client id set : ${{ vars.AZURE_CLIENT_ID != '' }}"
+          echo "endpoint      : ${{ vars.SIGNING_ENDPOINT }}"
+          echo "account       : ${{ vars.SIGNING_ACCOUNT }}"
+          echo "profile       : ${{ vars.SIGNING_PROFILE }}"
+
+      # Failure here means the OIDC subject did not match the federated
+      # credential. That is the single most likely thing to be wrong.
+      - name: Authenticate to Azure (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Confirm the identity we ended up as
+        shell: bash
+        run: az account show --query "{sub:name,user:user.name,type:user.type}" -o json
+
+      - name: Install trusted-signing-cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: trusted-signing-cli
+
+      # A throwaway PE to sign. Rust is preinstalled on the runner, so this is
+      # far cheaper than building the real app just to test the credential path.
+      - name: Build a throwaway binary
+        shell: bash
+        run: |
+          cargo new --bin "$RUNNER_TEMP/sigtest" --vcs none
+          cd "$RUNNER_TEMP/sigtest"
+          cargo build --release
+          cp target/release/sigtest.exe "$RUNNER_TEMP/sigtest.exe"
+          ls -l "$RUNNER_TEMP/sigtest.exe"
+
+      # Exercises the Certificate Profile Signer role assignment and every one
+      # of the endpoint/account/profile values.
+      - name: Sign it
+        shell: bash
+        run: |
+          trusted-signing-cli \
+            -e "${{ vars.SIGNING_ENDPOINT }}" \
+            -a "${{ vars.SIGNING_ACCOUNT }}" \
+            -c "${{ vars.SIGNING_PROFILE }}" \
+            -d "PSF Guard signing smoke test" \
+            "$RUNNER_TEMP/sigtest.exe"
+
+      - name: Verify the signature and publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+          signtool=$(find "/c/Program Files (x86)/Windows Kits/10/bin" \
+                       -name signtool.exe -path "*x64*" | sort | tail -1)
+          echo "using: $signtool"
+          "$signtool" verify //pa //v "$RUNNER_TEMP/sigtest.exe" | tee "$RUNNER_TEMP/verify.txt"
+          grep -q "StackFoundry LLC" "$RUNNER_TEMP/verify.txt" \
+            || { echo "FAIL: expected publisher StackFoundry LLC"; exit 1; }
+          echo "OK: signed and chains to a trusted root as StackFoundry LLC"


### PR DESCRIPTION
Windows installers have shipped unsigned — every download reads "Unknown Publisher", and Defender detonates a copy in an Azure VM to work out what it is (that detonation traffic is ~99% of what the updater endpoint sees). macOS has been signed/notarized/stapled for a while; this closes the gap.

## Approach

**Azure Artifact Signing** (the renamed Trusted Signing), $9.99/mo. Key stays in Microsoft's HSM — no hardware token, and **no signing secret in this repo**: the runner obtains a short-lived token by OIDC exchange with Entra.

Already provisioned on the Azure side:

| | |
|---|---|
| account | `github-signers` (eastus, Basic) |
| profile | `stackfoundry-signer` — **PublicTrust**, Active |
| publisher | `CN=StackFoundry LLC, O=StackFoundry LLC, L=Folsom, S=California, C=US` |
| CI identity | `psf-guard-github-signing`, scoped **Certificate Profile Signer on the profile only** |

Repo variables (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `SIGNING_*`) are identifiers, not secrets.

## Three decisions worth reviewing

**The job now runs in the `release` environment.** This is load-bearing, not tidiness. Classic Entra federated credentials need an *exact* subject match, and `refs/tags/v*` can't be a wildcard without the still-preview flexible-federation feature. Binding to `repo:theatrus/psf-guard:environment:release` gives an exact subject — and somewhere to hang an approval gate on the signing identity later, which I'd suggest adding.

**`signCommand` is injected at build time, not committed.** `tauri.bundle-windows.json` is used by local Windows builds too; baking a signCommand in would break every developer without Azure credentials. Signing stays a CI concern.

**Everything is gated on `vars.AZURE_CLIENT_ID != ''`.** A fork has neither the variables nor access to the federated credential, so it builds unsigned rather than failing the release job outright.

## The check that matters

The updater `.sig` must be computed over the **Authenticode-signed** installer. If those ever run in the wrong order, CI stays green, the artifacts look right, and the only symptom is that every existing install silently fails signature verification and cannot auto-update. The new verify step asserts Authenticode is present, the publisher is StackFoundry LLC rather than a test profile, and the `.sig` doesn't predate the signed binary.

## Testing caveat — read before merging

**This cannot be fully exercised without pushing a tag**, since that's the only trigger. The first real release is therefore the first live test. Two things I'd genuinely want confirmed on that run:

1. `azure/login` succeeds — a subject mismatch fails here with an unhelpful error.
2. The ordering assertion passes rather than being vacuously true.

The definitive check is still a manual one: install the previous release and confirm it auto-updates to the signed build.

If you'd rather de-risk it, I can add a `workflow_dispatch` trigger for a dry run that builds and verifies without publishing.

## Not fixed by this

SmartScreen warnings will continue. EV lost its instant-trust bypass in 2024 and reputation is scored per file hash, so each new build starts from zero regardless of signing. This buys a real publisher identity and clears enterprise policies that block unsigned binaries — it is not a fix for the updater-endpoint measurement problem, which needs a persistent install ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)