### PR TITLE
Accept calibration frames through remote image intake

### DIFF
--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -427,8 +427,10 @@ whose user never installed Target Scheduler.
 
 Identical retries are idempotent. The response returns the resolved database,
 frame kind, and either the project, target, and image IDs for a light or the
-calibration frame and rig UUIDs. A basename already registered elsewhere or
-an existing receive file with different content returns `409 Conflict`.
+calibration frame and rig UUIDs. If scheduler sync registered a unique light
+row first, the upload attaches the file to that row without importing a
+duplicate. An ambiguous registered basename or an existing receive file with
+different content returns `409 Conflict`.
 
 ## Security
 

--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -397,7 +397,8 @@ real use.
 ### Remote image ingest
 
 Image transfer is independent of Target Scheduler catalog sync. A capture
-client can post a light frame directly to one opted-in PSF Guard database:
+client can post a light or calibration frame directly to one opted-in PSF
+Guard database:
 
 ```http
 POST /api/db/{db_id}/images/upload
@@ -416,15 +417,18 @@ at most 512 MiB to a sibling temporary file, verifies SHA-256 and the frame
 headers, and publishes without overwriting an existing basename. The filename
 must carry a frame extension: `.fits`, `.fit`, `.fts`, or `.xisf`.
 
-The normal one-frame importer then resolves an existing target by object name
-or coordinates and reuses its exposure plan. If no target matches, it builds
-the project, target, template, and plan from FITS headers. This path therefore
-works with an existing Target Scheduler catalog and with a fresh PSF Guard
-catalog whose user never installed Target Scheduler.
+For a light, the normal one-frame importer resolves an existing target by
+object name or coordinates and reuses its exposure plan. If no target matches,
+it builds the project, target, template, and plan from FITS headers. A bias,
+dark, dark-flat, or flat instead enters PSF Guard's calibration library and
+never creates a Target Scheduler `acquiredimage` row. This path therefore works
+with an existing Target Scheduler catalog and with a fresh PSF Guard catalog
+whose user never installed Target Scheduler.
 
 Identical retries are idempotent. The response returns the resolved database,
-project, target, and image IDs. A basename already registered elsewhere or an
-existing receive file with different content returns `409 Conflict`.
+frame kind, and either the project, target, and image IDs for a light or the
+calibration frame and rig UUIDs. A basename already registered elsewhere or
+an existing receive file with different content returns `409 Conflict`.
 
 ## Security
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -62,6 +62,9 @@
 
 ## Fixed
 
+- Remote image upload can now attach image bytes after scheduler sync has
+  already registered the same light, instead of rejecting that normal order
+  of operations as a duplicate.
 - Remote scheduler previews can now run as background jobs, so large Target
   Scheduler catalogs no longer fail merely because preview planning takes
   longer than an HTTP reverse proxy timeout. Updated clients request this mode

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,10 @@
 
 ## Added
 
+- Remote image intake now accepts bias, dark, dark-flat, and flat frames as
+  well as lights. Calibration uploads enter PSF Guard's calibration library
+  without creating Target Scheduler image rows, and identical retries remain
+  idempotent.
 - How hard each kind of evidence lowers a quality score is now adjustable.
   The **Penalties** control in the Sequence view scales the score hit from
   satellite trails, pointing failures, and temporal anomalies between 0%

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -296,7 +296,11 @@ impl Default for AppliedCalibration {
 
 pub fn kind_from_meta(meta: &FrameMeta) -> Option<CalibrationKind> {
     let value = meta.image_type.as_deref()?.trim().to_ascii_uppercase();
-    if value.contains("DARKFLAT") || value.contains("DARK FLAT") || value.contains("FLATDARK") {
+    if value.contains("DARKFLAT")
+        || value.contains("DARK FLAT")
+        || value.contains("FLATDARK")
+        || value.contains("FLAT DARK")
+    {
         Some(CalibrationKind::DarkFlat)
     } else if value.contains("BIAS") || value.contains("OFFSET") {
         Some(CalibrationKind::Bias)
@@ -2716,6 +2720,10 @@ mod tests {
         );
         assert_eq!(
             kind_from_meta(&frame("/dark-flat.fits", "DARK FLAT")),
+            Some(CalibrationKind::DarkFlat)
+        );
+        assert_eq!(
+            kind_from_meta(&frame("/flat-dark.fits", "FLAT DARK")),
             Some(CalibrationKind::DarkFlat)
         );
         assert_eq!(

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -310,13 +310,24 @@ pub struct RemoteImageResolution {
 }
 
 #[derive(Debug, Serialize)]
+pub struct RemoteCalibrationResolution {
+    pub frame_uuid: String,
+    pub rig_uuid: String,
+    pub kind: crate::calibration::CalibrationKind,
+}
+
+#[derive(Debug, Serialize)]
 pub struct RemoteImageUploadResponse {
     pub database_id: String,
     pub filename: String,
     pub bytes: u64,
     pub sha256: String,
     pub already_present: bool,
-    pub resolution: RemoteImageResolution,
+    pub frame_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<RemoteImageResolution>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calibration: Option<RemoteCalibrationResolution>,
     pub import: crate::commands::import::ImportOutcome,
 }
 

--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -3,7 +3,9 @@
 //! The URL database, echoed database header, selected receive root, and
 //! bearer-token hash all come from the same `DatabaseContext`. Uploads are
 //! streamed to a temporary sibling, verified, published without clobbering,
-//! and passed through the normal one-frame FITS importer.
+//! and passed through the normal one-frame image importer. Light frames land
+//! in Target Scheduler-compatible tables; calibration frames land only in
+//! PSF Guard's sibling calibration tables.
 
 use axum::{
     extract::Multipart,
@@ -16,8 +18,11 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 
+use crate::calibration::{self, CalibrationKind};
 use crate::commands::import::{self, ImportOptions, ImportOutcome};
-use crate::server::api::{ApiResponse, RemoteImageResolution, RemoteImageUploadResponse};
+use crate::server::api::{
+    ApiResponse, RemoteCalibrationResolution, RemoteImageResolution, RemoteImageUploadResponse,
+};
 use crate::server::extract::DbContext;
 use crate::server::handlers::AppError;
 
@@ -140,9 +145,10 @@ pub async fn upload_image(
             "uploaded image is not a readable FITS or XISF file".into(),
         ));
     }
-    if !frame.is_light() {
+    let calibration_kind = calibration::kind_from_meta(&frame);
+    if !frame.is_light() && calibration_kind.is_none() {
         return Err(AppError::BadRequest(
-            "only light frames can be imported into an image database".into(),
+            "uploaded image must be a light, bias, dark, dark-flat, or flat frame".into(),
         ));
     }
 
@@ -164,6 +170,7 @@ pub async fn upload_image(
             filename,
             bytes,
             sha256,
+            calibration_kind,
         )
     })
     .await
@@ -192,6 +199,7 @@ fn publish_and_import(
     filename: String,
     bytes: u64,
     sha256: String,
+    calibration_kind: Option<CalibrationKind>,
 ) -> Result<RemoteImageUploadResponse, AppError> {
     let mut connection = rusqlite::Connection::open_with_flags(
         database_path,
@@ -200,9 +208,9 @@ fn publish_and_import(
     .map_err(AppError::db)?;
 
     let existing_resolution = find_resolution(&connection, &filename)?;
-    if existing_resolution.is_some() && !destination.is_file() {
+    if existing_resolution.is_some() && (calibration_kind.is_some() || !destination.is_file()) {
         return Err(AppError::Conflict(format!(
-            "{filename} is already registered in this database at another location"
+            "{filename} is already registered as a light in this database"
         )));
     }
 
@@ -236,7 +244,7 @@ fn publish_and_import(
         }
     };
 
-    let outcome = if existing_resolution.is_some() {
+    let outcome = if calibration_kind.is_none() && existing_resolution.is_some() {
         ImportOutcome {
             scanned: 1,
             skipped_existing: 1,
@@ -245,14 +253,28 @@ fn publish_and_import(
     } else {
         frame.path = destination.clone();
         match import::import_frames(&mut connection, vec![frame], &ImportOptions::default()) {
-            Ok(outcome) if outcome.imported == 1 => outcome,
+            Ok(outcome)
+                if (calibration_kind.is_none() && outcome.imported == 1)
+                    || (calibration_kind.is_some()
+                        && outcome.calibration.imported
+                            + outcome.calibration.updated
+                            + outcome.calibration.skipped_existing
+                            == 1) =>
+            {
+                outcome
+            }
             Ok(outcome) => {
                 if !already_present {
                     let _ = std::fs::remove_file(&destination);
                 }
                 return Err(AppError::BadRequest(format!(
-                    "uploaded image was not imported (unreadable={}, non_light={}, duplicate={})",
-                    outcome.unreadable, outcome.non_light, outcome.skipped_existing
+                    "uploaded image was not imported (unreadable={}, non_light={}, duplicate={}, calibration_imported={}, calibration_updated={}, calibration_duplicate={})",
+                    outcome.unreadable,
+                    outcome.non_light,
+                    outcome.skipped_existing,
+                    outcome.calibration.imported,
+                    outcome.calibration.updated,
+                    outcome.calibration.skipped_existing,
                 )));
             }
             Err(error) => {
@@ -266,18 +288,63 @@ fn publish_and_import(
         }
     };
 
-    let resolution = find_resolution(&connection, &filename)?.ok_or_else(|| {
-        AppError::InternalError("uploaded image was imported but cannot be resolved".into())
-    })?;
+    let (frame_kind, resolution, calibration) = match calibration_kind {
+        None => {
+            let resolution = find_resolution(&connection, &filename)?.ok_or_else(|| {
+                AppError::InternalError("uploaded light was imported but cannot be resolved".into())
+            })?;
+            ("light".to_string(), Some(resolution), None)
+        }
+        Some(kind) => {
+            let calibration = find_calibration_resolution(&connection, &destination, kind)?
+                .ok_or_else(|| {
+                    AppError::InternalError(
+                        "uploaded calibration frame was imported but cannot be resolved".into(),
+                    )
+                })?;
+            (kind.as_str().to_string(), None, Some(calibration))
+        }
+    };
     Ok(RemoteImageUploadResponse {
         database_id: database_id.to_string(),
         filename,
         bytes,
         sha256,
         already_present,
+        frame_kind,
         resolution,
+        calibration,
         import: outcome,
     })
+}
+
+fn find_calibration_resolution(
+    connection: &rusqlite::Connection,
+    source_path: &Path,
+    kind: CalibrationKind,
+) -> Result<Option<RemoteCalibrationResolution>, AppError> {
+    use rusqlite::OptionalExtension as _;
+
+    let source_path = std::fs::canonicalize(source_path)
+        .unwrap_or_else(|_| source_path.to_path_buf())
+        .to_string_lossy()
+        .into_owned();
+    connection
+        .query_row(
+            "SELECT frame_uuid, rig_uuid
+             FROM psf_guard_calibration_frame
+             WHERE source_path = ?1",
+            [&source_path],
+            |row| {
+                Ok(RemoteCalibrationResolution {
+                    frame_uuid: row.get(0)?,
+                    rig_uuid: row.get(1)?,
+                    kind,
+                })
+            },
+        )
+        .optional()
+        .map_err(AppError::db)
 }
 
 fn find_resolution(

--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -208,7 +208,7 @@ fn publish_and_import(
     .map_err(AppError::db)?;
 
     let existing_resolution = find_resolution(&connection, &filename)?;
-    if existing_resolution.is_some() && (calibration_kind.is_some() || !destination.is_file()) {
+    if existing_resolution.is_some() && calibration_kind.is_some() {
         return Err(AppError::Conflict(format!(
             "{filename} is already registered as a light in this database"
         )));

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -290,6 +290,7 @@ async fn calibration_uploads_are_cataloged_without_scheduler_images() {
         ("BIAS", "bias", "bias-001.fits"),
         ("DARK", "dark", "dark-001.fits"),
         ("DARK FLAT", "dark_flat", "dark-flat-001.fits"),
+        ("FLAT DARK", "dark_flat", "flat-dark-001.fits"),
         ("FLAT", "flat", "flat-001.fits"),
     ];
 
@@ -322,10 +323,10 @@ async fn calibration_uploads_are_cataloged_without_scheduler_images() {
     }
 
     assert_eq!(image_count(&fixture.database_a), 0);
-    assert_eq!(calibration_count(&fixture.database_a), 4);
+    assert_eq!(calibration_count(&fixture.database_a), 5);
     assert_eq!(calibration_count(&fixture.database_b), 0);
 
-    let retry = fits_bytes_with_type("FLAT", "Calibration", "2026-07-24T08:03:00");
+    let retry = fits_bytes_with_type("FLAT", "Calibration", "2026-07-24T08:04:00");
     let (status, body) = upload(
         fixture.state.clone(),
         "catalog-a",
@@ -340,7 +341,7 @@ async fn calibration_uploads_are_cataloged_without_scheduler_images() {
     assert_eq!(body["data"]["already_present"], true);
     assert_eq!(body["data"]["import"]["calibration"]["skipped_existing"], 1);
     assert_eq!(image_count(&fixture.database_a), 0);
-    assert_eq!(calibration_count(&fixture.database_a), 4);
+    assert_eq!(calibration_count(&fixture.database_a), 5);
 }
 
 #[tokio::test]

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -107,6 +107,10 @@ fn build_app(state: Arc<AppState>) -> Router {
 }
 
 fn fits_bytes(object: &str, date_obs: &str) -> Vec<u8> {
+    fits_bytes_with_type("LIGHT", object, date_obs)
+}
+
+fn fits_bytes_with_type(image_type: &str, object: &str, date_obs: &str) -> Vec<u8> {
     fn card(output: &mut Vec<u8>, text: &str) {
         let mut bytes = text.as_bytes().to_vec();
         assert!(bytes.len() <= 80);
@@ -120,7 +124,7 @@ fn fits_bytes(object: &str, date_obs: &str) -> Vec<u8> {
     card(&mut bytes, "NAXIS   =                    2");
     card(&mut bytes, "NAXIS1  =                   10");
     card(&mut bytes, "NAXIS2  =                   10");
-    card(&mut bytes, "IMAGETYP= 'LIGHT   '");
+    card(&mut bytes, &format!("IMAGETYP= '{image_type}'"));
     card(&mut bytes, &format!("OBJECT  = '{object}'"));
     card(&mut bytes, "FILTER  = 'Ha      '");
     card(&mut bytes, &format!("DATE-OBS= '{date_obs}'"));
@@ -225,6 +229,17 @@ fn image_count(path: &std::path::Path) -> i64 {
         .unwrap()
 }
 
+fn calibration_count(path: &std::path::Path) -> i64 {
+    rusqlite::Connection::open(path)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM psf_guard_calibration_frame",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0)
+}
+
 #[tokio::test]
 async fn upload_is_scoped_to_the_selected_database_and_attaches_followup_frames() {
     let fixture = Fixture::new();
@@ -241,6 +256,7 @@ async fn upload_is_scoped_to_the_selected_database_and_attaches_followup_frames(
     .await;
     assert_eq!(status, StatusCode::OK, "{body}");
     assert_eq!(body["data"]["database_id"], "catalog-a");
+    assert_eq!(body["data"]["frame_kind"], "light");
     assert_eq!(body["data"]["resolution"]["target_name"], "M 31");
     assert_eq!(body["data"]["import"]["targets_created"], 1);
     let target_id = body["data"]["resolution"]["target_id"].as_i64().unwrap();
@@ -265,6 +281,87 @@ async fn upload_is_scoped_to_the_selected_database_and_attaches_followup_frames(
     assert_eq!(body["data"]["import"]["attached"], 1);
     assert_eq!(body["data"]["import"]["targets_created"], 0);
     assert_eq!(image_count(&fixture.database_a), 2);
+}
+
+#[tokio::test]
+async fn calibration_uploads_are_cataloged_without_scheduler_images() {
+    let fixture = Fixture::new();
+    let cases = [
+        ("BIAS", "bias", "bias-001.fits"),
+        ("DARK", "dark", "dark-001.fits"),
+        ("DARK FLAT", "dark_flat", "dark-flat-001.fits"),
+        ("FLAT", "flat", "flat-001.fits"),
+    ];
+
+    for (index, (image_type, kind, filename)) in cases.iter().enumerate() {
+        let image = fits_bytes_with_type(
+            image_type,
+            "Calibration",
+            &format!("2026-07-24T08:{index:02}:00"),
+        );
+        let (status, body) = upload(
+            fixture.state.clone(),
+            "catalog-a",
+            "catalog-a",
+            TOKEN_A,
+            filename,
+            &image,
+            &sha256(&image),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["data"]["frame_kind"], *kind);
+        assert!(body["data"].get("resolution").is_none());
+        assert_eq!(body["data"]["calibration"]["kind"], *kind);
+        assert!(body["data"]["calibration"]["frame_uuid"].is_string());
+        assert!(body["data"]["calibration"]["rig_uuid"].is_string());
+        assert_eq!(body["data"]["import"]["calibration"][*kind], 1);
+        assert!(fixture.images_a.join(filename).is_file());
+        assert!(!fixture.images_b.join(filename).exists());
+    }
+
+    assert_eq!(image_count(&fixture.database_a), 0);
+    assert_eq!(calibration_count(&fixture.database_a), 4);
+    assert_eq!(calibration_count(&fixture.database_b), 0);
+
+    let retry = fits_bytes_with_type("FLAT", "Calibration", "2026-07-24T08:03:00");
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "flat-001.fits",
+        &retry,
+        &sha256(&retry),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["already_present"], true);
+    assert_eq!(body["data"]["import"]["calibration"]["skipped_existing"], 1);
+    assert_eq!(image_count(&fixture.database_a), 0);
+    assert_eq!(calibration_count(&fixture.database_a), 4);
+}
+
+#[tokio::test]
+async fn unsupported_non_light_frame_is_rejected_without_publishing() {
+    let fixture = Fixture::new();
+    let image = fits_bytes_with_type("SNAPSHOT", "Preview", "2026-07-24T09:00:00");
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "snapshot-001.fits",
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert!(!fixture.images_a.join("snapshot-001.fits").exists());
+    assert_eq!(image_count(&fixture.database_a), 0);
+    assert_eq!(calibration_count(&fixture.database_a), 0);
 }
 
 #[tokio::test]

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -240,6 +240,37 @@ fn calibration_count(path: &std::path::Path) -> i64 {
         .unwrap_or(0)
 }
 
+fn insert_synced_light(path: &std::path::Path, filename: &str) {
+    let connection = rusqlite::Connection::open(path).unwrap();
+    connection
+        .execute(
+            "INSERT INTO project (Id, profileId, name, isMosaic, flatsHandling, guid)
+             VALUES (1, 'profile', 'M 31', 0, 0, 'project-guid')",
+            [],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO target (Id, name, active, ra, dec, epochcode, projectId, guid)
+             VALUES (1, 'M 31', 1, 0.71, 41.27, 0, 1, 'target-guid')",
+            [],
+        )
+        .unwrap();
+    let metadata = serde_json::json!({
+        "FileName": format!(r"C:\remote-capture\{filename}"),
+    })
+    .to_string();
+    connection
+        .execute(
+            "INSERT INTO acquiredimage
+                (Id, projectId, targetId, acquireddate, filtername, gradingStatus,
+                 metadata, profileId, guid)
+             VALUES (1, 1, 1, 1784869200, 'Ha', 1, ?1, 'profile', 'image-guid')",
+            [&metadata],
+        )
+        .unwrap();
+}
+
 #[tokio::test]
 async fn upload_is_scoped_to_the_selected_database_and_attaches_followup_frames() {
     let fixture = Fixture::new();
@@ -281,6 +312,52 @@ async fn upload_is_scoped_to_the_selected_database_and_attaches_followup_frames(
     assert_eq!(body["data"]["import"]["attached"], 1);
     assert_eq!(body["data"]["import"]["targets_created"], 0);
     assert_eq!(image_count(&fixture.database_a), 2);
+}
+
+#[tokio::test]
+async fn upload_attaches_bytes_to_a_light_created_by_scheduler_sync() {
+    let fixture = Fixture::new();
+    let filename = "m31-synced.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    let image = fits_bytes("M 31", "2026-07-24T05:00:00");
+    let checksum = sha256(&image);
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["already_present"], false);
+    assert_eq!(body["data"]["resolution"]["image_id"], 1);
+    assert_eq!(body["data"]["resolution"]["project_name"], "M 31");
+    assert_eq!(body["data"]["import"]["imported"], 0);
+    assert_eq!(body["data"]["import"]["skipped_existing"], 1);
+    assert_eq!(image_count(&fixture.database_a), 1);
+    assert_eq!(
+        sha256(&std::fs::read(fixture.images_a.join(filename)).unwrap()),
+        checksum
+    );
+
+    let (status, body) = upload(
+        fixture.state,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["already_present"], true);
+    assert_eq!(image_count(&fixture.database_a), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- accept bias, dark, dark-flat, flat-dark, and flat files through the database-scoped remote image endpoint
- catalog calibration uploads in PSF Guard-owned tables without creating Target Scheduler acquired-image rows
- return a typed light or calibration resolution and document the expanded contract
- keep identical retries idempotent and recognize both `DARK FLAT` and `FLAT DARK` header spellings

## Checks
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test calibration::tests::classifies_calibration_headers`
- `cargo test --test integration_remote_upload` (7 passed)
- `git diff --check`