### PR TITLE
Calibrate each night of a multi-night stack with its own masters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2967,7 +2967,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.16",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4166,7 +4166,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4705,7 +4705,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4762,7 +4762,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4916,9 +4916,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.15.5"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d9305616a23ef7679465f24dda0d64c7c03ab12c4445c7cf202c5f353999e4"
+checksum = "3ecfed57d3d0cc5325959f06cb8e00b50f56cf25ba9fadc4f853e4284ad0e6fb"
 dependencies = [
  "directories",
  "image",
@@ -5031,9 +5031,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a80c65960c26997729cdc36900664bf73eef363f72f47885ac6515b253c8234"
+checksum = "a05feb8be6657e9e1310cf9e5604985c215ac63f271167a882037a2e30eb6f4a"
 dependencies = [
  "rayon",
  "seiza",
@@ -6058,7 +6058,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6555,7 +6555,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.16",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.1"
 seiza-satellites = { version = "0.4.5", features = ["serde"] }
-seiza-stacking = "0.6.0"
+seiza-stacking = "0.7.0"
 seiza-stretch = "0.2.0"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.
@@ -122,5 +122,3 @@ overflow-checks = false
 
 [build-dependencies]
 tauri-build = { version = "2.6.2", features = [] }
-
-

--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -78,6 +78,15 @@ session (within a day of each other — dust moves between sessions). The
 nearest cluster with enough frames builds the master, so a stray single flat
 near the lights cannot orphan a complete session from a week earlier.
 
+A stack group whose lights need different master sets — a multi-night
+target with per-night flats, or a library large enough that the selection
+horizon moves — partitions into calibration sessions. Each light calibrates
+with its own session's masters; the stack swaps masters between sessions as
+it integrates. The stack card reports the session count, the resume
+checkpoint and source-frame search compare the composed per-session
+identity, and the search reuses each session's recorded fitted pedestal
+rather than fitting its own from the searched subset.
+
 A flat needs the light's pedestal removed before division: dividing a flat
 into a light that still carries its pedestal amplifies that pedestal at the
 vignetted edges, inverting the vignette into bright edges. With a bias or

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -20,6 +20,12 @@
   back — and **Off** stacks the raw frames. The choice is remembered, and a
   preview built under a different mode is marked out of date. See [stack
   previews](https://github.com/theatrus/psf-guard/blob/main/docs/STACKING_PREVIEWS.md).
+- Multi-night stacks now calibrate each night with its own masters. A stack
+  group whose lights match different calibration sets — per-night flats
+  above all — used to stack uncalibrated with a warning; it now partitions
+  into sessions, builds each session's masters, and swaps them in as it
+  integrates. The stack card shows the session count. See [calibration
+  libraries](https://github.com/theatrus/psf-guard/blob/main/docs/CALIBRATION_LIBRARY.md).
 - The stack **Calibration** control can now be overridden per channel: each
   target-and-filter card has its own select, so one channel with a bad flat
   can stack raw while the rest calibrate. Overrides are remembered and the

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -244,6 +244,30 @@ pub struct AppliedCalibration {
     /// when calibration used measured masters (or none at all).
     #[serde(default)]
     pub estimated_pedestal_adu: Option<f32>,
+    /// How many calibration sessions the group's lights partitioned into.
+    /// Multi-night stacks calibrate each session with its own masters. Zero
+    /// on records written before sessions existed (single-session builds).
+    #[serde(default)]
+    pub sessions: usize,
+    /// Per-session identity, in a stable order. The source-frame search
+    /// pins each session's fitted pedestal from here instead of re-fitting
+    /// it from a different sample of lights.
+    #[serde(default)]
+    pub session_details: Vec<CalibrationSessionDetail>,
+}
+
+/// One calibration session of a stack group, as recorded on the artifact.
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct CalibrationSessionDetail {
+    /// The session's selection fingerprint.
+    pub fingerprint: String,
+    /// The masters the session actually applied.
+    pub masters_signature: String,
+    /// The fitted pedestal the session's flat divided under, when one was.
+    #[serde(default)]
+    pub estimated_pedestal_adu: Option<f32>,
+    /// How many of the group's lights calibrate in this session.
+    pub lights: usize,
 }
 
 impl Default for AppliedCalibration {
@@ -263,6 +287,8 @@ impl Default for AppliedCalibration {
             fingerprint: "none".into(),
             masters_signature: "bias=none;dark=none;dark_flat=none;flat=none".into(),
             estimated_pedestal_adu: None,
+            sessions: 0,
+            session_details: Vec::new(),
         }
     }
 }
@@ -1165,6 +1191,31 @@ pub fn resolve_or_build_masters(
     cancel: Option<&AtomicBool>,
     mode: CalibrationMode,
 ) -> Result<(seiza_stacking::CalibrationMasters, AppliedCalibration)> {
+    resolve_or_build_masters_pinned(
+        conn,
+        cache_root,
+        light_paths,
+        directory_tree,
+        cancel,
+        mode,
+        None,
+    )
+}
+
+/// [`resolve_or_build_masters`] with a previously fitted pedestal carried
+/// in. The source-frame search reproduces a stack's calibration from a
+/// possibly smaller set of lights (rejected frames are not searched), so it
+/// must reuse the pedestal the build recorded rather than fit its own from
+/// a different sample.
+fn resolve_or_build_masters_pinned(
+    conn: &Connection,
+    cache_root: &Path,
+    light_paths: &[PathBuf],
+    directory_tree: Option<&crate::directory_tree::DirectoryTree>,
+    cancel: Option<&AtomicBool>,
+    mode: CalibrationMode,
+    pinned_pedestal: Option<f32>,
+) -> Result<(seiza_stacking::CalibrationMasters, AppliedCalibration)> {
     if mode == CalibrationMode::Off {
         return Ok(calibration_off());
     }
@@ -1354,9 +1405,13 @@ pub fn resolve_or_build_masters(
         } else {
             // The pedestal the division needs removed can be fitted from
             // the lights themselves: background = sky * flat response +
-            // pedestal, so the intercept of that line is the pedestal.
-            estimated_pedestal = flat.as_ref().and_then(|master| {
-                estimate_flat_pedestal(&master.path, light_paths, header_pedestal_hint(&light))
+            // pedestal, so the intercept of that line is the pedestal. A
+            // pinned value from the stack being reproduced wins over a
+            // fresh fit.
+            estimated_pedestal = pinned_pedestal.or_else(|| {
+                flat.as_ref().and_then(|master| {
+                    estimate_flat_pedestal(&master.path, light_paths, header_pedestal_hint(&light))
+                })
             });
             if estimated_pedestal.is_some() {
                 flat
@@ -1470,6 +1525,13 @@ pub fn resolve_or_build_masters(
         });
     }
     applied.masters_signature = masters_signature(&applied);
+    applied.sessions = 1;
+    applied.session_details = vec![CalibrationSessionDetail {
+        fingerprint: applied.fingerprint.clone(),
+        masters_signature: applied.masters_signature.clone(),
+        estimated_pedestal_adu: applied.estimated_pedestal_adu,
+        lights: light_paths.len(),
+    }];
     Ok((masters, applied))
 }
 
@@ -1495,6 +1557,221 @@ fn masters_signature(applied: &AppliedCalibration) -> String {
     signature
 }
 
+/// One calibration session of a stack group: the masters its lights
+/// calibrate with and how they resolved.
+pub struct CalibrationSession {
+    pub masters: seiza_stacking::CalibrationMasters,
+    pub applied: AppliedCalibration,
+}
+
+/// How a stack group's lights calibrate: each light is assigned to a
+/// session, and each session carries its own masters. A single-night group
+/// has one session and behaves exactly like the old single-resolution path.
+pub struct CalibrationPlan {
+    /// Session index for each input light, in caller order.
+    pub assignments: Vec<usize>,
+    pub sessions: Vec<CalibrationSession>,
+    /// The group-level summary carried on the stack card, folded into the
+    /// resume checkpoint key, and compared by the source-frame search. For
+    /// one session it is that session's summary verbatim; for several it
+    /// composes their identities order-independently.
+    pub applied: AppliedCalibration,
+}
+
+impl CalibrationPlan {
+    fn single(
+        masters: seiza_stacking::CalibrationMasters,
+        applied: AppliedCalibration,
+        lights: usize,
+    ) -> Self {
+        Self {
+            assignments: vec![0; lights],
+            sessions: vec![CalibrationSession {
+                masters,
+                applied: applied.clone(),
+            }],
+            applied,
+        }
+    }
+}
+
+/// The master set a light's selection would build, as a comparable key.
+/// Two lights with equal keys calibrate identically — same coherent frame
+/// subsets per kind, therefore the same content-addressed masters. Keys
+/// differ across capture sessions (per-night flats), across a changed
+/// library, and across the selection horizon of very large libraries.
+fn session_key(selected: &CalibrationSelection) -> String {
+    let mut parts = Vec::new();
+    for (kind, frames) in [
+        (CalibrationKind::Bias, &selected.bias),
+        (CalibrationKind::Dark, &selected.dark),
+        (CalibrationKind::DarkFlat, &selected.dark_flat),
+        (CalibrationKind::Flat, &selected.flat),
+    ] {
+        let subset = coherent_master_subset(kind, frames);
+        let mut values = subset
+            .iter()
+            .map(|frame| format!("{}:{}", frame.frame_uuid, frame.source_fingerprint))
+            .collect::<Vec<_>>();
+        values.sort();
+        parts.push(format!("{}={}", kind.as_str(), values.join(",")));
+    }
+    hex_digest(&parts.join("\u{1e}"))
+}
+
+/// Resolve every session a group of lights needs, building masters once per
+/// session. `pinned` carries per-session details recorded on an existing
+/// stack, so a reproduction (the source-frame search) reuses each session's
+/// fitted pedestal instead of fitting its own.
+pub fn resolve_or_build_master_plan(
+    conn: &Connection,
+    cache_root: &Path,
+    light_paths: &[PathBuf],
+    directory_tree: Option<&crate::directory_tree::DirectoryTree>,
+    cancel: Option<&AtomicBool>,
+    mode: CalibrationMode,
+    pinned: &[CalibrationSessionDetail],
+) -> Result<CalibrationPlan> {
+    if mode == CalibrationMode::Off {
+        let (masters, applied) = calibration_off();
+        return Ok(CalibrationPlan::single(masters, applied, light_paths.len()));
+    }
+    if light_paths.is_empty() {
+        return Ok(CalibrationPlan::single(
+            seiza_stacking::CalibrationMasters::default(),
+            AppliedCalibration::default(),
+            0,
+        ));
+    }
+
+    // Partition by the masters each light would build. The key derivation
+    // mirrors the build (selection, remap, coherent subset), so every light
+    // in a partition resolves to the identical master set whichever of them
+    // acts as the reference.
+    let mut assignments = Vec::with_capacity(light_paths.len());
+    let mut session_lights: Vec<Vec<PathBuf>> = Vec::new();
+    let mut keys: Vec<String> = Vec::new();
+    for path in light_paths {
+        let light = crate::commands::import::headers::read_frame_meta(path);
+        let mut selected = select_for_light(conn, &light)?;
+        remap_missing_sources(&mut selected, directory_tree);
+        let key = session_key(&selected);
+        let index = match keys.iter().position(|existing| existing == &key) {
+            Some(index) => index,
+            None => {
+                keys.push(key);
+                session_lights.push(Vec::new());
+                keys.len() - 1
+            }
+        };
+        assignments.push(index);
+        session_lights[index].push(path.clone());
+    }
+
+    let mut sessions = Vec::with_capacity(session_lights.len());
+    for lights in &session_lights {
+        stop_requested(cancel)?;
+        // A session's pin is looked up by its selection fingerprint, which
+        // the resolution below recomputes identically from the same lights.
+        let fingerprint = selection_fingerprint(conn, &lights[0], directory_tree)?;
+        let pinned_pedestal = pinned
+            .iter()
+            .find(|detail| detail.fingerprint == fingerprint)
+            .and_then(|detail| detail.estimated_pedestal_adu);
+        let (masters, applied) = resolve_or_build_masters_pinned(
+            conn,
+            cache_root,
+            lights,
+            directory_tree,
+            cancel,
+            mode,
+            pinned_pedestal,
+        )?;
+        sessions.push(CalibrationSession { masters, applied });
+    }
+
+    let applied = if sessions.len() == 1 {
+        sessions[0].applied.clone()
+    } else {
+        compose_group_summary(&sessions, mode)
+    };
+    Ok(CalibrationPlan {
+        assignments,
+        sessions,
+        applied,
+    })
+}
+
+/// The group-level summary for a multi-session plan. Identities compose
+/// order-independently so a reordering of the group's lights cannot force a
+/// restack.
+fn compose_group_summary(
+    sessions: &[CalibrationSession],
+    mode: CalibrationMode,
+) -> AppliedCalibration {
+    let mut details = sessions
+        .iter()
+        .map(|session| CalibrationSessionDetail {
+            fingerprint: session.applied.fingerprint.clone(),
+            masters_signature: session.applied.masters_signature.clone(),
+            estimated_pedestal_adu: session.applied.estimated_pedestal_adu,
+            lights: session
+                .applied
+                .session_details
+                .first()
+                .map(|detail| detail.lights)
+                .unwrap_or(0),
+        })
+        .collect::<Vec<_>>();
+    details.sort_by(|left, right| left.fingerprint.cmp(&right.fingerprint));
+
+    let fingerprint = hex_digest(
+        &details
+            .iter()
+            .map(|detail| detail.fingerprint.as_str())
+            .collect::<Vec<_>>()
+            .join("\u{1e}"),
+    );
+    let masters_signature = details
+        .iter()
+        .map(|detail| detail.masters_signature.as_str())
+        .collect::<Vec<_>>()
+        .join("||");
+
+    let mut warning: Option<String> = None;
+    for (index, session) in sessions.iter().enumerate() {
+        if let Some(session_warning) = &session.applied.warning {
+            let line = format!("Session {}: {session_warning}", index + 1);
+            warning = Some(match warning.take() {
+                Some(previous) => format!("{previous}. {line}"),
+                None => line,
+            });
+        }
+    }
+
+    let any_applied = sessions
+        .iter()
+        .any(|session| session.applied.state == "applied");
+    AppliedCalibration {
+        mode,
+        state: if any_applied { "applied" } else { "incomplete" }.into(),
+        bias_frames: sessions.iter().map(|s| s.applied.bias_frames).sum(),
+        dark_frames: sessions.iter().map(|s| s.applied.dark_frames).sum(),
+        dark_flat_frames: sessions.iter().map(|s| s.applied.dark_flat_frames).sum(),
+        flat_frames: sessions.iter().map(|s| s.applied.flat_frames).sum(),
+        bias_master: None,
+        dark_master: None,
+        dark_flat_master: None,
+        flat_master: None,
+        warning,
+        fingerprint,
+        masters_signature,
+        estimated_pedestal_adu: None,
+        sessions: sessions.len(),
+        session_details: details,
+    }
+}
+
 pub fn resolve_or_build_masters_for_group(
     conn: &Connection,
     cache_root: &Path,
@@ -1503,39 +1780,23 @@ pub fn resolve_or_build_masters_for_group(
     cancel: Option<&AtomicBool>,
     mode: CalibrationMode,
 ) -> Result<(seiza_stacking::CalibrationMasters, AppliedCalibration)> {
-    if mode == CalibrationMode::Off {
-        return Ok(calibration_off());
-    }
-    if light_paths.is_empty() {
-        return Ok((
-            seiza_stacking::CalibrationMasters::default(),
-            AppliedCalibration::default(),
-        ));
-    }
-    let fingerprints = light_paths
-        .iter()
-        .map(|path| selection_fingerprint(conn, path, directory_tree))
-        .collect::<Result<Vec<_>>>()?;
-    if fingerprints
-        .iter()
-        .skip(1)
-        .any(|fingerprint| fingerprint != &fingerprints[0])
-    {
-        return Ok((
-            seiza_stacking::CalibrationMasters::default(),
-            AppliedCalibration {
-                mode,
-                state: "incomplete".into(),
-                warning: Some(
-                    "Stack inputs need different calibration sets; this preview was left uncalibrated"
-                        .into(),
-                ),
-                fingerprint: hex_digest(&fingerprints.join("\u{1e}")),
-                ..Default::default()
-            },
-        ));
-    }
-    resolve_or_build_masters(conn, cache_root, light_paths, directory_tree, cancel, mode)
+    let mut plan = resolve_or_build_master_plan(
+        conn,
+        cache_root,
+        light_paths,
+        directory_tree,
+        cancel,
+        mode,
+        &[],
+    )?;
+    let masters = if plan.sessions.len() == 1 {
+        plan.sessions.remove(0).masters
+    } else {
+        // Callers of this single-masters convenience cannot calibrate per
+        // session; the plan API is the one that can.
+        seiza_stacking::CalibrationMasters::default()
+    };
+    Ok((masters, plan.applied))
 }
 
 struct BuiltMaster {
@@ -3338,7 +3599,11 @@ mod tests {
     }
 
     #[test]
-    fn group_with_different_calibration_sets_stays_uncalibrated() {
+    fn group_with_different_calibration_sets_partitions_into_sessions() {
+        // Two lights whose selections differ (different gains here; per-night
+        // flats in the field) used to force the whole group to stack
+        // uncalibrated. They now partition: each light calibrates in its own
+        // session with its own masters, and the group summary composes both.
         let temp = tempfile::tempdir().unwrap();
         let mut calibration_meta = Vec::new();
         for gain in [100, 200] {
@@ -3359,21 +3624,93 @@ mod tests {
             import_calibration_frames(&tx, &calibration_meta, Some("profile")).unwrap();
             tx.commit().unwrap();
         }
-        let (masters, applied) = resolve_or_build_masters_for_group(
+        let plan = resolve_or_build_master_plan(
             &conn,
             &temp.path().join("cache"),
-            &[first, second],
+            &[first.clone(), second.clone()],
             None,
             None,
             CalibrationMode::Auto,
+            &[],
         )
         .unwrap();
-        assert!(masters.is_empty());
-        assert_eq!(applied.state, "incomplete");
-        assert!(applied
-            .warning
-            .as_deref()
-            .is_some_and(|warning| warning.contains("different calibration sets")));
+        assert_eq!(plan.sessions.len(), 2);
+        assert_eq!(plan.assignments, vec![0, 1]);
+        for session in &plan.sessions {
+            assert_eq!(session.applied.state, "applied");
+            assert!(session.applied.bias_master.is_some());
+            assert!(!session.masters.is_empty());
+        }
+        assert_ne!(
+            plan.sessions[0].applied.fingerprint,
+            plan.sessions[1].applied.fingerprint
+        );
+        assert_eq!(plan.applied.sessions, 2);
+        assert_eq!(plan.applied.state, "applied");
+        assert_eq!(plan.applied.session_details.len(), 2);
+        assert!(plan.applied.masters_signature.contains("||"));
+
+        // The composite identity must not depend on the caller's light
+        // order, or a reorder would force a restack.
+        let reversed = resolve_or_build_master_plan(
+            &conn,
+            &temp.path().join("cache"),
+            &[second, first],
+            None,
+            None,
+            CalibrationMode::Auto,
+            &[],
+        )
+        .unwrap();
+        assert_eq!(reversed.applied.fingerprint, plan.applied.fingerprint);
+        assert_eq!(
+            reversed.applied.masters_signature,
+            plan.applied.masters_signature
+        );
+        assert_eq!(reversed.assignments, vec![0, 1]);
+    }
+
+    #[test]
+    fn a_pinned_session_pedestal_is_reused_instead_of_refitted() {
+        // The source-frame search reproduces a stack's calibration from the
+        // accepted frames only. With a flats-only library the pedestal was
+        // fitted from the build's lights; the search must reuse the recorded
+        // value, not fit its own from a different sample.
+        let temp = tempfile::tempdir().unwrap();
+        let (conn, cache, lights) =
+            vignetted_flat_only_library(&temp, "ZWO ASI2600MM Pro", 30, 300.0);
+        let plan = resolve_or_build_master_plan(
+            &conn,
+            &cache,
+            &lights,
+            None,
+            None,
+            CalibrationMode::Auto,
+            &[],
+        )
+        .unwrap();
+        let fitted = plan
+            .applied
+            .estimated_pedestal_adu
+            .expect("a fitted pedestal");
+        assert_eq!(plan.applied.sessions, 1);
+
+        // Reproduce from a subset with an artificial pin: the pinned value
+        // must land verbatim, so the signature matches the stack's.
+        let mut pinned = plan.applied.session_details.clone();
+        pinned[0].estimated_pedestal_adu = Some(123.0);
+        let reproduced = resolve_or_build_master_plan(
+            &conn,
+            &cache,
+            std::slice::from_ref(&lights[0]),
+            None,
+            None,
+            CalibrationMode::Auto,
+            &pinned,
+        )
+        .unwrap();
+        assert_eq!(reproduced.applied.estimated_pedestal_adu, Some(123.0));
+        assert!((fitted - 300.0).abs() < 15.0);
     }
 
     #[test]

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -1864,14 +1864,17 @@ fn run_group(
         .map(|frame| frame.path.clone())
         .collect::<Vec<_>>();
     // Building a night of masters is minutes of work, so the stop flag reaches
-    // between them too.
-    let masters = crate::calibration::resolve_or_build_masters_for_group(
+    // between them too. The plan partitions a multi-night group into
+    // sessions, each with its own masters; a single-night group gets one
+    // session and stacks exactly as before.
+    let plan = crate::calibration::resolve_or_build_master_plan(
         &calibration_conn,
         cache_root,
         &light_paths,
         Some(&directory_tree),
         Some(cancel.as_ref()),
         group.calibration,
+        &[],
     );
     if cancel.load(Ordering::Relaxed) {
         return Ok(GroupOutcome::Cancelled);
@@ -1879,10 +1882,11 @@ fn run_group(
     // `{:#}` keeps the whole anyhow chain: "building master flat: <why>".
     // `to_string()` printed only the outermost context, which reported a
     // failed master build with no cause at all.
-    let (calibration_masters, applied_calibration) = masters.map_err(|error| {
+    let plan = plan.map_err(|error| {
         tracing::warn!("Stack group calibration failed: {error:#}");
         format!("{error:#}")
     })?;
+    let applied_calibration = plan.applied.clone();
     // The resume checkpoint key carries the applied-master signature too:
     // the selection fingerprint is computed before any build, so after a
     // transient build failure a later run with the same selection could
@@ -2043,7 +2047,10 @@ fn run_group(
                     normalization: NormalizationMode::Global,
                     ..StackOptions::default()
                 };
-                let stacker = LiveStacker::new(reference_frame, calibration_masters, options)
+                // The reference calibrates with its own session's masters;
+                // later sessions swap theirs in per batch.
+                let reference_masters = plan.sessions[plan.assignments[0]].masters.clone();
+                let stacker = LiveStacker::new(reference_frame, reference_masters, options)
                     .map_err(|error| error.to_string())?;
                 let reference_mapping = stacker.reference_mapping();
                 let reference_decision = StackFrameDecision {
@@ -2121,12 +2128,14 @@ fn run_group(
             }
         };
 
-        let pending: Vec<&PreparedFrame> = group
+        // Pending frames keep their index into `group.frames`, which is what
+        // the calibration plan's session assignments are aligned with.
+        let pending: Vec<(usize, &PreparedFrame)> = group
             .frames
             .iter()
-            .filter(|frame| !already_integrated.contains(&frame.image_id))
+            .enumerate()
+            .filter(|(_, frame)| !already_integrated.contains(&frame.image_id))
             .collect();
-        let paths: Vec<PathBuf> = pending.iter().map(|frame| frame.path.clone()).collect();
         // Reads, calibration, registration and normalization overlap across
         // frames while integration stays in this order, so the accumulator
         // sees exactly the sequence a frame-at-a-time loop would. A frame
@@ -2137,76 +2146,101 @@ fn run_group(
             ..seiza_stacking::PipelineOptions::default()
         };
         let mut cancelled = false;
-        let mut consumed = 0usize;
-        // Every frame's outcome is recorded in the callback above, so the
-        // summary adds nothing here.
-        let _report = stacker
-            .push_fits_pipelined(&paths, &pipeline, |_, outcome| {
-                let frame = pending[consumed];
-                consumed += 1;
-                let exposure = frame.exposure_seconds;
-                let decision = match outcome {
-                    Ok(FrameDisposition::Accepted(diagnostics)) => {
-                        orientation_vote
-                            .add(diagnostics.mapping.transform().rotation_radians, exposure);
-                        StackFrameDecision {
-                            image_id: frame.image_id,
-                            disposition: "accepted".into(),
-                            reason: None,
-                            quality_score: frame.quality_score,
-                            matched_stars: Some(diagnostics.matched_stars),
-                            registration_rms_pixels: Some(diagnostics.registration_rms_pixels),
-                            registration_drift_pixels: Some(diagnostics.registration_drift_pixels),
-                            registered_mapping: Some(*diagnostics.mapping),
-                            normalization_mean_gain: Some(diagnostics.normalization_mean_gain),
-                            normalization_mean_offset: Some(diagnostics.normalization_mean_offset),
-                            source_fingerprint: Some(frame.source_fingerprint.clone()),
-                            overlap_fraction: Some(diagnostics.overlap_fraction),
-                            integrated_fraction: Some(diagnostics.integrated_fraction),
+        // Consecutive frames of one calibration session push as one
+        // pipelined batch, with the session's masters swapped in first. The
+        // frames after the reference are chronological, so a night is one
+        // batch and a single-session group is exactly one call. On a
+        // resumed stack this also replaces whatever masters the checkpoint
+        // stored with the ones this batch needs.
+        let mut batch_start = 0usize;
+        while batch_start < pending.len() && !cancelled {
+            let session = plan.assignments[pending[batch_start].0];
+            let batch_end = pending[batch_start..]
+                .iter()
+                .position(|(index, _)| plan.assignments[*index] != session)
+                .map(|offset| batch_start + offset)
+                .unwrap_or(pending.len());
+            let batch = &pending[batch_start..batch_end];
+            let paths: Vec<PathBuf> = batch.iter().map(|(_, frame)| frame.path.clone()).collect();
+            stacker
+                .set_calibration(plan.sessions[session].masters.clone())
+                .map_err(|error| error.to_string())?;
+            let mut consumed = 0usize;
+            // Every frame's outcome is recorded in the callback above, so the
+            // summary adds nothing here.
+            let _report = stacker
+                .push_fits_pipelined(&paths, &pipeline, |_, outcome| {
+                    let (_, frame) = batch[consumed];
+                    consumed += 1;
+                    let exposure = frame.exposure_seconds;
+                    let decision = match outcome {
+                        Ok(FrameDisposition::Accepted(diagnostics)) => {
+                            orientation_vote
+                                .add(diagnostics.mapping.transform().rotation_radians, exposure);
+                            StackFrameDecision {
+                                image_id: frame.image_id,
+                                disposition: "accepted".into(),
+                                reason: None,
+                                quality_score: frame.quality_score,
+                                matched_stars: Some(diagnostics.matched_stars),
+                                registration_rms_pixels: Some(diagnostics.registration_rms_pixels),
+                                registration_drift_pixels: Some(
+                                    diagnostics.registration_drift_pixels,
+                                ),
+                                registered_mapping: Some(*diagnostics.mapping),
+                                normalization_mean_gain: Some(diagnostics.normalization_mean_gain),
+                                normalization_mean_offset: Some(
+                                    diagnostics.normalization_mean_offset,
+                                ),
+                                source_fingerprint: Some(frame.source_fingerprint.clone()),
+                                overlap_fraction: Some(diagnostics.overlap_fraction),
+                                integrated_fraction: Some(diagnostics.integrated_fraction),
+                            }
                         }
-                    }
-                    // A frame the stack turned away and one that could not be
-                    // read are both "not integrated" to a caller reading the
-                    // group's decisions; only the reason differs.
-                    Ok(FrameDisposition::Rejected(reason)) => {
-                        rejected_decision(frame, reason.to_string())
-                    }
-                    Err(error) => rejected_decision(frame, error.to_string()),
-                };
-                ledger.push(resume::ResumeFrame {
-                    decision: decision.clone(),
-                    exposure_seconds: exposure,
-                    rotation_radians: if decision.disposition == "accepted" {
-                        decision
-                            .registered_mapping
-                            .as_ref()
-                            .map(|mapping| mapping.transform().rotation_radians)
-                    } else {
-                        None
-                    },
-                });
-                state.stack_previews.update(job_id, |job| {
-                    let status = &mut job.groups[group.index];
-                    status.processed_frames += 1;
-                    if matches!(decision.disposition.as_str(), "accepted") {
-                        status.accepted_frames += 1;
-                        status.total_exposure_seconds += exposure;
-                    } else {
-                        status.rejected_frames += 1;
-                    }
-                    status.frames.push(decision);
-                });
+                        // A frame the stack turned away and one that could not be
+                        // read are both "not integrated" to a caller reading the
+                        // group's decisions; only the reason differs.
+                        Ok(FrameDisposition::Rejected(reason)) => {
+                            rejected_decision(frame, reason.to_string())
+                        }
+                        Err(error) => rejected_decision(frame, error.to_string()),
+                    };
+                    ledger.push(resume::ResumeFrame {
+                        decision: decision.clone(),
+                        exposure_seconds: exposure,
+                        rotation_radians: if decision.disposition == "accepted" {
+                            decision
+                                .registered_mapping
+                                .as_ref()
+                                .map(|mapping| mapping.transform().rotation_radians)
+                        } else {
+                            None
+                        },
+                    });
+                    state.stack_previews.update(job_id, |job| {
+                        let status = &mut job.groups[group.index];
+                        status.processed_frames += 1;
+                        if matches!(decision.disposition.as_str(), "accepted") {
+                            status.accepted_frames += 1;
+                            status.total_exposure_seconds += exposure;
+                        } else {
+                            status.rejected_frames += 1;
+                        }
+                        status.frames.push(decision);
+                    });
 
-                // Integrating one frame is the unit of work, so this is where
-                // a stop takes effect. Frames already prepared are discarded.
-                if cancel.load(Ordering::Relaxed) {
-                    cancelled = true;
-                    seiza_stacking::Continue::No
-                } else {
-                    seiza_stacking::Continue::Yes
-                }
-            })
-            .map_err(|error| error.to_string())?;
+                    // Integrating one frame is the unit of work, so this is where
+                    // a stop takes effect. Frames already prepared are discarded.
+                    if cancel.load(Ordering::Relaxed) {
+                        cancelled = true;
+                        seiza_stacking::Continue::No
+                    } else {
+                        seiza_stacking::Continue::Yes
+                    }
+                })
+                .map_err(|error| error.to_string())?;
+            batch_start = batch_end;
+        }
 
         if cancelled {
             // The frames that did land are checkpointed, so building again

--- a/src/server/stack_preview/artifact.rs
+++ b/src/server/stack_preview/artifact.rs
@@ -135,6 +135,11 @@ struct SearchGroup {
     /// The mode the stack calibrated under, so the search resolves the same
     /// way. Stacks recorded before the field existed were built in `Auto`.
     calibration_mode: crate::calibration::CalibrationMode,
+    /// Per-session identity from the stack, when it recorded one. Lets the
+    /// search validate session by session — a night whose every frame was
+    /// rejected is absent here without invalidating the rest — and pins
+    /// each session's fitted pedestal.
+    expected_sessions: Vec<crate::calibration::CalibrationSessionDetail>,
     sources: Vec<SearchSource>,
 }
 
@@ -584,6 +589,7 @@ fn prepare_search(
             expected_calibration_fingerprint: group.calibration.fingerprint,
             expected_masters_signature: group.calibration.masters_signature,
             calibration_mode: group.calibration.mode,
+            expected_sessions: group.calibration.session_details,
             sources,
         });
     }
@@ -717,42 +723,70 @@ fn run_search_inner(
             .iter()
             .map(|source| source.path.clone())
             .collect::<Vec<_>>();
-        let (masters, applied) = crate::calibration::resolve_or_build_masters_for_group(
+        let plan = crate::calibration::resolve_or_build_master_plan(
             &calibration_conn,
             &prepared.cache_root,
             &paths,
             Some(&directory_tree),
             None,
             group.calibration_mode,
+            &group.expected_sessions,
         )
         // `{:#}` keeps the anyhow cause chain; `to_string()` would report
         // only "building master <kind>" with no reason.
         .map_err(|error| format!("{error:#}"))?;
-        if applied.fingerprint != group.expected_calibration_fingerprint {
-            return Err(format!(
-                "The calibration selected for {} changed; rebuild the stack before searching",
-                group.label
-            ));
-        }
-        if !group.expected_masters_signature.is_empty()
-            && applied.masters_signature != group.expected_masters_signature
-        {
-            return Err(format!(
-                "The calibration masters for {} differ from the stack's (a master build                  failed or recovered since); rebuild the stack before searching",
-                group.label
-            ));
+        if group.expected_sessions.is_empty() {
+            // A stack recorded before per-session details: compare the
+            // group-level identity exactly as it was recorded.
+            if plan.applied.fingerprint != group.expected_calibration_fingerprint {
+                return Err(format!(
+                    "The calibration selected for {} changed; rebuild the stack before searching",
+                    group.label
+                ));
+            }
+            if !group.expected_masters_signature.is_empty()
+                && plan.applied.masters_signature != group.expected_masters_signature
+            {
+                return Err(format!(
+                    "The calibration masters for {} differ from the stack's (a master build failed or recovered since); rebuild the stack before searching",
+                    group.label
+                ));
+            }
+        } else {
+            // Session-by-session: the searched sources may omit a whole
+            // session (every frame rejected), but every session they DO
+            // calibrate under must match what the stack recorded.
+            for session in &plan.sessions {
+                let expected = group
+                    .expected_sessions
+                    .iter()
+                    .find(|detail| detail.fingerprint == session.applied.fingerprint);
+                let Some(expected) = expected else {
+                    return Err(format!(
+                        "The calibration selected for {} changed; rebuild the stack before searching",
+                        group.label
+                    ));
+                };
+                if session.applied.masters_signature != expected.masters_signature {
+                    return Err(format!(
+                        "The calibration masters for {} differ from the stack's (a master build failed or recovered since); rebuild the stack before searching",
+                        group.label
+                    ));
+                }
+            }
         }
         let max_samples_per_frame =
             (MAX_TOTAL_ANALYSIS_SAMPLES / group.sources.len()).clamp(1, MAX_ANALYSIS_SAMPLES);
         let mut crops = Vec::with_capacity(group.sources.len());
-        for source in &group.sources {
+        for (source_index, source) in group.sources.iter().enumerate() {
             if source_fingerprint(&source.path) != source.fingerprint {
                 return Err(format!(
                     "Image {} changed while the source-frame search was waiting; rebuild the stack before searching",
                     source.image_id
                 ));
             }
-            let crop = extract_source_crop(source, &masters, prepared)?;
+            let masters = &plan.sessions[plan.assignments[source_index]].masters;
+            let crop = extract_source_crop(source, masters, prepared)?;
             let analysis = sampled_luminance(&crop, max_samples_per_frame);
             crops.push(LoadedCrop {
                 source: source.clone(),
@@ -811,7 +845,13 @@ fn run_search_inner(
                     .iter()
                     .find(|source| source.image_id == result.image_id)
                     .ok_or_else(|| format!("Image {} left the source set", result.image_id))?;
-                let crop = extract_source_crop(source, &masters, prepared)?;
+                let source_index = group
+                    .sources
+                    .iter()
+                    .position(|candidate| candidate.image_id == source.image_id)
+                    .expect("ranked results come from group.sources");
+                let masters = &plan.sessions[plan.assignments[source_index]].masters;
+                let crop = extract_source_crop(source, masters, prepared)?;
                 let original_path = artifact_crop_path(
                     &prepared.cache_root,
                     &prepared.public.search_id,

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -475,6 +475,12 @@ export interface AppliedCalibration {
    * calibrated with measured masters.
    */
   estimated_pedestal_adu?: number | null;
+  /**
+   * How many calibration sessions the group's lights partitioned into. A
+   * multi-night stack calibrates each session with its own masters. Absent
+   * or zero on artifacts recorded before sessions existed.
+   */
+  sessions?: number;
 }
 
 export interface StackPreviewJob {

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -940,6 +940,8 @@ export default function StackPreviewPanel({
                               : calibration.state === 'incomplete'
                                 ? 'Calibration set incomplete'
                                 : 'Matching calibration'}
+                          {(calibration.sessions ?? 0) > 1 &&
+                            ` · ${calibration.sessions} sessions`}
                         </strong>
                         {calibration.state !== 'off' && (
                           <span>


### PR DESCRIPTION
Depends on seiza-stacking 0.7.0 (`LiveStacker::set_calibration`), published in theatrus/seiza#127 / #128.

## What changes

A stack group whose lights matched different calibration sets — per-night flats above all, but also a changed library or the 64-frame selection horizon of very large libraries — previously stacked **uncalibrated** with "Stack inputs need different calibration sets". The group now partitions into **calibration sessions**:

- Each light is keyed by the coherent master subsets its selection would build (`session_key`); lights sharing a key form a session, so any member acting as reference resolves the identical masters.
- Each session builds its masters once (`resolve_or_build_master_plan`); content-addressed caching still shares identical bias/dark masters across sessions.
- The stack pushes each session's frames as a pipelined batch, swapping masters in with `set_calibration` first. Frames after the reference are chronological, so a night is one batch; a single-night group is one session and stacks exactly as before — same fingerprints, no forced restacks.
- The reference frame calibrates with its own session's masters at stacker construction.

## Identity and reproduction

- The group summary composes per-session fingerprints and signatures **order-independently** (covered by a light-order permutation test), and feeds the resume checkpoint key unchanged in format.
- `AppliedCalibration` gains `sessions` and `session_details` (both serde-defaulted; old artifacts unaffected). The card shows "· N sessions".
- The source-frame search now resolves the same plan and validates **session by session**: a night whose every frame was rejected is simply absent from the search without invalidating the rest.
- The search **pins each session's fitted pedestal** from the recorded details instead of re-fitting from the searched subset. This also fixes a latent bug from #329: a flats-only stack with rejected frames could produce a slightly different pedestal fit at search time and refuse its own search.

## Verification

- Live on the C925 catalog copy: the flats-only Elephant's Trunk stack resolves identically (one session, 291 ADU pedestal, same flat master), and a source-frame search against it completes with results under the new session validation.
- New tests: mixed-selection groups partition into two working sessions with composite identity stable under light reordering; pinned pedestals land verbatim in a reproduction from a subset.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (705 passed) · `npm run lint` · `npx vitest run` (276 passed) · `npm run build` · `npx playwright test stack-preview` (3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)