### PR TITLE
Let each stack choose auto, forced, or no calibration

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -83,7 +83,10 @@ flat into a light that still carries its pedestal amplifies that pedestal at
 the vignetted edges, inverting the vignette into bright edges. A flats-only
 library therefore stacks without the flat and the warning says to import
 bias or dark frames; the built flat master stays cached and applies as soon
-as they arrive.
+as they arrive. The stack panel's **Calibration** control can override this:
+**Force on** applies every master that can be built, including a lone flat —
+the warning then says what to expect — and **Off** stacks the raw frames
+with no matching at all.
 
 A master that fails to build does not fail the stack. The frames integrate
 without that master, and the stack card's calibration warning names the

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -218,6 +218,19 @@ If no safe set exists, the card says that calibration is absent or incomplete.
 PSF Guard never labels an uncalibrated preview as calibrated. See
 [Calibration libraries](CALIBRATION_LIBRARY.md) for the full rules.
 
+The panel's **Calibration** control chooses how the next build calibrates:
+
+- **Auto** (the default) applies the safe masters and holds back combinations
+  that damage the result, such as a flat with no bias or dark master.
+- **Force on** applies every master that can be built, including the ones
+  Auto refuses. The calibration warning still says what to expect.
+- **Off** stacks the raw frames without touching the library.
+
+The choice is remembered across reloads, becomes part of the stack job key,
+and a finished preview built under a different mode is marked out of date.
+Source-frame searches re-create the stack's own mode, whatever the control
+says now.
+
 ## Frame selection and admission
 
 PSF Guard owns project policy; Seiza owns image registration and integration.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -14,6 +14,12 @@
   Sequence view, and the detail panel always agree. The zero-star cap does
   not scale. See
   [screening](https://github.com/theatrus/psf-guard/blob/main/docs/SCREENING.md).
+- Stack previews gained a **Calibration** control: **Auto** (the default)
+  applies the safe masters, **Force on** applies every master that can be
+  built — including a flat with no bias or dark master, which Auto holds
+  back — and **Off** stacks the raw frames. The choice is remembered, and a
+  preview built under a different mode is marked out of date. See [stack
+  previews](https://github.com/theatrus/psf-guard/blob/main/docs/STACKING_PREVIEWS.md).
 
 ## Fixed
 

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -191,8 +191,37 @@ pub struct CalibrationSyncOutcome {
     pub frames: CalibrationSyncCounts,
 }
 
+/// How a stack asks for calibration. `Auto` applies every master that can be
+/// built and refuses combinations that would damage the result (a flat with
+/// no bias or dark master). `On` applies whatever can be built, including the
+/// combinations `Auto` refuses. `Off` stacks the raw lights.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CalibrationMode {
+    #[default]
+    Auto,
+    On,
+    Off,
+}
+
+impl CalibrationMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::On => "on",
+            Self::Off => "off",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub struct AppliedCalibration {
+    /// The mode the resolution ran under. Recorded so consumers that must
+    /// reproduce a build — the source-frame search — resolve the same way,
+    /// and so the UI can mark a stack stale when the preference changes.
+    /// Artifacts recorded before this field existed were built in `Auto`.
+    #[serde(default)]
+    pub mode: CalibrationMode,
     pub state: String,
     pub bias_frames: usize,
     pub dark_frames: usize,
@@ -215,6 +244,7 @@ pub struct AppliedCalibration {
 impl Default for AppliedCalibration {
     fn default() -> Self {
         Self {
+            mode: CalibrationMode::Auto,
             state: "none".into(),
             bias_frames: 0,
             dark_frames: 0,
@@ -917,18 +947,37 @@ fn stop_requested(cancel: Option<&AtomicBool>) -> Result<()> {
     }
 }
 
+/// The resolution returned when calibration is switched off: no matching, no
+/// masters, and a fingerprint that cannot collide with a real selection.
+fn calibration_off() -> (seiza_stacking::CalibrationMasters, AppliedCalibration) {
+    (
+        seiza_stacking::CalibrationMasters::default(),
+        AppliedCalibration {
+            mode: CalibrationMode::Off,
+            state: "off".into(),
+            fingerprint: "off".into(),
+            ..Default::default()
+        },
+    )
+}
+
 pub fn resolve_or_build_masters(
     conn: &Connection,
     cache_root: &Path,
     light_path: &Path,
     directory_tree: Option<&crate::directory_tree::DirectoryTree>,
     cancel: Option<&AtomicBool>,
+    mode: CalibrationMode,
 ) -> Result<(seiza_stacking::CalibrationMasters, AppliedCalibration)> {
+    if mode == CalibrationMode::Off {
+        return Ok(calibration_off());
+    }
     let light = crate::commands::import::headers::read_frame_meta(light_path);
     let mut selected = select_for_light(conn, &light)?;
     let missing_sources = remap_missing_sources(&mut selected, directory_tree);
     let fingerprint = selection_hash(&selected);
     let mut applied = AppliedCalibration {
+        mode,
         state: "matching".into(),
         bias_frames: selected.bias.len(),
         dark_frames: selected.dark.len(),
@@ -1089,13 +1138,27 @@ pub fn resolve_or_build_masters(
     // (bright edges), which is worse than no flat at all. The flat master
     // itself stays cached: once bias or dark frames are imported, the
     // dependency-aware hash rebuilds and applies it properly.
+    let mut forced_flat_note = None;
     let flat = if flat.is_some() && bias.is_none() && dark.is_none() {
-        let reason = "skipped: dividing a flat into a light with no bias or dark master \
+        if mode == CalibrationMode::On {
+            // The caller forced calibration on, accepting the damage Auto
+            // refuses. Say what to expect so a bright-edged result is not
+            // mistaken for a broken flat.
+            forced_flat_note = Some(
+                "Flat applied without a bias or dark master because calibration is forced on; \
+                 vignetted edges may brighten (the light's pedestal is amplified by the flat \
+                 correction)",
+            );
+            flat
+        } else {
+            let reason = "skipped: dividing a flat into a light with no bias or dark master \
                       brightens vignetted edges (the light's pedestal is amplified by \
-                      the flat correction); import bias or dark frames for this camera";
-        tracing::warn!("flat master {reason}");
-        build_failures.push((CalibrationKind::Flat, reason.into()));
-        None
+                      the flat correction); import bias or dark frames for this camera, \
+                      or force calibration on for this stack";
+            tracing::warn!("flat master {reason}");
+            build_failures.push((CalibrationKind::Flat, reason.into()));
+            None
+        }
     } else {
         flat
     };
@@ -1154,6 +1217,12 @@ pub fn resolve_or_build_masters(
             None => failed,
         });
     }
+    if let Some(note) = forced_flat_note {
+        applied.warning = Some(match applied.warning.take() {
+            Some(previous) => format!("{previous}. {note}"),
+            None => note.into(),
+        });
+    }
     applied.masters_signature = masters_signature(&applied);
     Ok((masters, applied))
 }
@@ -1180,7 +1249,11 @@ pub fn resolve_or_build_masters_for_group(
     light_paths: &[PathBuf],
     directory_tree: Option<&crate::directory_tree::DirectoryTree>,
     cancel: Option<&AtomicBool>,
+    mode: CalibrationMode,
 ) -> Result<(seiza_stacking::CalibrationMasters, AppliedCalibration)> {
+    if mode == CalibrationMode::Off {
+        return Ok(calibration_off());
+    }
     let Some(reference) = light_paths.first() else {
         return Ok((
             seiza_stacking::CalibrationMasters::default(),
@@ -1199,6 +1272,7 @@ pub fn resolve_or_build_masters_for_group(
         return Ok((
             seiza_stacking::CalibrationMasters::default(),
             AppliedCalibration {
+                mode,
                 state: "incomplete".into(),
                 warning: Some(
                     "Stack inputs need different calibration sets; this preview was left uncalibrated"
@@ -1209,7 +1283,7 @@ pub fn resolve_or_build_masters_for_group(
             },
         ));
     }
-    resolve_or_build_masters(conn, cache_root, reference, directory_tree, cancel)
+    resolve_or_build_masters(conn, cache_root, reference, directory_tree, cancel, mode)
 }
 
 struct BuiltMaster {
@@ -2388,9 +2462,15 @@ mod tests {
             tx.commit().unwrap();
         }
         let cache = temp.path().join("cache");
-        let (masters, applied) =
-            resolve_or_build_masters_for_group(&conn, &cache, &[light_a, light_b], None, None)
-                .unwrap();
+        let (masters, applied) = resolve_or_build_masters_for_group(
+            &conn,
+            &cache,
+            &[light_a, light_b],
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
         assert!(
             applied.flat_master.is_some(),
             "one coherent session must build: {:?}",
@@ -2423,14 +2503,26 @@ mod tests {
             import_calibration_frames(&tx, &calibration_meta, Some("profile")).unwrap();
             tx.commit().unwrap();
         }
-        let (_, first) =
-            resolve_or_build_masters(&conn, &temp.path().join("cache-a"), &light_path, None, None)
-                .unwrap();
+        let (_, first) = resolve_or_build_masters(
+            &conn,
+            &temp.path().join("cache-a"),
+            &light_path,
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
         assert!(first.flat_master.is_some());
 
-        let (_, second) =
-            resolve_or_build_masters(&conn, &temp.path().join("cache-b"), &light_path, None, None)
-                .unwrap();
+        let (_, second) = resolve_or_build_masters(
+            &conn,
+            &temp.path().join("cache-b"),
+            &light_path,
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
         assert!(
             second.flat_master.is_some(),
             "same masters in a new cache dir must re-record cleanly: {:?}",
@@ -2463,8 +2555,15 @@ mod tests {
             tx.commit().unwrap();
         }
         let cache = temp.path().join("cache");
-        let (masters, applied) =
-            resolve_or_build_masters(&conn, &cache, &light_path, None, None).unwrap();
+        let (masters, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            &light_path,
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
 
         assert!(
             applied.flat_master.is_none(),
@@ -2477,6 +2576,100 @@ mod tests {
                 && warning.contains("import bias or dark frames"),
             "warning must explain the inversion and the remedy: {warning}"
         );
+    }
+
+    #[test]
+    fn forced_calibration_applies_a_flat_only_library_and_says_what_to_expect() {
+        // `On` overrides the flat-only refusal: the caller accepts the
+        // pedestal amplification. The flat must apply, and the warning must
+        // still say what the result may look like.
+        let temp = tempfile::tempdir().unwrap();
+        let mut calibration_meta = Vec::new();
+        for index in 0..2 {
+            let path = temp.path().join(format!("flat-{index}.fits"));
+            write_test_fits(&path, "FLAT", 1_000 + index);
+            calibration_meta.push(crate::commands::import::headers::read_frame_meta(&path));
+        }
+        let light_path = temp.path().join("light.fits");
+        write_test_fits(&light_path, "LIGHT", 1_100);
+
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            import_calibration_frames(&tx, &calibration_meta, Some("profile")).unwrap();
+            tx.commit().unwrap();
+        }
+        let cache = temp.path().join("cache");
+        let (masters, applied) =
+            resolve_or_build_masters(&conn, &cache, &light_path, None, None, CalibrationMode::On)
+                .unwrap();
+
+        assert!(
+            applied.flat_master.is_some(),
+            "forced-on must apply the flat"
+        );
+        assert!(!masters.is_empty());
+        assert_eq!(applied.mode, CalibrationMode::On);
+        assert_eq!(applied.state, "applied");
+        assert!(
+            applied.masters_signature.contains(";flat=flat-"),
+            "signature must record the forced flat: {}",
+            applied.masters_signature
+        );
+        let warning = applied.warning.as_deref().unwrap_or_default();
+        assert!(
+            warning.contains("forced on") && warning.contains("vignetted edges may brighten"),
+            "warning must say what forcing the flat can do: {warning}"
+        );
+    }
+
+    #[test]
+    fn calibration_off_skips_matching_and_cannot_collide_with_a_real_selection() {
+        // `Off` must not read the library at all, and its fingerprint must
+        // differ from both a real selection and the empty-selection "none"
+        // state, so resume checkpoints and searches never mix the two.
+        let temp = tempfile::tempdir().unwrap();
+        let mut calibration_meta = Vec::new();
+        for index in 0..2 {
+            let path = temp.path().join(format!("flat-{index}.fits"));
+            write_test_fits(&path, "FLAT", 1_000 + index);
+            calibration_meta.push(crate::commands::import::headers::read_frame_meta(&path));
+        }
+        let light_path = temp.path().join("light.fits");
+        write_test_fits(&light_path, "LIGHT", 1_100);
+
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            import_calibration_frames(&tx, &calibration_meta, Some("profile")).unwrap();
+            tx.commit().unwrap();
+        }
+        let cache = temp.path().join("cache");
+        let (masters, applied) = resolve_or_build_masters_for_group(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Off,
+        )
+        .unwrap();
+
+        assert!(masters.is_empty());
+        assert_eq!(applied.mode, CalibrationMode::Off);
+        assert_eq!(applied.state, "off");
+        assert_eq!(applied.fingerprint, "off");
+        assert!(applied.warning.is_none());
+        let (_, auto_applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            &light_path,
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        assert_ne!(applied.fingerprint, auto_applied.fingerprint);
     }
 
     #[test]
@@ -2532,8 +2725,15 @@ mod tests {
         std::fs::write(temp.path().join("bias-1.fits"), hot).unwrap();
 
         let cache = temp.path().join("cache");
-        let (masters, applied) =
-            resolve_or_build_masters(&conn, &cache, &light_path, None, None).unwrap();
+        let (masters, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            &light_path,
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
 
         assert!(applied.bias_master.is_none(), "bias build fails");
         assert!(
@@ -2604,8 +2804,15 @@ mod tests {
         std::fs::write(temp.path().join("flat-1.fits"), hot_flat).unwrap();
 
         let cache = temp.path().join("cache");
-        let (masters, applied) =
-            resolve_or_build_masters(&conn, &cache, &light_path, None, None).unwrap();
+        let (masters, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            &light_path,
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
 
         assert!(applied.bias_master.is_some(), "bias still builds");
         assert!(applied.flat_master.is_none(), "flat cannot build");
@@ -2644,8 +2851,15 @@ mod tests {
             tx.commit().unwrap();
         }
         let cache = temp.path().join("cache");
-        let (masters, applied) =
-            resolve_or_build_masters(&conn, &cache, &light_path, None, None).unwrap();
+        let (masters, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            &light_path,
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
         assert!(!masters.is_empty());
         assert_eq!(applied.state, "applied");
         assert!(applied
@@ -2685,7 +2899,15 @@ mod tests {
         assert!(flat_dependencies.0.is_some());
         assert!(flat_dependencies.1.is_some());
 
-        let (_, reused) = resolve_or_build_masters(&conn, &cache, &light_path, None, None).unwrap();
+        let (_, reused) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            &light_path,
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
         assert_eq!(reused.fingerprint, applied.fingerprint);
         assert_eq!(library_summary(&conn).unwrap().master_count, 4);
 
@@ -2731,6 +2953,7 @@ mod tests {
             &[first, second],
             None,
             None,
+            CalibrationMode::Auto,
         )
         .unwrap();
         assert!(masters.is_empty());

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -67,6 +67,11 @@ pub struct StackPreviewRequest {
     /// stacks must share one sky frame, such as a mosaic.
     #[serde(default)]
     pub north_up: bool,
+    /// How this build calibrates its lights: `auto` (default) applies the
+    /// safe masters, `on` forces every buildable master including the ones
+    /// auto refuses, and `off` stacks the raw frames.
+    #[serde(default)]
+    pub calibration: crate::calibration::CalibrationMode,
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]
@@ -636,6 +641,7 @@ struct PreparedJob {
     groups: Vec<PreparedGroup>,
     cache_root: PathBuf,
     north_up: bool,
+    calibration: crate::calibration::CalibrationMode,
 }
 
 /// Weighs how much integrated exposure faces the same way as the reference
@@ -1225,6 +1231,7 @@ fn prepare_job(
     hasher.update(project_id.to_le_bytes());
     hasher.update([request.accepted_only as u8]);
     hasher.update([request.north_up as u8]);
+    hasher.update(request.calibration.as_str().as_bytes());
     hasher.update(STACK_PREVIEW_CACHE_VERSION.to_le_bytes());
     hasher.update(SEIZA_STACKING_VERSION.as_bytes());
     hasher.update(seiza_stacking::SKY_ORIENTATION_VERSION.to_le_bytes());
@@ -1403,6 +1410,7 @@ fn prepare_job(
         groups: prepared_groups,
         cache_root: ctx.cache_dir_path.clone(),
         north_up: request.north_up,
+        calibration: request.calibration,
     })
 }
 
@@ -1681,6 +1689,7 @@ fn run_job(state: &Arc<AppState>, prepared: PreparedJob, cancel: &Arc<AtomicBool
         groups,
         cache_root,
         north_up,
+        calibration,
     } = prepared;
     state.stack_previews.update(&job_id, |job| {
         job.state = StackJobState::Running;
@@ -1696,6 +1705,7 @@ fn run_job(state: &Arc<AppState>, prepared: PreparedJob, cancel: &Arc<AtomicBool
         job_id: &job_id,
         cache_root: &cache_root,
         north_up,
+        calibration,
         accepted_only,
         worker_policy: &worker_policy,
         cancel,
@@ -1779,6 +1789,7 @@ struct GroupJob<'a> {
     job_id: &'a str,
     cache_root: &'a FsPath,
     north_up: bool,
+    calibration: crate::calibration::CalibrationMode,
     accepted_only: bool,
     worker_policy: &'a crate::concurrency::WorkerPolicy,
     cancel: &'a Arc<AtomicBool>,
@@ -1797,6 +1808,7 @@ fn run_group(
         job_id,
         cache_root,
         north_up,
+        calibration,
         accepted_only,
         worker_policy,
         cancel,
@@ -1825,6 +1837,7 @@ fn run_group(
         &light_paths,
         Some(&directory_tree),
         Some(cancel.as_ref()),
+        calibration,
     );
     if cancel.load(Ordering::Relaxed) {
         return Ok(GroupOutcome::Cancelled);
@@ -2741,6 +2754,7 @@ mod tests {
             accepted_only: false,
             force: false,
             north_up: false,
+            calibration: crate::calibration::CalibrationMode::Auto,
         })
         .is_err());
         assert!(validate_request(&StackPreviewRequest {
@@ -2748,6 +2762,7 @@ mod tests {
             accepted_only: false,
             force: false,
             north_up: false,
+            calibration: crate::calibration::CalibrationMode::Auto,
         })
         .is_err());
         assert!(validate_request(&StackPreviewRequest {
@@ -2755,6 +2770,7 @@ mod tests {
             accepted_only: false,
             force: false,
             north_up: false,
+            calibration: crate::calibration::CalibrationMode::Auto,
         })
         .is_ok());
     }

--- a/src/server/stack_preview/artifact.rs
+++ b/src/server/stack_preview/artifact.rs
@@ -132,6 +132,9 @@ struct SearchGroup {
     /// compare against differently calibrated pixels. Empty for stacks
     /// recorded before this field existed — those skip the check.
     expected_masters_signature: String,
+    /// The mode the stack calibrated under, so the search resolves the same
+    /// way. Stacks recorded before the field existed were built in `Auto`.
+    calibration_mode: crate::calibration::CalibrationMode,
     sources: Vec<SearchSource>,
 }
 
@@ -580,6 +583,7 @@ fn prepare_search(
             label,
             expected_calibration_fingerprint: group.calibration.fingerprint,
             expected_masters_signature: group.calibration.masters_signature,
+            calibration_mode: group.calibration.mode,
             sources,
         });
     }
@@ -719,6 +723,7 @@ fn run_search_inner(
             &paths,
             Some(&directory_tree),
             None,
+            group.calibration_mode,
         )
         // `{:#}` keeps the anyhow cause chain; `to_string()` would report
         // only "building master <kind>" with no reason.

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3389,6 +3389,21 @@
   white-space: nowrap;
 }
 
+.stack-preview-calibration-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.stack-preview-calibration-mode select {
+  padding: 0.28rem 0.4rem;
+  border-radius: 5px;
+  font-size: 0.82rem;
+}
+
 .stack-preview-build,
 .stack-preview-rebuild,
 .stack-preview-stop {

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -55,6 +55,7 @@ import type {
   SatelliteAnalysis,
   SatelliteAnalysisStatus,
   StackPreviewJob,
+  CalibrationMode,
   ArtifactSearchJob,
   ReferenceRegion,
   LatestStackPreviews,
@@ -726,6 +727,8 @@ export const apiClient = {
       force?: boolean;
       /** Reproject onto the shared north-up, east-left grid. Off by default. */
       north_up?: boolean;
+      /** How to calibrate the lights: auto (default), on (forced), or off. */
+      calibration?: CalibrationMode;
     }
   ): Promise<StackPreviewJob> => {
     const apiInstance = await getApi();

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -447,8 +447,18 @@ export interface StackGroupStatus {
   frames: StackFrameDecision[];
 }
 
+/**
+ * How a stack build calibrates its lights. `auto` applies the safe masters
+ * and refuses combinations that damage the result; `on` forces every
+ * buildable master, including the refused combinations; `off` stacks raw
+ * frames.
+ */
+export type CalibrationMode = 'auto' | 'on' | 'off';
+
 export interface AppliedCalibration {
-  state: 'none' | 'matching' | 'incomplete' | 'applied';
+  /** Absent on artifacts recorded before the mode existed; those ran `auto`. */
+  mode?: CalibrationMode;
+  state: 'none' | 'matching' | 'incomplete' | 'applied' | 'off';
   bias_frames: number;
   dark_frames: number;
   dark_flat_frames: number;

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import type {
+  CalibrationMode,
   Image,
   LatestStackPreviewGroup,
   StackFrameDecision,
@@ -56,6 +57,27 @@ interface StackArtifact {
   group: StackGroupStatus;
 }
 
+/**
+ * Remembered like the accepted-only choice is per session, but across
+ * reloads: how a stack calibrates is a lasting decision about someone's
+ * calibration library, not about one build.
+ */
+const CALIBRATION_MODE_KEY = 'psf-guard.stack-calibration-mode';
+
+function readCalibrationMode(): CalibrationMode {
+  try {
+    const stored = window.localStorage.getItem(CALIBRATION_MODE_KEY);
+    return stored === 'on' || stored === 'off' ? stored : 'auto';
+  } catch {
+    return 'auto';
+  }
+}
+
+/** The mode a finished artifact was built under; older artifacts ran auto. */
+function builtCalibrationMode(group: StackGroupStatus): CalibrationMode {
+  return group.calibration?.mode ?? 'auto';
+}
+
 const terminalStates = new Set(['completed', 'failed', 'cancelled']);
 
 function stackJobQueryKey(dbId: string, projectId: number, jobId: string | null) {
@@ -92,7 +114,9 @@ function staleReason(
   current: ChannelInput | undefined,
   inputImages: StackInputImage[],
   builtAcceptedOnly: boolean,
-  acceptedOnly: boolean
+  acceptedOnly: boolean,
+  builtCalibration: CalibrationMode,
+  calibrationMode: CalibrationMode
 ): string | null {
   if (!current) return 'Out of date — this channel is not in the current input';
   if (inputImages.length === 0) return 'Out of date — rebuild required';
@@ -110,6 +134,9 @@ function staleReason(
   }
   if (builtAcceptedOnly !== acceptedOnly) {
     return 'Out of date — Accepted only changed';
+  }
+  if (builtCalibration !== calibrationMode) {
+    return 'Out of date — calibration mode changed';
   }
   return null;
 }
@@ -161,6 +188,15 @@ export default function StackPreviewPanel({
     return next;
   });
   const [acceptedOnly, setAcceptedOnly] = useState(false);
+  const [calibrationMode, setCalibrationMode] = useState<CalibrationMode>(readCalibrationMode);
+  const chooseCalibrationMode = (mode: CalibrationMode) => {
+    setCalibrationMode(mode);
+    try {
+      window.localStorage.setItem(CALIBRATION_MODE_KEY, mode);
+    } catch {
+      // Keep the in-memory preference even when it cannot be persisted.
+    }
+  };
   const [watchedJobIds, setWatchedJobIds] = useState<string[]>([]);
   const [inspector, setInspector] = useState<StackArtifact | null>(null);
   const [stretches, setStretches] = useState<Record<string, StackStretchPreview>>({});
@@ -214,6 +250,7 @@ export default function StackPreviewPanel({
         image_ids: variables.imageIds,
         accepted_only: acceptedOnly,
         force: variables.force,
+        calibration: calibrationMode,
       }),
     onSuccess: (job) => {
       queryClient.setQueryData(stackJobQueryKey(dbId, projectId, job.job_id), job);
@@ -384,7 +421,9 @@ export default function StackPreviewPanel({
           currentChannels.get(key),
           artifact.group.input_images,
           artifact.acceptedOnly,
-          acceptedOnly
+          acceptedOnly,
+          builtCalibrationMode(artifact.group),
+          calibrationMode
         ) !== null
       : false;
   }).length;
@@ -397,14 +436,16 @@ export default function StackPreviewPanel({
           currentChannels.get(key),
           entry.group.input_images,
           entry.accepted_only,
-          acceptedOnly
+          acceptedOnly,
+          builtCalibrationMode(entry.group),
+          calibrationMode
         )
       ) {
         targetIds.add(entry.group.target_id);
       }
     }
     return targetIds;
-  }, [acceptedOnly, currentChannels, latest.data]);
+  }, [acceptedOnly, calibrationMode, currentChannels, latest.data]);
   const colorSourceRevision = useMemo(
     () => (latest.data?.groups ?? [])
       .map((entry) => `${entry.job_id}:${entry.group.index}:${entry.artifact_revision}`)
@@ -466,6 +507,26 @@ export default function StackPreviewPanel({
                 onChange={(event) => setAcceptedOnly(event.target.checked)}
               />
               Accepted only
+            </label>
+            <label
+              className="stack-preview-calibration-mode"
+              title={
+                'How the next build calibrates its lights. Auto applies the safe masters and ' +
+                'holds back combinations that damage the result, such as a flat with no bias ' +
+                'or dark master. Force on applies every master that can be built anyway. ' +
+                'Off stacks the raw frames.'
+              }
+            >
+              Calibration
+              <select
+                value={calibrationMode}
+                disabled={running}
+                onChange={(event) => chooseCalibrationMode(event.target.value as CalibrationMode)}
+              >
+                <option value="auto">Auto</option>
+                <option value="on">Force on</option>
+                <option value="off">Off</option>
+              </select>
             </label>
             <button
               className="stack-preview-build"
@@ -573,7 +634,9 @@ export default function StackPreviewPanel({
                       current,
                       artifact.group.input_images,
                       artifact.acceptedOnly,
-                      acceptedOnly
+                      acceptedOnly,
+                      builtCalibrationMode(artifact.group),
+                      calibrationMode
                     )
                   : null;
                 const groupBusy =
@@ -782,15 +845,21 @@ export default function StackPreviewPanel({
                       <div className="stack-preview-calibration">
                         <strong>
                           {calibration.state === 'applied'
-                            ? 'Calibration applied'
-                            : calibration.state === 'incomplete'
-                              ? 'Calibration set incomplete'
-                              : 'Matching calibration'}
+                            ? calibration.mode === 'on'
+                              ? 'Calibration applied (forced on)'
+                              : 'Calibration applied'
+                            : calibration.state === 'off'
+                              ? 'Calibration off'
+                              : calibration.state === 'incomplete'
+                                ? 'Calibration set incomplete'
+                                : 'Matching calibration'}
                         </strong>
-                        <span>
-                          {calibration.bias_frames} bias · {calibration.dark_frames} dark ·{' '}
-                          {calibration.dark_flat_frames} dark-flat · {calibration.flat_frames} flat
-                        </span>
+                        {calibration.state !== 'off' && (
+                          <span>
+                            {calibration.bias_frames} bias · {calibration.dark_frames} dark ·{' '}
+                            {calibration.dark_flat_frames} dark-flat · {calibration.flat_frames} flat
+                          </span>
+                        )}
                         {calibration.warning && <span>{calibration.warning}</span>}
                       </div>
                     )}


### PR DESCRIPTION
Follow-up to #327, prompted by a bright-edged flat-only stack. Two deliverables: the per-stack calibration control, and pixel evidence answering whether the bright edges were a flat-application bug.

## The physics, measured

The question was whether the inverted vignette pointed at broken flat application or bad acquisition, and whether darks could really fix it. Measured on two fresh builds of the same five Elephant's Trunk Ha frames (median background, 200 px boxes):

| build | corner / center background |
|---|---|
| raw (calibration off) | **0.95** — the true vignette, corners darker |
| flat forced, no bias/dark | **1.21** — inverted, corners brighter |

The application math is correct: seiza divides the light by the median-normalized flat. What inverts the vignette is the light's pedestal — `(signal·V + pedestal) / V = signal + pedestal/V`, so the constant offset is amplified wherever the flat response `V` dips. A conventional master dark **does** fix this, because it carries the same pedestal and is subtracted unscaled before the division; seiza refuses a bias-subtracted dark without a bias master for exactly this reason. Neither the flats nor the acquisition are at fault — the library just has nothing that removes the pedestal.

## The control

The stack panel gains a **Calibration** select, remembered across reloads:

- **Auto** (default) — current behavior: apply the safe masters, hold back damaging combinations.
- **Force on** — apply every master that can be built, including the flat-only case; the calibration warning says vignetted edges may brighten.
- **Off** — stack the raw frames without reading the library.

The mode rides on `AppliedCalibration`, so the stack job key, resume checkpoints, and source-frame searches all distinguish builds by mode, and a search re-creates the stack's own mode regardless of the current preference. `Off` resolves to a fixed `off` fingerprint that cannot collide with a real selection. A finished preview built under a different mode is marked out of date, like an Accepted-only change.

## Verification

- Live on the C925 catalog copy: `off` and `on` builds produce distinct jobs; `off` reports `Calibration off`; `on` applies the flat-only library with the expectation warning; the table above is measured from their FITS outputs.
- New tests: forced-on applies a flat-only library and records it in the masters signature; off skips matching and cannot collide with a real selection or the empty-selection state.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (700 passed) · `npm run lint` · `npx vitest run` (276 passed) · `npm run build` · `npx playwright test stack-preview` (3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)