### PR TITLE
Write measured star metrics into imported images' metadata

### DIFF
--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -168,6 +168,21 @@ new values comparable with Target Scheduler data. It also stores the full-star
 flux data needed by photometry, spatial cloud and obstruction metrics, and
 fresh plate-solving evidence for off-target and tracking checks.
 
+Once a frame has been measured, the scan writes its star count and HFR into
+the image's database metadata, so imported frames show the same star fields in
+the grid, detail, and comparison views as a N.I.N.A.-graded catalog. Only
+missing values are filled; measurements N.I.N.A. recorded are never replaced.
+Catalogs scanned before this write-back existed pick the values up the next
+time **Analyze Missing Quality** runs — no rescan needed.
+
+The **Write star count and HFR into image metadata** checkbox next to the
+analyze buttons controls this. It is remembered as the default for every
+analyze action — target scans, database analysis, and import-time analysis —
+and stays on unless you turn it off. The write goes only to the catalog's
+database records; the FITS and XISF files themselves are never modified. API
+callers pass `fill_metadata: false` on the quality-scan, backfill, or import
+request to opt out per call.
+
 ## Review and correct the imported plan
 
 Open **Overview**, then choose **Plan & coordinates** on a project. You can see

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -35,6 +35,19 @@
 
 ## Fixed
 
+- Imported frames now show star count and HFR after quality analysis runs.
+  Header-first imports carry no star metadata, and the quality scan kept its
+  measurements in a cache the grid, detail, and comparison views never read —
+  so a catalog built from image folders (FITS or XISF) looked unanalyzed no
+  matter what ran. The scan now writes its measured star count and HFR into
+  each imported image's metadata, filling only what is missing; values a
+  N.I.N.A. catalog already carries are never touched. Catalogs analyzed
+  before this fix pick the values up the next time **Analyze Missing
+  Quality** runs, straight from the cache. A checkbox beside the analyze
+  buttons turns the write-back off, and the choice is remembered as the
+  default for every analyze action. See
+  [importing](https://github.com/theatrus/psf-guard/blob/main/docs/IMPORTING.md).
+
 - A stack whose reference frame sits on the thin side of a meridian flip is
   turned the right way up again. The reference's exposure was weighed in
   seconds while every other frame counted as one, so on a catalog that records

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -8,7 +8,11 @@
 //! Import is header-only and fast: `gradingStatus` starts Pending and star /
 //! quality metrics are intentionally absent from the metadata JSON (readers
 //! treat missing keys as None). Database-wide quality analysis is a separate,
-//! on-demand background job; imports may queue it but never wait for it.
+//! on-demand background job; imports may queue it but never wait for it. Once
+//! that scan has measured a frame, it fills `DetectedStars` and `HFR` into
+//! the metadata (missing keys only — see `fill_missing_star_metadata` in the
+//! server handlers), so imported rows end up with the same star metadata a
+//! N.I.N.A. catalog carries.
 //!
 //! Idempotency: a frame whose basename already appears in any
 //! `acquiredimage.metadata` FileName is skipped, so re-running an import on a

--- a/src/db.rs
+++ b/src/db.rs
@@ -809,6 +809,23 @@ impl<'a> Database<'a> {
         Ok(())
     }
 
+    /// Replace an image's metadata JSON, but only while the row still holds
+    /// the metadata the caller read. A concurrent writer (grading sync, a
+    /// N.I.N.A. instance sharing the DB) wins and the fill is skipped.
+    /// Returns true when the row was updated.
+    pub fn update_image_metadata_if_unchanged(
+        &self,
+        image_id: i32,
+        expected_metadata: &str,
+        new_metadata: &str,
+    ) -> Result<bool> {
+        let changed = self.conn.execute(
+            "UPDATE acquiredimage SET metadata = ? WHERE Id = ? AND metadata = ?",
+            params![new_metadata, image_id, expected_metadata],
+        )?;
+        Ok(changed > 0)
+    }
+
     // ── Organize: correct imported project/target groupings ────────────────
 
     /// Rename a project. Returns false when no such project exists.

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -463,6 +463,10 @@ pub struct CreateDatabaseRequest {
     /// Queue the separate database quality job after import (default false).
     #[serde(default)]
     pub backfill: Option<bool>,
+    /// Let the queued quality job write measured star count and HFR into
+    /// imported images' metadata (missing keys only; default true).
+    #[serde(default)]
+    pub fill_metadata: Option<bool>,
 }
 
 /// `POST /api/databases/create` response: the registered database plus the
@@ -491,6 +495,10 @@ pub struct ImportRequest {
     /// Queue the separate database quality job after import (default false).
     #[serde(default)]
     pub backfill: Option<bool>,
+    /// Let the queued quality job write measured star count and HFR into
+    /// imported images' metadata (missing keys only; default true).
+    #[serde(default)]
+    pub fill_metadata: Option<bool>,
     /// Attach frames to existing targets (name/coordinate match) instead of
     /// synthesizing new structure for them (default true).
     #[serde(default)]
@@ -751,6 +759,10 @@ pub struct SpatialScanRequest {
     pub force_astrometry: bool,
     #[serde(default)]
     pub force_satellites: bool,
+    /// Write measured star count and HFR into imported images' metadata
+    /// (missing keys only; default true).
+    #[serde(default)]
+    pub fill_metadata: Option<bool>,
 }
 
 /// Optional target/filter scope for the quality-scan status endpoint.
@@ -791,6 +803,10 @@ pub struct QualityBackfillRequest {
     /// Recompute cached star, background, photometry, and pointing evidence.
     #[serde(default)]
     pub force: bool,
+    /// Write measured star count and HFR into imported images' metadata
+    /// (missing keys only; default true).
+    #[serde(default)]
+    pub fill_metadata: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -43,7 +43,7 @@ const DB_BUSY_TIMEOUT: Duration = Duration::from_secs(60);
 /// The one way to open a scheduler DB connection in the server: flags above +
 /// busy timeout. Every open site (initial, both reopen paths, the refresh
 /// connection) must go through here so none silently loses the busy handler.
-fn open_scheduler_connection(path: &str) -> rusqlite::Result<Connection> {
+pub(crate) fn open_scheduler_connection(path: &str) -> rusqlite::Result<Connection> {
     let conn = Connection::open_with_flags(path, db_open_flags())?;
     conn.busy_timeout(DB_BUSY_TIMEOUT)?;
     Ok(conn)

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1534,6 +1534,7 @@ pub async fn create_database_route(
         req.image_dirs.clone(),
         options,
         req.backfill.unwrap_or(false),
+        req.fill_metadata.unwrap_or(true),
     );
 
     Ok(Json(ApiResponse::success(CreateDatabaseResponse {
@@ -1591,6 +1592,7 @@ pub async fn start_import_route(
         dirs,
         options,
         req.backfill.unwrap_or(false),
+        req.fill_metadata.unwrap_or(true),
     );
     Ok(Json(ApiResponse::success(ImportStatusResponse {
         started,
@@ -1653,6 +1655,7 @@ fn spawn_import_job(
     dirs: Vec<String>,
     options: crate::commands::import::ImportOptions,
     backfill: bool,
+    fill_metadata: bool,
 ) -> bool {
     use crate::server::import_job as job;
 
@@ -1720,7 +1723,7 @@ fn spawn_import_job(
         // Quality analysis is a general database maintenance job, not an
         // import stage. An opt-in import only queues the changed targets.
         if backfill && !target_ids.is_empty() {
-            spawn_quality_backfill(&state, ctx.clone(), target_ids, false);
+            spawn_quality_backfill(&state, ctx.clone(), target_ids, false, fill_metadata);
         }
     });
     true
@@ -1768,6 +1771,7 @@ async fn run_quality_scan_for_target(
     ctx: &Arc<DatabaseContext>,
     target_id: i32,
     force: bool,
+    fill_metadata: bool,
 ) {
     use crate::server::spatial_scan;
 
@@ -1783,6 +1787,7 @@ async fn run_quality_scan_for_target(
                 force_spatial: force,
                 force_astrometry: force,
                 force_satellites: false,
+                fill_metadata: Some(fill_metadata),
             }),
             crate::concurrency::Priority::Background,
             false,
@@ -1821,11 +1826,64 @@ async fn run_quality_scan_for_target(
     }
 }
 
+/// Write scan-measured star count and HFR into `acquiredimage.metadata` for
+/// frames that imported without them, so an imported catalog carries the same
+/// star metadata a N.I.N.A. catalog does. `pending` is `(image id, filename,
+/// metadata JSON as read)`. The patch fills only missing keys — a measured
+/// N.I.N.A. value is never overwritten — and a row that changed since it was
+/// read is left alone.
+fn fill_missing_star_metadata(ctx: &DatabaseContext, pending: &[(i32, String, String)]) -> usize {
+    use crate::server::spatial_scan as scan;
+
+    let patches: Vec<(i32, &String, String)> = pending
+        .iter()
+        .filter_map(|(image_id, filename, metadata)| {
+            let entry = scan::valid_quality_entry(&ctx.spatial_metrics, *image_id, filename)?;
+            scan::star_metrics_metadata_patch(metadata, entry.star_count, entry.avg_hfr)
+                .map(|updated| (*image_id, metadata, updated))
+        })
+        .collect();
+    if patches.is_empty() {
+        return 0;
+    }
+
+    // A dedicated connection: this runs on a blocking scan thread and must
+    // not tie up the shared request connection.
+    let conn = match crate::server::database_context::open_scheduler_connection(&ctx.database_path)
+    {
+        Ok(conn) => conn,
+        Err(e) => {
+            tracing::warn!("📐 Star-metadata fill skipped for db={}: {}", ctx.id, e);
+            return 0;
+        }
+    };
+    let db = Database::new(&conn);
+    let mut filled = 0usize;
+    for (image_id, expected, updated) in &patches {
+        match db.update_image_metadata_if_unchanged(*image_id, expected, updated) {
+            Ok(true) => filled += 1,
+            Ok(false) => {} // concurrent writer wins; skip quietly
+            Err(e) => {
+                tracing::warn!("📐 Star-metadata fill failed for image {}: {}", image_id, e)
+            }
+        }
+    }
+    if filled > 0 {
+        tracing::info!(
+            "📐 Filled measured star metrics into {} imported image(s) (db={})",
+            filled,
+            ctx.id
+        );
+    }
+    filled
+}
+
 fn spawn_quality_backfill(
     state: &Arc<AppState>,
     ctx: Arc<DatabaseContext>,
     target_ids: Vec<i32>,
     force: bool,
+    fill_metadata: bool,
 ) -> bool {
     use crate::server::quality_backfill as job;
 
@@ -1846,7 +1904,7 @@ fn spawn_quality_backfill(
         );
         for target_id in target_ids {
             job::begin_target(&ctx.quality_backfill, target_id);
-            run_quality_scan_for_target(&state, &ctx, target_id, force).await;
+            run_quality_scan_for_target(&state, &ctx, target_id, force, fill_metadata).await;
             job::finish_target(&ctx.quality_backfill);
         }
         job::finish(&ctx.quality_backfill);
@@ -1870,7 +1928,13 @@ pub async fn start_quality_backfill_route(
             .map(|target| target.target.id)
             .collect::<Vec<_>>()
     };
-    let started = spawn_quality_backfill(&state, ctx.0.clone(), target_ids, req.force);
+    let started = spawn_quality_backfill(
+        &state,
+        ctx.0.clone(),
+        target_ids,
+        req.force,
+        req.fill_metadata.unwrap_or(true),
+    );
     Ok(Json(ApiResponse::success(QualityBackfillStatusResponse {
         started,
         progress: crate::server::quality_backfill::snapshot(&ctx.quality_backfill),
@@ -4249,6 +4313,11 @@ async fn start_spatial_scan_with_priority(
     // Keep the union of spatial, astrometry, and satellite work. One side may
     // already be cached while another still needs computation.
     let mut work = Vec::new();
+    // Frames whose metadata never got star metrics (header-first imports):
+    // once the scan has measurements, they are written back to the DB —
+    // unless the caller opted out of metadata writes.
+    let fill_metadata = req.fill_metadata.unwrap_or(true);
+    let mut star_fill: Vec<(i32, String, String)> = Vec::new();
     let mut skipped_cached = 0usize;
     let force_spatial = req.force || req.force_spatial;
     let force_astrometry = req.force || req.force_astrometry;
@@ -4257,6 +4326,10 @@ async fn start_spatial_scan_with_priority(
         let Some(file_only) = filename_from_metadata(&img.metadata) else {
             continue;
         };
+        if fill_metadata && crate::server::spatial_scan::metadata_lacks_star_metrics(&img.metadata)
+        {
+            star_fill.push((img.id, file_only.clone(), img.metadata.clone()));
+        }
         let spatial_cached = !force_spatial
             && scan::valid_quality_entry(&ctx.spatial_metrics, img.id, &file_only).is_some();
         if spatial_cached {
@@ -4298,6 +4371,16 @@ async fn start_spatial_scan_with_priority(
     }
 
     if work.is_empty() {
+        // Nothing to compute, but cached measurements may still be missing
+        // from imported rows (e.g. a catalog scanned before write-back
+        // existed) — heal them without forcing a rescan.
+        if !star_fill.is_empty() {
+            let fill_ctx = ctx.0.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                fill_missing_star_metadata(&fill_ctx, &star_fill)
+            })
+            .await;
+        }
         let (progress, cached_count) = scan::progress_snapshot(&ctx.spatial_metrics);
         return Ok(Json(ApiResponse::success(SpatialScanStatusResponse {
             started: false,
@@ -4418,6 +4501,11 @@ async fn start_spatial_scan_with_priority(
                     &wait_for_turn,
                 );
             }
+
+            // The star-detection stage is done (fresh or cached), so imported
+            // rows without star metrics can take the measured values now,
+            // before the (much slower) astrometry stage.
+            fill_missing_star_metadata(&ctx_arc, &star_fill);
 
             let astrometry_items = items
                 .iter()

--- a/src/server/spatial_scan.rs
+++ b/src/server/spatial_scan.rs
@@ -439,6 +439,51 @@ fn compute_one(
     })
 }
 
+/// Whether a metadata JSON is missing star metrics a quality scan can fill.
+///
+/// Header-first imports omit `DetectedStars` and `HFR` because no pixel
+/// evidence exists at import time. Unparsable metadata answers false: there
+/// is nothing safe to fill.
+pub fn metadata_lacks_star_metrics(metadata_json: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(metadata_json) else {
+        return false;
+    };
+    let Some(map) = value.as_object() else {
+        return false;
+    };
+    let missing = |key: &str| map.get(key).is_none_or(serde_json::Value::is_null);
+    missing("DetectedStars") || missing("HFR")
+}
+
+/// Fill scan-measured star metrics into a metadata JSON that lacks them.
+///
+/// The scan's detector is the scheduler-compatible one (`nina_fast`), so the
+/// filled values mean the same thing as a N.I.N.A. catalog's. Existing values
+/// are never overwritten, and a frame with no detected stars gets no HFR:
+/// zero would read as an impossibly sharp measurement rather than "none".
+/// Returns `None` when nothing was added.
+pub fn star_metrics_metadata_patch(
+    metadata_json: &str,
+    star_count: usize,
+    avg_hfr: f64,
+) -> Option<String> {
+    let mut value: serde_json::Value = serde_json::from_str(metadata_json).ok()?;
+    let map = value.as_object_mut()?;
+    let missing = |map: &serde_json::Map<String, serde_json::Value>, key: &str| {
+        map.get(key).is_none_or(serde_json::Value::is_null)
+    };
+    let mut changed = false;
+    if missing(map, "DetectedStars") {
+        map.insert("DetectedStars".to_string(), (star_count as u64).into());
+        changed = true;
+    }
+    if star_count > 0 && avg_hfr > 0.0 && missing(map, "HFR") {
+        map.insert("HFR".to_string(), avg_hfr.into());
+        changed = true;
+    }
+    changed.then(|| value.to_string())
+}
+
 /// Look up a cached entry that is still valid for the given filename.
 pub fn valid_entry(
     store: &RwLock<SpatialMetricsStore>,
@@ -579,6 +624,46 @@ mod tests {
         assert_eq!(progress.target_id, Some(5));
         assert_eq!(progress.total, 10);
         assert_eq!(progress.skipped_cached, 2);
+    }
+
+    #[test]
+    fn metadata_star_metrics_fill_only_missing_keys() {
+        // Header-first import: both keys absent → both filled.
+        let imported = r#"{"FileName":"a.xisf","SessionId":0}"#;
+        assert!(metadata_lacks_star_metrics(imported));
+        let patched = star_metrics_metadata_patch(imported, 120, 2.5).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&patched).unwrap();
+        assert_eq!(value["DetectedStars"], 120);
+        assert_eq!(value["HFR"], 2.5);
+        assert_eq!(value["FileName"], "a.xisf", "existing keys must survive");
+
+        // N.I.N.A. catalog: measurements present → untouched.
+        let nina = r#"{"DetectedStars":300,"HFR":1.8}"#;
+        assert!(!metadata_lacks_star_metrics(nina));
+        assert!(star_metrics_metadata_patch(nina, 120, 2.5).is_none());
+
+        // Null counts as missing (a writer may serialize unknowns as null).
+        let with_null = r#"{"DetectedStars":null,"HFR":1.8}"#;
+        assert!(metadata_lacks_star_metrics(with_null));
+        let patched = star_metrics_metadata_patch(with_null, 120, 2.5).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&patched).unwrap();
+        assert_eq!(value["DetectedStars"], 120);
+        assert_eq!(value["HFR"], 1.8, "measured HFR must not be overwritten");
+    }
+
+    #[test]
+    fn metadata_star_metrics_fill_handles_edge_inputs() {
+        // No detected stars: the count is a real measurement, HFR is not.
+        let patched = star_metrics_metadata_patch("{}", 0, 0.0).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&patched).unwrap();
+        assert_eq!(value["DetectedStars"], 0);
+        assert!(value.get("HFR").is_none(), "no stars → no HFR measurement");
+
+        // Unparsable or non-object metadata: nothing to check, nothing to fill.
+        assert!(!metadata_lacks_star_metrics("not json"));
+        assert!(star_metrics_metadata_patch("not json", 10, 2.0).is_none());
+        assert!(!metadata_lacks_star_metrics("[1,2]"));
+        assert!(star_metrics_metadata_patch("[1,2]", 10, 2.0).is_none());
     }
 
     #[test]

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1200,6 +1200,9 @@ export interface ImportRequest {
   profile_id?: string;
   dry_run?: boolean;
   backfill?: boolean;
+  /** Let the queued quality job write star count/HFR into imported images'
+   *  metadata (missing keys only; default true). */
+  fill_metadata?: boolean;
   /** Attach to existing targets by name/coordinates (default true). */
   attach_existing?: boolean;
   match_radius_deg?: number;
@@ -1214,6 +1217,9 @@ export interface CreateDatabaseRequest {
   time_gap_days?: number;
   profile_id?: string;
   backfill?: boolean;
+  /** Let the queued quality job write star count/HFR into imported images'
+   *  metadata (missing keys only; default true). */
+  fill_metadata?: boolean;
 }
 
 export interface CreateDatabaseResponse {
@@ -1649,6 +1655,9 @@ export interface SpatialScanRequest {
   force_spatial?: boolean;
   force_astrometry?: boolean;
   force_satellites?: boolean;
+  /** Write measured star count/HFR into imported images' metadata
+   *  (missing keys only; default true). */
+  fill_metadata?: boolean;
 }
 
 export interface QualityBackfillProgress {
@@ -1668,6 +1677,9 @@ export interface QualityBackfillStatus {
 
 export interface QualityBackfillRequest {
   force?: boolean;
+  /** Write measured star count/HFR into imported images' metadata
+   *  (missing keys only; default true). */
+  fill_metadata?: boolean;
 }
 
 export interface SequenceSummary {

--- a/static/src/components/QualityBackfillControls.tsx
+++ b/static/src/components/QualityBackfillControls.tsx
@@ -1,8 +1,12 @@
 import { useQualityBackfill } from '../hooks/useQualityBackfill';
+import { setStarMetadataFill, useStarMetadataFill } from '../hooks/useStarMetadataFill';
 
 export default function QualityBackfillControls({ dbId }: { dbId: string }) {
   const job = useQualityBackfill(dbId);
   const progress = job.status?.progress;
+  // One preference for every analyze action (scan, backfill, import), so the
+  // checkbox here is also the remembered default.
+  const fillMetadata = useStarMetadataFill();
 
   if (job.isRunning && progress) {
     return (
@@ -37,6 +41,20 @@ export default function QualityBackfillControls({ dbId }: { dbId: string }) {
       >
         Rescan All Quality
       </button>
+      <div className="quality-backfill-option">
+        <label title="Fill measured star count and HFR into images imported without them. Only missing values are written; N.I.N.A.-recorded measurements are never replaced. Remembered as the default for every analyze action.">
+          <input
+            type="checkbox"
+            checked={fillMetadata}
+            onChange={(event) => setStarMetadataFill(event.target.checked)}
+          />
+          Write star count and HFR into image metadata
+        </label>
+        <small>
+          Writes only to this catalog&apos;s database records. Your FITS and
+          XISF files are never modified.
+        </small>
+      </div>
       {job.error && <span className="quality-backfill-error">{job.error.message}</span>}
     </div>
   );

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -793,6 +793,27 @@
   font-size: 12px;
 }
 
+.tauri-settings .quality-backfill-option {
+  flex-basis: 100%;
+  font-size: 12px;
+}
+
+.tauri-settings .quality-backfill-option label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.tauri-settings .quality-backfill-option small {
+  display: block;
+  margin: 2px 0 0 22px;
+  color: var(--color-text-secondary);
+  opacity: 0.8;
+  line-height: 1.4;
+}
+
 .tauri-settings .quality-analysis-option small {
   margin-top: 4px;
   color: var(--color-text-secondary);

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -12,6 +12,7 @@ import { useAccess } from '../auth/access';
 import type { SettingsIntent } from '../utils/settingsIntent';
 import type { DatabaseSummary } from '../api/types';
 import { describeImportProgress, useImportJob } from '../hooks/useImportJob';
+import { starMetadataFillEnabled } from '../hooks/useStarMetadataFill';
 import QualityBackfillControls from './QualityBackfillControls';
 import RemotePeerSync from './RemotePeerSync';
 import SchedulerSyncControls from './SchedulerSyncControls';
@@ -376,6 +377,7 @@ export default function TauriSettings({
           name,
           image_dirs: formImageDirs,
           backfill: createAnalyzeQuality,
+          fill_metadata: starMetadataFillEnabled(),
         });
         queryClient.invalidateQueries({ queryKey: ['databases'] });
         queryClient.invalidateQueries({ queryKey: ['db'] });
@@ -518,6 +520,7 @@ export default function TauriSettings({
       await apiClient.startImport(entry.id, {
         dry_run: false,
         backfill: importAnalyzeQuality,
+        fill_metadata: starMetadataFillEnabled(),
       });
       setStatusMessage(`Importing images into ${entry.name}…`);
     } catch (err) {

--- a/static/src/components/__tests__/QualityBackfillControls.test.tsx
+++ b/static/src/components/__tests__/QualityBackfillControls.test.tsx
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import QualityBackfillControls from '../QualityBackfillControls';
+import { setStarMetadataFill } from '../../hooks/useStarMetadataFill';
+
+function wrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const idleStatus = {
+  success: true,
+  data: {
+    started: false,
+    progress: {
+      running: false,
+      force: false,
+      total_targets: 0,
+      processed_targets: 0,
+      current_target_id: null,
+      started_at: null,
+      finished_at: null,
+    },
+  },
+  error: null,
+  status: 'ready',
+};
+
+describe('QualityBackfillControls star-metadata option', () => {
+  beforeEach(() => {
+    setStarMetadataFill(true);
+    server.use(
+      http.get('/api/db/:dbId/analysis/quality-backfill', () =>
+        HttpResponse.json(idleStatus)
+      )
+    );
+  });
+
+  it('sends the checkbox state as fill_metadata when starting analysis', async () => {
+    const bodies: unknown[] = [];
+    server.use(
+      http.post('/api/db/:dbId/analysis/quality-backfill', async ({ request }) => {
+        bodies.push(await request.json());
+        return HttpResponse.json(idleStatus);
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<QualityBackfillControls dbId="test" />, { wrapper: wrapper() });
+
+    const checkbox = await screen.findByRole('checkbox', {
+      name: /write star count and hfr/i,
+    });
+    expect(checkbox).toBeChecked();
+    expect(
+      screen.getByText(/your fits and xisf files are never modified/i)
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Analyze Missing Quality' }));
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(bodies[0]).toMatchObject({ force: false, fill_metadata: true });
+
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: 'Analyze Missing Quality' }));
+    await waitFor(() => expect(bodies).toHaveLength(2));
+    expect(bodies[1]).toMatchObject({ force: false, fill_metadata: false });
+  });
+
+  it('remembers the opt-out as the default for a fresh mount', async () => {
+    const user = userEvent.setup();
+    const first = render(<QualityBackfillControls dbId="test" />, { wrapper: wrapper() });
+    await user.click(
+      await screen.findByRole('checkbox', { name: /write star count and hfr/i })
+    );
+    first.unmount();
+
+    render(<QualityBackfillControls dbId="test" />, { wrapper: wrapper() });
+    expect(
+      await screen.findByRole('checkbox', { name: /write star count and hfr/i })
+    ).not.toBeChecked();
+  });
+});

--- a/static/src/hooks/useQualityBackfill.ts
+++ b/static/src/hooks/useQualityBackfill.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
+import { starMetadataFillEnabled } from './useStarMetadataFill';
 import type { QualityBackfillStatus } from '../api/types';
 
 export function useQualityBackfillStatus(dbId: string | null | undefined) {
@@ -36,7 +37,11 @@ export function useQualityBackfill(dbId: string | null | undefined) {
   const queryKey = ['db', dbId, 'quality-backfill'] as const;
 
   const startMutation = useMutation({
-    mutationFn: (force: boolean) => apiClient.startQualityBackfill(dbId!, { force }),
+    mutationFn: (force: boolean) =>
+      apiClient.startQualityBackfill(dbId!, {
+        force,
+        fill_metadata: starMetadataFillEnabled(),
+      }),
     onSuccess: (status) => queryClient.setQueryData(queryKey, status),
   });
 

--- a/static/src/hooks/useSpatialScan.ts
+++ b/static/src/hooks/useSpatialScan.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
+import { starMetadataFillEnabled } from './useStarMetadataFill';
 import type { SpatialScanStatus } from '../api/types';
 
 /** Monitor the database's quality scan from any view. */
@@ -24,6 +25,10 @@ export function useSpatialScanStatus(dbId: string | null | undefined) {
       queryClient.invalidateQueries({ queryKey: ['db', dbId, 'sequence-analysis'] });
       queryClient.invalidateQueries({ queryKey: ['db', dbId, 'image-quality'] });
       queryClient.invalidateQueries({ queryKey: ['db', dbId, 'quality-scan-scope'] });
+      // The scan writes measured star count/HFR into imported images'
+      // metadata, so cards and detail views need fresh image rows too.
+      queryClient.invalidateQueries({ queryKey: ['db', dbId, 'all-images'] });
+      queryClient.invalidateQueries({ queryKey: ['db', dbId, 'image'] });
     }
     wasRunning.current = isRunning;
   }, [isRunning, dbId, queryClient]);
@@ -58,6 +63,7 @@ export function useSpatialScan(
         target_id: targetId!,
         filter_name: filterName,
         force,
+        fill_metadata: starMetadataFillEnabled(),
       }),
     onSuccess: (status) => {
       // Seed the poll query so refetchInterval kicks in immediately.

--- a/static/src/hooks/useStarMetadataFill.ts
+++ b/static/src/hooks/useStarMetadataFill.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Whether quality analysis writes its measured star count and HFR into
+ * imported images' database metadata, shared across every analyze action.
+ *
+ * The quality scan, the database-wide backfill, and the import-time analyze
+ * option all take the same choice, so a preference held per component would
+ * let one action silently disagree with another. The fill only adds missing
+ * keys — values a N.I.N.A. catalog carries are never replaced — so it
+ * defaults on; only an explicit opt-out turns it off.
+ */
+const STORAGE_KEY = 'psf-guard.fill-star-metadata';
+
+type Listener = (enabled: boolean) => void;
+
+const listeners = new Set<Listener>();
+
+function readStored(): boolean {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) !== 'false';
+  } catch {
+    // Private browsing and similar can refuse storage. The preference is a
+    // convenience, not something worth failing a render over.
+    return true;
+  }
+}
+
+let enabled = readStored();
+
+export function setStarMetadataFill(next: boolean): void {
+  if (next === enabled) return;
+  enabled = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(next));
+  } catch {
+    // Keep the in-memory preference even when it cannot be persisted.
+  }
+  listeners.forEach((listener) => listener(next));
+}
+
+export function starMetadataFillEnabled(): boolean {
+  return enabled;
+}
+
+/** Subscribe to the shared preference. Returns its current value. */
+export function useStarMetadataFill(): boolean {
+  const [value, setValue] = useState(enabled);
+  useEffect(() => {
+    listeners.add(setValue);
+    // A change between the initial render and this effect would otherwise be
+    // missed.
+    setValue(enabled);
+    return () => {
+      listeners.delete(setValue);
+    };
+  }, []);
+  return value;
+}


### PR DESCRIPTION
## Problem

A user reported that analyzing a directory of 100 UInt16 XISF files produced no star/PSF metadata. The decode pipeline turned out fine — the real gaps were:

1. The grid, detail, and comparison views read `DetectedStars`/`HFR` only from `acquiredimage.metadata`, which header-first imports deliberately never populate.
2. The quality scan kept its measurements in the spatial-metrics cache, which those views never read.

So any catalog built from image folders (FITS or XISF alike) looked unanalyzed forever, no matter how much analysis ran.

## Change

- After its star-detection stage, the quality scan writes measured star count and HFR into `acquiredimage.metadata` for rows that lack them. Fill-only: a value N.I.N.A. recorded is never replaced, null counts as missing, a zero-star frame gets no HFR, and the guarded `UPDATE ... WHERE metadata = ?` lets any concurrent writer win.
- A scan request whose work is fully cached runs the same fill, so catalogs analyzed before this change heal on the next plain **Analyze Missing Quality** — no rescan.
- The write-back is user-selectable: a checkbox beside the analyze buttons, remembered (localStorage) as the default for every analyze action — target scans, database analysis, import-time analysis — with a note that only database records change, never the image files. `fill_metadata: false` on the quality-scan, backfill, or import request opts out per call; absent means on.
- The scan-completion hook now refreshes image list/detail queries so the filled values appear without a reload.

## Tests

- Unit tests for the patch semantics (fill, never overwrite, null-as-missing, zero stars, unparsable metadata).
- Component test: the checkbox state is sent as `fill_metadata`, the on-files note renders, and the opt-out survives remount as the new default.
- Verified live against a scratch server: fresh import with backfill fills metadata; a pre-fix database heals from cache; `fill_metadata: false` leaves rows untouched and a later opt-in fills them.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` · `eslint` · `vitest run` (59 files, 271 tests) · `tsc -b && vite build`. Playwright was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)