### PR TITLE
Stop renaming projects to profile GUIDs when a catalog splits profiles

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -77,6 +77,14 @@
 
 ## Fixed
 
+- Projects are no longer "renamed" to profile GUIDs. When a catalog's
+  projects spanned two profiles — which an import could cause by filing new
+  projects under the telescope's current-but-empty profile instead of the
+  one owning the existing projects — every project name gained a raw GUID
+  prefix. Imports now join the profile that owns the existing projects, and
+  the display adds a short profile tag only when the same project name
+  truly exists under more than one profile.
+
 - Remote image upload can now attach image bytes after scheduler sync has
   already registered the same light, instead of rejecting that normal order
   of operations as a duplicate.

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -658,6 +658,22 @@ fn resolve_profile(conn: &Connection, options: &ImportOptions) -> Result<String>
         return Ok(profile_id.clone());
     }
 
+    // The profile that owns the existing projects wins: new work lands in
+    // the catalog the user is looking at. A telescope snapshot often
+    // carries a `profilepreference` row for the CURRENT N.I.N.A. profile
+    // while every project belongs to an older one — defaulting to the
+    // preference row filed new projects under a second profile, which
+    // split the catalog and made the UI disambiguate every project with a
+    // raw profile GUID.
+    let mut stmt = conn.prepare(
+        "SELECT profileid FROM project GROUP BY profileid          ORDER BY COUNT(*) DESC, profileid LIMIT 1",
+    )?;
+    let dominant: Option<String> = stmt.query_map([], |row| row.get(0))?.next().transpose()?;
+    if let Some(profile_id) = dominant {
+        ensure_profile_preference(conn, &profile_id)?;
+        return Ok(profile_id);
+    }
+
     let mut stmt = conn.prepare("SELECT DISTINCT profileId FROM profilepreference")?;
     let profiles: Vec<String> = stmt
         .query_map([], |row| row.get(0))?
@@ -1157,6 +1173,40 @@ mod tests {
             object: None,
             ..light("panel", filter, ts)
         }
+    }
+
+    #[test]
+    fn new_projects_join_the_profile_that_owns_the_existing_ones() {
+        // A telescope snapshot often carries a profilepreference row for
+        // the CURRENT N.I.N.A. profile while every project belongs to an
+        // older one. New projects must join the projects' profile, or the
+        // catalog splits and the UI disambiguates everything with GUIDs.
+        let mut conn = fresh_conn();
+        let outcome = import_frames(
+            &mut conn,
+            vec![light("M31", "Ha", 1_000)],
+            &ImportOptions::default(),
+        )
+        .unwrap();
+        let project_profile = outcome.profile_id.clone();
+
+        // The telescope's "current" profile appears with no projects.
+        super::ensure_profile_preference(&conn, "telescope-current-profile").unwrap();
+
+        let mut far_away = light("NGC 7000", "Ha", 9_000_000);
+        far_away.ra_deg = Some(315.7);
+        far_away.dec_deg = Some(44.5);
+        let outcome = import_frames(&mut conn, vec![far_away], &ImportOptions::default()).unwrap();
+        assert_eq!(
+            outcome.profile_id, project_profile,
+            "the new project must join the existing projects' profile"
+        );
+        let distinct: i64 = conn
+            .query_row("SELECT COUNT(DISTINCT profileid) FROM project", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(distinct, 1);
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -173,6 +173,18 @@ impl<'a> Database<'a> {
     ///
     /// This stays on the small `project` table. The file cache supplies latest
     /// capture dates after its existing background image walk.
+    /// Project names that appear under more than one profile — the only
+    /// case where a profile tag on the display name disambiguates anything.
+    pub fn ambiguous_project_names(&self) -> Result<std::collections::HashSet<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT name FROM project GROUP BY name HAVING COUNT(DISTINCT profileid) > 1",
+        )?;
+        let names = stmt
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<_, _>>()?;
+        Ok(names)
+    }
+
     pub fn get_projects_for_navigation(&self) -> Result<Vec<(ProjectWithProfile, i32)>> {
         let guid = if self.schema.has_project_guid {
             ", guid"

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -455,6 +455,24 @@ pub(super) fn require_database_management_allowed(state: &AppState) -> Result<()
     }
 }
 
+/// A project's name for display. The old behavior prefixed EVERY project
+/// with its profile id whenever two profiles existed — and scheduler
+/// databases carry no friendly profile names, so users saw their projects
+/// "renamed" to raw GUIDs. A short tag now appears only when the same
+/// project name exists under more than one profile.
+fn display_project_name(
+    name: &str,
+    profile_id: &str,
+    ambiguous: &std::collections::HashSet<String>,
+) -> String {
+    if ambiguous.contains(name) {
+        let tag: String = profile_id.chars().take(8).collect();
+        format!("{name} \u{00b7} {tag}")
+    } else {
+        name.to_string()
+    }
+}
+
 fn summary_of(ctx: &crate::server::database_context::DatabaseContext) -> DatabaseSummary {
     DatabaseSummary {
         id: ctx.id.clone(),
@@ -2445,11 +2463,14 @@ pub async fn list_projects(
 
     // Keep this request on the small project table. The background file scan
     // already walks the images and supplies the latest capture date above.
-    let projects = {
+    let (projects, ambiguous_names) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
-        db.get_projects_for_navigation().map_err(AppError::db)?
+        (
+            db.get_projects_for_navigation().map_err(AppError::db)?,
+            db.ambiguous_project_names().map_err(AppError::db)?,
+        )
     };
     // `projects_with_files` has one entry for every project that owns an
     // acquisition, even when no source file was found. Keep the picker's old
@@ -2459,22 +2480,12 @@ pub async fn list_projects(
         .filter(|(project, _)| file_existence_map.contains_key(&project.project.id))
         .collect::<Vec<_>>();
 
-    let show_profile = projects
-        .iter()
-        .map(|(project, _)| project.project.profile_id.as_str())
-        .collect::<std::collections::HashSet<_>>()
-        .len()
-        > 1;
-
     let response: Vec<ProjectResponse> = projects
         .into_iter()
         .map(|(project_with_profile, state)| {
             let project = &project_with_profile.project;
-            let display_name = if show_profile {
-                format!("{} → {}", project_with_profile.profile_name, project.name)
-            } else {
-                project.name.clone()
-            };
+            let display_name =
+                display_project_name(&project.name, &project.profile_id, &ambiguous_names);
 
             ProjectResponse {
                 id: project.id,
@@ -2626,9 +2637,7 @@ pub async fn get_images(
     let conn = conn.lock().map_err(AppError::db)?;
     let db = Database::new(&conn);
 
-    // Get profile count to determine display format
-    let profile_count = db.get_profile_count().map_err(AppError::db)?;
-    let show_profile = profile_count > 1;
+    let ambiguous_names = db.ambiguous_project_names().map_err(AppError::db)?;
 
     // Convert status string to GradingStatus enum
     let status_filter = params.status.as_ref().and_then(|s| match s.as_str() {
@@ -2656,10 +2665,9 @@ pub async fn get_images(
             let metadata: serde_json::Value = serde_json::from_str(&img.metadata)
                 .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
 
-            // Create display name - we need the profile_id to do this properly
             let project_display_name = match img.profile_id.as_ref() {
-                Some(profile_id) if show_profile => format!("{} → {}", profile_id, proj_name),
-                _ => proj_name.clone(),
+                Some(profile_id) => display_project_name(&proj_name, profile_id, &ambiguous_names),
+                None => proj_name.clone(),
             };
 
             ImageResponse {
@@ -2690,14 +2698,12 @@ pub async fn get_image(
     use crate::image_analysis::FitsImage;
 
     // Get image data from database first (before any async operations)
-    let (image, proj_name, target_name, mut metadata, show_profile) = {
+    let (image, proj_name, target_name, mut metadata, ambiguous_names) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
 
-        // Get profile count to determine display format
-        let profile_count = db.get_profile_count().map_err(AppError::db)?;
-        let show_profile = profile_count > 1;
+        let ambiguous_names = db.ambiguous_project_names().map_err(AppError::db)?;
 
         let images = db.get_images_by_ids(&[image_id]).map_err(AppError::db)?;
 
@@ -2716,7 +2722,7 @@ pub async fn get_image(
         let metadata: serde_json::Value = serde_json::from_str(&image.metadata)
             .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
 
-        (image, proj_name, target_name, metadata, show_profile)
+        (image, proj_name, target_name, metadata, ambiguous_names)
     }; // Database connection is dropped here
 
     // Now we can do async operations
@@ -2804,10 +2810,9 @@ pub async fn get_image(
         }
     }
 
-    // Create display name
     let project_display_name = match image.profile_id.as_ref() {
-        Some(profile_id) if show_profile => format!("{} → {}", profile_id, proj_name),
-        _ => proj_name.clone(),
+        Some(profile_id) => display_project_name(&proj_name, profile_id, &ambiguous_names),
+        None => proj_name.clone(),
     };
 
     let response = ImageResponse {
@@ -3691,8 +3696,7 @@ pub async fn get_projects_overview(
         .map_err(AppError::db)?;
     let navigation_metadata = db.get_project_navigation_metadata().map_err(AppError::db)?;
 
-    // Get profile count to determine display format
-    let profile_count = db.get_profile_count().map_err(AppError::db)?;
+    let ambiguous_names = db.ambiguous_project_names().map_err(AppError::db)?;
 
     // Get file existence map
     let file_existence_map: std::collections::HashMap<i32, bool> = {
@@ -3712,7 +3716,6 @@ pub async fn get_projects_overview(
     }
 
     let mut response = Vec::new();
-    let show_profile = profile_count > 1;
 
     for project_with_profile in projects {
         let project = &project_with_profile.project;
@@ -3756,11 +3759,8 @@ pub async fn get_projects_overview(
             _ => None,
         };
 
-        let display_name = if show_profile {
-            format!("{} → {}", project_with_profile.profile_name, project.name)
-        } else {
-            project.name.clone()
-        };
+        let display_name =
+            display_project_name(&project.name, &project.profile_id, &ambiguous_names);
 
         response.push(ProjectOverviewResponse {
             id: project.id,


### PR DESCRIPTION
Field report: importing calibration frames left every project on the Overview "renamed" to a UUID.

## What actually happened

The names never changed — the display did. The Overview disambiguates projects with a `{profile} → {name}` prefix whenever the catalog's projects span more than one profile id, and scheduler databases carry no friendly profile names, so the prefix is a raw GUID. The split itself came from the import: `resolve_profile` defaulted to the `profilepreference` table, and a telescope snapshot typically carries a preference row for the telescope's *current* N.I.N.A. profile while every project belongs to an older one (C925: 16 projects under `8f8e9c44…`, one preference row for `b279acd9…`; Ultracat: 19 projects, **zero** preference rows, so an import would mint a brand-new GUID). One new project under the "wrong" profile flipped every card.

## The fixes

- **Imports join the projects' profile**: when no `--profile-id` is given, the profile owning the most existing projects wins (deterministic tie-break), with a preference row ensured for it. The preference-table fallback now applies only to an empty catalog. Covered by a test that reproduces the snapshot shape: existing project + current-but-empty preference profile → the new project joins the existing one, one distinct profile id after.
- **No more GUID prefixes**: `display_project_name` adds a short eight-character profile tag **only when the same project name truly exists under more than one profile** — the only case where a tag disambiguates anything. Applied to all four display sites (project navigation, projects overview, image list, image detail).

No data repair needed: with the display fix, the existing C925 split renders plain names (verified live on the affected snapshot — 15 cards, zero GUID prefixes), and tomorrow's scheduler reset drops the stray project anyway.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (719 passed) · `npx vitest run` (276 passed) · `npm run build` · `npx playwright test overview add-database` (6 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)