### PR TITLE
Move to Seiza 0.15.4 and seiza-stacking 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4916,9 +4916,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99cbbe8e89620716d4f0423c74221f933db2c00f867023cd25aa5664ed487b6"
+checksum = "941769e37bb992fe77b97125c65f756dfdbd5179ac7fb20d3b2e6ddbe41249a4"
 dependencies = [
  "directories",
  "image",
@@ -5031,9 +5031,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b4c3a2cd7f24f06f2d5ee51f08851687241ce390c85646dd3e62fa5116df67"
+checksum = "e3362a35754e940c731d90a6469813c21c668470370589266df883fffbb7122a"
 dependencies = [
  "rayon",
  "seiza",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.15.2"
+seiza = "0.15.4"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.1", features = ["parallel"] }
 seiza-fits = "=0.2.1"
 seiza-satellites = { version = "0.4.5", features = ["serde"] }
-seiza-stacking = "0.4.0"
+seiza-stacking = "0.5.0"
 seiza-stretch = "0.2.0"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -26,6 +26,11 @@
 
 ## Changed
 
+- Stacking and calibration now build against Seiza 0.15.4, which adds a
+  concurrent frame-preparation pipeline. PSF Guard keeps its own stacking loop
+  for now, because that loop needs each frame's exposure time and applies the
+  normalized-XISF rescale as it reads; adopting the new path would drop both.
+
 - The reject archive no longer treats `.xisf` as a companion file. A frame
   carries its own grade, so archiving one alongside a rejected sibling would
   move a file the catalog still calls accepted. The default companion list is


### PR DESCRIPTION
Picks up the concurrent frame-preparation pipeline
([seiza#119](https://github.com/theatrus/seiza/pull/119)) and the panic and
deadlock fixes that followed it
([seiza#120](https://github.com/theatrus/seiza/pull/120)).

- `seiza` 0.15.2 → **0.15.4**
- `seiza-stacking` 0.4.0 → **0.5.0**

## Not adopted here, and why

The pipeline exists for this stack loop, but it is not a drop-in for it:

- `src/server/stack_preview.rs` reads each frame through
  `image_io::open_linear_frame`, which puts a normalized XISF frame on a 16-bit
  scale. `push_fits_pipelined` opens frames itself through `FitsFrame::open`,
  which does not — switching would silently undo the normalization that shipped
  in #308 and reopen [#309](https://github.com/theatrus/psf-guard/issues/309)'s
  symptom for stacks.
- The loop needs the opened frame's `exposure_seconds` to weight the
  orientation vote. The callback receives only the path and the disposition, so
  that value is no longer reachable.

Taking the 2x needs one of: `seiza-stacking` applying a declared `bounds="0:1"`
itself when it opens a frame, or the callback carrying the `FitsFrame`
alongside the disposition. Either is an upstream change, so this PR is the
version move alone.

## Checks run locally

`cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo test` — 661 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)