### PR TITLE
Suppress hot pixels in flat masters, and in lights with no dark

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -107,6 +107,17 @@ built, including a lone flat with no pedestal estimate — the warning then
 says what to expect — and **Off** stacks the raw frames with no matching at
 all.
 
+A flat master also gets a spatial defect pass after integration: a hot or
+dead sensor pixel repeats identically in every flat, so the across-frame
+clipping keeps it by construction, and it would divide a fixed-pattern
+artifact into every light. Samples far outside their same-plane
+neighborhood are replaced with the neighborhood median; the flat's true
+response is smooth at pixel scale, so dust shadows and vignette structure
+are untouched. Dark and dark-flat masters keep their hot pixels — they are
+what subtracts them from the frames they calibrate. When no dark master
+exists anywhere in a stack's plan, the stack instead runs the same impulse
+filter over each calibrated light, and the card says so.
+
 A master that fails to build does not fail the stack. The frames integrate
 without that master, and the stack card's calibration warning names the
 master that was skipped and the reason. A master whose input master failed —

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -20,6 +20,15 @@
   back — and **Off** stacks the raw frames. The choice is remembered, and a
   preview built under a different mode is marked out of date. See [stack
   previews](https://github.com/theatrus/psf-guard/blob/main/docs/STACKING_PREVIEWS.md).
+- Hot pixels are suppressed where they actually do damage. Flat masters get
+  a spatial defect pass after integration — a defective pixel repeats in
+  every flat, survives statistical rejection, and used to divide a
+  fixed-pattern artifact into every light (a 26-megapixel test flat carried
+  nearly ten thousand of them). Stacks with no dark master run the same
+  impulse filter over each calibrated light. Dark masters keep their hot
+  pixels, which subtract the lights' own. Existing flat masters rebuild
+  once. See [calibration
+  libraries](https://github.com/theatrus/psf-guard/blob/main/docs/CALIBRATION_LIBRARY.md).
 - Multi-night stacks now calibrate each night with its own masters. A stack
   group whose lights match different calibration sets — per-night flats
   above all — used to stack uncalibrated with a warning; it now partitions

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -14,7 +14,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::UNIX_EPOCH;
 
 pub const CALIBRATION_SCHEMA_VERSION: i64 = 1;
-pub const MASTER_CACHE_VERSION: u32 = 1;
+// 2: flat masters suppress defective pixels spatially after integration.
+pub const MASTER_CACHE_VERSION: u32 = 2;
 const MIN_MASTER_FRAMES: usize = 2;
 const MAX_MASTER_FRAMES: usize = 64;
 const DARK_TEMPERATURE_TOLERANCE_C: f64 = 3.0;
@@ -1878,6 +1879,13 @@ fn build_master(
         exposure_seconds: frames.first().and_then(|frame| frame.exposure_s),
         bias,
         dark,
+        // A defective sensor pixel repeats in every flat, so across-frame
+        // clipping keeps it and it would divide every light forever. The
+        // flat's true response is smooth at pixel scale, so a spatial pass
+        // is safe there. Darks and dark-flats must KEEP their hot pixels —
+        // they are what subtracts them from the frames they calibrate.
+        defect_suppression: (kind == CalibrationKind::Flat)
+            .then(seiza_stacking::ImpulseFilterOptions::default),
         ..Default::default()
     };
     let paths = frames
@@ -1886,6 +1894,13 @@ fn build_master(
         .collect::<Vec<_>>();
     let frame = seiza_stacking::build_master_from_fits(&paths, seiza_kind, &options)
         .with_context(|| format!("building master {}", kind.as_str()))?;
+    if frame.defect_pixels_replaced > 0 {
+        tracing::info!(
+            "master {} suppressed {} defective pixel(s)",
+            kind.as_str(),
+            frame.defect_pixels_replaced
+        );
+    }
     if !path.exists() {
         let temporary = path.with_extension(format!("fits.tmp-{}", std::process::id()));
         seiza_stacking::write_master_fits_f32(&temporary, &frame)
@@ -3167,6 +3182,67 @@ mod tests {
             tx.commit().unwrap();
         }
         (conn, temp.path().join("cache"), light_paths)
+    }
+
+    #[test]
+    fn flat_masters_suppress_a_defective_pixel_the_flats_share() {
+        // A hot pixel repeats identically in every flat, survives the
+        // across-frame clipping, and would divide every light forever. The
+        // spatial pass in the master build must take it out.
+        const SIZE: usize = 64;
+        let temp = tempfile::tempdir().unwrap();
+        let hot = 31 * SIZE + 17;
+        let vignette = |x: usize| 0.7 + 0.6 * x as f64 / (SIZE - 1) as f64;
+        let mut calibration_meta = Vec::new();
+        for index in 0..2 {
+            let path = temp.path().join(format!("bias-{index}.fits"));
+            write_gradient_fits(&path, "BIAS", SIZE, SIZE, "Camera", 30, |x, y| {
+                100.0 + ((x * 31 + y * 17 + index) % 13) as f64 / 13.0
+            });
+            calibration_meta.push(crate::commands::import::headers::read_frame_meta(&path));
+        }
+        for index in 0..2 {
+            let path = temp.path().join(format!("flat-{index}.fits"));
+            write_gradient_fits(&path, "FLAT", SIZE, SIZE, "Camera", 30, move |x, y| {
+                if y * SIZE + x == hot {
+                    30_000.0
+                } else {
+                    100.0 + 20_000.0 * vignette(x) + ((x * 7 + y * 3 + index) % 11) as f64
+                }
+            });
+            calibration_meta.push(crate::commands::import::headers::read_frame_meta(&path));
+        }
+        let light_path = temp.path().join("light.fits");
+        write_gradient_fits(&light_path, "LIGHT", SIZE, SIZE, "Camera", 30, |x, _| {
+            400.0 + 100.0 * vignette(x)
+        });
+
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            import_calibration_frames(&tx, &calibration_meta, Some("profile")).unwrap();
+            tx.commit().unwrap();
+        }
+        let cache = temp.path().join("cache");
+        let (_, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        let label = applied.flat_master.expect("a flat master");
+        let master =
+            crate::image_io::open_linear_frame(cache.join("calibration-masters").join(label))
+                .unwrap();
+        let value = master.image.data[hot];
+        let neighbor = master.image.data[hot + 2];
+        assert!(
+            (value - neighbor).abs() < 0.05,
+            "the defect must sit on the smooth response: {value} vs neighbor {neighbor}"
+        );
     }
 
     #[test]

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -45,10 +45,10 @@ use crate::server::extract::DbContext;
 use crate::server::handlers::AppError;
 use crate::server::state::AppState;
 
-pub const SEIZA_STACKING_VERSION: &str = "0.2.1";
+pub const SEIZA_STACKING_VERSION: &str = "0.2.2";
 /// Bump whenever stack admission, rendering, or persisted artifact semantics
 /// change. This deliberately versions PSF Guard policy separately from Seiza.
-pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 11;
+pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 12;
 const MAX_REQUEST_IMAGES: usize = 10_000;
 const MAX_REMEMBERED_JOBS: usize = 64;
 const PREVIEW_MAX_DIMENSION: u32 = 2400;
@@ -1886,7 +1886,21 @@ fn run_group(
         tracing::warn!("Stack group calibration failed: {error:#}");
         format!("{error:#}")
     })?;
-    let applied_calibration = plan.applied.clone();
+    let mut applied_calibration = plan.applied.clone();
+    // With no dark master anywhere in the plan, the lights keep their hot
+    // pixels and the stack runs the spatial impulse filter over each frame.
+    // Say so on the card; display only, after the identity is computed.
+    let no_dark_master = plan
+        .sessions
+        .iter()
+        .all(|session| session.applied.dark_master.is_none());
+    if no_dark_master && group.calibration != crate::calibration::CalibrationMode::Off {
+        let note = "Hot pixels suppressed in each light (no dark master to subtract them)";
+        applied_calibration.warning = Some(match applied_calibration.warning.take() {
+            Some(previous) => format!("{previous}. {note}"),
+            None => note.into(),
+        });
+    }
     // The resume checkpoint key carries the applied-master signature too:
     // the selection fingerprint is computed before any build, so after a
     // transient build failure a later run with the same selection could
@@ -2043,8 +2057,16 @@ fn run_group(
                 let reference_exposure = group.frames[0].exposure_seconds;
                 // The reference frame defines zero rotation; it votes upright.
                 orientation_vote.add(0.0, reference_exposure);
+                // With no dark master anywhere in the plan, nothing
+                // subtracts the lights' hot pixels, and a handful of frames
+                // cannot reject them statistically. The spatial impulse
+                // filter is the remaining defense; when any session has a
+                // dark, the dark does the job with real measurements.
                 let options = StackOptions {
                     normalization: NormalizationMode::Global,
+                    cosmetic: (no_dark_master
+                        && group.calibration != crate::calibration::CalibrationMode::Off)
+                        .then(seiza_stacking::ImpulseFilterOptions::default),
                     ..StackOptions::default()
                 };
                 // The reference calibrates with its own session's masters;

--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -109,7 +109,7 @@ function seedSyntheticColorStacks(databaseId: string, projectId: number): void {
       // Must track STACK_PREVIEW_CACHE_VERSION in src/server/stack_preview.rs.
       // The server hides remembered stacks from an older build, so a stale
       // number here leaves the color panel with no channels to combine.
-      cache_version: 11,
+      cache_version: 12,
       group: {
         index: 0,
         target_id: 2,


### PR DESCRIPTION
Last piece of the calibration track (seiza 0.7.0 → #331), addressing the field report of increased hot-pixel noise.

## Where hot pixels actually do damage, and what this does about each

- **Flat masters**: a defective pixel repeats identically in every flat, so the across-frame sigma clipping keeps it by construction — statistically it is not an outlier, it is the pixel's behavior. The normalized response then divides a fixed-pattern artifact into every light. Flat masters now run seiza's spatial impulse filter after integration (same-plane neighborhood median, MAD-scaled, conservative 16 sigma). `MASTER_CACHE_VERSION` → 2, so cached flat masters rebuild once.
- **Lights with no dark master**: nothing subtracts their hot pixels and a handful of frames cannot reject them statistically — exactly the flats-only stacks that started completing in #329. When no session of the plan has a dark master, the stack runs the same filter over each calibrated light before debayering, and the calibration card says so. Stack cache and resume versions move so no checkpoint mixes filtered and unfiltered frames.
- **Dark and dark-flat masters keep their hot pixels** — they are the measurement that subtracts the lights' own. Nothing touches them.

## Measured on the C925 flats-only library

The 26-megapixel flat master carried **9,719 defective pixels**; after the pass its sampled impulse density fell from **404 ppm to 28 ppm** (14×). The stacked output changes little for this 5-frame dithered set — per-frame impulses were already smeared and largely rejected — but the fixed-pattern flat artifact is gone at the source, and few-frame or poorly-dithered stacks get the per-light protection.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (706 passed, incl. a defective-flat-pixel regression test through the real master build) · `npx playwright test stack-preview` (3 passed, fixture tracking the new cache version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)