### PR TITLE
Export a WBPP-ready tree and the PixInsight invocation that runs it

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -99,7 +99,10 @@ reference light's set to every frame.
 
 ## Export
 
-Project and target exports add the raw frames matched to each selected light:
+Project and target exports add the raw frames matched to each selected light.
+Two layouts are available; the default is unchanged.
+
+**Grouped by target**, the default:
 
 ```text
 BIAS/
@@ -109,8 +112,29 @@ DARKFLAT/<exposure>_G<gain>/
 <target>/LIGHT/<filter>/
 ```
 
-Rejected lights remain excluded. Repeated calibration sources are deduplicated
-per destination. Name collisions receive a numbered suffix.
+**WBPP**, one root per frame type, for WeightedBatchPreprocessing:
+
+```text
+bias/G<gain>/
+darks/<exposure>s_G<gain>/
+flats/<target>/<filter>/
+lights/<target>/<filter>/
+```
+
+Dark flats land in `darks/` beside the lights' darks. WBPP has no dark-flat
+type: a dark flat is a dark it pairs to a flat by exposure, so a separate
+folder would only mean adding one to WBPP twice.
+
+Flats stay under their target because PSF Guard matched them to that target's
+lights. Two targets shot on different nights can need different flats for one
+filter, and merging them would have WBPP integrate both into a single master.
+
+Choose the layout with `--layout wbpp` on the CLI, the `layout` query parameter
+on the export download, or the **Export layout** control on the overview, which
+applies to every export on the page.
+
+Rejected lights remain excluded in either layout. Repeated calibration sources
+are deduplicated per destination. Name collisions receive a numbered suffix.
 
 ## Database transfer
 

--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -133,6 +133,24 @@ Choose the layout with `--layout wbpp` on the CLI, the `layout` query parameter
 on the export download, or the **Export layout** control on the overview, which
 applies to every export on the page.
 
+A WBPP export also carries `run-wbpp.sh` and `run-wbpp.cmd`, which hand it to
+PixInsight. WBPP 3.x is driven from PixInsight's command line rather than
+through a script API, so these are the invocation itself: readable, editable,
+and re-runnable. They default to WBPP's `loadOnly`, which loads the frames and
+groups and then stops with the dialog open — its grouping and reference choices
+are worth a look before an hour of integration starts. Delete that one line to
+run the pipeline.
+
+PixInsight prints nothing to the terminal in this mode, because WBPP writes to
+its own console. A finished run and a failed one look alike from outside, so
+read `wbpp-out/logs/*.log` for what happened; the results land in
+`wbpp-out/master` and `wbpp-out/calibrated`. The scripts say so too.
+
+This was verified against WBPP 3.0.1 in PixInsight 1.9.4: the generated
+invocation classified every frame from its `IMAGETYP` header, grouped by
+binning, size, filter and exposure, built master bias, dark and flat, matched
+the dark and flat to the lights automatically, and calibrated them.
+
 Rejected lights remain excluded in either layout. Repeated calibration sources
 are deduplicated per destination. Name collisions receive a numbered suffix.
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,13 @@
 
 ## Added
 
+- Export can lay a session out for PixInsight's WeightedBatchPreprocessing.
+  Pick **WBPP** as the export layout on the overview, or pass `--layout wbpp`,
+  and each frame type gets its own folder with dark flats among the darks
+  where WBPP expects them. The existing target-grouped layout stays the
+  default. See [calibration
+  libraries](https://github.com/theatrus/psf-guard/blob/main/docs/CALIBRATION_LIBRARY.md#export).
+
 - XISF frames count as images everywhere FITS frames do. Folder scans,
   imports, screening, and remote uploads now pick up `.xisf` next to `.fits`,
   `.fit`, and `.fts`, and a PixInsight-written frame grades, previews, and

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,8 +9,10 @@
 - Export can lay a session out for PixInsight's WeightedBatchPreprocessing.
   Pick **WBPP** as the export layout on the overview, or pass `--layout wbpp`,
   and each frame type gets its own folder with dark flats among the darks
-  where WBPP expects them. The existing target-grouped layout stays the
-  default. See [calibration
+  where WBPP expects them. The export carries `run-wbpp.sh` and `run-wbpp.cmd`
+  that hand it straight to PixInsight, stopping at WBPP's dialog so you can
+  check the groups before starting. The existing target-grouped layout stays
+  the default. See [calibration
   libraries](https://github.com/theatrus/psf-guard/blob/main/docs/CALIBRATION_LIBRARY.md#export).
 
 - XISF frames count as images everywhere FITS frames do. Folder scans,

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -1635,7 +1635,9 @@ pub fn export_destinations(
     light: &FrameMeta,
     target_name: &str,
     directory_tree: Option<&crate::directory_tree::DirectoryTree>,
+    layout: crate::commands::export::ExportLayout,
 ) -> Result<Vec<(CalibrationKind, CalibrationFrame, PathBuf)>> {
+    use crate::commands::export::ExportLayout;
     let mut selected = select_for_light(conn, light)?;
     remap_missing_sources(&mut selected, directory_tree);
     let target = crate::commands::export::sanitize_component(target_name);
@@ -1649,11 +1651,15 @@ pub fn export_destinations(
             .unwrap_or_default()
             .to_string_lossy()
             .into_owned();
-        output.push((
-            CalibrationKind::Bias,
-            frame,
-            PathBuf::from("BIAS").join(name),
-        ));
+        let destination = match layout {
+            ExportLayout::Standard => PathBuf::from("BIAS").join(&name),
+            // Grouped by gain so WBPP does not integrate two sensors'
+            // settings into one master bias.
+            ExportLayout::Wbpp => PathBuf::from("bias")
+                .join(gain_group(frame.gain))
+                .join(&name),
+        };
+        output.push((CalibrationKind::Bias, frame, destination));
     }
     for frame in selected.dark {
         let name = frame
@@ -1670,11 +1676,11 @@ pub fn export_destinations(
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "unknown".into())
         );
-        output.push((
-            CalibrationKind::Dark,
-            frame,
-            PathBuf::from("DARK").join(group).join(name),
-        ));
+        let destination = match layout {
+            ExportLayout::Standard => PathBuf::from("DARK").join(&group).join(&name),
+            ExportLayout::Wbpp => PathBuf::from("darks").join(&group).join(&name),
+        };
+        output.push((CalibrationKind::Dark, frame, destination));
     }
     for frame in selected.dark_flat {
         let name = frame
@@ -1691,11 +1697,15 @@ pub fn export_destinations(
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "unknown".into())
         );
-        output.push((
-            CalibrationKind::DarkFlat,
-            frame,
-            PathBuf::from("DARKFLAT").join(group).join(name),
-        ));
+        let destination = match layout {
+            ExportLayout::Standard => PathBuf::from("DARKFLAT").join(&group).join(&name),
+            // WBPP has no dark-flat type: a dark flat is a dark that happens
+            // to match the flats' exposure, and WBPP pairs them by exposure.
+            // Keeping a separate folder would mean adding it to WBPP a second
+            // time, as darks.
+            ExportLayout::Wbpp => PathBuf::from("darks").join(&group).join(&name),
+        };
+        output.push((CalibrationKind::DarkFlat, frame, destination));
     }
     for frame in selected.flat {
         let name = frame
@@ -1704,14 +1714,33 @@ pub fn export_destinations(
             .unwrap_or_default()
             .to_string_lossy()
             .into_owned();
-        output.push((
-            CalibrationKind::Flat,
-            frame,
-            PathBuf::from(&target).join("FLAT").join(&filter).join(name),
-        ));
+        let destination = match layout {
+            ExportLayout::Standard => PathBuf::from(&target)
+                .join("FLAT")
+                .join(&filter)
+                .join(&name),
+            // Kept under the target, because PSF Guard matched these flats to
+            // that target's lights. Two targets shot on different nights can
+            // need different flats for one filter, and merging them would have
+            // WBPP integrate both into a single master.
+            ExportLayout::Wbpp => PathBuf::from("flats")
+                .join(&target)
+                .join(&filter)
+                .join(&name),
+        };
+        output.push((CalibrationKind::Flat, frame, destination));
     }
     output.sort_by(|left, right| left.2.cmp(&right.2));
     Ok(output)
+}
+
+/// The folder a bias frame's gain puts it in. An unrecorded gain gets its own
+/// group rather than joining a numbered one.
+fn gain_group(gain: Option<i64>) -> String {
+    match gain {
+        Some(gain) => format!("G{gain}"),
+        None => "G-unknown".to_string(),
+    }
 }
 
 fn remap_missing_sources(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,25 @@ pub struct Cli {
     pub command: Commands,
 }
 
+/// CLI spelling of [`crate::commands::export::ExportLayout`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum ExportLayoutArg {
+    /// Grouped by target, PSF Guard's own tree.
+    #[default]
+    Standard,
+    /// One root per frame type, for WeightedBatchPreprocessing.
+    Wbpp,
+}
+
+impl From<ExportLayoutArg> for crate::commands::export::ExportLayout {
+    fn from(value: ExportLayoutArg) -> Self {
+        match value {
+            ExportLayoutArg::Standard => Self::Standard,
+            ExportLayoutArg::Wbpp => Self::Wbpp,
+        }
+    }
+}
+
 #[derive(Subcommand)]
 pub enum Commands {
     /// Dump grading results for all images
@@ -149,10 +168,10 @@ pub enum Commands {
     /// Export ("take out") graded lights into a stacking-friendly folder.
     ///
     /// Selects non-rejected images (accepted only by default), locates the
-    /// files under the database's image directories, and lays them out
-    /// WBPP-style: <dest>/<target>/LIGHT/<filter>/. Re-runs skip files that
-    /// already exist with the right size, so an export folder can be topped
-    /// up after each session. Rejects are never exported.
+    /// files under the database's image directories, and lays them out under
+    /// <dest>. Re-runs skip files that already exist with the right size, so
+    /// an export folder can be topped up after each session. Rejects are
+    /// never exported.
     Export {
         /// Registry slug or path of the database.
         db: String,
@@ -176,6 +195,12 @@ pub enum Commands {
         /// Restrict to one filter name (exact, case-insensitive).
         #[arg(long)]
         filter: Option<String>,
+
+        /// How to arrange the tree. `standard` groups by target;
+        /// `wbpp` gives each frame type its own root for
+        /// WeightedBatchPreprocessing and folds dark flats in with the darks.
+        #[arg(long, value_enum, default_value_t = ExportLayoutArg::Standard)]
+        layout: ExportLayoutArg,
 
         /// Hardlink instead of copy (instant + no extra disk when the
         /// destination is on the same filesystem; falls back to copy).

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -191,7 +191,21 @@ pub fn main() -> Result<()> {
                 ..Default::default()
             };
             let plan = plan_export(&conn, &dirs, &options)?;
-            let summary = execute_plan(&plan, &PathBuf::from(&dest), link, dry_run);
+            let dest_root = PathBuf::from(&dest);
+            let summary = execute_plan(&plan, &dest_root, link, dry_run);
+            if options.layout == crate::commands::export::ExportLayout::Wbpp && !dry_run {
+                use crate::commands::export::{wbpp, write_wbpp_scripts};
+                match write_wbpp_scripts(&plan, &dest_root, wbpp::WbppRun::default()) {
+                    Ok(scripts) => {
+                        for script in scripts {
+                            println!("Wrote {}", script.display());
+                        }
+                    }
+                    // The frames are already placed; a missing runner is worth
+                    // reporting but not worth failing the export over.
+                    Err(error) => eprintln!("⚠️  No WBPP runner script: {error}"),
+                }
+            }
 
             println!(
                 "\nExport {}: planned={}, copied={}, linked={}, already_present={}, \

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -143,6 +143,7 @@ pub fn main() -> Result<()> {
             project,
             target,
             filter,
+            layout,
             link,
             dry_run,
             image_dirs,
@@ -186,6 +187,7 @@ pub fn main() -> Result<()> {
                 project_filter: project,
                 target_filter: target,
                 filter_name: filter,
+                layout: layout.into(),
                 ..Default::default()
             };
             let plan = plan_export(&conn, &dirs, &options)?;

--- a/src/commands/export/mod.rs
+++ b/src/commands/export/mod.rs
@@ -22,6 +22,8 @@ use crate::directory_tree::DirectoryTree;
 use crate::models::GradingStatus;
 use anyhow::{Context, Result};
 use rusqlite::Connection;
+pub mod wbpp;
+
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -354,6 +356,37 @@ pub fn execute_plan(
         }
     }
     summary
+}
+
+/// Write the WBPP runner scripts beside a finished export.
+///
+/// Both platforms' scripts are written, because an export is often zipped and
+/// opened on the machine PixInsight runs on rather than the one that made it.
+pub fn write_wbpp_scripts(
+    plan: &ExportPlan,
+    dest_root: &Path,
+    run: wbpp::WbppRun,
+) -> Result<Vec<PathBuf>> {
+    if let Some(reason) = wbpp::unusable_destination(dest_root) {
+        anyhow::bail!(reason);
+    }
+    std::fs::create_dir_all(dest_root)
+        .with_context(|| format!("creating {}", dest_root.display()))?;
+    let mut written = Vec::new();
+    for (name, body) in [
+        ("run-wbpp.sh", wbpp::shell_script(plan, run)),
+        ("run-wbpp.cmd", wbpp::batch_script(plan, run)),
+    ] {
+        let path = dest_root.join(name);
+        std::fs::write(&path, body).with_context(|| format!("writing {}", path.display()))?;
+        #[cfg(unix)]
+        if name.ends_with(".sh") {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
+        }
+        written.push(path);
+    }
+    Ok(written)
 }
 
 #[cfg(test)]

--- a/src/commands/export/mod.rs
+++ b/src/commands/export/mod.rs
@@ -55,6 +55,46 @@ pub struct ExportPlan {
     pub unresolvable: usize,
 }
 
+/// How an export arranges its files under the destination root.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportLayout {
+    /// PSF Guard's own tree, grouped by target first:
+    /// `<target>/LIGHT/<filter>/`, `<target>/FLAT/<filter>/`, and `BIAS/`,
+    /// `DARK/`, `DARKFLAT/` at the root.
+    #[default]
+    Standard,
+    /// One root per frame type, which is what WeightedBatchPreprocessing
+    /// wants: `lights/`, `flats/`, `darks/`, `bias/`.
+    ///
+    /// Dark flats live under `darks/` beside the lights' darks, because WBPP
+    /// has no dark-flat type — it matches a dark to a flat by exposure like
+    /// any other. Keeping them apart, as the standard layout does, means
+    /// adding one folder to WBPP twice.
+    Wbpp,
+}
+
+impl ExportLayout {
+    /// Where one light frame lands.
+    fn light_destination(self, target: &str, filter: &str, basename: &str) -> PathBuf {
+        let (target, filter, basename) = (
+            sanitize_component(target),
+            sanitize_component(filter),
+            sanitize_component(basename),
+        );
+        match self {
+            Self::Standard => PathBuf::from(target)
+                .join("LIGHT")
+                .join(filter)
+                .join(basename),
+            Self::Wbpp => PathBuf::from("lights")
+                .join(target)
+                .join(filter)
+                .join(basename),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ExportOptions {
     pub include_pending: bool,
@@ -66,6 +106,8 @@ pub struct ExportOptions {
     pub target_id: Option<i32>,
     /// Restrict to one filter name (exact, case-insensitive).
     pub filter_name: Option<String>,
+    /// How the destination tree is arranged.
+    pub layout: ExportLayout,
 }
 
 #[derive(Debug, Default, serde::Serialize)]
@@ -164,6 +206,7 @@ pub fn plan_export(
                     &light_meta,
                     &target_name,
                     Some(&tree),
+                    options.layout,
                 )
                 .context("matching export calibration frames")?,
             );
@@ -172,10 +215,10 @@ pub fn plan_export(
         // The basename comes from the row's metadata JSON; sanitize it too so
         // a degenerate FileName (e.g. "..") can never shift the destination
         // or produce a traversal-shaped archive entry name.
-        let mut relative_dest = PathBuf::from(sanitize_component(&target_name))
-            .join("LIGHT")
-            .join(sanitize_component(&image.filter_name))
-            .join(sanitize_component(&basename));
+        let mut relative_dest =
+            options
+                .layout
+                .light_destination(&target_name, &image.filter_name, &basename);
         let clashes = used_dests.entry(relative_dest.clone()).or_insert(0);
         *clashes += 1;
         if *clashes > 1 {
@@ -405,7 +448,7 @@ mod tests {
     }
 
     #[test]
-    fn layout_is_wbpp_style_with_sanitized_names() {
+    fn the_standard_layout_groups_by_target_and_sanitizes_names() {
         let dir = tempfile::tempdir().unwrap();
         let conn = seed(dir.path());
         let dirs = vec![dir.path().to_string_lossy().into_owned()];
@@ -415,6 +458,70 @@ mod tests {
             plan.items[0].relative_dest,
             PathBuf::from("M42_Trapezium/LIGHT/Ha/acc_Ha_0001.fits")
         );
+    }
+
+    /// WBPP wants one root per frame type, and has no dark-flat type at all
+    /// — a dark flat is a dark it pairs to a flat by exposure. Keeping them in
+    /// their own folder, as the standard layout does, means adding one folder
+    /// to WBPP twice.
+    #[test]
+    fn the_wbpp_layout_gives_each_frame_type_one_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut conn = seed(dir.path());
+        let light_path = dir.path().join("acc_Ha_0001.fits");
+        write_test_fits(&light_path, "LIGHT");
+
+        let mut calibration = Vec::new();
+        for (name, kind) in [
+            ("bias-0.fits", "BIAS"),
+            ("dark-0.fits", "DARK"),
+            ("flat-0.fits", "FLAT"),
+        ] {
+            let path = dir.path().join(name);
+            write_test_fits(&path, kind);
+            calibration.push(crate::commands::import::headers::read_frame_meta(&path));
+        }
+        {
+            let tx = conn.transaction().unwrap();
+            crate::calibration::import_calibration_frames(&tx, &calibration, Some("p")).unwrap();
+            tx.commit().unwrap();
+        }
+
+        let dirs = vec![dir.path().to_string_lossy().into_owned()];
+        let options = ExportOptions {
+            layout: ExportLayout::Wbpp,
+            ..ExportOptions::default()
+        };
+        let plan = plan_export(&conn, &dirs, &options).unwrap();
+        let destinations: Vec<String> = plan
+            .items
+            .iter()
+            .map(|item| item.relative_dest.to_string_lossy().replace('\\', "/"))
+            .collect();
+
+        assert!(
+            destinations
+                .iter()
+                .any(|path| path == "lights/M42_Trapezium/Ha/acc_Ha_0001.fits"),
+            "{destinations:?}"
+        );
+        assert!(
+            destinations.iter().any(|path| path.starts_with("bias/")),
+            "{destinations:?}"
+        );
+        // Nothing may land in the standard layout's roots.
+        for path in &destinations {
+            assert!(
+                !path.starts_with("DARKFLAT/") && !path.contains("/LIGHT/"),
+                "the standard tree leaked into a WBPP export: {path}"
+            );
+        }
+    }
+
+    /// The default is untouched, so an existing export folder keeps its shape.
+    #[test]
+    fn the_default_layout_is_still_the_standard_one() {
+        assert_eq!(ExportOptions::default().layout, ExportLayout::Standard);
     }
 
     #[test]

--- a/src/commands/export/wbpp.rs
+++ b/src/commands/export/wbpp.rs
@@ -1,0 +1,302 @@
+//! The runner script that hands a WBPP-layout export to PixInsight.
+//!
+//! WeightedBatchPreprocessing 3.x is driven from PixInsight's command line
+//! rather than through a script API: `automationMode=true` suppresses the
+//! dialog, `dir=` adds a directory, and `outputDirectory=` says where the
+//! results go. So the useful thing to generate is not PJSR but the invocation
+//! itself, which a user can read, edit, and re-run.
+//!
+//! Verified against WBPP 3.0.1, the version in PixInsight 1.9.4.
+
+use super::ExportPlan;
+
+/// WBPP release these scripts were written against. Its automation parameters
+/// are stable within a major version but have changed across them, so the
+/// generated script says what it expects.
+pub const TARGET_WBPP_VERSION: &str = "3.0.1";
+
+/// The four roots the WBPP layout writes, in the order the script scans them.
+///
+/// Named explicitly rather than scanning the export root, because `dir=` is
+/// recursive: one root would sweep up `wbpp-out/` on a second run and feed
+/// WBPP its own output.
+const FRAME_ROOTS: [&str; 4] = ["lights", "flats", "darks", "bias"];
+
+/// Where WBPP writes. A sibling of the frame roots, never inside one.
+const OUTPUT_DIRECTORY: &str = "wbpp-out";
+
+/// Whether the generated script runs the pipeline or only loads it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WbppRun {
+    /// Load the frames and groups, then stop with the dialog open. WBPP's
+    /// grouping and reference choices are worth a look before an hour of
+    /// integration starts, so this is the default.
+    #[default]
+    LoadOnly,
+    /// Run the whole pipeline headless and exit.
+    Full,
+}
+
+/// Which roots a plan actually filled. A script that scans an empty directory
+/// makes WBPP complain, and a missing one is worth seeing in the script rather
+/// than in a stack trace.
+fn populated_roots(plan: &ExportPlan) -> Vec<&'static str> {
+    FRAME_ROOTS
+        .iter()
+        .copied()
+        .filter(|root| {
+            plan.items.iter().any(|item| {
+                item.relative_dest
+                    .components()
+                    .next()
+                    .is_some_and(|first| first.as_os_str() == *root)
+            })
+        })
+        .collect()
+}
+
+/// The POSIX runner, for Linux and macOS.
+pub fn shell_script(plan: &ExportPlan, run: WbppRun) -> String {
+    let roots = populated_roots(plan);
+    let mut script = String::new();
+    script.push_str("#!/bin/sh\n");
+    script.push_str(&preamble("# "));
+    script.push_str(
+        "\n\
+         set -e\n\
+         HERE=$(cd \"$(dirname \"$0\")\" && pwd)\n\
+         \n\
+         # Point these at your install if they are somewhere else.\n\
+         if [ \"$(uname)\" = \"Darwin\" ]; then\n\
+         \x20 PI_ROOT=\"${PI_ROOT:-/Applications/PixInsight}\"\n\
+         \x20 PI_BIN=\"${PI_BIN:-$PI_ROOT/PixInsight.app/Contents/MacOS/PixInsight}\"\n\
+         else\n\
+         \x20 PI_ROOT=\"${PI_ROOT:-/opt/PixInsight}\"\n\
+         \x20 PI_BIN=\"${PI_BIN:-$PI_ROOT/bin/PixInsight.sh}\"\n\
+         fi\n\
+         WBPP=\"${WBPP:-$PI_ROOT/src/scripts/BatchPreprocessing/WBPP.js}\"\n\
+         \n",
+    );
+
+    script.push_str("PARAMS=\"$WBPP,automationMode=true\"\n");
+    for root in &roots {
+        script.push_str(&format!("PARAMS=\"$PARAMS,dir=$HERE/{root}\"\n"));
+    }
+    script.push_str(&format!(
+        "PARAMS=\"$PARAMS,outputDirectory=$HERE/{OUTPUT_DIRECTORY}\"\n"
+    ));
+    match run {
+        WbppRun::LoadOnly => script.push_str(
+            "\n\
+             # Loads the frames and groups, then stops with the dialog open so\n\
+             # you can check them. Delete this line to run the pipeline.\n\
+             PARAMS=\"$PARAMS,loadOnly\"\n",
+        ),
+        WbppRun::Full => script.push_str(
+            "\n\
+             # Runs the whole pipeline headless. Add\n\
+             #   PARAMS=\"$PARAMS,loadOnly\"\n\
+             # to stop at the dialog and check the groups first.\n",
+        ),
+    }
+    script.push_str(&format!(
+        "\nmkdir -p \"$HERE/{OUTPUT_DIRECTORY}\"\n\
+         exec \"$PI_BIN\" -n --automation-mode -r=\"$PARAMS\" --force-exit\n"
+    ));
+    script
+}
+
+/// The Windows runner, so an export can be zipped and taken to another machine.
+pub fn batch_script(plan: &ExportPlan, run: WbppRun) -> String {
+    let roots = populated_roots(plan);
+    let mut script = String::new();
+    script.push_str("@echo off\r\n");
+    script.push_str(&preamble("REM ").replace('\n', "\r\n"));
+    script.push_str(
+        "\r\n\
+         setlocal\r\n\
+         set \"HERE=%~dp0\"\r\n\
+         set \"HERE=%HERE:~0,-1%\"\r\n\
+         \r\n\
+         REM Point these at your install if it is somewhere else.\r\n\
+         if not defined PI_ROOT set \"PI_ROOT=C:\\Program Files\\PixInsight\"\r\n\
+         if not defined PI_BIN set \"PI_BIN=%PI_ROOT%\\bin\\PixInsight.exe\"\r\n\
+         if not defined WBPP set \"WBPP=%PI_ROOT%\\src\\scripts\\BatchPreprocessing\\WBPP.js\"\r\n\
+         \r\n",
+    );
+    script.push_str("set \"PARAMS=%WBPP%,automationMode=true\"\r\n");
+    for root in &roots {
+        script.push_str(&format!("set \"PARAMS=%PARAMS%,dir=%HERE%\\{root}\"\r\n"));
+    }
+    script.push_str(&format!(
+        "set \"PARAMS=%PARAMS%,outputDirectory=%HERE%\\{OUTPUT_DIRECTORY}\"\r\n"
+    ));
+    if run == WbppRun::LoadOnly {
+        script.push_str(
+            "\r\n\
+             REM Loads the frames and groups, then stops with the dialog open so\r\n\
+             REM you can check them. Delete this line to run the pipeline.\r\n\
+             set \"PARAMS=%PARAMS%,loadOnly\"\r\n",
+        );
+    }
+    script.push_str(&format!(
+        "\r\nif not exist \"%HERE%\\{OUTPUT_DIRECTORY}\" mkdir \"%HERE%\\{OUTPUT_DIRECTORY}\"\r\n\
+         \"%PI_BIN%\" -n --automation-mode -r=\"%PARAMS%\" --force-exit\r\n"
+    ));
+    script
+}
+
+fn preamble(comment: &str) -> String {
+    format!(
+        "{comment}Hand this export to PixInsight's WeightedBatchPreprocessing.\n\
+         {comment}Generated by PSF Guard for WBPP {TARGET_WBPP_VERSION}.\n\
+         {comment}\n\
+         {comment}WBPP reads each frame's type from its IMAGETYP header, so the\n\
+         {comment}folders below are for your benefit rather than its. It groups\n\
+         {comment}lights by filter, exposure, binning and gain the same way.\n\
+         {comment}\n\
+         {comment}Each directory is scanned recursively, which is why the frame\n\
+         {comment}roots are listed one by one: scanning the export root would\n\
+         {comment}sweep up {OUTPUT_DIRECTORY}/ on a second run and feed WBPP its\n\
+         {comment}own output.\n\
+         {comment}\n\
+         {comment}PixInsight prints nothing to the terminal in this mode: WBPP\n\
+         {comment}writes to its own console, so a finished run and a failed one\n\
+         {comment}look alike from outside. Read\n\
+         {comment}  {OUTPUT_DIRECTORY}/logs/*.log\n\
+         {comment}for what actually happened, and look in {OUTPUT_DIRECTORY}/master\n\
+         {comment}and {OUTPUT_DIRECTORY}/calibrated for the results.\n"
+    )
+}
+
+/// Whether a destination can be expressed in a WBPP command line at all.
+///
+/// Parameters are comma-separated inside one `-r=` argument, so a comma in the
+/// export's own path would split it. The frame roots below it are fixed names,
+/// so only the root the user chose can carry one.
+pub fn unusable_destination(dest_root: &std::path::Path) -> Option<String> {
+    dest_root.to_string_lossy().contains(',').then(|| {
+        format!(
+            "the export path {} contains a comma, which WBPP's command line uses \
+             to separate parameters; the frames were written but the runner script \
+             was not, because it could not be expressed",
+            dest_root.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::export::{ExportItem, FrameKind};
+    use std::path::PathBuf;
+
+    fn plan_with(roots: &[&str]) -> ExportPlan {
+        let mut plan = ExportPlan::default();
+        for root in roots {
+            plan.items.push(ExportItem {
+                image_id: 0,
+                calibration_frame_id: None,
+                kind: FrameKind::Light,
+                source: PathBuf::from("/tmp/x.fits"),
+                relative_dest: PathBuf::from(root).join("a").join("x.fits"),
+                size_bytes: 0,
+            });
+        }
+        plan
+    }
+
+    /// The invocation this produces was run against PixInsight 1.9.4 with WBPP
+    /// 3.0.1: it built master bias, dark and flat, matched the dark and flat to
+    /// the lights, and calibrated them. These assertions pin the parts that
+    /// made that work.
+    #[test]
+    fn the_shell_runner_matches_the_invocation_that_was_verified() {
+        let script = shell_script(
+            &plan_with(&["lights", "flats", "darks", "bias"]),
+            WbppRun::Full,
+        );
+
+        assert!(script.starts_with("#!/bin/sh\n"));
+        assert!(script.contains("automationMode=true"), "{script}");
+        assert!(script.contains("--automation-mode"));
+        assert!(script.contains("--force-exit"));
+        assert!(script.contains("WBPP.js"));
+        // Every frame root listed separately, never the export root.
+        for root in ["lights", "flats", "darks", "bias"] {
+            assert!(
+                script.contains(&format!("dir=$HERE/{root}")),
+                "missing {root}"
+            );
+        }
+        assert!(script.contains(&format!("outputDirectory=$HERE/{OUTPUT_DIRECTORY}")));
+        // A full run must set no loadOnly parameter. The comment showing how
+        // to add one does mention it, so look only at what executes.
+        let active_load_only = script
+            .lines()
+            .any(|line| !line.trim_start().starts_with('#') && line.contains("loadOnly"));
+        assert!(
+            !active_load_only,
+            "a full run must not stop at the dialog:\n{script}"
+        );
+    }
+
+    /// The default stops before an hour of integration starts.
+    #[test]
+    fn the_default_run_only_loads() {
+        assert_eq!(WbppRun::default(), WbppRun::LoadOnly);
+        let script = shell_script(&plan_with(&["lights"]), WbppRun::LoadOnly);
+        let active_load_only = script
+            .lines()
+            .any(|line| !line.trim_start().starts_with('#') && line.contains("loadOnly"));
+        assert!(active_load_only, "{script}");
+    }
+
+    /// A root with no frames must not be scanned: WBPP complains about an
+    /// empty directory, and an export filtered to one target often has no
+    /// bias or darks of its own.
+    #[test]
+    fn only_the_roots_a_plan_filled_are_scanned() {
+        let script = shell_script(&plan_with(&["lights", "flats"]), WbppRun::LoadOnly);
+        assert!(script.contains("dir=$HERE/lights"));
+        assert!(script.contains("dir=$HERE/flats"));
+        assert!(!script.contains("dir=$HERE/darks"), "{script}");
+        assert!(!script.contains("dir=$HERE/bias"), "{script}");
+    }
+
+    /// PixInsight prints nothing to the terminal in this mode, so a run that
+    /// failed looks exactly like one that worked. The script has to say where
+    /// to look.
+    #[test]
+    fn the_runner_says_where_the_real_output_is() {
+        let script = shell_script(&plan_with(&["lights"]), WbppRun::LoadOnly);
+        assert!(
+            script.contains(&format!("{OUTPUT_DIRECTORY}/logs/*.log")),
+            "{script}"
+        );
+    }
+
+    #[test]
+    fn the_windows_runner_uses_crlf_and_percent_expansion() {
+        let script = batch_script(&plan_with(&["lights", "bias"]), WbppRun::LoadOnly);
+        assert!(script.starts_with("@echo off\r\n"));
+        assert!(script.contains("dir=%HERE%\\lights"), "{script}");
+        assert!(script.contains("dir=%HERE%\\bias"), "{script}");
+        assert!(!script.contains("dir=%HERE%\\darks"));
+        // Every line ends CRLF, or cmd.exe mangles it.
+        assert!(
+            !script.contains("\n")
+                || script.matches('\n').count() == script.matches("\r\n").count()
+        );
+    }
+
+    /// WBPP takes every parameter in one comma-separated argument, so a comma
+    /// in the export path would split it into nonsense. The frame roots below
+    /// it are fixed names, so only the chosen root can carry one.
+    #[test]
+    fn a_comma_in_the_export_path_is_refused_rather_than_mangled() {
+        assert!(unusable_destination(std::path::Path::new("/data/M42, Trapezium")).is_some());
+        assert!(unusable_destination(std::path::Path::new("/data/M42_Trapezium")).is_none());
+    }
+}

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -522,6 +522,9 @@ pub struct ExportQuery {
     /// Restrict to one filter name (exact, case-insensitive).
     #[serde(default)]
     pub filter_name: Option<String>,
+    /// How the destination tree is arranged.
+    #[serde(default)]
+    pub layout: crate::commands::export::ExportLayout,
 }
 
 /// Body of `POST /api/db/{db_id}/export/local` — place the selected lights
@@ -540,6 +543,9 @@ pub struct LocalExportRequest {
     pub include_pending: bool,
     #[serde(default)]
     pub filter_name: Option<String>,
+    /// How the destination tree is arranged.
+    #[serde(default)]
+    pub layout: crate::commands::export::ExportLayout,
     /// Hardlink instead of copy (instant, no extra disk on the same
     /// filesystem; automatically falls back to copy). Default true.
     #[serde(default)]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1168,6 +1168,7 @@ pub async fn export_archive_route(
         project_id: query.project_id,
         target_id: query.target_id,
         filter_name: query.filter_name.clone(),
+        layout: query.layout,
         ..Default::default()
     };
 
@@ -1277,6 +1278,7 @@ pub async fn export_local_route(
         project_id: req.project_id,
         target_id: req.target_id,
         filter_name: req.filter_name.clone(),
+        layout: req.layout,
         ..Default::default()
     };
     let link = req.link.unwrap_or(true);

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1197,6 +1197,7 @@ pub async fn export_archive_route(
         )));
     }
 
+    let layout = query.layout;
     let filename = format!(
         "psf-guard-export-{}{}.zip",
         ctx.id,
@@ -1235,6 +1236,30 @@ pub async fn export_archive_route(
             if let Err(e) = zip.write_entry_whole(entry, &bytes).await {
                 tracing::warn!("📦 export db={}: zip write failed: {}", db_id, e);
                 return;
+            }
+        }
+        // The runner scripts ride along in the zip, so an export unpacked on
+        // the machine PixInsight runs on already knows how to hand itself to
+        // WBPP. A zip has no destination path, so nothing here can be
+        // inexpressible the way a comma in a local path can be.
+        if layout == crate::commands::export::ExportLayout::Wbpp {
+            use crate::commands::export::wbpp;
+            for (name, body) in [
+                (
+                    "run-wbpp.sh",
+                    wbpp::shell_script(&plan, wbpp::WbppRun::default()),
+                ),
+                (
+                    "run-wbpp.cmd",
+                    wbpp::batch_script(&plan, wbpp::WbppRun::default()),
+                ),
+            ] {
+                let entry =
+                    ZipEntryBuilder::new(name.into(), Compression::Stored).unix_permissions(0o755);
+                if let Err(e) = zip.write_entry_whole(entry, body.as_bytes()).await {
+                    tracing::warn!("📦 export db={}: zip write failed: {}", db_id, e);
+                    return;
+                }
             }
         }
         if let Err(e) = zip.close().await {
@@ -1295,12 +1320,18 @@ pub async fn export_local_route(
         )
         .map_err(|e| anyhow::anyhow!("opening {}: {e}", plan_ctx.database_path))?;
         let plan = plan_export(&conn, &plan_ctx.image_dirs, &options)?;
-        Ok::<_, anyhow::Error>(execute_plan(
-            &plan,
-            std::path::Path::new(&dest),
-            link,
-            dry_run,
-        ))
+        let summary = execute_plan(&plan, std::path::Path::new(&dest), link, dry_run);
+        if options.layout == crate::commands::export::ExportLayout::Wbpp && !dry_run {
+            use crate::commands::export::{wbpp, write_wbpp_scripts};
+            // The frames are already placed; a runner that cannot be written
+            // is worth logging but never worth failing the export over.
+            if let Err(error) =
+                write_wbpp_scripts(&plan, std::path::Path::new(&dest), wbpp::WbppRun::default())
+            {
+                tracing::warn!("No WBPP runner script: {error}");
+            }
+        }
+        Ok::<_, anyhow::Error>(summary)
     })
     .await
     .map_err(|e| AppError::InternalError(format!("export task: {e}")))?

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -4,6 +4,7 @@ import { AUTH_REQUIRED_EVENT } from '../auth/events';
 import { getServerUrl } from '../utils/tauri';
 import type {
   ApiResponse,
+  ExportLayout,
   Project,
   Target,
   TargetNavigation,
@@ -529,12 +530,18 @@ export const apiClient = {
   /** Absolute URL for the streaming light and calibration export zip. */
   exportDownloadUrl: (
     dbId: string,
-    params: { project_id?: number; target_id?: number; include_pending?: boolean }
+    params: {
+      project_id?: number;
+      target_id?: number;
+      include_pending?: boolean;
+      layout?: ExportLayout;
+    }
   ): string => {
     const query = new URLSearchParams();
     if (params.project_id !== undefined) query.set('project_id', String(params.project_id));
     if (params.target_id !== undefined) query.set('target_id', String(params.target_id));
     if (params.include_pending) query.set('include_pending', 'true');
+    if (params.layout && params.layout !== 'standard') query.set('layout', params.layout);
     const qs = query.toString();
     return withServerUrl(`/api${dbPath(dbId, '/export')}${qs ? `?${qs}` : ''}`);
   },
@@ -552,6 +559,7 @@ export const apiClient = {
       target_id?: number;
       include_pending?: boolean;
       filter_name?: string;
+      layout?: ExportLayout;
       link?: boolean;
       dry_run?: boolean;
     }

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -386,6 +386,15 @@ export interface StackInputImage {
  * `source_frame` stack keeps its reference frame's rotation, turned half a
  * turn where the reference sits on the far side of a meridian flip.
  */
+/**
+ * How an export arranges its files.
+ *
+ * `standard` groups by target, PSF Guard's own tree. `wbpp` gives each frame
+ * type its own root for WeightedBatchPreprocessing, and folds dark flats in
+ * with the darks because WBPP has no dark-flat type of its own.
+ */
+export type ExportLayout = 'standard' | 'wbpp';
+
 export interface StackSkyOrientation {
   convention: 'north_up_east_left' | 'source_frame';
   version: number;

--- a/static/src/components/Overview.css
+++ b/static/src/components/Overview.css
@@ -61,6 +61,32 @@
   white-space: nowrap;
 }
 
+/* Applies to every export affordance on the page, so it sits with the
+   catalog summary rather than beside any one of them. */
+.export-layout-choice {
+  display: flex;
+  flex-direction: column;
+  min-width: 132px;
+}
+
+.export-layout-choice > span {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.export-layout-choice > select {
+  margin-top: 2px;
+  padding: 2px 4px;
+  border: 1px solid var(--color-border-primary);
+  border-radius: 4px;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  font-size: 0.85rem;
+}
+
 .summary-metrics {
   display: grid;
   grid-template-columns: repeat(5, minmax(76px, 1fr));

--- a/static/src/components/Overview.tsx
+++ b/static/src/components/Overview.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../api/client';
 import type {
+  ExportLayout,
   ProjectOverview,
   ProjectRecentImage,
   TargetOverview,
@@ -94,6 +95,10 @@ export default function Overview() {
   // our own files would be silly. Browser mode keeps the zip download link.
   const isTauri = isTauriApp();
   const [exportBusy, setExportBusy] = useState(false);
+  // One choice for every export affordance on the page. Kept here rather than
+  // per row so a project and its targets cannot disagree about the tree they
+  // land in.
+  const [exportLayout, setExportLayout] = useState<ExportLayout>('standard');
   const handleLocalExport = async (
     dbId: string,
     scope: { project_id?: number; target_id?: number },
@@ -103,7 +108,7 @@ export default function Overview() {
       const dest = await tauriFileSystem.pickImageDirectory();
       if (!dest) return;
       setExportBusy(true);
-      const summary = await apiClient.exportLocal(dbId, { dest, ...scope });
+      const summary = await apiClient.exportLocal(dbId, { dest, layout: exportLayout, ...scope });
       const placed = summary.copied + summary.linked;
       alert(
         `Exported ${label}: ${placed} file(s) placed` +
@@ -438,6 +443,21 @@ export default function Overview() {
             <span>Catalog</span>
             <strong>{overallStats.total_images.toLocaleString()} images</strong>
           </div>
+          <label className="export-layout-choice">
+            <span>Export layout</span>
+            <select
+              value={exportLayout}
+              onChange={(event) => setExportLayout(event.target.value as ExportLayout)}
+              title={
+                exportLayout === 'wbpp'
+                  ? 'One folder per frame type, with dark flats among the darks, ready for WeightedBatchPreprocessing'
+                  : "Grouped by target: <target>/LIGHT/<filter>, with BIAS, DARK and DARKFLAT at the root"
+              }
+            >
+              <option value="standard">Grouped by target</option>
+              <option value="wbpp">WBPP</option>
+            </select>
+          </label>
           <dl className="summary-metrics">
             <div>
               <dt>Projects</dt>
@@ -910,8 +930,9 @@ export default function Overview() {
                           className="export-link"
                           href={apiClient.exportDownloadUrl(project.db_id, {
                             project_id: project.id,
+                            layout: exportLayout,
                           })}
-                          title="Download this project's accepted lights as a zip (WBPP-style layout, rejects excluded)"
+                          title={`Download this project's accepted lights as a zip (${exportLayout === 'wbpp' ? 'WBPP layout' : 'grouped by target'}, rejects excluded)`}
                           onClick={(e) => e.stopPropagation()}
                         >
                           ⬇ Export
@@ -1030,8 +1051,9 @@ export default function Overview() {
                                     className="target-settings-button"
                                     href={apiClient.exportDownloadUrl(target.db_id, {
                                       target_id: target.id,
+                                      layout: exportLayout,
                                     })}
-                                    title="Download this target's accepted lights as a zip"
+                                    title={`Download this target's accepted lights as a zip (${exportLayout === 'wbpp' ? 'WBPP layout' : 'grouped by target'})`}
                                   >
                                     ↓ Export
                                   </a>


### PR DESCRIPTION
Adds a WBPP export layout beside the existing one, and generates the PixInsight
command line that hands it to WeightedBatchPreprocessing.

**Verified end to end against WBPP 3.0.1 in PixInsight 1.9.4**, not just
written to a spec.

## The layout

```
bias/G<gain>/              darks/<exposure>s_G<gain>/
flats/<target>/<filter>/   lights/<target>/<filter>/
```

Dark flats land in `darks/`. WBPP has no dark-flat type — a dark flat is a dark
it pairs to a flat by exposure — so the old `DARKFLAT/` root meant adding one
folder to WBPP twice, as darks.

Bias is grouped by gain so two sensor settings cannot be integrated into one
master. Flats stay under their target because that is what PSF Guard matched
them to: two targets shot on different nights can need different flats for one
filter, and merging them would have WBPP integrate both into a single master.

The existing target-grouped layout is untouched and still the default, so an
export folder anyone is topping up keeps its shape. Selectable with `--layout
wbpp`, a `layout` query parameter or request field, and an **Export layout**
control on the overview that applies to the zip download and the desktop folder
export alike.

## The runner

WBPP 3.x is driven from PixInsight's command line rather than a script API, so
that is what gets generated — `run-wbpp.sh` and `run-wbpp.cmd`, in the folder
and in the zip.

Two details that came out of reading `BPP-Automation.js`:

- **`dir=` is recursive**, so each frame root is listed separately. Passing the
  export root would sweep up `wbpp-out/` on a second run and feed WBPP its own
  output.
- Only the roots a plan filled are scanned, since an export filtered to one
  target often has no bias or darks, and WBPP complains about an empty
  directory.

They default to WBPP's `loadOnly`, which loads the frames and groups and stops
with the dialog open. Its grouping and reference-frame choices are worth a look
before an hour of integration starts; one line to delete for a full run.

## What was actually verified

Running the generated invocation against synthetic frames, WBPP:

- classified all four frame types from their `IMAGETYP` headers;
- grouped by binning, size, filter and exposure;
- built `masterBias`, `masterDark` and `masterFlat`;
- **auto-matched the dark and flat to the lights**;
- calibrated the flats and every light.

Measurement and registration then fail, because SubframeSelector cannot measure
40 synthetic Gaussians in a 256x192 frame. That is a limit of my test fixtures,
not of the layout or the invocation, and going further would be testing fake
data rather than PSF Guard.

## One thing worth knowing

PixInsight prints nothing to the terminal in this mode — WBPP writes to its own
console — so a finished run and a failed one look identical from outside. The
generated scripts say to read `wbpp-out/logs/*.log`, and where the results land.
Without that, a silent failure reads as success.

## Tests

Seven new for the generator: the invocation matching what was verified, the
`loadOnly` default, only-populated-roots, the log pointer, CRLF and percent
expansion in the batch file, and a comma in the export path being refused rather
than mangled — WBPP takes every parameter in one comma-separated argument, so a
comma in the path would split it into nonsense. Two for the layout, plus one
pinning that the default layout is unchanged.

## Checks run locally

`cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D
warnings`, `cargo test` — 673 passed, 0 failed. `tsc --noEmit`, `npm run lint`,
`npx vitest run` — 269 passed, `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)