### PR TITLE
Harden the penalty scales against review findings

### DIFF
--- a/src/sequence_analysis.rs
+++ b/src/sequence_analysis.rs
@@ -674,21 +674,17 @@ enum ScoreScope {
 /// applied after it — a satellite trail, a pointing failure, a temporal
 /// anomaly. The zero-star cap is deliberately not scalable: a frame measured
 /// to have no stars is ruined whatever the operator's preferences.
+/// One `#[serde(default)]` at the struct level: missing fields come from
+/// the `Default` impl below, the single place the 1.0 calibration lives.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct PenaltyScales {
     /// Pixel-confirmed satellite trail score caps.
-    #[serde(default = "default_penalty_scale")]
     pub satellite: f64,
     /// Off-target / pointing-jump / pointing-drift score caps.
-    #[serde(default = "default_penalty_scale")]
     pub pointing: f64,
     /// The temporal-anomaly multiplicative penalty.
-    #[serde(default = "default_penalty_scale")]
     pub temporal: f64,
-}
-
-fn default_penalty_scale() -> f64 {
-    1.0
 }
 
 impl Default for PenaltyScales {
@@ -702,15 +698,19 @@ impl Default for PenaltyScales {
 }
 
 impl PenaltyScales {
-    /// Blend `base` toward `penalized` by this scale: 0 → no effect,
-    /// 1 → the built-in penalty, up to 2 → double the hit, clamped to a
-    /// valid score.
-    fn blend(scale: f64, base: f64, penalized: f64) -> f64 {
-        let scale = if scale.is_finite() {
+    fn sanitize(scale: f64) -> f64 {
+        if scale.is_finite() {
             scale.clamp(0.0, 2.0)
         } else {
             1.0
-        };
+        }
+    }
+
+    /// Blend `base` toward `penalized` by this scale: 0 → no effect,
+    /// 1 → the built-in penalty, clamped to a valid score. Only sound for
+    /// scales up to 1 — extrapolating past `penalized` flips the ordering
+    /// of frames sharing a flag (see [`Self::scale_cap`]).
+    fn blend(scale: f64, base: f64, penalized: f64) -> f64 {
         if scale == 1.0 {
             // The default must reproduce the built-in penalty bit for bit:
             // recomputing it through the blend arithmetic drifts by an ulp
@@ -719,6 +719,27 @@ impl PenaltyScales {
             return penalized.clamp(0.0, 1.0);
         }
         (base - (base - penalized) * scale).clamp(0.0, 1.0)
+    }
+
+    /// Scale a cap-style penalty (`score.min(cap)`) while keeping the score
+    /// monotone in the underlying composite. Below 1 the score blends
+    /// toward the cap; above 1 the CAP itself deepens toward zero. A linear
+    /// blend above 1 would subtract more from better frames — an OffTarget
+    /// frame with composite 0.95 would land at 0.0 while a 0.25 frame kept
+    /// 0.15, inverting the ranking the threshold slider selects on.
+    fn scale_cap(scale: f64, score: f64, cap: f64) -> f64 {
+        let scale = Self::sanitize(scale);
+        if scale <= 1.0 {
+            return Self::blend(scale, score, score.min(cap));
+        }
+        score.min((cap * (2.0 - scale)).max(0.0))
+    }
+
+    /// Scale a multiplicative penalty factor (`1 − hit`), where the factor
+    /// multiplies the score and monotonicity is inherent.
+    fn scale_factor(scale: f64, hit: f64) -> f64 {
+        let scale = Self::sanitize(scale);
+        Self::blend(scale, 1.0, 1.0 - hit)
     }
 }
 
@@ -1398,14 +1419,11 @@ impl SequenceAnalyzer {
             let quality_score = self.composite_score(&normalized_metrics);
 
             // Apply temporal penalty, scaled by the operator's preference:
-            // blend(scale, 1, 1 - hit) = 1 - hit*scale, clamped to a valid
-            // multiplier.
+            // the factor 1 − hit·scale multiplies the score, so ordering is
+            // preserved at every scale.
             let temporal = temporal_scores[i];
-            let penalty = PenaltyScales::blend(
-                self.config.penalty_scales.temporal,
-                1.0,
-                1.0 - temporal.min(0.5),
-            );
+            let penalty =
+                PenaltyScales::scale_factor(self.config.penalty_scales.temporal, temporal.min(0.5));
             let final_score = apply_pointing_score(
                 (quality_score * penalty).clamp(0.0, 1.0),
                 pointing_quality[i].as_ref(),
@@ -1532,7 +1550,18 @@ impl SequenceAnalyzer {
                 Some(satellite),
                 self.config.penalty_scales.satellite,
             );
-            if satellite.reject_recommended && satellite.pixel_aligned_high_risk_count > 0 {
+            // A satellite scale of zero means "ignore this evidence": the
+            // score is untouched above, and the rejection recommendation
+            // must not survive either — the recommended-selection preset,
+            // stack exclusion, and CLI regrade all key off regrade_reason,
+            // and recommending rejection on ignored evidence would mass-
+            // reject frames the operator asked to stop penalizing. Flags
+            // and details stay: the trail remains a fact worth showing.
+            let evidence_ignored = self.config.penalty_scales.satellite == 0.0;
+            if satellite.reject_recommended
+                && satellite.pixel_aligned_high_risk_count > 0
+                && !evidence_ignored
+            {
                 let reason = format!(
                     "[Auto] Pixel-aligned bright satellite trail - {} high-risk candidate(s), risk {:.2}; verify overlay",
                     satellite.pixel_aligned_high_risk_count,
@@ -2070,7 +2099,13 @@ impl SequenceAnalyzer {
                     )
                 );
                 if corroborated {
-                    result.quality_score = result.quality_score.min(0.30);
+                    // Same pointing scale as the other pointing caps: this
+                    // is pointing evidence too, and 0% must stop it biting.
+                    result.quality_score = PenaltyScales::scale_cap(
+                        self.config.penalty_scales.pointing,
+                        result.quality_score,
+                        0.30,
+                    );
                 }
                 (
                     original_category.or(Some(IssueCategory::PlateSolveFailed)),
@@ -2107,7 +2142,16 @@ impl SequenceAnalyzer {
                 (original_category, None, None)
             };
             result.category = category;
-            result.regrade_reason = reason;
+            // A pointing scale of zero means "ignore this evidence": the
+            // caps above already leave the score alone, and the rejection
+            // recommendation must not survive either — the recommended
+            // preset, stack exclusion, and CLI regrade key off
+            // regrade_reason. Categories, flags, and details stay visible.
+            result.regrade_reason = if self.config.penalty_scales.pointing == 0.0 {
+                None
+            } else {
+                reason
+            };
             if let Some(astrometry_detail) = astrometry_detail {
                 result.details = Some(match result.details.take() {
                     Some(existing) => format!("{astrometry_detail} {existing}"),
@@ -2601,19 +2645,19 @@ fn apply_pointing_score(score: f64, pointing: Option<&PointingQuality>, scale: f
     let Some(pointing) = pointing else {
         return score;
     };
-    let penalized = if pointing.flags.contains(&IssueCategory::OffTarget) {
-        score.min(0.20)
+    let cap = if pointing.flags.contains(&IssueCategory::OffTarget) {
+        0.20
     } else if pointing.flags.iter().any(|flag| {
         matches!(
             flag,
             IssueCategory::PointingJump | IssueCategory::PointingDrift
         )
     }) {
-        score.min(0.30)
+        0.30
     } else {
-        score
+        return score;
     };
-    PenaltyScales::blend(scale, score, penalized)
+    PenaltyScales::scale_cap(scale, score, cap)
 }
 
 fn apply_satellite_score(score: f64, satellite: Option<&SatelliteFrameMetrics>, scale: f64) -> f64 {
@@ -2623,12 +2667,12 @@ fn apply_satellite_score(score: f64, satellite: Option<&SatelliteFrameMetrics>, 
     if satellite.pixel_aligned_count == 0 {
         return score;
     }
-    let penalized = if satellite.reject_recommended && satellite.pixel_aligned_high_risk_count > 0 {
-        score.min(0.35)
+    let cap = if satellite.reject_recommended && satellite.pixel_aligned_high_risk_count > 0 {
+        0.35
     } else {
-        score.min(0.75)
+        0.75
     };
-    PenaltyScales::blend(scale, score, penalized)
+    PenaltyScales::scale_cap(scale, score, cap)
 }
 
 /// Group solved centers by spatial connectivity. Single-link clustering is
@@ -3291,20 +3335,44 @@ mod tests {
     }
 
     #[test]
-    fn penalty_blend_scales_between_off_default_and_double() {
+    fn penalty_cap_scales_between_off_default_and_double() {
         // Off: the evidence leaves the score alone.
-        assert_eq!(PenaltyScales::blend(0.0, 0.9, 0.3), 0.9);
-        // Default: exactly the built-in penalty, no float drift.
-        assert_eq!(PenaltyScales::blend(1.0, 0.95, 0.30), 0.30);
-        // Half: midway between untouched and penalized.
-        assert!((PenaltyScales::blend(0.5, 0.9, 0.3) - 0.6).abs() < 1e-12);
-        // Double: twice the hit, clamped at zero.
-        assert!((PenaltyScales::blend(2.0, 0.9, 0.5) - 0.1).abs() < 1e-12);
-        assert_eq!(PenaltyScales::blend(2.0, 0.9, 0.3), 0.0);
-        // Nonsense scales fall back to the default behavior; out-of-range
-        // scales clamp to the doubled hit.
-        assert_eq!(PenaltyScales::blend(f64::NAN, 0.9, 0.3), 0.3);
-        assert!((PenaltyScales::blend(9.0, 0.9, 0.5) - 0.1).abs() < 1e-12);
+        assert_eq!(PenaltyScales::scale_cap(0.0, 0.9, 0.3), 0.9);
+        // Default: exactly the built-in cap, no float drift.
+        assert_eq!(PenaltyScales::scale_cap(1.0, 0.95, 0.30), 0.30);
+        // Half: midway between untouched and capped.
+        assert!((PenaltyScales::scale_cap(0.5, 0.9, 0.3) - 0.6).abs() < 1e-12);
+        // Above 1 the CAP deepens toward zero.
+        assert!((PenaltyScales::scale_cap(1.5, 0.9, 0.3) - 0.15).abs() < 1e-12);
+        assert_eq!(PenaltyScales::scale_cap(2.0, 0.9, 0.3), 0.0);
+        // Nonsense scales fall back to the default; out-of-range clamps.
+        assert_eq!(PenaltyScales::scale_cap(f64::NAN, 0.9, 0.3), 0.3);
+        assert_eq!(PenaltyScales::scale_cap(9.0, 0.9, 0.3), 0.0);
+        // A score already below the cap only ever goes down, never up.
+        assert_eq!(PenaltyScales::scale_cap(0.5, 0.2, 0.3), 0.2);
+    }
+
+    #[test]
+    fn penalty_cap_scaling_never_inverts_frame_ranking() {
+        // Among frames sharing a flag, a better composite must never come
+        // out below a worse one, at any scale. A linear blend above 1
+        // subtracted more from better frames: composite 0.95 landed on 0.0
+        // while 0.25 kept 0.15.
+        for cap in [0.20, 0.30, 0.35, 0.75] {
+            for scale in [0.0, 0.3, 0.7, 1.0, 1.3, 1.7, 2.0] {
+                let mut previous = -1.0;
+                for step in 0..=20 {
+                    let score = step as f64 / 20.0;
+                    let scaled = PenaltyScales::scale_cap(scale, score, cap);
+                    assert!(
+                        scaled + 1e-12 >= previous,
+                        "ranking inverted: cap {cap} scale {scale} score {score} \
+                         gave {scaled} below {previous}"
+                    );
+                    previous = scaled;
+                }
+            }
+        }
     }
 
     #[test]
@@ -3329,6 +3397,42 @@ mod tests {
             apply_satellite_score(0.95, Some(&prediction_only), 2.0),
             0.95
         );
+    }
+
+    #[test]
+    fn zero_satellite_scale_suppresses_the_reject_recommendation() {
+        let analyzer_for = |satellite_scale: f64| {
+            let mut config = SequenceAnalyzerConfig::default();
+            config.penalty_scales.satellite = satellite_scale;
+            SequenceAnalyzer::new(config)
+        };
+        let mut images: Vec<_> = (0..6)
+            .map(|i| make_image(i, i as i64 * 300, 500.0, 2.5))
+            .collect();
+        images[3].satellite = Some(SatelliteFrameMetrics {
+            pixel_aligned_count: 1,
+            pixel_aligned_high_risk_count: 1,
+            reject_recommended: true,
+            ..Default::default()
+        });
+
+        let default_run = &analyzer_for(1.0).analyze(&images, 1, "t", "L")[0].images[3];
+        assert!(
+            default_run.regrade_reason.is_some(),
+            "default scale keeps the recommendation"
+        );
+        assert!(default_run.quality_score <= 0.35);
+
+        let ignored = &analyzer_for(0.0).analyze(&images, 1, "t", "L")[0].images[3];
+        assert!(
+            ignored.regrade_reason.is_none(),
+            "scale 0 must not recommend rejecting on ignored evidence"
+        );
+        assert!(ignored.quality_score > 0.9, "score untouched at scale 0");
+        // The trail stays visible as information.
+        assert!(ignored
+            .flags
+            .contains(&IssueCategory::SatelliteTrailDetected));
     }
 
     #[test]

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -773,12 +773,42 @@ pub struct SpatialScanRequest {
 
 /// Penalty-scale overrides for endpoints that score without the full
 /// sequence query (the per-image quality context). Same semantics as the
-/// `penalty_*` fields on [`SequenceAnalysisQuery`].
+/// `penalty_*` fields on [`SequenceAnalysisQuery`], which converts into
+/// this via [`SequenceAnalysisQuery::penalty_scales`] so both endpoints
+/// apply overrides through one method.
 #[derive(Debug, Deserialize, Default)]
 pub struct PenaltyScaleQuery {
     pub penalty_satellite: Option<f64>,
     pub penalty_pointing: Option<f64>,
     pub penalty_temporal: Option<f64>,
+}
+
+impl PenaltyScaleQuery {
+    /// Apply the supplied overrides onto a config's scales; absent fields
+    /// keep the calibrated defaults.
+    pub fn apply_to(&self, scales: &mut crate::sequence_analysis::PenaltyScales) {
+        if let Some(scale) = self.penalty_satellite {
+            scales.satellite = scale;
+        }
+        if let Some(scale) = self.penalty_pointing {
+            scales.pointing = scale;
+        }
+        if let Some(scale) = self.penalty_temporal {
+            scales.temporal = scale;
+        }
+    }
+}
+
+impl SequenceAnalysisQuery {
+    /// The query's penalty overrides as the shared application type, so a
+    /// field added to one struct without the other fails to compile here.
+    pub fn penalty_scales(&self) -> PenaltyScaleQuery {
+        PenaltyScaleQuery {
+            penalty_satellite: self.penalty_satellite,
+            penalty_pointing: self.penalty_pointing,
+            penalty_temporal: self.penalty_temporal,
+        }
+    }
 }
 
 /// Optional target/filter scope for the quality-scan status endpoint.

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -3726,9 +3726,7 @@ pub async fn analyze_sequence(
     let weight_background = params.weight_background;
     let weight_spatial = params.weight_spatial;
     let weight_pointing = params.weight_pointing;
-    let penalty_satellite = params.penalty_satellite;
-    let penalty_pointing = params.penalty_pointing;
-    let penalty_temporal = params.penalty_temporal;
+    let penalty_overrides = params.penalty_scales();
 
     // Fetch images from the requested target, project, or database. Wider
     // scopes still score each target/filter group independently and only read
@@ -3834,15 +3832,7 @@ pub async fn analyze_sequence(
         }
         // Penalty scaling: how hard event evidence (satellite trails,
         // pointing failures, temporal anomalies) hits the score.
-        if let Some(scale) = penalty_satellite {
-            config.penalty_scales.satellite = scale;
-        }
-        if let Some(scale) = penalty_pointing {
-            config.penalty_scales.pointing = scale;
-        }
-        if let Some(scale) = penalty_temporal {
-            config.penalty_scales.temporal = scale;
-        }
+        penalty_overrides.apply_to(&mut config.penalty_scales);
 
         let session_gap_minutes = config.session_gap_minutes;
         let analyzer = SequenceAnalyzer::new(config);
@@ -4004,15 +3994,7 @@ pub async fn get_image_quality(
 
     let result = tokio::task::spawn_blocking(move || {
         let mut config = SequenceAnalyzerConfig::default();
-        if let Some(scale) = penalties.penalty_satellite {
-            config.penalty_scales.satellite = scale;
-        }
-        if let Some(scale) = penalties.penalty_pointing {
-            config.penalty_scales.pointing = scale;
-        }
-        if let Some(scale) = penalties.penalty_temporal {
-            config.penalty_scales.temporal = scale;
-        }
+        penalties.apply_to(&mut config.penalty_scales);
         let session_gap_minutes = config.session_gap_minutes;
         let analyzer = SequenceAnalyzer::new(config);
 

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -43,6 +43,7 @@ import type {
   DatabaseSequenceAnalysisRequest,
   SequenceAnalysisResponse,
   ImageQualityResponse,
+  PenaltyScaleParams,
   SpatialScanRequest,
   SpatialScanStatus,
   SpatialScanStatusRequest,
@@ -1209,10 +1210,15 @@ export const apiClient = {
     return data.data;
   },
 
-  getImageQuality: async (dbId: string, imageId: number): Promise<ImageQualityResponse> => {
+  getImageQuality: async (
+    dbId: string,
+    imageId: number,
+    penalties?: PenaltyScaleParams
+  ): Promise<ImageQualityResponse> => {
     const apiInstance = await getApi();
     const { data } = await apiInstance.get<ApiResponse<ImageQualityResponse>>(
-      dbPath(dbId, `/analysis/image/${imageId}`)
+      dbPath(dbId, `/analysis/image/${imageId}`),
+      { params: penalties }
     );
     if (!data.data) throw new Error('Image quality data not found');
     return data.data;

--- a/static/src/components/ScoringPenaltyControl.tsx
+++ b/static/src/components/ScoringPenaltyControl.tsx
@@ -1,17 +1,31 @@
+import { useState } from 'react';
 import {
   setScoringPreferences,
   useScoringPreferences,
 } from '../hooks/useScoringPreferences';
+import type { ScoringPreferences } from '../hooks/useScoringPreferences';
 
 /**
  * Compact control for how hard each kind of event evidence hits the quality
  * score. One shared, remembered preference: the Sequence view, grid badges,
  * and detail panel all score with the same scales.
+ *
+ * Sliders track locally while dragging and commit on release: every commit
+ * changes the scoring query keys and refetches whole-scope analyses, so
+ * per-step commits would fire one full analysis per 0.1 tick of a drag.
  */
 export default function ScoringPenaltyControl() {
   const preferences = useScoringPreferences();
-  const isDefault =
-    preferences.satellite === 1 && preferences.pointing === 1 && preferences.temporal === 1;
+  const [draft, setDraft] = useState<ScoringPreferences | null>(null);
+  const shown = draft ?? preferences;
+  const isDefault = shown.satellite === 1 && shown.pointing === 1 && shown.temporal === 1;
+
+  const commit = () => {
+    if (draft) {
+      setScoringPreferences(draft);
+      setDraft(null);
+    }
+  };
 
   const slider = (
     key: 'satellite' | 'pointing' | 'temporal',
@@ -25,12 +39,15 @@ export default function ScoringPenaltyControl() {
         min="0"
         max="2"
         step="0.1"
-        value={preferences[key]}
+        value={shown[key]}
         onChange={(event) =>
-          setScoringPreferences({ ...preferences, [key]: parseFloat(event.target.value) })
+          setDraft({ ...shown, [key]: parseFloat(event.target.value) })
         }
+        onPointerUp={commit}
+        onKeyUp={commit}
+        onBlur={commit}
       />
-      <span className="penalty-value">{Math.round(preferences[key] * 100)}%</span>
+      <span className="penalty-value">{Math.round(shown[key] * 100)}%</span>
     </label>
   );
 
@@ -43,12 +60,12 @@ export default function ScoringPenaltyControl() {
         {slider(
           'satellite',
           'Satellite trails',
-          'Score hit for a pixel-confirmed satellite trail crossing the frame.'
+          'Score hit for a pixel-confirmed satellite trail crossing the frame. At 0% the trail also stops driving reject recommendations.'
         )}
         {slider(
           'pointing',
           'Pointing',
-          'Score hit for off-target, pointing-jump, and pointing-drift evidence.'
+          'Score hit for off-target, pointing-jump, pointing-drift, and corroborated solve-failure evidence. At 0% pointing evidence also stops driving reject recommendations.'
         )}
         {slider(
           'temporal',
@@ -59,7 +76,10 @@ export default function ScoringPenaltyControl() {
           type="button"
           className="penalty-reset"
           disabled={isDefault}
-          onClick={() => setScoringPreferences({ satellite: 1, pointing: 1, temporal: 1 })}
+          onClick={() => {
+            setDraft(null);
+            setScoringPreferences({ satellite: 1, pointing: 1, temporal: 1 });
+          }}
         >
           Reset to defaults
         </button>

--- a/static/src/hooks/__tests__/useScoringPreferences.test.ts
+++ b/static/src/hooks/__tests__/useScoringPreferences.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
-  scoringPenaltyParams,
+  penaltyKeyOf,
+  penaltyParamsOf,
   scoringPreferences,
   setScoringPreferences,
 } from '../useScoringPreferences';
@@ -11,15 +12,26 @@ describe('scoring preferences', () => {
   });
 
   it('omits defaults from the request params entirely', () => {
-    expect(scoringPenaltyParams()).toEqual({});
+    expect(penaltyParamsOf(scoringPreferences())).toEqual({});
   });
 
   it('sends only the scales that differ from the calibrated default', () => {
     setScoringPreferences({ satellite: 0, pointing: 1, temporal: 1.5 });
-    expect(scoringPenaltyParams()).toEqual({
+    expect(penaltyParamsOf(scoringPreferences())).toEqual({
       penalty_satellite: 0,
       penalty_temporal: 1.5,
     });
+  });
+
+  it('derives params and key from the same snapshot', () => {
+    const snapshot = { satellite: 0.5, pointing: 1, temporal: 2 };
+    // Pure functions of the snapshot: mutating the store afterwards must
+    // not change what a caller derived from an earlier snapshot.
+    const params = penaltyParamsOf(snapshot);
+    const key = penaltyKeyOf(snapshot);
+    setScoringPreferences({ satellite: 1, pointing: 1, temporal: 1 });
+    expect(params).toEqual({ penalty_satellite: 0.5, penalty_temporal: 2 });
+    expect(key).toEqual([0.5, 1, 2]);
   });
 
   it('clamps out-of-range and non-finite values', () => {

--- a/static/src/hooks/useScoringPreferences.ts
+++ b/static/src/hooks/useScoringPreferences.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import type { PenaltyScaleParams } from '../api/types';
 
 /**
@@ -19,7 +19,7 @@ export interface ScoringPreferences {
 const STORAGE_KEY = 'psf-guard.penalty-scales';
 const DEFAULTS: ScoringPreferences = { satellite: 1, pointing: 1, temporal: 1 };
 
-type Listener = (preferences: ScoringPreferences) => void;
+type Listener = () => void;
 
 const listeners = new Set<Listener>();
 
@@ -45,6 +45,16 @@ function readStored(): ScoringPreferences {
 
 let current = readStored();
 
+// A second tab writes the same localStorage key: adopt its value so two
+// windows cannot score the same frame differently.
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    current = readStored();
+    listeners.forEach((listener) => listener());
+  });
+}
+
 export function setScoringPreferences(next: ScoringPreferences): void {
   current = {
     satellite: sanitize(next.satellite),
@@ -56,32 +66,42 @@ export function setScoringPreferences(next: ScoringPreferences): void {
   } catch {
     // Keep the in-memory preference even when it cannot be persisted.
   }
-  listeners.forEach((listener) => listener(current));
+  listeners.forEach((listener) => listener());
 }
 
 export function scoringPreferences(): ScoringPreferences {
   return current;
 }
 
-/** The preference as request query params; defaults are omitted so the
- * server's calibrated behavior needs no parameters at all. */
-export function scoringPenaltyParams(): PenaltyScaleParams {
+/** A preference snapshot as request query params; defaults are omitted so
+ * the server's calibrated behavior needs no parameters at all. Pure — pass
+ * the same snapshot used for the query key so key and payload agree. */
+export function penaltyParamsOf(preferences: ScoringPreferences): PenaltyScaleParams {
   const params: PenaltyScaleParams = {};
-  if (current.satellite !== 1) params.penalty_satellite = current.satellite;
-  if (current.pointing !== 1) params.penalty_pointing = current.pointing;
-  if (current.temporal !== 1) params.penalty_temporal = current.temporal;
+  if (preferences.satellite !== 1) params.penalty_satellite = preferences.satellite;
+  if (preferences.pointing !== 1) params.penalty_pointing = preferences.pointing;
+  if (preferences.temporal !== 1) params.penalty_temporal = preferences.temporal;
   return params;
 }
 
-/** Subscribe to the shared preference. Returns its current value. */
+/** The same snapshot as react-query key segments. Every scoring query key
+ * spreads this, so a preference change refetches every surface. */
+export function penaltyKeyOf(preferences: ScoringPreferences): number[] {
+  return [preferences.satellite, preferences.pointing, preferences.temporal];
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function snapshot(): ScoringPreferences {
+  return current;
+}
+
+/** Subscribe to the shared preference. Returns the current snapshot. */
 export function useScoringPreferences(): ScoringPreferences {
-  const [value, setValue] = useState(current);
-  useEffect(() => {
-    listeners.add(setValue);
-    setValue(current);
-    return () => {
-      listeners.delete(setValue);
-    };
-  }, []);
-  return value;
+  return useSyncExternalStore(subscribe, snapshot);
 }

--- a/static/src/hooks/useSequenceAnalysis.ts
+++ b/static/src/hooks/useSequenceAnalysis.ts
@@ -7,19 +7,42 @@ import type {
   SequenceAnalysisRequest,
 } from '../api/types';
 import { useState, useCallback } from 'react';
-import { scoringPenaltyParams, useScoringPreferences } from './useScoringPreferences';
+import {
+  penaltyKeyOf,
+  penaltyParamsOf,
+  useScoringPreferences,
+} from './useScoringPreferences';
+import type { ScoringPreferences } from './useScoringPreferences';
+
+/**
+ * Query key for a target-scoped analysis. One builder shared by
+ * useSequenceAnalysis and useScopedQuality: the Sequence view and the grid
+ * badges cache-share only while their keys stay byte-identical, and the
+ * penalty scales must be in the key so a preference change refetches.
+ */
+function targetAnalysisKey(
+  dbId: string | null | undefined,
+  targetId: number | undefined | null,
+  filterName: string | undefined,
+  penalties: ScoringPreferences,
+) {
+  return [
+    'db', dbId, 'sequence-analysis', targetId, filterName,
+    ...penaltyKeyOf(penalties),
+  ];
+}
 
 export function useSequenceAnalysis(dbId: string | null | undefined) {
   const [request, setRequest] = useState<SequenceAnalysisRequest | null>(null);
+  // Key and payload derive from the same snapshot: reading the store again
+  // at fetch time could cache a response computed with new scales under a
+  // key naming the old ones.
   const penalties = useScoringPreferences();
 
   const query = useQuery({
-    queryKey: [
-      'db', dbId, 'sequence-analysis', request?.target_id, request?.filter_name,
-      penalties.satellite, penalties.pointing, penalties.temporal,
-    ],
+    queryKey: targetAnalysisKey(dbId, request?.target_id, request?.filter_name, penalties),
     queryFn: () =>
-      apiClient.analyzeSequence(dbId!, { ...request!, ...scoringPenaltyParams() }),
+      apiClient.analyzeSequence(dbId!, { ...request!, ...penaltyParamsOf(penalties) }),
     enabled: !!dbId && !!request?.target_id,
     staleTime: 60000,
   });
@@ -38,9 +61,10 @@ export function useSequenceAnalysis(dbId: string | null | undefined) {
 }
 
 export function useImageQuality(dbId: string | null | undefined, imageId: number | undefined) {
+  const penalties = useScoringPreferences();
   return useQuery({
-    queryKey: ['db', dbId, 'image-quality', imageId],
-    queryFn: () => apiClient.getImageQuality(dbId!, imageId!),
+    queryKey: ['db', dbId, 'image-quality', imageId, ...penaltyKeyOf(penalties)],
+    queryFn: () => apiClient.getImageQuality(dbId!, imageId!, penaltyParamsOf(penalties)),
     enabled: !!dbId && !!imageId,
     staleTime: 60000,
   });
@@ -58,7 +82,7 @@ export function useScopedQuality(
   filterName?: string,
 ) {
   const penalties = useScoringPreferences();
-  const penaltyParams = scoringPenaltyParams();
+  const penaltyParams = penaltyParamsOf(penalties);
   const request:
     | SequenceAnalysisRequest
     | ProjectSequenceAnalysisRequest
@@ -67,12 +91,11 @@ export function useScopedQuality(
       : projectId != null
         ? { project_id: projectId, filter_name: filterName, ...penaltyParams }
         : { all_projects: true, filter_name: filterName, ...penaltyParams };
-  const penaltyKey = [penalties.satellite, penalties.pointing, penalties.temporal];
   const queryKey = targetId != null
-    ? ['db', dbId, 'sequence-analysis', targetId, filterName, ...penaltyKey]
+    ? targetAnalysisKey(dbId, targetId, filterName, penalties)
     : projectId != null
-      ? ['db', dbId, 'sequence-analysis', 'project', projectId, filterName, ...penaltyKey]
-      : ['db', dbId, 'sequence-analysis', 'all-projects', filterName, ...penaltyKey];
+      ? ['db', dbId, 'sequence-analysis', 'project', projectId, filterName, ...penaltyKeyOf(penalties)]
+      : ['db', dbId, 'sequence-analysis', 'all-projects', filterName, ...penaltyKeyOf(penalties)];
   const query = useQuery({
     queryKey,
     queryFn: () => apiClient.analyzeSequence(dbId!, request),


### PR DESCRIPTION
High-effort code review of merged #324 confirmed six defects. This PR fixes all of them:

1. **Ranking inversion above 100%** — the linear blend subtracted more from *better* frames (composite 0.95 → 0.0 while 0.25 → 0.15 under the same flag at 200%). Cap-style penalties now scale the **cap** (below 1: blend toward cap; above 1: cap deepens toward zero), monotone at every scale — pinned by a property test sweeping caps × scales × scores.
2. **Recommendations on ignored evidence** — at scale 0 the score was untouched but the `[Auto]` regrade reason still drove the Recommended preset, stack exclusion, and CLI regrade. Scale 0 now suppresses that evidence's recommendation; flags/categories/details stay visible as information.
3. **Corroborated solve-failure cap** (0.30) now goes through the pointing scale like the other pointing caps.
4. **Key/params snapshot race** — a fetch racing a slider change could cache new-scale scores under the old key. Key and payload now derive from one snapshot via pure `penaltyParamsOf`/`penaltyKeyOf`; the target-scope key has one shared builder so Sequence view and grid badges keep cache-sharing.
5. **Slider request storms** — each 0.1 drag step refetched whole-scope analyses; sliders now hold a local draft and commit on release.
6. **Per-image endpoint plumbing** — `useImageQuality` now sends and keys on the scales; the preference store moved to `useSyncExternalStore` with cross-tab `storage` sync; `PenaltyScaleQuery::apply_to` is the single override path for both endpoints.

Declined from review, with reasons in the review transcript: server-side preference persistence for stack previews/CLI (feature-scale follow-up), request AbortSignal plumbing (minor once commits are per-release), 400-shape change on malformed query params (matches every other endpoint).

Checks: `cargo fmt --check` · `clippy --all-targets --all-features -D warnings` · `cargo test` (19 suites, 86 sequence tests incl. new monotonicity property test) · `eslint` · `vitest` (276) · `tsc + vite build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)