### PR TITLE
docs: sky flats need drift or dither so stars clip out across frames

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -114,7 +114,14 @@ artifact into every light. Samples far outside their same-plane
 neighborhood are replaced with the neighborhood median; the flat's true
 response is smooth at pixel scale, so dust shadows and vignette structure
 are untouched. Dark and dark-flat masters keep their hot pixels — they are
-what subtracts them from the frames they calibrate. When no dark master
+what subtracts them from the frames they calibrate.
+
+The defect pass removes pixel-scale impulses, not star images. Stars in
+sky flats are handled by the across-frame clipping instead, and only when
+they move between exposures — let the sky drift or dither between sky
+flats. Sky flats taken with tracking on hold each star on the same pixels
+in every frame, and a star that survives into the master is wider than
+the defect pass can remove. When no dark master
 exists anywhere in a stack's plan, the stack instead runs the same impulse
 filter over each calibrated light, and the card says so.
 


### PR DESCRIPTION
Follow-up to #332, from a field note that the C925 flats were sky flats and their stars might be what the defect pass suppressed.

Checked against the master itself: in three full-resolution 1200×1200 crops of the pre-suppression flat master, the impulse population is 1,461 isolated single pixels and 9 pairs — no cluster of three or more. That is the signature of sensor defects, not stars. The flats' stars were already gone before the spatial pass: they moved between exposures, so the across-frame sigma clip rejected them (~2.2% of samples clipped on that master).

The doc now states the division of labor and the acquisition practice it depends on: the defect pass removes pixel-scale impulses; stars in sky flats are removed by the across-frame clip, and only when the sky drifts or the mount dithers between exposures. Tracked sky flats hold stars still, and a star that survives into the master is wider than the defect pass can remove.

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)