### PR TITLE
Make remote sync previews proxy-safe

### DIFF
--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -261,6 +261,13 @@ POST /api/sync/v1/previews/{preview_id}/refresh
 GET  /api/sync/v1/jobs/{job_id}
 ```
 
+Clients send `Prefer: respond-async` when a preview may outlive an HTTP proxy
+timeout. The server returns `202 Accepted` with a job ID, builds the preview in
+the background, and exposes the eventual preview or failure through the job
+route. Omitting the preference keeps the original synchronous response for
+older clients. Retrying the same `Idempotency-Key` returns the existing job
+instead of building a second preview.
+
 For a pull, the coordinator requests a bundle from the remote source and plans
 and applies it locally. For a push, it creates a local bundle and sends it to
 the remote destination, which owns preview and Apply.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -50,6 +50,12 @@
 
 ## Fixed
 
+- Remote scheduler previews can now run as background jobs, so large Target
+  Scheduler catalogs no longer fail merely because preview planning takes
+  longer than an HTTP reverse proxy timeout. Updated clients request this mode
+  and poll the token-scoped job until the preview is ready. Capabilities also
+  advertise image upload only when that database has enabled its separate
+  upload gate.
 - Stacking a target whose calibration library holds frames from several
   sessions no longer fails with "building master flat". The frames feeding
   each master now cluster by sensor temperature (the stacker's own 1 °C

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -605,6 +605,7 @@ async fn run_server_internal(
         )
         .route("/sync/v1/exports", post(remote_sync::create_export))
         .route("/sync/v1/exports/{export_id}", get(remote_sync::get_export))
+        .route("/sync/v1/jobs/{job_id}", get(remote_sync::get_preview_job))
         .nest("/db/{db_id}", db_routes)
         .layer(axum::middleware::from_fn_with_state(
             Arc::clone(&state),

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -14,7 +14,8 @@
 
 use axum::{
     extract::{Path, State},
-    http::{header::AUTHORIZATION, HeaderMap},
+    http::{header::AUTHORIZATION, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
     Json,
 };
 use base64::Engine as _;
@@ -35,8 +36,8 @@ use uuid::Uuid;
 
 use crate::server::{
     api::{
-        ApiResponse, SchedulerSyncKind, SchedulerSyncRequest, SchedulerSyncResponse,
-        SchedulerSyncTableCounts,
+        ApiRefreshStatus, ApiResponse, SchedulerSyncKind, SchedulerSyncRequest,
+        SchedulerSyncResponse, SchedulerSyncTableCounts,
     },
     database_context::DatabaseContext,
     handlers::{execute_scheduler_sync_paths, AppError, SyncGuardMode},
@@ -50,6 +51,7 @@ const PROTOCOL_VERSION: u32 = 1;
 /// How long a built export stays fetchable, matching the preview lifetime.
 const EXPORT_LIFETIME_SECS: i64 = 30 * 60;
 const MAX_RETAINED_EXPORTS: usize = 16;
+const MAX_RETAINED_PREVIEW_JOBS: usize = 32;
 /// Stands in for the catalog in an audit entry written before the token
 /// identified one — a bad token names no database.
 const UNKNOWN_CATALOG: &str = "-";
@@ -184,6 +186,121 @@ pub struct SyncPreview {
     pub summary: BTreeMap<String, i64>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct PreviewJob {
+    pub job_id: String,
+    pub state: &'static str,
+    pub preview: Option<SyncPreview>,
+    pub error: Option<String>,
+}
+
+struct StoredPreviewJob {
+    catalog_id: String,
+    created_at: i64,
+    sequence: u64,
+    job: PreviewJob,
+}
+
+#[derive(Default)]
+pub struct PreviewJobStore {
+    entries: Mutex<HashMap<String, StoredPreviewJob>>,
+    next_sequence: std::sync::atomic::AtomicU64,
+}
+
+impl PreviewJobStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn start(
+        &self,
+        catalog_id: String,
+        requested_id: Option<String>,
+    ) -> Result<(PreviewJob, bool), AppError> {
+        let now = unix_seconds();
+        let sequence = self
+            .next_sequence
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut entries = self.lock()?;
+        entries.retain(|_, stored| stored.created_at + EXPORT_LIFETIME_SECS > now);
+        if let Some(existing) = requested_id.as_ref().and_then(|id| entries.get(id))
+            && existing.catalog_id == catalog_id
+        {
+            return Ok((existing.job.clone(), false));
+        }
+        while entries.len() >= MAX_RETAINED_PREVIEW_JOBS {
+            let Some(oldest) = entries
+                .iter()
+                .min_by_key(|(_, stored)| stored.sequence)
+                .map(|(id, _)| id.clone())
+            else {
+                break;
+            };
+            entries.remove(&oldest);
+        }
+        let job = PreviewJob {
+            job_id: requested_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+            state: "running",
+            preview: None,
+            error: None,
+        };
+        entries.insert(
+            job.job_id.clone(),
+            StoredPreviewJob {
+                catalog_id,
+                created_at: now,
+                sequence,
+                job: job.clone(),
+            },
+        );
+        Ok((job, true))
+    }
+
+    fn finish(&self, job_id: &str, result: Result<SyncPreview, AppError>) {
+        let Ok(mut entries) = self.entries.lock() else {
+            tracing::error!("remote preview job lock poisoned while finishing {job_id}");
+            return;
+        };
+        let Some(stored) = entries.get_mut(job_id) else {
+            return;
+        };
+        match result {
+            Ok(preview) => {
+                stored.job.state = "ready";
+                stored.job.preview = Some(preview);
+            }
+            Err(error) => {
+                stored.job.state = "failed";
+                stored.job.error = Some(detail_of(&error));
+            }
+        }
+    }
+
+    fn get(&self, id: &str, catalog_id: &str) -> Result<Option<PreviewJob>, AppError> {
+        let now = unix_seconds();
+        let mut entries = self.lock()?;
+        let Some(stored) = entries.get(id) else {
+            return Ok(None);
+        };
+        if stored.created_at + EXPORT_LIFETIME_SECS <= now {
+            entries.remove(id);
+            return Ok(None);
+        }
+        if stored.catalog_id != catalog_id {
+            return Ok(None);
+        }
+        Ok(Some(stored.job.clone()))
+    }
+
+    fn lock(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashMap<String, StoredPreviewJob>>, AppError> {
+        self.entries.lock().map_err(|error| {
+            AppError::InternalError(format!("remote preview job lock poisoned: {error}"))
+        })
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct SyncApplyResult {
     pub state: &'static str,
@@ -279,19 +396,28 @@ pub async fn capabilities(
     headers: HeaderMap,
 ) -> Result<Json<ApiResponse<SyncCapabilities>>, AppError> {
     let catalog = authenticated_catalog(&state, &headers, AuditAction::Capabilities)?;
+    let mut capabilities = vec![
+        "merge",
+        "push_planning",
+        "push_grades",
+        "preview_apply",
+        "preview_refresh",
+        "async_preview_jobs",
+        "exports",
+    ];
+    if catalog
+        .remote_image_upload
+        .as_ref()
+        .is_some_and(|config| config.enabled)
+        && catalog.remote_image_upload_dir.is_some()
+    {
+        capabilities.push("image_upload");
+    }
     Ok(Json(ApiResponse::success(SyncCapabilities {
         protocol_version: PROTOCOL_VERSION,
         product: "PSF Guard",
         product_version: env!("CARGO_PKG_VERSION"),
-        capabilities: vec![
-            "merge",
-            "push_planning",
-            "push_grades",
-            "preview_apply",
-            "preview_refresh",
-            "exports",
-            "image_upload",
-        ],
+        capabilities,
         catalogs: vec![SyncCatalogCapability {
             id: catalog.id.clone(),
             name: catalog.name.clone(),
@@ -305,8 +431,62 @@ pub async fn create_preview(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Json(request): Json<CreatePreviewRequest>,
-) -> Result<Json<ApiResponse<SyncPreview>>, AppError> {
+) -> Result<Response, AppError> {
     let catalog = authenticated_catalog(&state, &headers, AuditAction::Preview)?;
+    let respond_async = headers
+        .get("prefer")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(',')
+                .any(|preference| preference.trim().eq_ignore_ascii_case("respond-async"))
+        });
+    if respond_async {
+        let idempotency_key = headers
+            .get("idempotency-key")
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| digest_hex(format!("{}:{value}", catalog.id).as_bytes()));
+        let (job, started) = state
+            .remote_preview_jobs
+            .start(catalog.id.clone(), idempotency_key)?;
+        if !started {
+            return Ok((
+                StatusCode::ACCEPTED,
+                Json(ApiResponse::success_with_status(
+                    job,
+                    ApiRefreshStatus::Loading,
+                )),
+            )
+                .into_response());
+        }
+        let job_id = job.job_id.clone();
+        let background_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            let result =
+                create_preview_inner(Arc::clone(&background_state), catalog, request).await;
+            background_state.remote_preview_jobs.finish(&job_id, result);
+        });
+        return Ok((
+            StatusCode::ACCEPTED,
+            Json(ApiResponse::success_with_status(
+                job,
+                ApiRefreshStatus::Loading,
+            )),
+        )
+            .into_response());
+    }
+
+    let preview = create_preview_inner(state, catalog, request).await?;
+    Ok(Json(ApiResponse::success(preview)).into_response())
+}
+
+async fn create_preview_inner(
+    state: Arc<AppState>,
+    catalog: Arc<DatabaseContext>,
+    request: CreatePreviewRequest,
+) -> Result<SyncPreview, AppError> {
     let operation = request.operation;
     // Copy the identifiers the audit log needs before the bundle moves, so
     // auditing never forces the whole payload to be cloned.
@@ -410,12 +590,25 @@ pub async fn create_preview(
         })?;
     let summary = result_summary(&result);
     audit(AuditOutcome::Ok, None, Some(&record.id), summary.clone());
-    Ok(Json(ApiResponse::success(SyncPreview {
+    Ok(SyncPreview {
         preview_id: record.id,
         state: "ready",
         expires_at: unix_timestamp(record.expires_at),
         summary,
-    })))
+    })
+}
+
+pub async fn get_preview_job(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(job_id): Path<String>,
+) -> Result<Json<ApiResponse<PreviewJob>>, AppError> {
+    let catalog = authenticated_catalog(&state, &headers, AuditAction::Preview)?;
+    let job = state
+        .remote_preview_jobs
+        .get(&job_id, &catalog.id)?
+        .ok_or(AppError::NotFound)?;
+    Ok(Json(ApiResponse::success(job)))
 }
 
 pub async fn get_preview(

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -92,6 +92,8 @@ pub struct AppState {
     pub sync_apply_lock: tokio::sync::Mutex<()>,
     /// Export bundles built for remote sync clients, capacity- and time-bound.
     pub remote_exports: crate::server::remote_sync::ExportStore,
+    /// Long-running remote preview builds requested with `Prefer: respond-async`.
+    pub remote_preview_jobs: crate::server::remote_sync::PreviewJobStore,
     /// Append-only record of remote sync actions, so an operator can tell
     /// afterwards which token-holder changed the scheduler database and when.
     pub remote_audit: crate::server::remote_audit::RemoteAuditLog,
@@ -406,6 +408,7 @@ impl AppState {
             sync_previews: crate::server::sync_preview::SyncPreviewManager::new(&cache_dir),
             sync_apply_lock: tokio::sync::Mutex::new(()),
             remote_exports: crate::server::remote_sync::ExportStore::new(),
+            remote_preview_jobs: crate::server::remote_sync::PreviewJobStore::new(),
             remote_audit: crate::server::remote_audit::RemoteAuditLog::new(&cache_dir),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::new(astrometry_config)),
             satellites: Arc::new(satellites),
@@ -574,6 +577,7 @@ impl AppState {
             ),
             sync_apply_lock: tokio::sync::Mutex::new(()),
             remote_exports: crate::server::remote_sync::ExportStore::new(),
+            remote_preview_jobs: crate::server::remote_sync::PreviewJobStore::new(),
             remote_audit: crate::server::remote_audit::RemoteAuditLog::new("/tmp/psf-guard-test"),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::default()),
             satellites: Arc::new(

--- a/tests/integration_remote_sync.rs
+++ b/tests/integration_remote_sync.rs
@@ -80,6 +80,10 @@ fn app(state: Arc<AppState>) -> Router {
             "/api/sync/v1/exports/{export_id}",
             get(remote_sync::get_export),
         )
+        .route(
+            "/api/sync/v1/jobs/{job_id}",
+            get(remote_sync::get_preview_job),
+        )
         .with_state(state)
 }
 
@@ -111,6 +115,35 @@ async fn call(
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
     (status, value)
+}
+
+async fn create_async_preview(app: Router, operation: &str, bundle: Value) -> (StatusCode, Value) {
+    let idempotency_key = bundle["bundle_id"].as_str().unwrap().to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sync/v1/previews")
+                .header("authorization", format!("Bearer {DESTINATION_TOKEN}"))
+                .header("content-type", "application/json")
+                .header("prefer", "respond-async")
+                .header("idempotency-key", idempotency_key)
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "protocol_version": 1,
+                        "catalog_id": "destination",
+                        "operation": operation,
+                        "bundle": bundle
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    (status, serde_json::from_slice(&bytes).unwrap())
 }
 
 /// Two token-scoped catalogs wired to one router, the shape every remote sync
@@ -357,6 +390,78 @@ async fn token_scoped_export_previews_and_applies_to_the_selected_database() {
         .query_row("SELECT description FROM project", [], |row| row.get(0))
         .unwrap();
     assert_eq!(description, "remote settings");
+}
+
+#[tokio::test]
+async fn capabilities_only_advertise_image_upload_when_its_gate_is_enabled() {
+    let harness = Harness::new("", "");
+    let (status, response) = call(
+        harness.router,
+        "GET",
+        "/api/sync/v1/capabilities",
+        Some(DESTINATION_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{response:#}");
+    let capabilities = response["data"]["capabilities"].as_array().unwrap();
+    assert!(capabilities
+        .iter()
+        .any(|value| value == "async_preview_jobs"));
+    assert!(!capabilities.iter().any(|value| value == "image_upload"));
+}
+
+#[tokio::test]
+async fn async_preview_jobs_return_before_building_and_remain_token_scoped() {
+    let harness = Harness::new(
+        "INSERT INTO project VALUES (1,'p','M42','remote settings',2,8,'project-guid');
+         INSERT INTO target VALUES (1,'M42',1,5.5,-5.4,0,1,'target-guid');
+         INSERT INTO exposuretemplate VALUES (1,'p','Ha 300','Ha',120,'template-guid');
+         INSERT INTO exposureplan VALUES (1,'p',300,40,18,16,1,1,1,'plan-guid');",
+        "",
+    );
+    let bundle = harness.export("push_planning").await;
+    let (status, started) =
+        create_async_preview(harness.router.clone(), "push_planning", bundle.clone()).await;
+    assert_eq!(status, StatusCode::ACCEPTED, "{started:#}");
+    assert_eq!(started["data"]["state"], "running");
+    let job_id = started["data"]["job_id"].as_str().unwrap();
+
+    let (status, retried) =
+        create_async_preview(harness.router.clone(), "push_planning", bundle).await;
+    assert_eq!(status, StatusCode::ACCEPTED, "{retried:#}");
+    assert_eq!(retried["data"]["job_id"], job_id);
+
+    let (status, _) = call(
+        harness.router.clone(),
+        "GET",
+        &format!("/api/sync/v1/jobs/{job_id}"),
+        Some(SOURCE_TOKEN),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let ready = loop {
+        let (status, job) = call(
+            harness.router.clone(),
+            "GET",
+            &format!("/api/sync/v1/jobs/{job_id}"),
+            Some(DESTINATION_TOKEN),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{job:#}");
+        if job["data"]["state"] == "ready" {
+            break job;
+        }
+        assert_eq!(job["data"]["state"], "running", "{job:#}");
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    };
+    let preview_id = ready["data"]["preview"]["preview_id"].as_str().unwrap();
+    let (status, applied) = harness.apply(preview_id).await;
+    assert_eq!(status, StatusCode::OK, "{applied:#}");
+    assert_eq!(count(&harness.destination(), "project"), 1);
 }
 
 /// Rows for a source catalog that has actually observed something.


### PR DESCRIPTION
## Summary
- add opt-in asynchronous remote preview builds with `Prefer: respond-async`
- expose token-scoped preview job polling at `GET /api/sync/v1/jobs/{job_id}`
- reuse retained jobs for repeated bundle idempotency keys
- advertise `image_upload` only when the database's separate upload gate is enabled

## Live conformance
Against `psf-guard.atpn.co` / Ultra Cat, planning export and a zero-change preview completed successfully. A reviewed-grade bundle containing 9,706 acquired images exported in about one second, but its synchronous preview exceeded the nginx timeout and returned 504. The server also advertised `image_upload` while the gated upload route returned 403. This change addresses both findings.

## Checks
- `cargo fmt -- --check`
- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (610 unit tests passed, 5 ignored; all integration suites passed)
- `cargo test --test integration_remote_sync` (13 passed)
- `git diff --check`