### PR TITLE
Weigh every orientation vote in the same unit

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -24,6 +24,14 @@
   across reloads, and its result cards follow the grid's thumbnail-size
   slider up to one full-width column.
 
+## Fixed
+
+- A stack whose reference frame sits on the thin side of a meridian flip is
+  turned the right way up again. The reference's exposure was weighed in
+  seconds while every other frame counted as one, so on a catalog that records
+  no exposure length the reference alone outvoted the whole night and the stack
+  published upside down.
+
 ## Changed
 
 - Stack previews build faster. Frames are now read, calibrated, registered and

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -1970,7 +1970,12 @@ fn run_group(
                 (stacker, ledger)
             }
             None => {
-                let reference_exposure = reference_frame.exposure_seconds.unwrap_or(0.0);
+                // From the record, like every other frame's. Reading this one
+                // from its opened header instead would weigh it in seconds
+                // against frames weighing 1.0 apiece whenever the catalog does
+                // not record an exposure, and the reference alone would then
+                // outvote the whole night.
+                let reference_exposure = group.frames[0].exposure_seconds;
                 // The reference frame defines zero rotation; it votes upright.
                 orientation_vote.add(0.0, reference_exposure);
                 let options = StackOptions {
@@ -2900,6 +2905,51 @@ mod tests {
             north_up: None,
             west_of_pier: Some(west_of_pier),
         }
+    }
+
+    /// Every frame's vote must be weighed in the same unit. Reading the
+    /// reference's exposure from its opened header while the rest come from
+    /// the catalog gave the reference hundreds of seconds against one vote
+    /// each for every other frame, so a whole night on the far side of a
+    /// meridian flip could not outvote it and the stack published upside
+    /// down.
+    #[test]
+    fn a_night_past_a_flip_outvotes_the_reference_frame() {
+        // What a catalog with no recorded exposure yields: zero, which the
+        // vote reads as one vote per frame.
+        let mut vote = OrientationVote::default();
+        vote.add(0.0, 0.0);
+        for _ in 0..8 {
+            vote.add(std::f64::consts::PI, 0.0);
+        }
+        assert!(
+            vote.prefers_half_turn(),
+            "eight flipped frames must outvote one reference"
+        );
+
+        // And the reference still wins when it really is the majority.
+        let mut vote = OrientationVote::default();
+        for _ in 0..8 {
+            vote.add(0.0, 300.0);
+        }
+        vote.add(std::f64::consts::PI, 300.0);
+        assert!(!vote.prefers_half_turn());
+    }
+
+    /// The mixed-unit failure itself, so nobody reintroduces it by sourcing
+    /// one weight differently from the others.
+    #[test]
+    fn a_reference_weighed_in_seconds_would_outvote_frames_weighed_by_count() {
+        let mut mixed = OrientationVote::default();
+        mixed.add(0.0, 300.0);
+        for _ in 0..8 {
+            mixed.add(std::f64::consts::PI, 0.0);
+        }
+        assert!(
+            !mixed.prefers_half_turn(),
+            "this is the behaviour the fix exists to prevent; if it ever \
+             changes, the guard above is what matters"
+        );
     }
 
     /// Whether a channel ends up turned, given the job it was built in.


### PR DESCRIPTION
Fixes a stack whose reference frame sits on the thin side of a meridian flip
being published upside down. This is a regression from #313, merged today, and
it matches a report of stack output not being turned the right way up.

## What happened

Adopting the frame pipeline moved each frame's exposure from the opened FITS
header to the acquired-image record, because the pipeline prepares frames on its
own threads and reports back only the disposition. The **reference frame's**
weight was left reading its opened header.

`OrientationVote::add` treats a missing exposure as one vote per frame. So on a
catalog that records no exposure length:

| | weight |
|---|---|
| reference frame (from its header) | 300.0 |
| every other frame (from the record, absent → 1.0) | 1.0 each |

The reference alone outvoted 299 frames. `prefers_half_turn` never fired, and
the stack kept the reference frame's orientation however much of the night was
shot on the other side of the flip.

Both weights now come from the record, so they are comparable whether or not the
catalog knows the exposure.

## Scope

Only the exposure-majority fallback was affected. A group whose reference frame
has a cached solve, an embedded WCS, or a `PIERSIDE` header is anchored
absolutely and never consulted the vote. That is also why this is worth knowing:
**the fallback can only make one stack self-consistent, not absolutely
north-up** — it publishes in whichever orientation most of the exposure was
taken at, relative to the reference. A frame with no anchor at all can still
look upside down, by design. If that is what you are seeing rather than this
bug, the fix is to get the reference frame solved.

## Tests

Two new. One pins that eight flipped frames outvote one reference on a catalog
with no recorded exposure. The other pins the mixed-unit arithmetic itself — a
reference weighed in seconds against frames weighed by count — so the failure
cannot return unnoticed.

## Checks run locally

`cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo test` — 665 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)