### PR TITLE
Let each kind of evidence scale its quality-score hit

### DIFF
--- a/docs/SCREENING.md
+++ b/docs/SCREENING.md
@@ -88,6 +88,16 @@ evidence of clouds, trailing, or an obstructed aperture, not a normalization
 artifact. A frame with no star measurement at all is never capped; grading
 does not punish an image because an optional scan has not run.
 
+How hard event evidence hits the score is adjustable. The **Penalties**
+control in the Sequence view scales the score hit from satellite trails,
+pointing failures, and temporal anomalies between 0% (ignore that evidence),
+100% (the calibrated default), and 200% (double the hit). The preference is
+remembered and applies to every scoring surface — Sequence view, grid
+badges, and the detail panel — so one frame cannot wear two different
+scores. The zero-star cap does not scale: a frame measured to have no stars
+is ruined whatever the preference. API callers pass `penalty_satellite`,
+`penalty_pointing`, or `penalty_temporal` on the analysis endpoints.
+
 Capture sessions split at a Target Scheduler session change, a capture-profile
 change, or a 60-minute gap. CLI screening still reports **OK**, **WARN**, and
 **REJECT** verdicts for its file-screening workflow.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -3,3 +3,14 @@
 > Add a line here as each user-visible change merges. At release time this
 > file becomes `vVERSION.md`; rewrite the opening sentence for the version
 > being shipped and delete this note. See [the release guide](../RELEASING.md).
+
+## Added
+
+- How hard each kind of evidence lowers a quality score is now adjustable.
+  The **Penalties** control in the Sequence view scales the score hit from
+  satellite trails, pointing failures, and temporal anomalies between 0%
+  (ignore), 100% (the calibrated default), and 200% (double). The choice is
+  remembered and applies to every scoring surface, so grid badges, the
+  Sequence view, and the detail panel always agree. The zero-star cap does
+  not scale. See
+  [screening](https://github.com/theatrus/psf-guard/blob/main/docs/SCREENING.md).

--- a/src/sequence_analysis.rs
+++ b/src/sequence_analysis.rs
@@ -666,6 +666,62 @@ enum ScoreScope {
     TargetFilter,
 }
 
+/// How hard each kind of event evidence hits the quality score, as a
+/// multiplier on that evidence's built-in penalty. 1.0 keeps the calibrated
+/// behavior, 0.0 ignores the evidence entirely, and values up to 2.0 deepen
+/// the hit. Separate from [`QualityWeights`], which balances the *measured
+/// metrics* inside the composite: these scale the score *caps and penalties*
+/// applied after it — a satellite trail, a pointing failure, a temporal
+/// anomaly. The zero-star cap is deliberately not scalable: a frame measured
+/// to have no stars is ruined whatever the operator's preferences.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PenaltyScales {
+    /// Pixel-confirmed satellite trail score caps.
+    #[serde(default = "default_penalty_scale")]
+    pub satellite: f64,
+    /// Off-target / pointing-jump / pointing-drift score caps.
+    #[serde(default = "default_penalty_scale")]
+    pub pointing: f64,
+    /// The temporal-anomaly multiplicative penalty.
+    #[serde(default = "default_penalty_scale")]
+    pub temporal: f64,
+}
+
+fn default_penalty_scale() -> f64 {
+    1.0
+}
+
+impl Default for PenaltyScales {
+    fn default() -> Self {
+        Self {
+            satellite: 1.0,
+            pointing: 1.0,
+            temporal: 1.0,
+        }
+    }
+}
+
+impl PenaltyScales {
+    /// Blend `base` toward `penalized` by this scale: 0 → no effect,
+    /// 1 → the built-in penalty, up to 2 → double the hit, clamped to a
+    /// valid score.
+    fn blend(scale: f64, base: f64, penalized: f64) -> f64 {
+        let scale = if scale.is_finite() {
+            scale.clamp(0.0, 2.0)
+        } else {
+            1.0
+        };
+        if scale == 1.0 {
+            // The default must reproduce the built-in penalty bit for bit:
+            // recomputing it through the blend arithmetic drifts by an ulp
+            // (0.95 − 0.65 ≠ 0.30 exactly), which is enough to leak past
+            // `<=` comparisons calibrated on the exact cap values.
+            return penalized.clamp(0.0, 1.0);
+        }
+        (base - (base - penalized) * scale).clamp(0.0, 1.0)
+    }
+}
+
 /// Configurable weights for composite quality scoring.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QualityWeights {
@@ -784,6 +840,8 @@ pub struct SequenceAnalyzerConfig {
     pub min_sequence_length: usize,
     pub ewma_alpha: f64,
     pub quality_weights: QualityWeights,
+    #[serde(default)]
+    pub penalty_scales: PenaltyScales,
     pub temporal_weights: TemporalWeights,
     pub star_drop_threshold: f64,
     pub bg_rise_threshold: f64,
@@ -889,6 +947,7 @@ impl Default for SequenceAnalyzerConfig {
             min_sequence_length: 3,
             ewma_alpha: 0.3,
             quality_weights: QualityWeights::default(),
+            penalty_scales: PenaltyScales::default(),
             temporal_weights: TemporalWeights::default(),
             star_drop_threshold: 0.25,
             bg_rise_threshold: 0.10,
@@ -1018,13 +1077,17 @@ impl SequenceAnalyzer {
             result.quality_score = apply_pointing_score(
                 self.composite_score(&result.normalized_metrics),
                 result.pointing.as_ref(),
+                self.config.penalty_scales.pointing,
             );
             result.category = session.category.clone();
             result.flags = session.flags.clone();
             result.satellite = session.satellite.clone();
             result.regrade_reason = session.regrade_reason.clone();
-            result.quality_score =
-                apply_satellite_score(result.quality_score, result.satellite.as_ref());
+            result.quality_score = apply_satellite_score(
+                result.quality_score,
+                result.satellite.as_ref(),
+                self.config.penalty_scales.satellite,
+            );
             if session.category.is_some()
                 || !session.flags.is_empty()
                 || session.regrade_reason.is_some()
@@ -1188,7 +1251,11 @@ impl SequenceAnalyzer {
                 .enumerate()
                 .map(|(idx, img)| ImageQualityResult {
                     image_id: img.image_id,
-                    quality_score: apply_pointing_score(1.0, pointing_quality[idx].as_ref()),
+                    quality_score: apply_pointing_score(
+                        1.0,
+                        pointing_quality[idx].as_ref(),
+                        self.config.penalty_scales.pointing,
+                    ),
                     temporal_anomaly_score: 0.0,
                     category: None,
                     flags: Vec::new(),
@@ -1330,12 +1397,19 @@ impl SequenceAnalyzer {
             };
             let quality_score = self.composite_score(&normalized_metrics);
 
-            // Apply temporal penalty
+            // Apply temporal penalty, scaled by the operator's preference:
+            // blend(scale, 1, 1 - hit) = 1 - hit*scale, clamped to a valid
+            // multiplier.
             let temporal = temporal_scores[i];
-            let penalty = 1.0 - temporal.min(0.5);
+            let penalty = PenaltyScales::blend(
+                self.config.penalty_scales.temporal,
+                1.0,
+                1.0 - temporal.min(0.5),
+            );
             let final_score = apply_pointing_score(
                 (quality_score * penalty).clamp(0.0, 1.0),
                 pointing_quality[i].as_ref(),
+                self.config.penalty_scales.pointing,
             );
 
             results.push(ImageQualityResult {
@@ -1453,7 +1527,11 @@ impl SequenceAnalyzer {
                 None => detail,
             });
 
-            result.quality_score = apply_satellite_score(result.quality_score, Some(satellite));
+            result.quality_score = apply_satellite_score(
+                result.quality_score,
+                Some(satellite),
+                self.config.penalty_scales.satellite,
+            );
             if satellite.reject_recommended && satellite.pixel_aligned_high_risk_count > 0 {
                 let reason = format!(
                     "[Auto] Pixel-aligned bright satellite trail - {} high-risk candidate(s), risk {:.2}; verify overlay",
@@ -2519,11 +2597,11 @@ fn pointing_normalized(pointing: &PointingQuality) -> Option<f64> {
     }
 }
 
-fn apply_pointing_score(score: f64, pointing: Option<&PointingQuality>) -> f64 {
+fn apply_pointing_score(score: f64, pointing: Option<&PointingQuality>, scale: f64) -> f64 {
     let Some(pointing) = pointing else {
         return score;
     };
-    if pointing.flags.contains(&IssueCategory::OffTarget) {
+    let penalized = if pointing.flags.contains(&IssueCategory::OffTarget) {
         score.min(0.20)
     } else if pointing.flags.iter().any(|flag| {
         matches!(
@@ -2534,21 +2612,23 @@ fn apply_pointing_score(score: f64, pointing: Option<&PointingQuality>) -> f64 {
         score.min(0.30)
     } else {
         score
-    }
+    };
+    PenaltyScales::blend(scale, score, penalized)
 }
 
-fn apply_satellite_score(score: f64, satellite: Option<&SatelliteFrameMetrics>) -> f64 {
+fn apply_satellite_score(score: f64, satellite: Option<&SatelliteFrameMetrics>, scale: f64) -> f64 {
     let Some(satellite) = satellite else {
         return score;
     };
     if satellite.pixel_aligned_count == 0 {
         return score;
     }
-    if satellite.reject_recommended && satellite.pixel_aligned_high_risk_count > 0 {
+    let penalized = if satellite.reject_recommended && satellite.pixel_aligned_high_risk_count > 0 {
         score.min(0.35)
     } else {
         score.min(0.75)
-    }
+    };
+    PenaltyScales::blend(scale, score, penalized)
 }
 
 /// Group solved centers by spatial connectivity. Single-link clustering is
@@ -3208,6 +3288,70 @@ mod tests {
         let regions = cataloged_extended_emission(&solution);
         assert_eq!(regions.len(), 1);
         assert_eq!(regions[0].name, "NGC 1499");
+    }
+
+    #[test]
+    fn penalty_blend_scales_between_off_default_and_double() {
+        // Off: the evidence leaves the score alone.
+        assert_eq!(PenaltyScales::blend(0.0, 0.9, 0.3), 0.9);
+        // Default: exactly the built-in penalty, no float drift.
+        assert_eq!(PenaltyScales::blend(1.0, 0.95, 0.30), 0.30);
+        // Half: midway between untouched and penalized.
+        assert!((PenaltyScales::blend(0.5, 0.9, 0.3) - 0.6).abs() < 1e-12);
+        // Double: twice the hit, clamped at zero.
+        assert!((PenaltyScales::blend(2.0, 0.9, 0.5) - 0.1).abs() < 1e-12);
+        assert_eq!(PenaltyScales::blend(2.0, 0.9, 0.3), 0.0);
+        // Nonsense scales fall back to the default behavior; out-of-range
+        // scales clamp to the doubled hit.
+        assert_eq!(PenaltyScales::blend(f64::NAN, 0.9, 0.3), 0.3);
+        assert!((PenaltyScales::blend(9.0, 0.9, 0.5) - 0.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn satellite_penalty_scale_tunes_the_trail_hit() {
+        let satellite = SatelliteFrameMetrics {
+            pixel_aligned_count: 1,
+            pixel_aligned_high_risk_count: 1,
+            reject_recommended: true,
+            ..Default::default()
+        };
+        // Built-in cap is 0.35; scaling moves the hit around it.
+        assert_eq!(apply_satellite_score(0.95, Some(&satellite), 1.0), 0.35);
+        assert_eq!(apply_satellite_score(0.95, Some(&satellite), 0.0), 0.95);
+        let half = apply_satellite_score(0.95, Some(&satellite), 0.5);
+        assert!((half - 0.65).abs() < 1e-12, "got {half}");
+        // Prediction-only evidence is never penalized, whatever the scale.
+        let prediction_only = SatelliteFrameMetrics {
+            pixel_aligned_count: 0,
+            ..Default::default()
+        };
+        assert_eq!(
+            apply_satellite_score(0.95, Some(&prediction_only), 2.0),
+            0.95
+        );
+    }
+
+    #[test]
+    fn temporal_penalty_scale_tunes_the_anomaly_hit() {
+        // A mid-sequence outlier draws a temporal anomaly penalty; scaling
+        // it to zero removes exactly that component.
+        let mut config = SequenceAnalyzerConfig::default();
+        config.penalty_scales.temporal = 0.0;
+        let relaxed = SequenceAnalyzer::new(config);
+        let strict = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+
+        let mut images: Vec<_> = (0..8)
+            .map(|i| make_image(i, i as i64 * 300, 500.0, 2.5))
+            .collect();
+        // A sudden one-frame star-count dip mid-sequence.
+        images[4].star_count = Some(250.0);
+
+        let strict_score = strict.analyze(&images, 1, "t", "L")[0].images[4].quality_score;
+        let relaxed_score = relaxed.analyze(&images, 1, "t", "L")[0].images[4].quality_score;
+        assert!(
+            relaxed_score >= strict_score,
+            "relaxed {relaxed_score} vs strict {strict_score}"
+        );
     }
 
     #[test]

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -737,6 +737,12 @@ pub struct SequenceAnalysisQuery {
     pub weight_background: Option<f64>,
     pub weight_spatial: Option<f64>,
     pub weight_pointing: Option<f64>,
+    /// How hard event evidence hits the score, as a multiplier on the
+    /// built-in penalty: 0 ignores it, 1 (default) keeps the calibrated
+    /// behavior, up to 2 deepens it.
+    pub penalty_satellite: Option<f64>,
+    pub penalty_pointing: Option<f64>,
+    pub penalty_temporal: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -763,6 +769,16 @@ pub struct SpatialScanRequest {
     /// (missing keys only; default true).
     #[serde(default)]
     pub fill_metadata: Option<bool>,
+}
+
+/// Penalty-scale overrides for endpoints that score without the full
+/// sequence query (the per-image quality context). Same semantics as the
+/// `penalty_*` fields on [`SequenceAnalysisQuery`].
+#[derive(Debug, Deserialize, Default)]
+pub struct PenaltyScaleQuery {
+    pub penalty_satellite: Option<f64>,
+    pub penalty_pointing: Option<f64>,
+    pub penalty_temporal: Option<f64>,
 }
 
 /// Optional target/filter scope for the quality-scan status endpoint.

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -3726,6 +3726,9 @@ pub async fn analyze_sequence(
     let weight_background = params.weight_background;
     let weight_spatial = params.weight_spatial;
     let weight_pointing = params.weight_pointing;
+    let penalty_satellite = params.penalty_satellite;
+    let penalty_pointing = params.penalty_pointing;
+    let penalty_temporal = params.penalty_temporal;
 
     // Fetch images from the requested target, project, or database. Wider
     // scopes still score each target/filter group independently and only read
@@ -3829,6 +3832,17 @@ pub async fn analyze_sequence(
                 pointing: weight_pointing.unwrap_or(config.quality_weights.pointing),
             };
         }
+        // Penalty scaling: how hard event evidence (satellite trails,
+        // pointing failures, temporal anomalies) hits the score.
+        if let Some(scale) = penalty_satellite {
+            config.penalty_scales.satellite = scale;
+        }
+        if let Some(scale) = penalty_pointing {
+            config.penalty_scales.pointing = scale;
+        }
+        if let Some(scale) = penalty_temporal {
+            config.penalty_scales.temporal = scale;
+        }
 
         let session_gap_minutes = config.session_gap_minutes;
         let analyzer = SequenceAnalyzer::new(config);
@@ -3917,6 +3931,7 @@ pub async fn analyze_sequence(
 pub async fn get_image_quality(
     ctx: DbContext,
     Path((_db_id, image_id)): Path<(String, i32)>,
+    Query(penalties): Query<crate::server::api::PenaltyScaleQuery>,
 ) -> Result<Json<ApiResponse<crate::server::api::ImageQualityContextResponse>>, AppError> {
     use crate::sequence_analysis::{
         extract_metrics_from_metadata, SequenceAnalyzer, SequenceAnalyzerConfig,
@@ -3988,7 +4003,16 @@ pub async fn get_image_quality(
     let astrometry_evidence = ctx.astrometry_evidence.clone();
 
     let result = tokio::task::spawn_blocking(move || {
-        let config = SequenceAnalyzerConfig::default();
+        let mut config = SequenceAnalyzerConfig::default();
+        if let Some(scale) = penalties.penalty_satellite {
+            config.penalty_scales.satellite = scale;
+        }
+        if let Some(scale) = penalties.penalty_pointing {
+            config.penalty_scales.pointing = scale;
+        }
+        if let Some(scale) = penalties.penalty_temporal {
+            config.penalty_scales.temporal = scale;
+        }
         let session_gap_minutes = config.session_gap_minutes;
         let analyzer = SequenceAnalyzer::new(config);
 

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -6440,3 +6440,64 @@
 .access-badge.read-write {
   color: var(--color-success);
 }
+
+.scoring-penalty-control {
+  position: relative;
+}
+
+.scoring-penalty-control summary {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  list-style: none;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  user-select: none;
+}
+
+.scoring-penalty-control[open] summary {
+  color: var(--color-text);
+}
+
+.scoring-penalty-panel {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 4px);
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 230px;
+  padding: 0.7rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.penalty-slider {
+  display: grid;
+  grid-template-columns: 1fr 90px 38px;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.penalty-slider input[type="range"] {
+  width: 90px;
+}
+
+.penalty-value {
+  text-align: right;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.penalty-reset {
+  align-self: flex-end;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+}

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1470,7 +1470,17 @@ export interface CacheRefreshProgress {
 }
 
 // Sequence analysis types
-export interface SequenceAnalysisRequest {
+
+/** How hard event evidence hits the quality score: a multiplier on the
+ * built-in penalty. 0 ignores the evidence, 1 (default) keeps calibrated
+ * behavior, up to 2 deepens it. */
+export interface PenaltyScaleParams {
+  penalty_satellite?: number;
+  penalty_pointing?: number;
+  penalty_temporal?: number;
+}
+
+export interface SequenceAnalysisRequest extends PenaltyScaleParams {
   target_id: number;
   filter_name?: string;
   session_gap_minutes?: number;
@@ -1483,12 +1493,12 @@ export interface SequenceAnalysisRequest {
   weight_pointing?: number;
 }
 
-export interface ProjectSequenceAnalysisRequest {
+export interface ProjectSequenceAnalysisRequest extends PenaltyScaleParams {
   project_id: number;
   filter_name?: string;
 }
 
-export interface DatabaseSequenceAnalysisRequest {
+export interface DatabaseSequenceAnalysisRequest extends PenaltyScaleParams {
   all_projects: true;
   filter_name?: string;
 }

--- a/static/src/components/ScoringPenaltyControl.tsx
+++ b/static/src/components/ScoringPenaltyControl.tsx
@@ -1,0 +1,69 @@
+import {
+  setScoringPreferences,
+  useScoringPreferences,
+} from '../hooks/useScoringPreferences';
+
+/**
+ * Compact control for how hard each kind of event evidence hits the quality
+ * score. One shared, remembered preference: the Sequence view, grid badges,
+ * and detail panel all score with the same scales.
+ */
+export default function ScoringPenaltyControl() {
+  const preferences = useScoringPreferences();
+  const isDefault =
+    preferences.satellite === 1 && preferences.pointing === 1 && preferences.temporal === 1;
+
+  const slider = (
+    key: 'satellite' | 'pointing' | 'temporal',
+    label: string,
+    title: string
+  ) => (
+    <label className="penalty-slider" title={title}>
+      <span className="penalty-label">{label}</span>
+      <input
+        type="range"
+        min="0"
+        max="2"
+        step="0.1"
+        value={preferences[key]}
+        onChange={(event) =>
+          setScoringPreferences({ ...preferences, [key]: parseFloat(event.target.value) })
+        }
+      />
+      <span className="penalty-value">{Math.round(preferences[key] * 100)}%</span>
+    </label>
+  );
+
+  return (
+    <details className="scoring-penalty-control">
+      <summary title="How hard each kind of evidence lowers the quality score. 100% is the calibrated default; 0% ignores that evidence; 200% doubles the hit.">
+        Penalties{isDefault ? '' : ' *'}
+      </summary>
+      <div className="scoring-penalty-panel">
+        {slider(
+          'satellite',
+          'Satellite trails',
+          'Score hit for a pixel-confirmed satellite trail crossing the frame.'
+        )}
+        {slider(
+          'pointing',
+          'Pointing',
+          'Score hit for off-target, pointing-jump, and pointing-drift evidence.'
+        )}
+        {slider(
+          'temporal',
+          'Temporal anomalies',
+          'Score hit when a frame suddenly deviates from its neighbours.'
+        )}
+        <button
+          type="button"
+          className="penalty-reset"
+          disabled={isDefault}
+          onClick={() => setScoringPreferences({ satellite: 1, pointing: 1, temporal: 1 })}
+        >
+          Reset to defaults
+        </button>
+      </div>
+    </details>
+  );
+}

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -14,6 +14,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { apiClient } from '../api/client';
 import { useSequenceAnalysis } from '../hooks/useSequenceAnalysis';
 import { useSpatialScan } from '../hooks/useSpatialScan';
+import ScoringPenaltyControl from './ScoringPenaltyControl';
 import { useGrading } from '../hooks/useGrading';
 import { useDbProjectTarget, useGridState } from '../hooks/useUrlState';
 import UndoRedoToolbar from './UndoRedoToolbar';
@@ -747,6 +748,7 @@ export default function SequenceView() {
             />
             <span className="threshold-value">{threshold.toFixed(2)}</span>
           </div>
+          <ScoringPenaltyControl />
           <div className="selection-preset-control">
             <label htmlFor="sequence-select-preset">Select:</label>
             <select

--- a/static/src/hooks/__tests__/useScoringPreferences.test.ts
+++ b/static/src/hooks/__tests__/useScoringPreferences.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  scoringPenaltyParams,
+  scoringPreferences,
+  setScoringPreferences,
+} from '../useScoringPreferences';
+
+describe('scoring preferences', () => {
+  beforeEach(() => {
+    setScoringPreferences({ satellite: 1, pointing: 1, temporal: 1 });
+  });
+
+  it('omits defaults from the request params entirely', () => {
+    expect(scoringPenaltyParams()).toEqual({});
+  });
+
+  it('sends only the scales that differ from the calibrated default', () => {
+    setScoringPreferences({ satellite: 0, pointing: 1, temporal: 1.5 });
+    expect(scoringPenaltyParams()).toEqual({
+      penalty_satellite: 0,
+      penalty_temporal: 1.5,
+    });
+  });
+
+  it('clamps out-of-range and non-finite values', () => {
+    setScoringPreferences({ satellite: 9, pointing: -3, temporal: NaN });
+    expect(scoringPreferences()).toEqual({ satellite: 2, pointing: 0, temporal: 1 });
+  });
+
+  it('persists across a reload of the module state', () => {
+    setScoringPreferences({ satellite: 0.5, pointing: 1, temporal: 1 });
+    const stored = JSON.parse(
+      window.localStorage.getItem('psf-guard.penalty-scales') ?? '{}'
+    );
+    expect(stored.satellite).toBe(0.5);
+  });
+});

--- a/static/src/hooks/useScoringPreferences.ts
+++ b/static/src/hooks/useScoringPreferences.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import type { PenaltyScaleParams } from '../api/types';
+
+/**
+ * How hard each kind of event evidence hits the quality score, shared
+ * across every scoring surface (Sequence view, grid badges, detail panel).
+ *
+ * Each value multiplies that evidence's built-in penalty: 0 ignores it,
+ * 1 (the default) keeps the calibrated behavior, 2 doubles the hit. Kept
+ * as one shared preference so a satellite trail cannot cost a frame its
+ * badge in one view and nothing in another.
+ */
+export interface ScoringPreferences {
+  satellite: number;
+  pointing: number;
+  temporal: number;
+}
+
+const STORAGE_KEY = 'psf-guard.penalty-scales';
+const DEFAULTS: ScoringPreferences = { satellite: 1, pointing: 1, temporal: 1 };
+
+type Listener = (preferences: ScoringPreferences) => void;
+
+const listeners = new Set<Listener>();
+
+function sanitize(value: unknown): number {
+  const scale = typeof value === 'number' && Number.isFinite(value) ? value : 1;
+  return Math.min(2, Math.max(0, scale));
+}
+
+function readStored(): ScoringPreferences {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULTS };
+    const parsed = JSON.parse(raw) as Partial<ScoringPreferences>;
+    return {
+      satellite: sanitize(parsed.satellite),
+      pointing: sanitize(parsed.pointing),
+      temporal: sanitize(parsed.temporal),
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+let current = readStored();
+
+export function setScoringPreferences(next: ScoringPreferences): void {
+  current = {
+    satellite: sanitize(next.satellite),
+    pointing: sanitize(next.pointing),
+    temporal: sanitize(next.temporal),
+  };
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(current));
+  } catch {
+    // Keep the in-memory preference even when it cannot be persisted.
+  }
+  listeners.forEach((listener) => listener(current));
+}
+
+export function scoringPreferences(): ScoringPreferences {
+  return current;
+}
+
+/** The preference as request query params; defaults are omitted so the
+ * server's calibrated behavior needs no parameters at all. */
+export function scoringPenaltyParams(): PenaltyScaleParams {
+  const params: PenaltyScaleParams = {};
+  if (current.satellite !== 1) params.penalty_satellite = current.satellite;
+  if (current.pointing !== 1) params.penalty_pointing = current.pointing;
+  if (current.temporal !== 1) params.penalty_temporal = current.temporal;
+  return params;
+}
+
+/** Subscribe to the shared preference. Returns its current value. */
+export function useScoringPreferences(): ScoringPreferences {
+  const [value, setValue] = useState(current);
+  useEffect(() => {
+    listeners.add(setValue);
+    setValue(current);
+    return () => {
+      listeners.delete(setValue);
+    };
+  }, []);
+  return value;
+}

--- a/static/src/hooks/useSequenceAnalysis.ts
+++ b/static/src/hooks/useSequenceAnalysis.ts
@@ -7,13 +7,19 @@ import type {
   SequenceAnalysisRequest,
 } from '../api/types';
 import { useState, useCallback } from 'react';
+import { scoringPenaltyParams, useScoringPreferences } from './useScoringPreferences';
 
 export function useSequenceAnalysis(dbId: string | null | undefined) {
   const [request, setRequest] = useState<SequenceAnalysisRequest | null>(null);
+  const penalties = useScoringPreferences();
 
   const query = useQuery({
-    queryKey: ['db', dbId, 'sequence-analysis', request?.target_id, request?.filter_name],
-    queryFn: () => apiClient.analyzeSequence(dbId!, request!),
+    queryKey: [
+      'db', dbId, 'sequence-analysis', request?.target_id, request?.filter_name,
+      penalties.satellite, penalties.pointing, penalties.temporal,
+    ],
+    queryFn: () =>
+      apiClient.analyzeSequence(dbId!, { ...request!, ...scoringPenaltyParams() }),
     enabled: !!dbId && !!request?.target_id,
     staleTime: 60000,
   });
@@ -51,19 +57,22 @@ export function useScopedQuality(
   targetId: number | null | undefined,
   filterName?: string,
 ) {
+  const penalties = useScoringPreferences();
+  const penaltyParams = scoringPenaltyParams();
   const request:
     | SequenceAnalysisRequest
     | ProjectSequenceAnalysisRequest
     | DatabaseSequenceAnalysisRequest = targetId != null
-      ? { target_id: targetId, filter_name: filterName }
+      ? { target_id: targetId, filter_name: filterName, ...penaltyParams }
       : projectId != null
-        ? { project_id: projectId, filter_name: filterName }
-        : { all_projects: true, filter_name: filterName };
+        ? { project_id: projectId, filter_name: filterName, ...penaltyParams }
+        : { all_projects: true, filter_name: filterName, ...penaltyParams };
+  const penaltyKey = [penalties.satellite, penalties.pointing, penalties.temporal];
   const queryKey = targetId != null
-    ? ['db', dbId, 'sequence-analysis', targetId, filterName]
+    ? ['db', dbId, 'sequence-analysis', targetId, filterName, ...penaltyKey]
     : projectId != null
-      ? ['db', dbId, 'sequence-analysis', 'project', projectId, filterName]
-      : ['db', dbId, 'sequence-analysis', 'all-projects', filterName];
+      ? ['db', dbId, 'sequence-analysis', 'project', projectId, filterName, ...penaltyKey]
+      : ['db', dbId, 'sequence-analysis', 'all-projects', filterName, ...penaltyKey];
   const query = useQuery({
     queryKey,
     queryFn: () => apiClient.analyzeSequence(dbId!, request),


### PR DESCRIPTION
The score caps and penalties for event evidence were fixed constants: a pixel-confirmed satellite trail capped the score at 0.35/0.75, pointing failures at 0.20/0.30, and a temporal anomaly took up to half the score. Operators weigh this evidence differently — good stacking rejection makes satellite trails cheap; an unattended rig may want pointing evidence to bite harder.

## Change

**`PenaltyScales`** on the analyzer config multiplies each built-in penalty: **0** ignores the evidence, **1** (default) keeps the calibrated behavior *bit for bit* (at scale 1 the blend returns the built-in cap exactly — recomputing through the blend arithmetic drifts by an ulp, which broke three calibrated `<=` assertions until handled), up to **2** doubles the hit, clamped to a valid score. Deliberate boundaries:

- The **zero-star cap does not scale** — a frame measured to have no stars is ruined whatever the preference.
- **Prediction-only satellite results stay unpenalized** at any scale (orbital geometry alone is not image evidence).
- Applied at all penalty sites: main scoring loop, short-sequence path, target/filter rollup, and satellite merge.

**API**: `penalty_satellite` / `penalty_pointing` / `penalty_temporal` on the sequence endpoint (beside the existing weight overrides) and on the per-image quality endpoint via `PenaltyScaleQuery`. Absent params = calibrated defaults.

**UI**: a compact **Penalties** control in the Sequence view (three sliders 0–200% + reset, dirty-state marker). One remembered preference sent from every scoring surface — sequence, scoped grid badges, detail — with the scales in the react-query keys so changes refetch. Defaults are omitted from requests entirely.

## Tests

Blend semantics (off/default-exactness/half/double/clamp/NaN), satellite scaling end-to-end, temporal scaling end-to-end, plus preference-store tests (default omission, partial sends, clamping, persistence). 84 sequence-analysis tests and the full suites green.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (19 suites) · `eslint` · `vitest run` (60 files / 275 tests) · `tsc -b && vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)