### PR TITLE
Let each channel override the stack calibration mode

### DIFF
--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -233,6 +233,13 @@ and a finished preview built under a different mode is marked out of date.
 Source-frame searches re-create the stack's own mode, whatever the control
 says now.
 
+Each channel card carries its own smaller select that can override the
+panel-wide choice for that target and filter alone — one channel with a bad
+flat can stack raw while the rest calibrate. "Project" follows the
+panel-wide control; the override is remembered per database, project, and
+channel, and staleness is judged against the mode the channel actually
+stacks under.
+
 ## Frame selection and admission
 
 PSF Guard owns project policy; Seiza owns image registration and integration.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -20,6 +20,10 @@
   back — and **Off** stacks the raw frames. The choice is remembered, and a
   preview built under a different mode is marked out of date. See [stack
   previews](https://github.com/theatrus/psf-guard/blob/main/docs/STACKING_PREVIEWS.md).
+- The stack **Calibration** control can now be overridden per channel: each
+  target-and-filter card has its own select, so one channel with a bad flat
+  can stack raw while the rest calibrate. Overrides are remembered and the
+  card's out-of-date marker follows the mode the channel actually uses.
 - A flats-only calibration library now flat-corrects instead of stacking
   uncorrected. PSF Guard fits the bias pedestal from the lights themselves
   (background against flat response), corroborates it against the camera's

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -72,6 +72,35 @@ pub struct StackPreviewRequest {
     /// auto refuses, and `off` stacks the raw frames.
     #[serde(default)]
     pub calibration: crate::calibration::CalibrationMode,
+    /// Per-channel exceptions to `calibration`. A channel is one target and
+    /// filter group; a channel without an entry uses `calibration`.
+    #[serde(default)]
+    pub calibration_overrides: Vec<CalibrationOverride>,
+}
+
+/// One channel's calibration mode, overriding the request-wide choice.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CalibrationOverride {
+    pub target_id: i32,
+    #[serde(default)]
+    pub filter_name: String,
+    pub calibration: crate::calibration::CalibrationMode,
+}
+
+impl StackPreviewRequest {
+    /// The mode one channel stacks under: its override, or the request-wide
+    /// mode.
+    fn calibration_for(
+        &self,
+        target_id: i32,
+        filter_name: &str,
+    ) -> crate::calibration::CalibrationMode {
+        self.calibration_overrides
+            .iter()
+            .find(|entry| entry.target_id == target_id && entry.filter_name == filter_name)
+            .map(|entry| entry.calibration)
+            .unwrap_or(self.calibration)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]
@@ -633,6 +662,9 @@ fn rejected_decision(frame: &PreparedFrame, reason: String) -> StackFrameDecisio
 #[derive(Clone)]
 struct PreparedGroup {
     index: usize,
+    /// The mode this channel calibrates under: its request override, or the
+    /// request-wide mode.
+    calibration: crate::calibration::CalibrationMode,
     frames: Vec<PreparedFrame>,
 }
 
@@ -641,7 +673,6 @@ struct PreparedJob {
     groups: Vec<PreparedGroup>,
     cache_root: PathBuf,
     north_up: bool,
-    calibration: crate::calibration::CalibrationMode,
 }
 
 /// Weighs how much integrated exposure faces the same way as the reference
@@ -1231,7 +1262,6 @@ fn prepare_job(
     hasher.update(project_id.to_le_bytes());
     hasher.update([request.accepted_only as u8]);
     hasher.update([request.north_up as u8]);
-    hasher.update(request.calibration.as_str().as_bytes());
     hasher.update(STACK_PREVIEW_CACHE_VERSION.to_le_bytes());
     hasher.update(SEIZA_STACKING_VERSION.as_bytes());
     hasher.update(seiza_stacking::SKY_ORIENTATION_VERSION.to_le_bytes());
@@ -1242,9 +1272,14 @@ fn prepare_job(
     for (index, ((target_id, target_name, filter_name), mut entries)) in
         grouped.into_iter().enumerate()
     {
+        // Hash the mode each channel actually stacks under, so the same
+        // effective configuration lands on the same job whether it came from
+        // the request-wide mode or an override.
+        let group_calibration = request.calibration_for(target_id, &filter_name);
         hasher.update(target_id.to_le_bytes());
         hasher.update(target_name.as_bytes());
         hasher.update(filter_name.as_bytes());
+        hasher.update(group_calibration.as_str().as_bytes());
         entries.sort_by_key(|(image, _)| (image.acquired_date.unwrap_or(0), image.id));
         let total_candidates = entries.len();
         let input_images = entries
@@ -1371,7 +1406,11 @@ fn prepare_job(
             input_images,
             frames: decisions,
         });
-        prepared_groups.push(PreparedGroup { index, frames });
+        prepared_groups.push(PreparedGroup {
+            index,
+            calibration: group_calibration,
+            frames,
+        });
     }
 
     let digest = hasher.finalize();
@@ -1410,7 +1449,6 @@ fn prepare_job(
         groups: prepared_groups,
         cache_root: ctx.cache_dir_path.clone(),
         north_up: request.north_up,
-        calibration: request.calibration,
     })
 }
 
@@ -1689,7 +1727,6 @@ fn run_job(state: &Arc<AppState>, prepared: PreparedJob, cancel: &Arc<AtomicBool
         groups,
         cache_root,
         north_up,
-        calibration,
     } = prepared;
     state.stack_previews.update(&job_id, |job| {
         job.state = StackJobState::Running;
@@ -1705,7 +1742,6 @@ fn run_job(state: &Arc<AppState>, prepared: PreparedJob, cancel: &Arc<AtomicBool
         job_id: &job_id,
         cache_root: &cache_root,
         north_up,
-        calibration,
         accepted_only,
         worker_policy: &worker_policy,
         cancel,
@@ -1789,7 +1825,6 @@ struct GroupJob<'a> {
     job_id: &'a str,
     cache_root: &'a FsPath,
     north_up: bool,
-    calibration: crate::calibration::CalibrationMode,
     accepted_only: bool,
     worker_policy: &'a crate::concurrency::WorkerPolicy,
     cancel: &'a Arc<AtomicBool>,
@@ -1808,7 +1843,6 @@ fn run_group(
         job_id,
         cache_root,
         north_up,
-        calibration,
         accepted_only,
         worker_policy,
         cancel,
@@ -1837,7 +1871,7 @@ fn run_group(
         &light_paths,
         Some(&directory_tree),
         Some(cancel.as_ref()),
-        calibration,
+        group.calibration,
     );
     if cancel.load(Ordering::Relaxed) {
         return Ok(GroupOutcome::Cancelled);
@@ -2755,6 +2789,7 @@ mod tests {
             force: false,
             north_up: false,
             calibration: crate::calibration::CalibrationMode::Auto,
+            calibration_overrides: Vec::new(),
         })
         .is_err());
         assert!(validate_request(&StackPreviewRequest {
@@ -2763,6 +2798,7 @@ mod tests {
             force: false,
             north_up: false,
             calibration: crate::calibration::CalibrationMode::Auto,
+            calibration_overrides: Vec::new(),
         })
         .is_err());
         assert!(validate_request(&StackPreviewRequest {
@@ -2771,8 +2807,29 @@ mod tests {
             force: false,
             north_up: false,
             calibration: crate::calibration::CalibrationMode::Auto,
+            calibration_overrides: Vec::new(),
         })
         .is_ok());
+    }
+
+    #[test]
+    fn a_channel_override_wins_over_the_request_mode() {
+        use crate::calibration::CalibrationMode;
+        let request = StackPreviewRequest {
+            image_ids: vec![1, 2],
+            accepted_only: false,
+            force: false,
+            north_up: false,
+            calibration: CalibrationMode::Auto,
+            calibration_overrides: vec![CalibrationOverride {
+                target_id: 7,
+                filter_name: "Ha".into(),
+                calibration: CalibrationMode::Off,
+            }],
+        };
+        assert_eq!(request.calibration_for(7, "Ha"), CalibrationMode::Off);
+        assert_eq!(request.calibration_for(7, "OIII"), CalibrationMode::Auto);
+        assert_eq!(request.calibration_for(8, "Ha"), CalibrationMode::Auto);
     }
 
     #[test]

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3404,6 +3404,13 @@
   font-size: 0.82rem;
 }
 
+.stack-preview-channel-calibration select {
+  padding: 0.18rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
 .stack-preview-build,
 .stack-preview-rebuild,
 .stack-preview-stop {

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -729,6 +729,12 @@ export const apiClient = {
       north_up?: boolean;
       /** How to calibrate the lights: auto (default), on (forced), or off. */
       calibration?: CalibrationMode;
+      /** Per-channel exceptions to `calibration`, by target and filter. */
+      calibration_overrides?: Array<{
+        target_id: number;
+        filter_name: string;
+        calibration: CalibrationMode;
+      }>;
     }
   ): Promise<StackPreviewJob> => {
     const apiInstance = await getApi();

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -78,6 +78,34 @@ function builtCalibrationMode(group: StackGroupStatus): CalibrationMode {
   return group.calibration?.mode ?? 'auto';
 }
 
+/**
+ * Per-channel exceptions to the project-wide calibration mode, remembered
+ * like the mode itself. Keys carry the database and project, so target ids
+ * from different catalogs cannot collide.
+ */
+const CALIBRATION_OVERRIDES_KEY = 'psf-guard.stack-calibration-overrides';
+
+function overrideStorageKey(dbId: string, projectId: number, channel: string) {
+  return `${dbId}:${projectId}:${channel}`;
+}
+
+function readCalibrationOverrides(): Record<string, CalibrationMode> {
+  try {
+    const raw = window.localStorage.getItem(CALIBRATION_OVERRIDES_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const overrides: Record<string, CalibrationMode> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (value === 'auto' || value === 'on' || value === 'off') {
+        overrides[key] = value;
+      }
+    }
+    return overrides;
+  } catch {
+    return {};
+  }
+}
+
 const terminalStates = new Set(['completed', 'failed', 'cancelled']);
 
 function stackJobQueryKey(dbId: string, projectId: number, jobId: string | null) {
@@ -140,6 +168,8 @@ function staleReason(
   }
   return null;
 }
+// `calibrationMode` above is the channel's EFFECTIVE mode — its override
+// when one is set, else the project-wide choice.
 
 function artifactFromLatest(latest: LatestStackPreviewGroup | undefined): StackArtifact | undefined {
   if (!latest) return undefined;
@@ -197,6 +227,31 @@ export default function StackPreviewPanel({
       // Keep the in-memory preference even when it cannot be persisted.
     }
   };
+  const [overrides, setOverrides] = useState<Record<string, CalibrationMode>>(
+    readCalibrationOverrides
+  );
+  // '' clears the channel back to the project-wide mode.
+  const chooseChannelCalibration = (channel: string, mode: CalibrationMode | '') => {
+    setOverrides((current) => {
+      const next = { ...current };
+      const key = overrideStorageKey(dbId, projectId, channel);
+      if (mode === '') {
+        delete next[key];
+      } else {
+        next[key] = mode;
+      }
+      try {
+        window.localStorage.setItem(CALIBRATION_OVERRIDES_KEY, JSON.stringify(next));
+      } catch {
+        // Keep the in-memory preference even when it cannot be persisted.
+      }
+      return next;
+    });
+  };
+  const channelOverride = (channel: string): CalibrationMode | undefined =>
+    overrides[overrideStorageKey(dbId, projectId, channel)];
+  const effectiveCalibration = (channel: string): CalibrationMode =>
+    channelOverride(channel) ?? calibrationMode;
   const [watchedJobIds, setWatchedJobIds] = useState<string[]>([]);
   const [inspector, setInspector] = useState<StackArtifact | null>(null);
   const [stretches, setStretches] = useState<Record<string, StackStretchPreview>>({});
@@ -251,6 +306,13 @@ export default function StackPreviewPanel({
         accepted_only: acceptedOnly,
         force: variables.force,
         calibration: calibrationMode,
+        calibration_overrides: [...currentChannels.values()]
+          .filter((channel) => channelOverride(channel.key) !== undefined)
+          .map((channel) => ({
+            target_id: channel.targetId,
+            filter_name: channel.filterName,
+            calibration: channelOverride(channel.key)!,
+          })),
       }),
     onSuccess: (job) => {
       queryClient.setQueryData(stackJobQueryKey(dbId, projectId, job.job_id), job);
@@ -423,7 +485,7 @@ export default function StackPreviewPanel({
           artifact.acceptedOnly,
           acceptedOnly,
           builtCalibrationMode(artifact.group),
-          calibrationMode
+          effectiveCalibration(key)
         ) !== null
       : false;
   }).length;
@@ -438,14 +500,15 @@ export default function StackPreviewPanel({
           entry.accepted_only,
           acceptedOnly,
           builtCalibrationMode(entry.group),
-          calibrationMode
+          effectiveCalibration(key)
         )
       ) {
         targetIds.add(entry.group.target_id);
       }
     }
     return targetIds;
-  }, [acceptedOnly, calibrationMode, currentChannels, latest.data]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- effectiveCalibration reads calibrationMode and overrides, listed below.
+  }, [acceptedOnly, calibrationMode, overrides, currentChannels, latest.data]);
   const colorSourceRevision = useMemo(
     () => (latest.data?.groups ?? [])
       .map((entry) => `${entry.job_id}:${entry.group.index}:${entry.artifact_revision}`)
@@ -636,7 +699,7 @@ export default function StackPreviewPanel({
                       artifact.acceptedOnly,
                       acceptedOnly,
                       builtCalibrationMode(artifact.group),
-                      calibrationMode
+                      effectiveCalibration(key)
                     )
                   : null;
                 const groupBusy =
@@ -700,6 +763,30 @@ export default function StackPreviewPanel({
                         <span className={`stack-group-state ${activeGroup?.state ?? group?.state ?? 'not-built'}`}>
                           {activeGroup?.state ?? group?.state ?? 'not built'}
                         </span>
+                        <label
+                          className="stack-preview-channel-calibration"
+                          title={
+                            'Calibration for this channel only. "Project" follows the ' +
+                            'panel-wide Calibration choice; the other options override it ' +
+                            'for this target and filter, and are remembered.'
+                          }
+                        >
+                          <select
+                            value={channelOverride(key) ?? ''}
+                            disabled={running}
+                            onChange={(event) =>
+                              chooseChannelCalibration(
+                                key,
+                                event.target.value as CalibrationMode | ''
+                              )
+                            }
+                          >
+                            <option value="">Project ({calibrationMode})</option>
+                            <option value="auto">Auto</option>
+                            <option value="on">Force on</option>
+                            <option value="off">Off</option>
+                          </select>
+                        </label>
                         {artifact && (
                           <button
                             className="stack-preview-card-action"


### PR DESCRIPTION
Follow-up to #328: the Calibration control was project-wide; one channel with a bad flat forced a whole-project choice. Each channel card now has its own smaller select — "Project (auto)" follows the panel-wide control, and Auto / Force on / Off override it for that target and filter alone.

- `StackPreviewRequest` gains `calibration_overrides` (target, filter, mode); a channel without an entry uses the request-wide mode.
- The job hash covers the **effective** mode per group instead of the request-wide scalar, so identical effective configurations land on the same job however they were expressed.
- The mode moves from `GroupJob` to `PreparedGroup`; each group resolves calibration under its own mode, which flows into `AppliedCalibration.mode` and back to staleness and the source-frame search unchanged.
- Overrides persist per database, project, and channel (localStorage, like the panel-wide mode), and all three staleness surfaces compare against the channel's effective mode.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (704 passed, incl. a new override-resolution test) · `npm run lint` · `npx vitest run` (276 passed) · `npm run build` · `npx playwright test stack-preview` (3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)