### PR TITLE
Scope imports by frame kind and folder, and mark processing artifacts

### DIFF
--- a/docs/IMPORTING.md
+++ b/docs/IMPORTING.md
@@ -132,15 +132,38 @@ The same scan catalogs calibration frames and deduplicates them by canonical
 path and file fingerprint. A dry run reports those changes but rolls back the
 PSF Guard tables with the scheduler changes.
 
+The preview also carries the run's scope controls:
+
+- **Import**: lights and calibration (the default), lights only, or
+  calibration only. Frames outside the scope are counted and left alone —
+  a calibration-only run after a database reset rebuilds the library
+  without touching the scheduler rows.
+- **Folders**: the configured image roots and two levels of their
+  subdirectories, each with a checkbox. Unchecking a root and checking one
+  night's folder imports exactly that folder. A folder inside a configured
+  root needs no extra grant; only a path outside every configured root
+  requires database management.
+- **Skip processing artifacts** (opt-in): leaves out integration masters
+  and PixInsight calibrated/registered intermediates, which repeat
+  exposures the catalog already has under new basenames. Off by default —
+  masters are worth cataloging, and later releases will surface a finished
+  project's master lights in its display.
+
+Change any of them and choose **Update preview** to re-run the dry preview
+before confirming.
+
 The CLI exposes the same path:
 
 ```bash
 psf-guard import archive ./new-lights --dry-run
 psf-guard import archive ./new-lights
+psf-guard import archive ./new-flats --calibration-only
+psf-guard import archive ./processing-tree --skip-processed
 ```
 
 Use `--no-attach` when every new frame should create imported structure instead
-of attaching to an existing name or coordinate match. `remove-imported` can
+of attaching to an existing name or coordinate match. `--lights-only` and
+`--calibration-only` scope the run to one frame kind. `remove-imported` can
 remove projects created by an import; always preview it first.
 
 ## Fill or refresh quality data

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -48,6 +48,15 @@
   [calibration
   libraries](https://github.com/theatrus/psf-guard/blob/main/docs/CALIBRATION_LIBRARY.md).
 
+- Imports can be scoped. The import preview gained an **Import** selector
+  (lights and calibration, lights only, or calibration only), per-folder
+  checkboxes over the configured roots and two levels of subfolders, and an
+  opt-in **skip processing artifacts** toggle that recognizes integration
+  masters and PixInsight calibrated/registered intermediates by their own
+  signatures. A folder inside a configured root no longer needs the
+  database-management grant. The CLI grows matching `--lights-only`,
+  `--calibration-only`, and `--skip-processed` flags. See
+  [importing](https://github.com/theatrus/psf-guard/blob/main/docs/IMPORTING.md).
 - A remote server can now export onto its own drive. Configure a **server
   export directory** per database (Settings, or `export_dir` in the
   registry); the Overview's Export action then runs as a background job with

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,6 +138,21 @@ pub enum Commands {
         #[arg(long, default_value_t = crate::commands::import::DEFAULT_MATCH_RADIUS_DEG)]
         match_radius_deg: f64,
 
+        /// Import only light frames; calibration files are counted and
+        /// left alone.
+        #[arg(long, conflicts_with = "calibration_only")]
+        lights_only: bool,
+
+        /// Import only calibration frames; lights are counted and left
+        /// alone.
+        #[arg(long)]
+        calibration_only: bool,
+
+        /// Leave processing artifacts (integration masters, PixInsight
+        /// calibrated/registered intermediates) out of the catalog.
+        #[arg(long)]
+        skip_processed: bool,
+
         /// Path to the database registry JSON file (defaults to the platform
         /// config directory).
         #[arg(long)]

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -317,6 +317,9 @@ pub fn main() -> Result<()> {
             dry_run,
             no_attach,
             match_radius_deg,
+            lights_only,
+            calibration_only,
+            skip_processed,
             registry,
         } => {
             use crate::commands::import::{
@@ -356,6 +359,14 @@ pub fn main() -> Result<()> {
                 dry_run,
                 attach_existing: !no_attach,
                 match_radius_deg,
+                scope: if lights_only {
+                    crate::commands::import::ImportScope::Lights
+                } else if calibration_only {
+                    crate::commands::import::ImportScope::Calibration
+                } else {
+                    crate::commands::import::ImportScope::All
+                },
+                skip_processed,
             };
             let outcome = import_frames(&mut conn, frames, &options)?;
             print_outcome(&outcome);

--- a/src/commands/import/headers.rs
+++ b/src/commands/import/headers.rs
@@ -18,6 +18,10 @@ pub struct FrameMeta {
     pub readable: bool,
     /// IMAGETYP, uppercased ("LIGHT", "DARK", "FLAT", "BIAS", ...).
     pub image_type: Option<String>,
+    /// The output of processing (an integration master or a PixInsight
+    /// calibrated/registered intermediate) rather than an acquisition.
+    /// Skipped by import unless explicitly included.
+    pub processed: bool,
     pub object: Option<String>,
     pub filter: Option<String>,
     /// DATE-OBS as epoch seconds (UTC).
@@ -88,6 +92,7 @@ pub fn read_frame_meta_named(path: &Path, declared: &Path) -> FrameMeta {
         return meta;
     };
     meta.readable = true;
+    meta.processed = crate::image_io::is_processing_artifact(path, declared, &headers);
 
     let find = |names: &[&str]| -> Option<&HeaderValue> {
         names.iter().find_map(|wanted| {

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -31,6 +31,19 @@ use rusqlite::{params, Connection};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
+/// Which frames an import run touches.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportScope {
+    /// Lights and calibration frames alike.
+    #[default]
+    All,
+    /// Only light frames; calibration files are counted and left alone.
+    Lights,
+    /// Only calibration frames; lights are counted and left alone.
+    Calibration,
+}
+
 #[derive(Debug, Clone)]
 pub struct ImportOptions {
     /// Gap between consecutive frames (same rig) that starts a new project.
@@ -49,6 +62,14 @@ pub struct ImportOptions {
     /// Coordinate-match radius for attaching to an existing target, in
     /// degrees of angular separation.
     pub match_radius_deg: f64,
+    /// Which frame kinds this run imports.
+    pub scope: ImportScope,
+    /// Leave processing artifacts (integration masters, PixInsight
+    /// intermediates) out of the catalog. Off by default — masters are
+    /// worth cataloging for a finished project's display — but a sweep
+    /// over a processing tree can opt in to skip the derived files, which
+    /// repeat exposures the catalog already has under new basenames.
+    pub skip_processed: bool,
 }
 
 pub const DEFAULT_MATCH_RADIUS_DEG: f64 = 0.5;
@@ -61,6 +82,8 @@ impl Default for ImportOptions {
             dry_run: false,
             attach_existing: true,
             match_radius_deg: DEFAULT_MATCH_RADIUS_DEG,
+            scope: ImportScope::default(),
+            skip_processed: false,
         }
     }
 }
@@ -88,6 +111,14 @@ pub struct ImportOutcome {
     pub scanned: usize,
     pub unreadable: usize,
     pub non_light: usize,
+    /// Processing artifacts (masters, calibrated/registered intermediates)
+    /// left out of the catalog.
+    #[serde(default)]
+    pub skipped_processed: usize,
+    /// Frames outside the run's scope (lights during a calibration-only
+    /// run, and the reverse).
+    #[serde(default)]
+    pub skipped_out_of_scope: usize,
     /// Calibration frames stored in PSF Guard's sibling tables.
     pub calibration: crate::calibration::CalibrationImportOutcome,
     pub skipped_existing: usize,
@@ -193,11 +224,19 @@ pub fn import_frames(
     for frame in frames {
         if !frame.readable {
             outcome.unreadable += 1;
+        } else if frame.processed && options.skip_processed {
+            outcome.skipped_processed += 1;
         } else if !frame.is_light() {
-            outcome.non_light += 1;
-            if crate::calibration::kind_from_meta(&frame).is_some() {
-                calibrations.push(frame);
+            if options.scope == ImportScope::Lights {
+                outcome.skipped_out_of_scope += 1;
+            } else {
+                outcome.non_light += 1;
+                if crate::calibration::kind_from_meta(&frame).is_some() {
+                    calibrations.push(frame);
+                }
             }
+        } else if options.scope == ImportScope::Calibration {
+            outcome.skipped_out_of_scope += 1;
         } else if existing.contains(&frame.basename().to_lowercase()) {
             outcome.skipped_existing += 1;
         } else {
@@ -1020,6 +1059,16 @@ pub fn print_outcome(outcome: &ImportOutcome) {
     if outcome.non_light > 0 {
         println!("  Non-light frames: {}", outcome.non_light);
     }
+    if outcome.skipped_processed > 0 {
+        println!(
+            "  Processing artifacts skipped: {} (masters and calibrated/registered \
+             intermediates)",
+            outcome.skipped_processed
+        );
+    }
+    if outcome.skipped_out_of_scope > 0 {
+        println!("  Out of scope:     {}", outcome.skipped_out_of_scope);
+    }
     if outcome.calibration.imported > 0
         || outcome.calibration.updated > 0
         || outcome.calibration.skipped_existing > 0
@@ -1100,6 +1149,67 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         ts_schema::apply_schema(&conn).unwrap();
         conn
+    }
+
+    fn flat(filter: &str, ts: i64) -> FrameMeta {
+        FrameMeta {
+            image_type: Some("FLAT".into()),
+            object: None,
+            ..light("panel", filter, ts)
+        }
+    }
+
+    #[test]
+    fn lights_scope_leaves_calibration_frames_alone() {
+        let mut conn = fresh_conn();
+        let frames = vec![light("M31", "Ha", 1_000), flat("Ha", 1_100)];
+        let options = ImportOptions {
+            scope: ImportScope::Lights,
+            ..Default::default()
+        };
+        let outcome = import_frames(&mut conn, frames, &options).unwrap();
+        assert_eq!(outcome.imported, 1);
+        assert_eq!(outcome.skipped_out_of_scope, 1);
+        assert_eq!(outcome.calibration.flat, 0, "no calibration rows");
+    }
+
+    #[test]
+    fn calibration_scope_leaves_lights_alone() {
+        let mut conn = fresh_conn();
+        let frames = vec![light("M31", "Ha", 1_000), flat("Ha", 1_100)];
+        let options = ImportOptions {
+            scope: ImportScope::Calibration,
+            ..Default::default()
+        };
+        let outcome = import_frames(&mut conn, frames, &options).unwrap();
+        assert_eq!(outcome.imported, 0);
+        assert_eq!(outcome.skipped_out_of_scope, 1);
+        assert_eq!(outcome.projects_created, 0);
+        assert_eq!(outcome.non_light, 1);
+    }
+
+    #[test]
+    fn skipping_processing_artifacts_is_opt_in() {
+        // A WBPP-calibrated light keeps IMAGETYP=LIGHT and its original
+        // DATE-OBS under a new basename. By default it imports like any
+        // frame — masters are worth cataloging for a finished project —
+        // and a sweep over a processing tree can opt in to skip them.
+        let mut conn = fresh_conn();
+        let artifact = FrameMeta {
+            processed: true,
+            ..light("M31", "Ha", 1_000)
+        };
+        let options = ImportOptions {
+            skip_processed: true,
+            ..Default::default()
+        };
+        let outcome = import_frames(&mut conn, vec![artifact.clone()], &options).unwrap();
+        assert_eq!(outcome.imported, 0);
+        assert_eq!(outcome.skipped_processed, 1);
+
+        let outcome = import_frames(&mut conn, vec![artifact], &ImportOptions::default()).unwrap();
+        assert_eq!(outcome.imported, 1);
+        assert_eq!(outcome.skipped_processed, 0);
     }
 
     #[test]

--- a/src/image_io.rs
+++ b/src/image_io.rs
@@ -109,6 +109,52 @@ pub fn read_header_named(
     }
 }
 
+/// Whether a frame is the OUTPUT of processing — an integration master or a
+/// calibrated/registered intermediate — rather than an acquisition.
+///
+/// Processing tools preserve the acquisition keywords (a WBPP-calibrated
+/// frame still says `IMAGETYP = LIGHT` with the original `DATE-OBS`), so an
+/// importer that trusts those alone catalogs every artifact as a new light.
+/// The reliable marks are the ones the tools ADD: `NCOMBINE` and
+/// master-type `IMAGETYP` values on integrations, `SEIZAMST` on Seiza
+/// masters, and PixInsight's processing-history and signature properties on
+/// everything its pipeline writes.
+pub fn is_processing_artifact(
+    path: &Path,
+    declared: impl AsRef<Path>,
+    headers: &[(String, HeaderValue)],
+) -> bool {
+    let has_card = |wanted: &str| {
+        headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case(wanted))
+    };
+    if has_card("NCOMBINE") || has_card("SEIZAMST") {
+        return true;
+    }
+    let image_type_is_master = headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("IMAGETYP"))
+        .and_then(|(_, value)| match value {
+            HeaderValue::String(text) | HeaderValue::Raw(text) => Some(text),
+            _ => None,
+        })
+        .is_some_and(|text| text.to_ascii_uppercase().contains("MASTER"));
+    if image_type_is_master {
+        return true;
+    }
+    if seiza_xisf::is_xisf_path(declared.as_ref())
+        && let Ok(info) = seiza_xisf::inspect(path)
+        && let Some(image) = info.images.first()
+    {
+        return image.properties.iter().any(|property| {
+            property.id.starts_with("PixInsight:ProcessingHistory")
+                || property.id.starts_with("PCL:Signature:")
+        });
+    }
+    false
+}
+
 /// The scale a normalized frame is placed on: full-well for 16-bit data.
 ///
 /// PSF Guard compares background and flux across frames in physical ADU, and

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -507,6 +507,14 @@ pub struct ImportRequest {
     /// synthesizing new structure for them (default true).
     #[serde(default)]
     pub attach_existing: Option<bool>,
+    /// Which frame kinds to import: `all` (default), `lights`, or
+    /// `calibration`.
+    #[serde(default)]
+    pub scope: Option<crate::commands::import::ImportScope>,
+    /// Leave processing artifacts (integration masters, PixInsight
+    /// intermediates) out of the catalog (default false).
+    #[serde(default)]
+    pub skip_processed: Option<bool>,
     /// Coordinate-match radius in degrees (default 0.5).
     #[serde(default)]
     pub match_radius_deg: Option<f64>,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1689,6 +1689,85 @@ pub async fn create_database_route(
     })))
 }
 
+/// Whether every requested directory sits at or below one of the
+/// database's configured image roots, after resolving symlinks on both
+/// sides. Paths that fail to resolve are NOT within the roots.
+fn dirs_within_roots(requested: &[String], roots: &[String]) -> bool {
+    let resolved_roots: Vec<std::path::PathBuf> = roots
+        .iter()
+        .filter_map(|root| dunce::canonicalize(root).ok())
+        .collect();
+    if resolved_roots.is_empty() {
+        return false;
+    }
+    requested.iter().all(|dir| {
+        dunce::canonicalize(dir)
+            .is_ok_and(|resolved| resolved_roots.iter().any(|root| resolved.starts_with(root)))
+    })
+}
+
+/// One directory in the import folder listing.
+#[derive(Debug, serde::Serialize)]
+pub struct ImportFolder {
+    pub path: String,
+    pub name: String,
+    pub children: Vec<ImportFolder>,
+}
+
+fn list_subfolders(dir: &std::path::Path, depth: usize) -> Vec<ImportFolder> {
+    if depth == 0 {
+        return Vec::new();
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut folders: Vec<ImportFolder> = entries
+        .flatten()
+        .filter(|entry| entry.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name.starts_with('.') {
+                return None;
+            }
+            let path = entry.path();
+            Some(ImportFolder {
+                name,
+                children: list_subfolders(&path, depth - 1),
+                path: path.to_string_lossy().into_owned(),
+            })
+        })
+        .collect();
+    folders.sort_by(|a, b| a.name.cmp(&b.name));
+    folders
+}
+
+/// `GET /api/db/{db_id}/import/folders` — the configured image roots and
+/// two levels of their subdirectories, for choosing what an import scans.
+pub async fn get_import_folders(
+    ctx: DbContext,
+) -> Result<Json<ApiResponse<Vec<ImportFolder>>>, AppError> {
+    let roots = ctx.image_dirs.clone();
+    let listing = tokio::task::spawn_blocking(move || {
+        roots
+            .iter()
+            .map(|root| {
+                let path = std::path::Path::new(root);
+                ImportFolder {
+                    name: path
+                        .file_name()
+                        .map(|n| n.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| root.clone()),
+                    path: root.clone(),
+                    children: list_subfolders(path, 2),
+                }
+            })
+            .collect::<Vec<_>>()
+    })
+    .await
+    .map_err(|e| AppError::InternalError(format!("folder listing: {e}")))?;
+    Ok(Json(ApiResponse::success(listing)))
+}
+
 /// `POST /api/db/{db_id}/import` — start a background FITS import into an
 /// existing database. One import runs per database at a time.
 pub async fn start_import_route(
@@ -1702,7 +1781,12 @@ pub async fn start_import_route(
     // only from directories the operator already configured.
     let dirs = match req.image_dirs {
         Some(dirs) if !dirs.is_empty() => {
-            require_database_management_allowed(&state)?;
+            // A folder inside an already-configured root was consented to
+            // when the root was; only a NEW server path needs the
+            // management grant.
+            if !dirs_within_roots(&dirs, &ctx.image_dirs) {
+                require_database_management_allowed(&state)?;
+            }
             dirs
         }
         _ => ctx.image_dirs.clone(),
@@ -1731,6 +1815,8 @@ pub async fn start_import_route(
         match_radius_deg: req
             .match_radius_deg
             .unwrap_or(crate::commands::import::DEFAULT_MATCH_RADIUS_DEG),
+        scope: req.scope.unwrap_or_default(),
+        skip_processed: req.skip_processed.unwrap_or(false),
     };
     let started = spawn_import_job(
         &state,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -502,6 +502,7 @@ async fn run_server_internal(
             "/import",
             post(handlers::start_import_route).get(handlers::get_import_progress),
         )
+        .route("/import/folders", get(handlers::get_import_folders))
         .route("/export", get(handlers::export_archive_route))
         .route("/export/local", post(handlers::export_local_route))
         .route(

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3404,6 +3404,49 @@
   font-size: 0.82rem;
 }
 
+.import-scope-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--color-border, #444);
+  margin-bottom: 0.6rem;
+}
+
+.import-scope-choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.import-folder-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.82rem;
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+.import-folder-root > summary {
+  cursor: pointer;
+}
+
+.import-folder-child {
+  margin-left: 1.4rem;
+}
+
+.import-folder-grandchildren {
+  margin-left: 1.4rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.import-scope-controls .browse-button {
+  align-self: flex-start;
+}
+
 .server-export-status {
   font-size: 0.82rem;
   color: var(--color-text-muted);

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -483,6 +483,16 @@ export const apiClient = {
     return data.data;
   },
 
+  /** The configured image roots and two levels of their subdirectories. */
+  getImportFolders: async (dbId: string): Promise<import('./types').ImportFolder[]> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<import('./types').ImportFolder[]>>(
+      dbPath(dbId, '/import/folders')
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to list import folders');
+    return data.data;
+  },
+
   /** Import job progress (poll ~1s while running). */
   getImportStatus: async (dbId: string): Promise<ImportStatus> => {
     const apiInstance = await getApi();

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1150,6 +1150,10 @@ export interface ImportOutcome {
   scanned: number;
   unreadable: number;
   non_light: number;
+  /** Masters and calibrated/registered intermediates left out. */
+  skipped_processed?: number;
+  /** Frames outside the run's scope. */
+  skipped_out_of_scope?: number;
   calibration: CalibrationImportOutcome;
   skipped_existing: number;
   imported: number;
@@ -1265,6 +1269,20 @@ export interface ImportRequest {
   /** Attach to existing targets by name/coordinates (default true). */
   attach_existing?: boolean;
   match_radius_deg?: number;
+  /** Which frame kinds to import (default all). */
+  scope?: ImportScope;
+  /** Leave processing artifacts out of the catalog (default false). */
+  skip_processed?: boolean;
+}
+
+/** Which frames an import run touches. */
+export type ImportScope = 'all' | 'lights' | 'calibration';
+
+/** One directory in the import folder listing (two levels deep). */
+export interface ImportFolder {
+  path: string;
+  name: string;
+  children: ImportFolder[];
 }
 
 /** Body of `POST /api/databases/create`. */

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { isTauriApp, tauriConfig, tauriFileSystem } from '../utils/tauri';
+import type { ImportFolder, ImportScope } from '../api/types';
 import type { DbEntry, DbRegistry } from '../utils/tauri';
 import { apiClient } from '../api/client';
 import { useAccess } from '../auth/access';
@@ -107,6 +108,12 @@ export default function TauriSettings({
   // A running preview survives closing or reloading this page. Keep the
   // destination so its completed dry-run can still show the confirm step.
   const [confirmImport, setConfirmImport] = useState<DbEntry | null>(null);
+  const [importScope, setImportScope] = useState<ImportScope>('all');
+  const [importSkipProcessed, setImportSkipProcessed] = useState(false);
+  const [importFolders, setImportFolders] = useState<ImportFolder[]>([]);
+  // Checked folder paths. Exactly the configured roots means "everything",
+  // and the request then omits image_dirs entirely.
+  const [importSelectedDirs, setImportSelectedDirs] = useState<string[]>([]);
 
   const reload = useCallback(async () => {
     setIsLoading(true);
@@ -488,6 +495,36 @@ export default function TauriSettings({
   // Import is two-step: a dry-run PREVIEW first (rolled back server-side),
   // then an explicit confirmation. Nothing touches the database until the
   // user has seen exactly what would be attached vs newly created.
+  // Scope, folder, and artifact choices as request fields. Selection equal
+  // to the configured roots means "everything" and sends no image_dirs, so
+  // the default run needs no folder consent beyond what is configured.
+  const importOptionsOf = (entry: DbEntry) => {
+    const roots = [...entry.image_dirs].sort();
+    const selection = [...importSelectedDirs].sort();
+    const isDefaultSelection =
+      selection.length === roots.length && selection.every((dir, i) => dir === roots[i]);
+    return {
+      scope: importScope === 'all' ? undefined : importScope,
+      skip_processed: importSkipProcessed || undefined,
+      image_dirs: isDefaultSelection || selection.length === 0 ? undefined : selection,
+    };
+  };
+
+  const previewImport = async (entry: DbEntry, options: ReturnType<typeof importOptionsOf>) => {
+    const status = await apiClient.startImport(entry.id, {
+      dry_run: true,
+      backfill: false,
+      ...options,
+    });
+    setImportDbId(entry.id);
+    setConfirmImport(entry);
+    setStatusMessage(
+      status.started
+        ? `Previewing import into ${entry.name}… nothing is written until you confirm.`
+        : 'An import is already running for this database.'
+    );
+  };
+
   const handleImport = async (entry: DbEntry) => {
     if (entry.image_dirs.length === 0) {
       setStatusMessage(
@@ -498,17 +535,35 @@ export default function TauriSettings({
     setIsApplying(true);
     setStatusMessage('');
     setImportAnalyzeQuality(false);
+    setImportScope('all');
+    setImportSkipProcessed(false);
+    setImportSelectedDirs([...entry.image_dirs]);
+    setImportFolders([]);
+    apiClient
+      .getImportFolders(entry.id)
+      .then(setImportFolders)
+      .catch(() => setImportFolders([]));
     try {
-      const status = await apiClient.startImport(entry.id, { dry_run: true, backfill: false });
-      setImportDbId(entry.id);
-      setConfirmImport(entry);
-      setStatusMessage(
-        status.started
-          ? `Previewing import into ${entry.name}… nothing is written until you confirm.`
-          : 'An import is already running for this database.'
-      );
+      await previewImport(entry, {
+        scope: undefined,
+        skip_processed: undefined,
+        image_dirs: undefined,
+      });
     } catch (err) {
       console.error('import preview failed to start:', err);
+      const msg = err instanceof Error ? err.message : String(err);
+      setStatusMessage(`Failed to preview import: ${msg}`);
+    } finally {
+      setIsApplying(false);
+    }
+  };
+
+  const handleRepreviewImport = async () => {
+    if (!confirmImport) return;
+    setIsApplying(true);
+    try {
+      await previewImport(confirmImport, importOptionsOf(confirmImport));
+    } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setStatusMessage(`Failed to preview import: ${msg}`);
     } finally {
@@ -526,6 +581,7 @@ export default function TauriSettings({
         dry_run: false,
         backfill: importAnalyzeQuality,
         fill_metadata: starMetadataFillEnabled(),
+        ...importOptionsOf(entry),
       });
       setStatusMessage(`Importing images into ${entry.name}…`);
     } catch (err) {
@@ -813,12 +869,138 @@ export default function TauriSettings({
 
             {importDbId && importProgress && importProgress.stage !== '' && (
               <div className="import-progress-panel">
+                {confirmImport && importDbId === confirmImport.id && (
+                  <div className="import-scope-controls">
+                    <label className="import-scope-choice">
+                      Import
+                      <select
+                        value={importScope}
+                        onChange={(event) => setImportScope(event.target.value as ImportScope)}
+                        disabled={importRunning || isApplying}
+                      >
+                        <option value="all">Lights and calibration</option>
+                        <option value="lights">Lights only</option>
+                        <option value="calibration">Calibration only</option>
+                      </select>
+                    </label>
+                    {importFolders.length > 0 && (
+                      <div className="import-folder-tree">
+                        {importFolders.map((root) => (
+                          <details key={root.path} className="import-folder-root">
+                            <summary>
+                              <label onClick={(event) => event.stopPropagation()}>
+                                <input
+                                  type="checkbox"
+                                  checked={importSelectedDirs.includes(root.path)}
+                                  onChange={() =>
+                                    setImportSelectedDirs((current) =>
+                                      current.includes(root.path)
+                                        ? current.filter((d) => d !== root.path)
+                                        : [...current, root.path]
+                                    )
+                                  }
+                                />
+                                {root.path}
+                              </label>
+                            </summary>
+                            {root.children.map((child) => (
+                              <div key={child.path} className="import-folder-child">
+                                <label>
+                                  <input
+                                    type="checkbox"
+                                    checked={
+                                      importSelectedDirs.includes(child.path) ||
+                                      importSelectedDirs.includes(root.path)
+                                    }
+                                    disabled={importSelectedDirs.includes(root.path)}
+                                    onChange={() =>
+                                      setImportSelectedDirs((current) =>
+                                        current.includes(child.path)
+                                          ? current.filter((d) => d !== child.path)
+                                          : [...current, child.path]
+                                      )
+                                    }
+                                  />
+                                  {child.name}
+                                </label>
+                                {child.children.length > 0 && (
+                                  <div className="import-folder-grandchildren">
+                                    {child.children.map((grandchild) => (
+                                      <label key={grandchild.path}>
+                                        <input
+                                          type="checkbox"
+                                          checked={
+                                            importSelectedDirs.includes(grandchild.path) ||
+                                            importSelectedDirs.includes(child.path) ||
+                                            importSelectedDirs.includes(root.path)
+                                          }
+                                          disabled={
+                                            importSelectedDirs.includes(child.path) ||
+                                            importSelectedDirs.includes(root.path)
+                                          }
+                                          onChange={() =>
+                                            setImportSelectedDirs((current) =>
+                                              current.includes(grandchild.path)
+                                                ? current.filter((d) => d !== grandchild.path)
+                                                : [...current, grandchild.path]
+                                            )
+                                          }
+                                        />
+                                        {grandchild.name}
+                                      </label>
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
+                            ))}
+                          </details>
+                        ))}
+                      </div>
+                    )}
+                    <label className="quality-analysis-option import-skip-processed">
+                      <input
+                        type="checkbox"
+                        checked={importSkipProcessed}
+                        onChange={(event) => setImportSkipProcessed(event.target.checked)}
+                        disabled={importRunning || isApplying}
+                      />
+                      <span>
+                        <small>
+                          Skip processing artifacts (integration masters and
+                          calibrated/registered intermediates). Useful when a scanned
+                          folder contains a processing tree whose derived files repeat
+                          exposures already cataloged.
+                        </small>
+                      </span>
+                    </label>
+                    <button
+                      className="browse-button"
+                      onClick={handleRepreviewImport}
+                      disabled={importRunning || isApplying}
+                      title="Re-run the preview with the selection above; nothing is written."
+                    >
+                      Update preview
+                    </button>
+                  </div>
+                )}
                 <div className="import-progress-line">
                   {importRunning && <span className="import-spinner">⏳ </span>}
                   {describeImportProgress(importProgress)}
                 </div>
                 {importProgress.stage === 'complete' && importProgress.outcome && (
                   <>
+                    {(importProgress.outcome.skipped_processed ?? 0) > 0 && (
+                      <div className="muted">
+                        {importProgress.outcome.skipped_processed} processing artifact(s)
+                        (masters, calibrated/registered intermediates) skipped.
+                      </div>
+                    )}
+                    {(importProgress.outcome.skipped_out_of_scope ?? 0) > 0 && (
+                      <div className="muted">
+                        {importProgress.outcome.skipped_out_of_scope} frame(s) outside the
+                        selected scope.
+                      </div>
+                    )}
                     {importProgress.outcome.attach_summaries.length > 0 && (
                       <ul className="import-project-list">
                         {importProgress.outcome.attach_summaries.map((a) => (


### PR DESCRIPTION
Born from the C925 incident where an import swept a PixInsight `_Process` tree and cataloged 2,168 derived files as new lights. Three additions to the import flow:

## Scope by frame kind

The import preview gains an **Import** selector: lights and calibration (default), **lights only**, or **calibration only**. Out-of-scope frames are counted (`skipped_out_of_scope`) and left alone. A calibration-only run rebuilds the library after a scheduler-DB reset without touching scheduler rows — exactly the daily-reset flow where the `psf_guard_*` tables are wiped with the file.

## Folder selection

A new `GET /api/db/{id}/import/folders` lists the configured roots and two levels of their subdirectories; the preview shows them as checkboxes, so one night's folder can import alone. The consent model extends naturally: a requested folder **inside an already-configured root** needs no database-management grant (consent came with the root, resolved via canonicalized prefix check); paths outside every root still require it.

## Processing-artifact detection (skip is opt-in)

`image_io::is_processing_artifact` recognizes derived files by the marks processing tools **add** — `NCOMBINE` and master `IMAGETYP` values, `SEIZAMST` on Seiza masters, and PixInsight's `ProcessingHistory`/`PCL:Signature:*` XISF properties — because the acquisition keywords they copy are indistinguishable from the originals. `FrameMeta.processed` carries the mark. Skipping is **opt-in** (`--skip-processed` / a preview checkbox): masters are worth cataloging, and a later release will surface a finished project's master lights in its display; the detection primitive is the hook for that.

Changing any control re-runs the dry preview before confirming. The CLI grows `--lights-only`, `--calibration-only`, `--skip-processed`.

## Verification

- Against the real `_Process` tree from the incident: all **1,074 files recognized as artifacts** (0 imported with skip enabled) — calibrated, registered, master, drizzle, and autocrop XISF alike.
- Live against a management-**disabled** server: the folders endpoint lists `_Source` years and targets; a subfolder import starts without the grant; an outside path gets the 403.
- New unit tests: lights-only and calibration-only scoping, opt-in artifact skipping.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (714 passed) · `npm run lint` · `npx tsc --noEmit` · `npx vitest run` (276 passed) · `npm run build` · `npx playwright test add-database` (2 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)