### PR TITLE
Export onto the server's own drive from the UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2967,7 +2967,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.16",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4036,6 +4036,7 @@ dependencies = [
  "nalgebra",
  "rand 0.10.2",
  "rayon",
+ "reflink-copy",
  "regex",
  "reqwest 0.12.28",
  "rpassword",
@@ -4166,7 +4167,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4459,6 +4460,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "reflink-copy"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,7 +4718,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4762,7 +4775,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6058,7 +6071,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6555,7 +6568,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.16",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ dirs = "6.0"
 dunce = "1"
 rpassword = "7.5.4"
 async_zip = { version = "0.0.18", features = ["tokio"] }
+reflink-copy = "0.1.30"
 # Platform memory probes for the occlusion-scan worker budget in
 # `concurrency` (both already in the tree transitively). Linux uses
 # /proc/meminfo and needs no crate.

--- a/README.md
+++ b/README.md
@@ -640,6 +640,15 @@ includes raw `BIAS`, `DARK`, `DARKFLAT`, and target/filter `FLAT` folders.
 
 ![Overview project card with the Export action](docs/export-overview.png)
 
+A remote server can export onto its own drive instead of streaming a ZIP.
+Set a **server export directory** for the database (Settings, or `export_dir`
+in the registry JSON). The Export action then runs as a background job with
+progress: it places the same tree — lights, matching calibration frames, and
+the WBPP runner scripts — into a per-scope folder below that directory,
+cloning files (reflink) where the filesystem supports it and copying where it
+does not. Because the operator named the directory up front, the action needs
+no database-management grant.
+
 You can export a whole project or one target. The action appears when PSF Guard
 has found at least one accepted source file. The CLI offers the same filters
 and a dry run:

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -48,6 +48,14 @@
   [calibration
   libraries](https://github.com/theatrus/psf-guard/blob/main/docs/CALIBRATION_LIBRARY.md).
 
+- A remote server can now export onto its own drive. Configure a **server
+  export directory** per database (Settings, or `export_dir` in the
+  registry); the Overview's Export action then runs as a background job with
+  progress, placing lights, matching calibration frames, and the WBPP runner
+  into a per-scope folder there — cloning files (reflink) where the
+  filesystem supports it, copying where it does not. No database-management
+  grant needed: consent was given when the directory was configured.
+
 ## Fixed
 
 - Remote scheduler previews can now run as background jobs, so large Target

--- a/src/commands/export/mod.rs
+++ b/src/commands/export/mod.rs
@@ -112,11 +112,16 @@ pub struct ExportOptions {
     pub layout: ExportLayout,
 }
 
-#[derive(Debug, Default, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ExportSummary {
     pub planned: usize,
     pub copied: usize,
     pub linked: usize,
+    /// Placed as copy-on-write clones (reflink). A clone is an independent
+    /// copy that shares extents until either side is written, so it costs
+    /// no time or space on a supporting filesystem yet stays safe to edit.
+    #[serde(default)]
+    pub reflinked: usize,
     pub skipped_existing: usize,
     pub missing: usize,
     pub errors: usize,
@@ -295,6 +300,19 @@ pub fn plan_export(
     Ok(plan)
 }
 
+/// How planned files land at the destination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Placement {
+    Copy,
+    /// Hardlink, falling back to copy across filesystems. The export then
+    /// shares inodes with the originals — editing one edits both.
+    Hardlink,
+    /// Copy-on-write clone (reflink), falling back to copy when the
+    /// filesystem cannot clone. Free like a hardlink, independent like a
+    /// copy — the right default for a tree another program will consume.
+    Reflink,
+}
+
 /// Place the planned files under `dest_root`. `link` uses hardlinks (falling
 /// back to copy when the link fails, e.g. across filesystems).
 pub fn execute_plan(
@@ -303,28 +321,50 @@ pub fn execute_plan(
     link: bool,
     dry_run: bool,
 ) -> ExportSummary {
+    let placement = if link {
+        Placement::Hardlink
+    } else {
+        Placement::Copy
+    };
+    execute_plan_with(plan, dest_root, placement, dry_run, &mut |_, _| {})
+}
+
+/// [`execute_plan`] with an explicit placement mode and a progress callback
+/// receiving `(placed, total)` after every item.
+pub fn execute_plan_with(
+    plan: &ExportPlan,
+    dest_root: &Path,
+    placement: Placement,
+    dry_run: bool,
+    progress: &mut dyn FnMut(usize, usize),
+) -> ExportSummary {
     let mut summary = ExportSummary {
         planned: plan.items.len(),
         missing: plan.missing.len(),
         ..Default::default()
     };
 
-    for item in &plan.items {
+    let total = plan.items.len();
+    for (index, item) in plan.items.iter().enumerate() {
         let dest = dest_root.join(&item.relative_dest);
         if let Ok(meta) = std::fs::metadata(&dest)
             && meta.len() == item.size_bytes
         {
             summary.skipped_existing += 1;
+            progress(index + 1, total);
             continue;
         }
         if dry_run {
-            // Count what a live run would do; hardlinks report as links.
-            if link {
-                summary.linked += 1;
-            } else {
-                summary.copied += 1;
+            // Count what a live run would do, by intent; a live run can
+            // still fall back to copy where the filesystem cannot link or
+            // clone.
+            match placement {
+                Placement::Copy => summary.copied += 1,
+                Placement::Hardlink => summary.linked += 1,
+                Placement::Reflink => summary.reflinked += 1,
             }
             summary.bytes += item.size_bytes;
+            progress(index + 1, total);
             continue;
         }
         if let Some(parent) = dest.parent()
@@ -332,16 +372,29 @@ pub fn execute_plan(
         {
             eprintln!("⚠️  {}: {}", parent.display(), e);
             summary.errors += 1;
+            progress(index + 1, total);
             continue;
         }
-        if link {
+        if placement == Placement::Hardlink {
             match std::fs::hard_link(&item.source, &dest) {
                 Ok(()) => {
                     summary.linked += 1;
                     summary.bytes += item.size_bytes;
+                    progress(index + 1, total);
                     continue;
                 }
                 Err(_) => { /* cross-device or unsupported — fall through to copy */ }
+            }
+        }
+        if placement == Placement::Reflink {
+            match reflink_copy::reflink(&item.source, &dest) {
+                Ok(()) => {
+                    summary.reflinked += 1;
+                    summary.bytes += item.size_bytes;
+                    progress(index + 1, total);
+                    continue;
+                }
+                Err(_) => { /* filesystem cannot clone — fall through to copy */ }
             }
         }
         match std::fs::copy(&item.source, &dest) {
@@ -354,6 +407,7 @@ pub fn execute_plan(
                 summary.errors += 1;
             }
         }
+        progress(index + 1, total);
     }
     summary
 }
@@ -586,6 +640,34 @@ mod tests {
         let plan = plan_export(&conn, &dirs, &ExportOptions::default()).unwrap();
         let s = execute_plan(&plan, &dest, true, false);
         assert_eq!((s.linked, s.copied, s.errors), (1, 0, 0));
+    }
+
+    #[test]
+    fn reflink_mode_places_every_file_and_reports_progress() {
+        // Whether the filesystem clones or the fallback copies, every
+        // planned file must land and the summary must account for each.
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out"); // same fs, so a clone is possible
+        let conn = seed(dir.path());
+        let dirs = vec![dir.path().to_string_lossy().into_owned()];
+        let plan = plan_export(&conn, &dirs, &ExportOptions::default()).unwrap();
+
+        let mut updates = Vec::new();
+        let summary = execute_plan_with(
+            &plan,
+            &dest,
+            Placement::Reflink,
+            false,
+            &mut |placed, total| {
+                updates.push((placed, total));
+            },
+        );
+        assert_eq!(summary.errors, 0);
+        assert_eq!(summary.reflinked + summary.copied, 1);
+        assert!(dest
+            .join("M42_Trapezium/LIGHT/Ha/acc_Ha_0001.fits")
+            .is_file());
+        assert_eq!(updates.last(), Some(&(1, 1)));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1005,6 +1005,7 @@ directory = "./cache"
             image_dirs: vec![],
             reject_archive: None,
             remote_image_upload: None,
+            export_dir: None,
         }
     }
 

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -45,6 +45,13 @@ pub struct DbEntry {
     /// SHA-256 digest; plaintext exists only in the management request.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_image_upload: Option<RemoteImageUploadConfig>,
+    /// Server-side destination for UI-triggered exports. Because the
+    /// operator names this directory here (or in Settings), the export
+    /// action itself needs no database-management grant — the UI only ever
+    /// asks to export into this pre-consented location. Absent means server
+    /// export is off and the UI offers the archive download instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub export_dir: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -312,6 +319,7 @@ impl DbRegistry {
                 image_dirs: v1.image_directories,
                 reject_archive: None,
                 remote_image_upload: None,
+                export_dir: None,
             });
         }
         reg.save(path)?;
@@ -379,6 +387,7 @@ impl DbRegistry {
             image_dirs,
             reject_archive: None,
             remote_image_upload: None,
+            export_dir: None,
         });
         Ok(self.databases.last().unwrap())
     }

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -269,6 +269,10 @@ pub struct DatabaseSummary {
     pub database_path: String,
     pub image_directories: Vec<String>,
     pub remote_image_upload: RemoteImageUploadSummary,
+    /// Operator-configured server-side export destination. When present the
+    /// UI offers a server export that runs without database management.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub export_directory: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -562,6 +566,41 @@ pub struct LocalExportRequest {
     pub dry_run: bool,
 }
 
+/// Body of `POST /api/db/{db_id}/export/server` — run the export into the
+/// operator-configured export directory as a background job. There is no
+/// destination field: consent to write was given when the directory was
+/// configured, which is what lets this route skip the management grant.
+#[derive(Debug, Deserialize)]
+pub struct ServerExportRequest {
+    #[serde(default)]
+    pub project_id: Option<i32>,
+    #[serde(default)]
+    pub target_id: Option<i32>,
+    #[serde(default)]
+    pub include_pending: bool,
+    #[serde(default)]
+    pub filter_name: Option<String>,
+    #[serde(default)]
+    pub layout: crate::commands::export::ExportLayout,
+    /// Folder created below the configured directory, so repeated exports
+    /// of different scopes do not interleave. Sanitized to one path
+    /// component; empty or absent exports into the directory itself.
+    #[serde(default)]
+    pub subdirectory: Option<String>,
+    /// Display label for the progress line ("project Bubble").
+    #[serde(default)]
+    pub scope_label: Option<String>,
+}
+
+/// Response of both methods on `/api/db/{db_id}/export/server`. On POST,
+/// `started` says whether THIS request began the job; on GET it mirrors
+/// `progress.running`.
+#[derive(Debug, Serialize)]
+pub struct ExportStatusResponse {
+    pub started: bool,
+    pub progress: crate::server::export_job::ExportJobProgress,
+}
+
 /// Body of `PUT /api/db/{db_id}/projects/{project_id}`.
 #[derive(Debug, Deserialize, Default)]
 pub struct UpdateProjectRequest {
@@ -644,6 +683,9 @@ pub struct UpdateDatabaseRequest {
     pub image_dirs: Option<Vec<String>>,
     #[serde(default)]
     pub remote_image_upload: Option<RemoteImageUploadUpdate>,
+    /// New export directory. `Some("")` clears it; absent leaves it alone.
+    #[serde(default)]
+    pub export_dir: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -153,6 +153,10 @@ pub struct DatabaseContext {
     pub image_dir_paths: Vec<PathBuf>,
     pub remote_image_upload: Option<crate::db_registry::RemoteImageUploadConfig>,
     pub remote_image_upload_dir: Option<PathBuf>,
+    /// Operator-configured destination for UI-triggered exports. Consent to
+    /// write here was given when the directory was configured, so the export
+    /// job runs without the database-management grant.
+    pub export_dir: Option<PathBuf>,
     /// Per-DB cache directory: `<cache_root>/<slug>/`. Created on construction.
     /// All preview/annotated/PSF artifacts for this database live below here,
     /// so two DBs with overlapping image IDs do not collide.
@@ -186,6 +190,8 @@ pub struct DatabaseContext {
     pub spatial_metrics: crate::server::spatial_scan::SharedSpatialStore,
     /// Per-DB singleton FITS import job state (see `server::import_job`).
     pub import_job: crate::server::import_job::SharedImportJob,
+    /// Per-DB singleton export job state (see `server::export_job`).
+    pub export_job: crate::server::export_job::SharedExportJob,
     /// Database-wide, low-priority quality analysis state.
     pub quality_backfill: crate::server::quality_backfill::SharedQualityBackfill,
     /// Serializes publish/import for remotely posted images within one
@@ -202,6 +208,7 @@ impl DatabaseContext {
         db_path: String,
         image_dirs: Vec<String>,
         remote_image_upload: Option<crate::db_registry::RemoteImageUploadConfig>,
+        export_dir: Option<String>,
         cache_root: String,
     ) -> Result<Self> {
         use std::path::Path;
@@ -231,6 +238,24 @@ impl DatabaseContext {
             .map(|config| config.validated_image_dir(&image_dirs))
             .transpose()?;
 
+        // The directory itself may not exist yet (an operator can configure
+        // it before mounting the drive); the export job creates it and
+        // reports failures per run. Only an obviously unusable value —
+        // empty or relative — is refused here.
+        let export_dir = export_dir
+            .filter(|dir| !dir.trim().is_empty())
+            .map(|dir| {
+                let path = PathBuf::from(&dir);
+                if path.is_relative() {
+                    Err(anyhow::anyhow!(
+                        "Export directory must be an absolute path: {dir}"
+                    ))
+                } else {
+                    Ok(path)
+                }
+            })
+            .transpose()?;
+
         let cache_dir_path = PathBuf::from(&cache_root).join(&id);
         std::fs::create_dir_all(&cache_dir_path).map_err(|e| {
             anyhow::anyhow!(
@@ -252,6 +277,7 @@ impl DatabaseContext {
             image_dir_paths,
             remote_image_upload,
             remote_image_upload_dir,
+            export_dir,
             cache_dir,
             cache_dir_path,
             db_connection: Arc::new(Mutex::new(conn)),
@@ -266,6 +292,7 @@ impl DatabaseContext {
             astrometry_evidence: Arc::new(crate::astrometry::AstrometryEvidenceCache::new()),
             spatial_metrics: Arc::new(RwLock::new(Default::default())),
             import_job: Arc::new(RwLock::new(Default::default())),
+            export_job: Arc::new(RwLock::new(Default::default())),
             quality_backfill: Arc::new(RwLock::new(Default::default())),
             image_import_mutex: Arc::new(TokioMutex::new(())),
         })
@@ -967,6 +994,7 @@ impl DatabaseContext {
             image_dir_paths: vec![],
             remote_image_upload: None,
             remote_image_upload_dir: None,
+            export_dir: None,
             cache_dir: "/tmp/psf-guard-test".to_string(),
             cache_dir_path: PathBuf::from("/tmp/psf-guard-test"),
             db_connection: Arc::new(Mutex::new(conn)),
@@ -981,6 +1009,7 @@ impl DatabaseContext {
             astrometry_evidence: Arc::new(crate::astrometry::AstrometryEvidenceCache::new()),
             spatial_metrics: Arc::new(RwLock::new(Default::default())),
             import_job: Arc::new(RwLock::new(Default::default())),
+            export_job: Arc::new(RwLock::new(Default::default())),
             quality_backfill: Arc::new(RwLock::new(Default::default())),
             image_import_mutex: Arc::new(TokioMutex::new(())),
         }
@@ -997,6 +1026,7 @@ impl Clone for DatabaseContext {
             image_dir_paths: self.image_dir_paths.clone(),
             remote_image_upload: self.remote_image_upload.clone(),
             remote_image_upload_dir: self.remote_image_upload_dir.clone(),
+            export_dir: self.export_dir.clone(),
             cache_dir: self.cache_dir.clone(),
             cache_dir_path: self.cache_dir_path.clone(),
             db_connection: self.db_connection.clone(),
@@ -1011,6 +1041,7 @@ impl Clone for DatabaseContext {
             astrometry_evidence: self.astrometry_evidence.clone(),
             spatial_metrics: self.spatial_metrics.clone(),
             import_job: self.import_job.clone(),
+            export_job: self.export_job.clone(),
             quality_backfill: self.quality_backfill.clone(),
             image_import_mutex: self.image_import_mutex.clone(),
         }
@@ -1123,6 +1154,7 @@ mod tests {
             "Test".into(),
             db_path.to_string_lossy().into_owned(),
             vec![img_dir.to_string_lossy().into_owned()],
+            None,
             None,
             dir.join("cache").to_string_lossy().into_owned(),
         )

--- a/src/server/export_job.rs
+++ b/src/server/export_job.rs
@@ -1,0 +1,127 @@
+//! Singleton per-DB background export job.
+//!
+//! Modeled on `import_job`: one job per database at a time, a serializable
+//! progress snapshot the frontend polls (~1s), and `try_begin` / `finish`
+//! guards so a panic can never wedge the singleton.
+//!
+//! Export stages: `planning` (catalog walk + calibration join) → `placing`
+//! (reflink-or-copy of every planned file) → `scripts` (WBPP runner) →
+//! `complete` / `error`.
+
+use crate::commands::export::ExportSummary;
+use serde::Serialize;
+use std::sync::{Arc, RwLock};
+
+/// Progress of the (singleton per-DB) export job.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ExportJobProgress {
+    pub running: bool,
+    /// `planning`, `placing`, `scripts`, `complete`, or `error`.
+    pub stage: String,
+    /// Where this export lands, for display. Set at begin.
+    pub destination: String,
+    /// What was asked for, for display ("project Bubble", "target M 74 Ha").
+    pub scope: String,
+    /// Placement progress once the plan is known.
+    pub total_files: usize,
+    pub placed_files: usize,
+    /// Set once placement finishes.
+    pub outcome: Option<ExportSummary>,
+    pub started_at: Option<i64>,
+    pub finished_at: Option<i64>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct ExportJobStore {
+    pub progress: ExportJobProgress,
+}
+
+pub type SharedExportJob = Arc<RwLock<ExportJobStore>>;
+
+/// Claim the singleton. Returns false when a job is already running.
+pub fn try_begin(store: &RwLock<ExportJobStore>, destination: String, scope: String) -> bool {
+    let mut s = store.write().unwrap();
+    if s.progress.running {
+        return false;
+    }
+    s.progress = ExportJobProgress {
+        running: true,
+        stage: "planning".to_string(),
+        destination,
+        scope,
+        started_at: Some(chrono::Utc::now().timestamp()),
+        ..Default::default()
+    };
+    true
+}
+
+pub fn set_stage(store: &RwLock<ExportJobStore>, stage: &str) {
+    let mut s = store.write().unwrap();
+    s.progress.stage = stage.to_string();
+}
+
+pub fn set_placement_totals(store: &RwLock<ExportJobStore>, total: usize, placed: usize) {
+    let mut s = store.write().unwrap();
+    s.progress.total_files = total;
+    s.progress.placed_files = placed;
+}
+
+/// Publish the completed export and release the per-database singleton.
+pub fn complete_export(store: &RwLock<ExportJobStore>, outcome: ExportSummary) {
+    let mut s = store.write().unwrap();
+    s.progress.outcome = Some(outcome);
+    s.progress.running = false;
+    s.progress.stage = "complete".to_string();
+    s.progress.finished_at = Some(chrono::Utc::now().timestamp());
+}
+
+/// Finalize the job. `error = None` marks success.
+pub fn finish(store: &RwLock<ExportJobStore>, error: Option<String>) {
+    let mut s = store.write().unwrap();
+    s.progress.running = false;
+    s.progress.stage = if error.is_some() {
+        "error".to_string()
+    } else {
+        "complete".to_string()
+    };
+    s.progress.error = error;
+    s.progress.finished_at = Some(chrono::Utc::now().timestamp());
+}
+
+pub fn progress_snapshot(store: &RwLock<ExportJobStore>) -> ExportJobProgress {
+    store.read().unwrap().progress.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn begin_is_a_singleton_and_resets_prior_state() {
+        let store = RwLock::new(ExportJobStore::default());
+        assert!(try_begin(&store, "/exports".into(), "project A".into()));
+        assert!(!try_begin(&store, "/exports".into(), "project B".into()));
+        finish(&store, Some("boom".into()));
+        assert_eq!(progress_snapshot(&store).stage, "error");
+        assert!(try_begin(&store, "/exports".into(), "project B".into()));
+        let progress = progress_snapshot(&store);
+        assert_eq!(progress.scope, "project B");
+        assert!(progress.error.is_none());
+        assert!(progress.outcome.is_none());
+    }
+
+    #[test]
+    fn completion_publishes_the_summary() {
+        let store = RwLock::new(ExportJobStore::default());
+        assert!(try_begin(&store, "/exports".into(), "target T".into()));
+        set_stage(&store, "placing");
+        set_placement_totals(&store, 10, 4);
+        complete_export(&store, ExportSummary::default());
+        let progress = progress_snapshot(&store);
+        assert!(!progress.running);
+        assert_eq!(progress.stage, "complete");
+        assert_eq!(progress.total_files, 10);
+        assert!(progress.outcome.is_some());
+    }
+}

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -419,13 +419,7 @@ pub async fn list_databases(
     let mut summaries: Vec<DatabaseSummary> = state
         .all_databases()
         .iter()
-        .map(|ctx| DatabaseSummary {
-            id: ctx.id.clone(),
-            name: ctx.name.clone(),
-            database_path: ctx.database_path.clone(),
-            image_directories: ctx.image_dirs.clone(),
-            remote_image_upload: remote_image_upload_summary(ctx),
-        })
+        .map(|ctx| summary_of(ctx))
         .collect();
     summaries.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(Json(ApiResponse::success(summaries)))
@@ -468,6 +462,10 @@ fn summary_of(ctx: &crate::server::database_context::DatabaseContext) -> Databas
         database_path: ctx.database_path.clone(),
         image_directories: ctx.image_dirs.clone(),
         remote_image_upload: remote_image_upload_summary(ctx),
+        export_directory: ctx
+            .export_dir
+            .as_ref()
+            .map(|path| path.to_string_lossy().into_owned()),
     }
 }
 
@@ -972,6 +970,7 @@ pub async fn add_database_route(
             entry.db_path.clone(),
             entry.image_dirs.clone(),
             entry.remote_image_upload.clone(),
+            entry.export_dir.clone(),
             state.cache_dir_root.clone(),
         )
         .map_err(|e| AppError::BadRequest(format!("opening database: {}", e)))?,
@@ -1034,6 +1033,26 @@ pub async fn update_database_route(
             ))?;
         apply_remote_image_upload_update(entry, update)?;
     }
+    if let Some(export_dir) = req.export_dir.as_ref() {
+        let entry = reg
+            .databases
+            .iter_mut()
+            .find(|entry| entry.id == new_id)
+            .ok_or(AppError::InternalError(
+                "registry update lost the entry".into(),
+            ))?;
+        let trimmed = export_dir.trim();
+        entry.export_dir = if trimmed.is_empty() {
+            None
+        } else {
+            if std::path::Path::new(trimmed).is_relative() {
+                return Err(AppError::BadRequest(
+                    "Export directory must be an absolute path".into(),
+                ));
+            }
+            Some(trimmed.to_string())
+        };
+    }
     let entry = reg
         .find(&new_id)
         .ok_or(AppError::InternalError(
@@ -1072,6 +1091,7 @@ pub async fn update_database_route(
             entry.db_path.clone(),
             entry.image_dirs.clone(),
             entry.remote_image_upload.clone(),
+            entry.export_dir.clone(),
             state.cache_dir_root.clone(),
         )
         .map_err(|e| AppError::BadRequest(format!("opening database: {}", e)))?,
@@ -1351,6 +1371,131 @@ pub async fn export_local_route(
     Ok(Json(ApiResponse::success(summary)))
 }
 
+/// `POST /api/db/{db_id}/export/server` — run the export into the
+/// operator-configured export directory as a background job. Unlike
+/// `/export/local`, the caller never names a path: the operator consented
+/// to writes here when configuring the directory, so no management grant
+/// is needed. Reflinks where the filesystem supports it, copies elsewhere.
+pub async fn start_server_export_route(
+    ctx: DbContext,
+    Json(req): Json<crate::server::api::ServerExportRequest>,
+) -> Result<Json<ApiResponse<crate::server::api::ExportStatusResponse>>, AppError> {
+    use crate::commands::export::{
+        execute_plan_with, plan_export, sanitize_component, ExportOptions, Placement,
+    };
+    use crate::server::export_job;
+
+    let Some(export_root) = ctx.0.export_dir.clone() else {
+        return Err(AppError::BadRequest(
+            "No export directory is configured for this database. Set one in Settings, \
+             or edit the registry's export_dir."
+                .into(),
+        ));
+    };
+    let dest = match req.subdirectory.as_deref().map(str::trim) {
+        Some(subdirectory) if !subdirectory.is_empty() => {
+            export_root.join(sanitize_component(subdirectory))
+        }
+        _ => export_root,
+    };
+    let scope = req
+        .scope_label
+        .clone()
+        .filter(|label| !label.trim().is_empty())
+        .unwrap_or_else(|| "selection".into());
+
+    let options = ExportOptions {
+        include_pending: req.include_pending,
+        project_id: req.project_id,
+        target_id: req.target_id,
+        filter_name: req.filter_name.clone(),
+        layout: req.layout,
+        ..Default::default()
+    };
+
+    let store = ctx.0.export_job.clone();
+    if !export_job::try_begin(&store, dest.display().to_string(), scope) {
+        return Ok(Json(ApiResponse::success(
+            crate::server::api::ExportStatusResponse {
+                started: false,
+                progress: export_job::progress_snapshot(&store),
+            },
+        )));
+    }
+
+    let job_ctx = ctx.0.clone();
+    let job_store = store.clone();
+    tokio::task::spawn_blocking(move || {
+        let run = || -> anyhow::Result<()> {
+            let conn = rusqlite::Connection::open_with_flags(
+                &job_ctx.database_path,
+                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+            )
+            .map_err(|e| anyhow::anyhow!("opening {}: {e}", job_ctx.database_path))?;
+            let plan = plan_export(&conn, &job_ctx.image_dirs, &options)?;
+            std::fs::create_dir_all(&dest)
+                .map_err(|e| anyhow::anyhow!("creating {}: {e}", dest.display()))?;
+            export_job::set_stage(&job_store, "placing");
+            export_job::set_placement_totals(&job_store, plan.items.len(), 0);
+            let summary = execute_plan_with(
+                &plan,
+                &dest,
+                Placement::Reflink,
+                false,
+                &mut |placed, total| {
+                    export_job::set_placement_totals(&job_store, total, placed);
+                },
+            );
+            if options.layout == crate::commands::export::ExportLayout::Wbpp {
+                use crate::commands::export::{wbpp, write_wbpp_scripts};
+                export_job::set_stage(&job_store, "scripts");
+                // The frames are already placed; a runner that cannot be
+                // written is worth logging but never worth failing over.
+                if let Err(error) = write_wbpp_scripts(&plan, &dest, wbpp::WbppRun::default()) {
+                    tracing::warn!("No WBPP runner script: {error}");
+                }
+            }
+            tracing::info!(
+                "📤 Server export db={}: planned={} reflinked={} copied={} skipped={} missing={} errors={} -> {}",
+                job_ctx.id,
+                summary.planned,
+                summary.reflinked,
+                summary.copied,
+                summary.skipped_existing,
+                summary.missing,
+                summary.errors,
+                dest.display(),
+            );
+            export_job::complete_export(&job_store, summary);
+            Ok(())
+        };
+        if let Err(error) = run() {
+            tracing::warn!("Server export failed: {error:#}");
+            export_job::finish(&job_store, Some(format!("{error:#}")));
+        }
+    });
+
+    Ok(Json(ApiResponse::success(
+        crate::server::api::ExportStatusResponse {
+            started: true,
+            progress: export_job::progress_snapshot(&store),
+        },
+    )))
+}
+
+/// `GET /api/db/{db_id}/export/server` — progress of the export job.
+pub async fn get_server_export_progress(
+    ctx: DbContext,
+) -> Result<Json<ApiResponse<crate::server::api::ExportStatusResponse>>, AppError> {
+    let progress = crate::server::export_job::progress_snapshot(&ctx.0.export_job);
+    Ok(Json(ApiResponse::success(
+        crate::server::api::ExportStatusResponse {
+            started: progress.running,
+            progress,
+        },
+    )))
+}
+
 /// `PUT /api/db/{db_id}/projects/{project_id}` — update scheduler fields.
 pub async fn update_project_route(
     State(_state): State<Arc<AppState>>,
@@ -1506,6 +1651,7 @@ pub async fn create_database_route(
             entry.db_path.clone(),
             entry.image_dirs.clone(),
             entry.remote_image_upload.clone(),
+            entry.export_dir.clone(),
             state.cache_dir_root.clone(),
         )
         .map_err(|e| AppError::InternalError(format!("opening new database: {}", e)))?,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,6 +4,7 @@ pub mod cache;
 pub mod catalog_install;
 pub mod database_context;
 pub mod embedded_static;
+pub mod export_job;
 pub mod extract;
 pub mod handlers;
 pub mod import_job;
@@ -502,7 +503,11 @@ async fn run_server_internal(
             post(handlers::start_import_route).get(handlers::get_import_progress),
         )
         .route("/export", get(handlers::export_archive_route))
-        .route("/export/local", post(handlers::export_local_route));
+        .route("/export/local", post(handlers::export_local_route))
+        .route(
+            "/export/server",
+            post(handlers::start_server_export_route).get(handlers::get_server_export_progress),
+        );
 
     // Top-level API: global endpoints + nested per-DB routes.
     let api_routes = Router::new()

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -382,6 +382,7 @@ impl AppState {
                 entry.db_path,
                 entry.image_dirs,
                 entry.remote_image_upload,
+                entry.export_dir,
                 cache_dir.clone(),
             )?);
             map.insert(entry.id, ctx);
@@ -526,6 +527,7 @@ impl AppState {
                 image_dirs,
                 reject_archive: None,
                 remote_image_upload: None,
+                export_dir: None,
             }],
             cache_dir,
             pregeneration_config,

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -533,6 +533,7 @@ mod tests {
                 image_dirs: vec![root.display().to_string()],
                 reject_archive: None,
                 remote_image_upload: None,
+                export_dir: None,
             }],
             active_db_id: None,
             astrometry: None,

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3404,6 +3404,16 @@
   font-size: 0.82rem;
 }
 
+.server-export-status {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  max-width: 42rem;
+}
+
+.server-export-status.error {
+  color: var(--color-error, #c0392b);
+}
+
 .stack-preview-channel-calibration select {
   padding: 0.18rem 0.3rem;
   border-radius: 4px;

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -311,6 +311,8 @@ export const apiClient = {
         token?: string;
         sync_enabled?: boolean;
       };
+      /** New export directory; empty string clears it. */
+      export_dir?: string;
     }
   ): Promise<DatabaseSummary> => {
     const apiInstance = await getApi();
@@ -587,6 +589,41 @@ export const apiClient = {
       }>
     >(dbPath(dbId, '/export/local'), req);
     if (!data.data) throw new Error(data.error || 'Failed to export');
+    return data.data;
+  },
+
+  /**
+   * Start the background export into the server's configured export
+   * directory. Reflinks where the filesystem supports it, copies elsewhere.
+   * Only offered when the database reports an `export_directory`.
+   */
+  startServerExport: async (
+    dbId: string,
+    req: {
+      project_id?: number;
+      target_id?: number;
+      include_pending?: boolean;
+      filter_name?: string;
+      layout?: ExportLayout;
+      subdirectory?: string;
+      scope_label?: string;
+    }
+  ): Promise<import('./types').ExportStatus> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<import('./types').ExportStatus>>(
+      dbPath(dbId, '/export/server'),
+      req
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to start the export');
+    return data.data;
+  },
+
+  getServerExportStatus: async (dbId: string): Promise<import('./types').ExportStatus> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<import('./types').ExportStatus>>(
+      dbPath(dbId, '/export/server')
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to read export progress');
     return data.data;
   },
 

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1023,6 +1023,43 @@ export interface DatabaseSummary {
   database_path: string;
   image_directories: string[];
   remote_image_upload: RemoteImageUploadSummary;
+  /**
+   * Operator-configured server-side export destination. When present the
+   * UI offers a server export that runs without database management.
+   */
+  export_directory?: string;
+}
+
+/** What one export placed, and how. */
+export interface ExportSummary {
+  planned: number;
+  copied: number;
+  linked: number;
+  /** Copy-on-write clones: free like a hardlink, independent like a copy. */
+  reflinked?: number;
+  skipped_existing: number;
+  missing: number;
+  errors: number;
+  bytes: number;
+}
+
+/** Progress of the singleton per-DB server export job. */
+export interface ExportJobProgress {
+  running: boolean;
+  stage: string;
+  destination: string;
+  scope: string;
+  total_files: number;
+  placed_files: number;
+  outcome?: ExportSummary | null;
+  started_at?: number | null;
+  finished_at?: number | null;
+  error?: string | null;
+}
+
+export interface ExportStatus {
+  started: boolean;
+  progress: ExportJobProgress;
 }
 
 export interface RemoteImageUploadSummary {

--- a/static/src/components/Overview.tsx
+++ b/static/src/components/Overview.tsx
@@ -17,6 +17,7 @@ import {
   type WithDb,
 } from '../hooks/useDatabases';
 import { isTauriApp, tauriFileSystem } from '../utils/tauri';
+import { describeExportProgress, useExportJob } from '../hooks/useExportJob';
 import { openSettings } from '../utils/settingsIntent';
 import {
   loadProjectSeenState,
@@ -95,6 +96,9 @@ export default function Overview() {
   // our own files would be silly. Browser mode keeps the zip download link.
   const isTauri = isTauriApp();
   const [exportBusy, setExportBusy] = useState(false);
+  // The database whose server export this page last started (or found
+  // running); drives the progress line under the catalog summary.
+  const [exportJobDb, setExportJobDb] = useState<string | null>(null);
   // One choice for every export affordance on the page. Kept here rather than
   // per row so a project and its targets cannot disagree about the tree they
   // land in.
@@ -123,6 +127,35 @@ export default function Overview() {
       setExportBusy(false);
     }
   };
+  // Which databases have an operator-configured export directory: those get
+  // a server export instead of the zip download.
+  const serverExportDir = (dbId: string) =>
+    databases?.find((db) => db.id === dbId)?.export_directory;
+  const handleServerExport = async (
+    dbId: string,
+    scope: { project_id?: number; target_id?: number },
+    label: string
+  ) => {
+    try {
+      setExportBusy(true);
+      const status = await apiClient.startServerExport(dbId, {
+        ...scope,
+        layout: exportLayout,
+        subdirectory: label,
+        scope_label: label,
+      });
+      setExportJobDb(dbId);
+      if (!status.started) {
+        alert('An export is already running for this database; watch its progress below.');
+      }
+    } catch (err) {
+      alert(`Export failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setExportBusy(false);
+    }
+  };
+  const exportJob = useExportJob(exportJobDb);
+  const exportJobLine = describeExportProgress(exportJob.progress);
 
   // Persist an organize edit (rename / move / merge), then refresh this DB's
   // overview queries so the new grouping shows up.
@@ -458,6 +491,15 @@ export default function Overview() {
               <option value="wbpp">WBPP</option>
             </select>
           </label>
+          {exportJobLine && (
+            <div
+              className={`server-export-status${
+                exportJob.progress?.stage === 'error' ? ' error' : ''
+              }`}
+            >
+              {exportJobLine}
+            </div>
+          )}
           <dl className="summary-metrics">
             <div>
               <dt>Projects</dt>
@@ -925,6 +967,23 @@ export default function Overview() {
                         >
                           ⬇ Export
                         </span>
+                      ) : serverExportDir(project.db_id) ? (
+                        <span
+                          className="export-link"
+                          title={`Export this project's accepted lights to the server's export directory (${serverExportDir(project.db_id)}), reflinking where the filesystem supports it`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (!exportBusy) {
+                              handleServerExport(
+                                project.db_id,
+                                { project_id: project.id },
+                                project.display_name
+                              );
+                            }
+                          }}
+                        >
+                          ⬇ Export
+                        </span>
                       ) : (
                         <a
                           className="export-link"
@@ -1037,6 +1096,23 @@ export default function Overview() {
                                     onClick={() => {
                                       if (!exportBusy) {
                                         handleLocalExport(
+                                          target.db_id,
+                                          { target_id: target.id },
+                                          target.name
+                                        );
+                                      }
+                                    }}
+                                  >
+                                    ↓ Export
+                                  </button>
+                                ) : serverExportDir(target.db_id) ? (
+                                  <button
+                                    type="button"
+                                    className="target-settings-button"
+                                    title={`Export this target's accepted lights to the server's export directory (${serverExportDir(target.db_id)})`}
+                                    onClick={() => {
+                                      if (!exportBusy) {
+                                        handleServerExport(
                                           target.db_id,
                                           { target_id: target.id },
                                           target.name

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -84,6 +84,7 @@ export default function TauriSettings({
   const [formRemoteUploadEnabled, setFormRemoteUploadEnabled] = useState(false);
   const [formRemoteSyncEnabled, setFormRemoteSyncEnabled] = useState(false);
   const [formRemoteUploadDir, setFormRemoteUploadDir] = useState('');
+  const [formExportDir, setFormExportDir] = useState('');
   const [formRemoteUploadToken, setFormRemoteUploadToken] = useState('');
   const [formRemoteUploadTokenConfigured, setFormRemoteUploadTokenConfigured] =
     useState(false);
@@ -130,6 +131,7 @@ export default function TauriSettings({
                 name: summary.name,
                 db_path: summary.database_path,
                 image_dirs: summary.image_directories,
+                export_dir: summary.export_directory,
                 remote_image_upload: {
                   enabled: summary.remote_image_upload?.enabled ?? false,
                   image_dir: summary.remote_image_upload?.image_directory,
@@ -151,6 +153,7 @@ export default function TauriSettings({
             name: s.name,
             db_path: s.database_path,
             image_dirs: s.image_directories,
+            export_dir: s.export_directory,
             remote_image_upload: {
               enabled: s.remote_image_upload?.enabled ?? false,
               image_dir: s.remote_image_upload?.image_directory,
@@ -223,6 +226,7 @@ export default function TauriSettings({
     setFormName(entry.name);
     setFormDbPath(entry.db_path);
     setFormImageDirs(entry.image_dirs);
+    setFormExportDir(entry.export_dir ?? '');
     setFormRemoteUploadEnabled(entry.remote_image_upload?.enabled ?? false);
     setFormRemoteSyncEnabled(entry.remote_image_upload?.sync_enabled ?? false);
     setFormRemoteUploadDir(
@@ -448,6 +452,7 @@ export default function TauriSettings({
           name: inferredName,
           db_path: formDbPath.trim(),
           image_dirs: formImageDirs,
+          export_dir: formExportDir.trim(),
           remote_image_upload: {
             enabled: formRemoteUploadEnabled,
             image_directory: formRemoteUploadDir || undefined,
@@ -1079,6 +1084,18 @@ export default function TauriSettings({
                       <strong>Accept remote image uploads</strong>
                     </span>
                   </label>
+                  <label htmlFor="server-export-directory">
+                    Server export directory:
+                  </label>
+                  <input
+                    id="server-export-directory"
+                    type="text"
+                    className="file-path-input"
+                    placeholder="Absolute server path; empty disables server export"
+                    title="Exports triggered from the Overview land here (reflinked where the filesystem supports it). Leave empty to offer the archive download instead."
+                    value={formExportDir}
+                    onChange={(event) => setFormExportDir(event.target.value)}
+                  />
                   {formRemoteUploadEnabled && (
                     <>
                       <label htmlFor="remote-upload-directory">Receive directory:</label>

--- a/static/src/hooks/useExportJob.ts
+++ b/static/src/hooks/useExportJob.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import type { ExportJobProgress, ExportStatus } from '../api/types';
+
+/**
+ * Monitor the singleton per-DB server export job (started via
+ * `apiClient.startServerExport`). Polls at 1s while the export runs.
+ */
+export function useExportJob(dbId: string | null | undefined) {
+  const queryClient = useQueryClient();
+
+  const statusQuery = useQuery<ExportStatus>({
+    queryKey: ['db', dbId, 'export-job'],
+    queryFn: () => apiClient.getServerExportStatus(dbId!),
+    enabled: !!dbId,
+    refetchInterval: (query) => (query.state.data?.progress.running ? 1000 : false),
+    refetchIntervalInBackground: true,
+  });
+
+  const progress = statusQuery.data?.progress;
+  const isRunning = progress?.running ?? false;
+
+  const wasRunning = useRef(false);
+  useEffect(() => {
+    if (wasRunning.current && !isRunning && dbId) {
+      queryClient.invalidateQueries({ queryKey: ['db', dbId, 'export-job'] });
+    }
+    wasRunning.current = isRunning;
+  }, [isRunning, dbId, queryClient]);
+
+  return {
+    progress,
+    isRunning,
+    refresh: statusQuery.refetch,
+  };
+}
+
+/** One-line human description of an export job's current state. */
+export function describeExportProgress(progress: ExportJobProgress | undefined): string | null {
+  if (!progress || (!progress.running && !progress.finished_at)) return null;
+  const scope = progress.scope ? ` ${progress.scope}` : '';
+  switch (progress.stage) {
+    case 'planning':
+      return `Planning export of${scope}…`;
+    case 'placing':
+      return progress.total_files > 0
+        ? `Exporting${scope}: ${progress.placed_files} of ${progress.total_files} files`
+        : `Exporting${scope}…`;
+    case 'scripts':
+      return `Writing the WBPP runner…`;
+    case 'error':
+      return `Export failed: ${progress.error ?? 'unknown error'}`;
+    case 'complete': {
+      const outcome = progress.outcome;
+      if (!outcome) return `Export of${scope} finished`;
+      const placed = outcome.copied + outcome.linked + (outcome.reflinked ?? 0);
+      const parts = [`${placed} file(s) placed`];
+      if ((outcome.reflinked ?? 0) > 0) parts.push(`${outcome.reflinked} reflinked`);
+      if (outcome.skipped_existing > 0) parts.push(`${outcome.skipped_existing} already present`);
+      if (outcome.missing > 0) parts.push(`${outcome.missing} missing on disk`);
+      if (outcome.errors > 0) parts.push(`${outcome.errors} ERRORS`);
+      return `Exported${scope}: ${parts.join(', ')} → ${progress.destination}`;
+    }
+    default:
+      return null;
+  }
+}

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -66,6 +66,8 @@ export interface DbEntry {
     token_configured?: boolean;
     sync_enabled?: boolean;
   };
+  /** Server-side destination for UI-triggered exports. */
+  export_dir?: string;
 }
 
 // Process-global Seiza catalog paths. data_dir configures a complete bundle;

--- a/tests/integration_remote_sync.rs
+++ b/tests/integration_remote_sync.rs
@@ -185,6 +185,7 @@ impl Harness {
                         image_dirs: image_dirs.clone(),
                         reject_archive: None,
                         remote_image_upload: Some(api_config(SOURCE_TOKEN)),
+                        export_dir: None,
                     },
                     DbEntry {
                         id: "destination".into(),
@@ -193,6 +194,7 @@ impl Harness {
                         image_dirs,
                         reject_archive: None,
                         remote_image_upload: Some(api_config(DESTINATION_TOKEN)),
+                        export_dir: None,
                     },
                 ],
                 directory
@@ -896,6 +898,7 @@ async fn an_upload_only_key_cannot_reach_the_sync_protocol() {
                 image_dirs: vec![image_path.to_string_lossy().into_owned()],
                 reject_archive: None,
                 remote_image_upload: Some(upload_only_config(SOURCE_TOKEN)),
+                export_dir: None,
             }],
             directory
                 .path()

--- a/tests/integration_remote_sync_real_schema.rs
+++ b/tests/integration_remote_sync_real_schema.rs
@@ -82,6 +82,7 @@ impl Harness {
                         image_dirs: image_dirs.clone(),
                         reject_archive: None,
                         remote_image_upload: Some(config(SOURCE_TOKEN)),
+                        export_dir: None,
                     },
                     DbEntry {
                         id: "destination".into(),
@@ -90,6 +91,7 @@ impl Harness {
                         image_dirs,
                         reject_archive: None,
                         remote_image_upload: Some(config(DESTINATION_TOKEN)),
+                        export_dir: None,
                     },
                 ],
                 directory

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -60,6 +60,7 @@ impl Fixture {
                 image_dirs: vec![images_a.to_string_lossy().into_owned()],
                 reject_archive: None,
                 remote_image_upload: Some(config_a),
+                export_dir: None,
             },
             DbEntry {
                 id: "catalog-b".into(),
@@ -68,6 +69,7 @@ impl Fixture {
                 image_dirs: vec![images_b.to_string_lossy().into_owned()],
                 reject_archive: None,
                 remote_image_upload: Some(config_b),
+                export_dir: None,
             },
         ];
         let state = Arc::new(

--- a/tests/integration_sync_api.rs
+++ b/tests/integration_sync_api.rs
@@ -96,6 +96,7 @@ async fn planning_and_grade_pushes_preview_before_writing() {
             image_dirs: vec![image_dir.to_string_lossy().into_owned()],
             reject_archive: None,
             remote_image_upload: None,
+            export_dir: None,
         },
         DbEntry {
             id: "scope".into(),
@@ -104,6 +105,7 @@ async fn planning_and_grade_pushes_preview_before_writing() {
             image_dirs: vec![image_dir.to_string_lossy().into_owned()],
             reject_archive: None,
             remote_image_upload: None,
+            export_dir: None,
         },
     ];
     let state = Arc::new(
@@ -394,6 +396,7 @@ async fn a_pull_brings_structure_and_captures_down_and_keeps_local_grades() {
                     image_dirs: image_dirs.clone(),
                     reject_archive: None,
                     remote_image_upload: None,
+                    export_dir: None,
                 },
                 DbEntry {
                     id: "scope".into(),
@@ -402,6 +405,7 @@ async fn a_pull_brings_structure_and_captures_down_and_keeps_local_grades() {
                     image_dirs,
                     reject_archive: None,
                     remote_image_upload: None,
+                    export_dir: None,
                 },
             ],
             dir.path().join("cache").to_string_lossy().into_owned(),


### PR DESCRIPTION
Server export: the Overview's Export action can now place the full export tree on the server's own drive, as a background job, without any client-supplied path.

## Design

- **Consent lives in configuration.** The operator sets a per-database export directory (Settings → database edit, or `export_dir` in the registry JSON). The job route (`POST/GET /api/db/{id}/export/server`) writes only below that directory, so it needs no database-management grant — mirroring how importing into configured dirs is ungated while naming new dirs is not. The old `/export/local` (client-supplied `dest`) keeps its management gate unchanged.
- **Same export, all of it**: accepted lights, matching bias/dark/dark-flat/flat frames from the calibration library, and the generated WBPP runner scripts, in the chosen layout. Each export lands in a per-scope subfolder (sanitized to one path component) so projects don't interleave.
- **Reflink, then copy**: placement gains a `Placement::Reflink` mode — copy-on-write clones where the filesystem supports them (free like a hardlink, independent like a copy — safe to hand to PixInsight), byte copies elsewhere. The summary counts `reflinked` separately.
- **Background job with progress**: singleton-per-database like the import job, with stages planning → placing (n of m files) → scripts → complete/error, polled at 1 s by a new `useExportJob` hook. The Overview shows the progress line under the catalog summary; project and target Export affordances become three-way: Tauri picker / server export when configured / ZIP download otherwise.

## Verification

Live end-to-end on a scratch registry: a 77-file, 4.0 GB WBPP export of the Elephant's Trunk project (48 lights + flats) completed in 37 s with progress polled through every stage, per-scope folder, and both runner scripts. Cross-filesystem placement fell back to copy as designed; FICLONE cloning verified working on the deployment XFS. Unit tests: reflink placement accounting with progress callbacks, export-job singleton/reset/completion.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (709 passed) · `npm run lint` · `npx tsc --noEmit` · `npx vitest run` (276 passed) · `npm run build` · `npx playwright test overview add-database` (6 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)