### PR TITLE
Build stack previews through the concurrent frame pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4916,9 +4916,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941769e37bb992fe77b97125c65f756dfdbd5179ac7fb20d3b2e6ddbe41249a4"
+checksum = "c8d9305616a23ef7679465f24dda0d64c7c03ab12c4445c7cf202c5f353999e4"
 dependencies = [
  "directories",
  "image",
@@ -5031,9 +5031,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3362a35754e940c731d90a6469813c21c668470370589266df883fffbb7122a"
+checksum = "0a80c65960c26997729cdc36900664bf73eef363f72f47885ac6515b253c8234"
 dependencies = [
  "rayon",
  "seiza",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.15.4"
+seiza = "0.15.5"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.1", features = ["parallel"] }
 seiza-fits = "=0.2.1"
 seiza-satellites = { version = "0.4.5", features = ["serde"] }
-seiza-stacking = "0.5.0"
+seiza-stacking = "0.6.0"
 seiza-stretch = "0.2.0"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -26,10 +26,11 @@
 
 ## Changed
 
-- Stacking and calibration now build against Seiza 0.15.4, which adds a
-  concurrent frame-preparation pipeline. PSF Guard keeps its own stacking loop
-  for now, because that loop needs each frame's exposure time and applies the
-  normalized-XISF rescale as it reads; adopting the new path would drop both.
+- Stack previews build faster. Frames are now read, calibrated, registered and
+  normalized several at a time while they are still integrated in order, so the
+  stack is unchanged — measured about twice as quick on local disks, and more
+  when the frames sit on a network share, where the reads are what the overlap
+  hides best.
 
 - The reject archive no longer treats `.xisf` as a companion file. A frame
   carries its own grade, so archiving one alongside a rejected sibling would

--- a/src/image_io.rs
+++ b/src/image_io.rs
@@ -115,7 +115,7 @@ pub fn read_header_named(
 /// almost every frame it meets is 16-bit camera data. A PixInsight float
 /// frame that declares itself normalized has no ADU of its own, so the
 /// nearest honest thing is to put it on the same scale as its neighbours.
-const NORMALIZED_FULL_SCALE: f32 = 65535.0;
+pub const NORMALIZED_FULL_SCALE: f32 = 65535.0;
 
 /// Decode a frame's pixels and headers.
 ///
@@ -149,12 +149,7 @@ pub fn open_linear_frame(
     path: impl AsRef<Path>,
 ) -> Result<seiza_stacking::FitsFrame, seiza_stacking::Error> {
     let mut frame = seiza_stacking::FitsFrame::open(path)?;
-    if frame.bounds == Some((0.0, 1.0)) {
-        for sample in &mut frame.image.data {
-            *sample *= NORMALIZED_FULL_SCALE;
-        }
-        frame.bounds = Some((0.0, f64::from(NORMALIZED_FULL_SCALE)));
-    }
+    frame.rescale_declared_unit_bounds(NORMALIZED_FULL_SCALE);
     Ok(frame)
 }
 

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -574,6 +574,55 @@ struct PreparedFrame {
     path: PathBuf,
     source_fingerprint: String,
     expected_target: Option<(f64, f64)>,
+    /// Exposure length from the catalog, for weighting the orientation vote
+    /// and totalling a group's integration time.
+    ///
+    /// Taken from the record rather than the opened frame: the stacking
+    /// pipeline opens frames on its own threads and reports back only the
+    /// disposition, and PSF Guard already knows this from the import.
+    exposure_seconds: f64,
+}
+
+/// Exposure length in seconds from an acquired-image record, or zero when the
+/// record does not say.
+///
+/// N.I.N.A. and PSF Guard's own importer spell this differently, and a value
+/// can arrive as a number or as text, so take the first that reads as a finite
+/// positive number.
+fn exposure_seconds_from_metadata(metadata_json: &str) -> f64 {
+    let Ok(metadata) = serde_json::from_str::<serde_json::Value>(metadata_json) else {
+        return 0.0;
+    };
+    ["ExposureDuration", "ExposureTime", "EXPTIME"]
+        .iter()
+        .find_map(|key| {
+            let value = &metadata[*key];
+            value
+                .as_f64()
+                .or_else(|| value.as_str().and_then(|text| text.trim().parse().ok()))
+        })
+        .filter(|value: &f64| value.is_finite() && *value > 0.0)
+        .unwrap_or(0.0)
+}
+
+/// The decision recorded for a frame that did not reach the accumulator,
+/// whether the stack turned it away or it could not be read at all.
+fn rejected_decision(frame: &PreparedFrame, reason: String) -> StackFrameDecision {
+    StackFrameDecision {
+        image_id: frame.image_id,
+        disposition: "rejected".into(),
+        reason: Some(reason),
+        quality_score: frame.quality_score,
+        matched_stars: None,
+        registration_rms_pixels: None,
+        registration_drift_pixels: None,
+        registered_mapping: None,
+        normalization_mean_gain: None,
+        normalization_mean_offset: None,
+        source_fingerprint: Some(frame.source_fingerprint.clone()),
+        overlap_fraction: None,
+        integrated_fraction: None,
+    }
 }
 
 #[derive(Clone)]
@@ -1249,6 +1298,7 @@ fn prepare_job(
                 path,
                 source_fingerprint,
                 expected_target: expected_by_image.get(&image.id).copied().flatten(),
+                exposure_seconds: exposure_seconds_from_metadata(&image.metadata),
             });
         }
 
@@ -2005,27 +2055,32 @@ fn run_group(
             }
         };
 
-        for frame in group
+        let pending: Vec<&PreparedFrame> = group
             .frames
             .iter()
             .filter(|frame| !already_integrated.contains(&frame.image_id))
-        {
-            // Registering and integrating one frame is the unit of work here,
-            // so this is where a stop takes effect. The frames already pushed
-            // are checkpointed, so building again continues from them.
-            if cancel.load(Ordering::Relaxed) {
-                save_checkpoint(&stacker, &ledger);
-                return Ok(GroupOutcome::Cancelled);
-            }
-            let opened = crate::image_io::open_linear_frame(&frame.path);
-            let exposure = opened
-                .as_ref()
-                .ok()
-                .and_then(|value| value.exposure_seconds)
-                .unwrap_or(0.0);
-            let decision = match opened {
-                Ok(opened) => match stacker.push(opened).map_err(|error| error.to_string())? {
-                    FrameDisposition::Accepted(diagnostics) => {
+            .collect();
+        let paths: Vec<PathBuf> = pending.iter().map(|frame| frame.path.clone()).collect();
+        // Reads, calibration, registration and normalization overlap across
+        // frames while integration stays in this order, so the accumulator
+        // sees exactly the sequence a frame-at-a-time loop would. A frame
+        // declaring itself normalized is put on the same 16-bit scale the
+        // rest of the catalog uses as it is read.
+        let pipeline = seiza_stacking::PipelineOptions {
+            normalized_full_scale: Some(crate::image_io::NORMALIZED_FULL_SCALE),
+            ..seiza_stacking::PipelineOptions::default()
+        };
+        let mut cancelled = false;
+        let mut consumed = 0usize;
+        // Every frame's outcome is recorded in the callback above, so the
+        // summary adds nothing here.
+        let _report = stacker
+            .push_fits_pipelined(&paths, &pipeline, |_, outcome| {
+                let frame = pending[consumed];
+                consumed += 1;
+                let exposure = frame.exposure_seconds;
+                let decision = match outcome {
+                    Ok(FrameDisposition::Accepted(diagnostics)) => {
                         orientation_vote
                             .add(diagnostics.mapping.transform().rotation_radians, exposure);
                         StackFrameDecision {
@@ -2044,61 +2099,54 @@ fn run_group(
                             integrated_fraction: Some(diagnostics.integrated_fraction),
                         }
                     }
-                    FrameDisposition::Rejected(reason) => StackFrameDecision {
-                        image_id: frame.image_id,
-                        disposition: "rejected".into(),
-                        reason: Some(reason.to_string()),
-                        quality_score: frame.quality_score,
-                        matched_stars: None,
-                        registration_rms_pixels: None,
-                        registration_drift_pixels: None,
-                        registered_mapping: None,
-                        normalization_mean_gain: None,
-                        normalization_mean_offset: None,
-                        source_fingerprint: Some(frame.source_fingerprint.clone()),
-                        overlap_fraction: None,
-                        integrated_fraction: None,
+                    // A frame the stack turned away and one that could not be
+                    // read are both "not integrated" to a caller reading the
+                    // group's decisions; only the reason differs.
+                    Ok(FrameDisposition::Rejected(reason)) => {
+                        rejected_decision(frame, reason.to_string())
+                    }
+                    Err(error) => rejected_decision(frame, error.to_string()),
+                };
+                ledger.push(resume::ResumeFrame {
+                    decision: decision.clone(),
+                    exposure_seconds: exposure,
+                    rotation_radians: if decision.disposition == "accepted" {
+                        decision
+                            .registered_mapping
+                            .as_ref()
+                            .map(|mapping| mapping.transform().rotation_radians)
+                    } else {
+                        None
                     },
-                },
-                Err(error) => StackFrameDecision {
-                    image_id: frame.image_id,
-                    disposition: "rejected".into(),
-                    reason: Some(error.to_string()),
-                    quality_score: frame.quality_score,
-                    matched_stars: None,
-                    registration_rms_pixels: None,
-                    registration_drift_pixels: None,
-                    registered_mapping: None,
-                    normalization_mean_gain: None,
-                    normalization_mean_offset: None,
-                    source_fingerprint: Some(frame.source_fingerprint.clone()),
-                    overlap_fraction: None,
-                    integrated_fraction: None,
-                },
-            };
-            ledger.push(resume::ResumeFrame {
-                decision: decision.clone(),
-                exposure_seconds: exposure,
-                rotation_radians: if decision.disposition == "accepted" {
-                    decision
-                        .registered_mapping
-                        .as_ref()
-                        .map(|mapping| mapping.transform().rotation_radians)
+                });
+                state.stack_previews.update(job_id, |job| {
+                    let status = &mut job.groups[group.index];
+                    status.processed_frames += 1;
+                    if matches!(decision.disposition.as_str(), "accepted") {
+                        status.accepted_frames += 1;
+                        status.total_exposure_seconds += exposure;
+                    } else {
+                        status.rejected_frames += 1;
+                    }
+                    status.frames.push(decision);
+                });
+
+                // Integrating one frame is the unit of work, so this is where
+                // a stop takes effect. Frames already prepared are discarded.
+                if cancel.load(Ordering::Relaxed) {
+                    cancelled = true;
+                    seiza_stacking::Continue::No
                 } else {
-                    None
-                },
-            });
-            state.stack_previews.update(job_id, |job| {
-                let status = &mut job.groups[group.index];
-                status.processed_frames += 1;
-                if matches!(decision.disposition.as_str(), "accepted") {
-                    status.accepted_frames += 1;
-                    status.total_exposure_seconds += exposure;
-                } else {
-                    status.rejected_frames += 1;
+                    seiza_stacking::Continue::Yes
                 }
-                status.frames.push(decision);
-            });
+            })
+            .map_err(|error| error.to_string())?;
+
+        if cancelled {
+            // The frames that did land are checkpointed, so building again
+            // continues from them.
+            save_checkpoint(&stacker, &ledger);
+            return Ok(GroupOutcome::Cancelled);
         }
         // The accumulator is complete: checkpoint it before the snapshot
         // consumes the stacker, so an additive rebuild can pick it up here.
@@ -2424,6 +2472,46 @@ fn fits_path(cache_root: &FsPath, job_id: &str, group_index: usize) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+
+    /// The stacking pipeline opens frames on its own threads and reports only
+    /// the disposition, so the exposure has to come from the record. Both
+    /// N.I.N.A. and PSF Guard's importer write it, but they disagree on the
+    /// key and on whether it is a number or text.
+    #[test]
+    fn exposure_reads_every_spelling_a_catalog_uses() {
+        for metadata in [
+            r#"{"ExposureDuration": 300.0}"#,
+            r#"{"ExposureTime": 300}"#,
+            r#"{"EXPTIME": "300.0"}"#,
+            r#"{"ExposureDuration": "300"}"#,
+        ] {
+            assert_eq!(
+                super::exposure_seconds_from_metadata(metadata),
+                300.0,
+                "{metadata}"
+            );
+        }
+    }
+
+    /// A record that does not say falls back to zero, which the orientation
+    /// vote reads as one vote per frame rather than a zero-weight frame.
+    #[test]
+    fn a_record_without_an_exposure_reads_as_zero() {
+        for metadata in [
+            r#"{"FileName": "light.fits"}"#,
+            r#"{"ExposureDuration": null}"#,
+            r#"{"ExposureDuration": "not a number"}"#,
+            r#"{"ExposureDuration": 0}"#,
+            r#"{"ExposureDuration": -5}"#,
+            "not json at all",
+        ] {
+            assert_eq!(
+                super::exposure_seconds_from_metadata(metadata),
+                0.0,
+                "{metadata}"
+            );
+        }
+    }
     use super::*;
 
     fn sky_orientation() -> StackSkyOrientation {


### PR DESCRIPTION
This is what the whole seiza pipeline series was for. Stack preview builds are
now about **twice as quick** on local disks, and more when the frames sit on a
network share, where the reads are what the overlap hides best.

Frames are read, calibrated, registered and normalized several at a time while
integration stays strictly in order, so the accumulator sees exactly the
sequence it saw before and the stack is unchanged.

## What had to move first

[psf-guard#312](https://github.com/theatrus/psf-guard/pull/312) took the version
bump but not the pipeline, because two things blocked adoption. Both are gone:

- **Normalized XISF.** This loop read every frame through a helper that puts a
  frame declaring `bounds="0:1"` onto a 16-bit scale; the pipeline opens frames
  itself, so adopting it would have silently dropped that.
  [seiza#122](https://github.com/theatrus/seiza/pull/122) added
  `PipelineOptions::normalized_full_scale`, released in seiza-stacking 0.6.0.
  `open_linear_frame` now calls the upstream
  `FitsFrame::rescale_declared_unit_bounds` instead of repeating it.
- **Exposure length.** The loop needed the opened frame's `exposure_seconds` to
  weight the orientation vote, and the callback reports only the disposition.
  It turned out PSF Guard never needed seiza for this — the acquired-image
  record already carries it from the import, so `PreparedFrame` reads it from
  there.

## Behaviour worth reviewing

- **Cancelling** moves from before each read to after each integration, since
  that is where the callback runs. Frames already prepared are discarded, and
  the ones that landed are still checkpointed, so building again continues from
  them. Cancel granularity is unchanged at one frame; what changes is that a
  few already-started reads finish before the call returns.
- **Exposure source.** A record without `ExposureDuration` / `ExposureTime` /
  `EXPTIME` now reads as zero where the FITS header might have had a value.
  `OrientationVote::add` already treats zero as one vote per frame, so
  orientation degrades to a per-frame vote rather than breaking; the visible
  effect is a group's reported `total_exposure_seconds`. Both N.I.N.A. and PSF
  Guard's own importer write the field, so this only bites a catalog that never
  recorded it.

## Tests

`integration_stack_resume`'s bit-identical resume test drives this loop and
still passes, which is the main assurance that ordering survived. New unit
tests cover the exposure parsing across every key and both number and text
forms, and the zero fallback for a record that does not say.

## Checks run locally

`cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo test` — 663 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)