### PR TITLE
Default JSON API responses to Cache-Control: no-store

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -77,6 +77,13 @@
 
 ## Fixed
 
+- The same image can no longer show different quality scores in different
+  views inside the desktop app. Analysis responses carried no cache policy,
+  so the embedding webview could serve one view's request from its own HTTP
+  cache while another view fetched fresh scores. JSON API responses now
+  default to `Cache-Control: no-store`; previews and static assets keep
+  their existing caching.
+
 - Projects are no longer "renamed" to profile GUIDs. When a catalog's
   projects spanned two profiles — which an import could cause by filing new
   projects under the telescope's current-but-empty profile instead of the

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -617,6 +617,7 @@ async fn run_server_internal(
         .route("/sync/v1/exports/{export_id}", get(remote_sync::get_export))
         .route("/sync/v1/jobs/{job_id}", get(remote_sync::get_preview_job))
         .nest("/db/{db_id}", db_routes)
+        .layer(axum::middleware::from_fn(json_no_store))
         .layer(axum::middleware::from_fn_with_state(
             Arc::clone(&state),
             auth::authorize_api,
@@ -1160,6 +1161,74 @@ async fn pregenerate_annotated(
 
     tracing::trace!("✅ Generated annotated image for image {}", image_id);
     Ok(true) // Successfully generated
+}
+
+/// Default JSON API responses to `Cache-Control: no-store` when the handler
+/// set no policy of its own.
+///
+/// Analysis endpoints return sequence-relative scores that change whenever a
+/// quality scan lands new evidence. Without a cache policy, an embedding
+/// webview (the desktop app) may serve its own cached copy of one view's
+/// request while another view fetches fresh — the same image then shows two
+/// different scores depending on the page. Binary responses (previews,
+/// thumbnails) keep their own explicit policies and are not touched.
+async fn json_no_store(
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let mut response = next.run(request).await;
+    apply_json_no_store(&mut response);
+    response
+}
+
+/// The policy itself, separated so it can be tested without a router.
+fn apply_json_no_store(response: &mut axum::response::Response) {
+    use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
+    let is_json = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .is_some_and(|value| value.as_bytes().starts_with(b"application/json"));
+    if is_json && !response.headers().contains_key(CACHE_CONTROL) {
+        response.headers_mut().insert(
+            CACHE_CONTROL,
+            axum::http::HeaderValue::from_static("no-store"),
+        );
+    }
+}
+
+#[cfg(test)]
+mod cache_policy_tests {
+    use super::apply_json_no_store;
+    use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
+
+    fn response(content_type: &str) -> axum::response::Response {
+        axum::response::Response::builder()
+            .header(CONTENT_TYPE, content_type)
+            .body(axum::body::Body::empty())
+            .unwrap()
+    }
+
+    #[test]
+    fn json_without_a_policy_becomes_no_store() {
+        let mut r = response("application/json");
+        apply_json_no_store(&mut r);
+        assert_eq!(r.headers()[CACHE_CONTROL], "no-store");
+    }
+
+    #[test]
+    fn explicit_policies_and_binary_responses_are_untouched() {
+        let mut r = axum::response::Response::builder()
+            .header(CONTENT_TYPE, "application/json")
+            .header(CACHE_CONTROL, "max-age=5")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        apply_json_no_store(&mut r);
+        assert_eq!(r.headers()[CACHE_CONTROL], "max-age=5");
+
+        let mut image = response("image/png");
+        apply_json_no_store(&mut image);
+        assert!(!image.headers().contains_key(CACHE_CONTROL));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Field report from the desktop app: the same rejected images showed **58** in the grid badge and **82** in the Sequence view.

## Diagnosis

Both views consume the same `/analysis/sequence` endpoint, and the server provably returns identical scores: verified per-image equality across target/project/all-projects scope, filtered vs unfiltered requests, and the per-image context endpoint against a real catalog. Client-side, all scoring surfaces share the penalty preference, key their caches on it, and sync it across tabs. What remained: **JSON API responses carried no `Cache-Control` header at all**, so the desktop app's embedding webview may answer one view's GET from its own HTTP cache while the other view fetches fresh. Each view uses a slightly different URL (filter parameter present or absent), so each can pin a different vintage — and sequence-relative scores legitimately change when a quality scan lands new evidence, making two vintages read as two entirely different scores. React-query's own 60-second staleness heals on remount; a webview HTTP cache does not.

## Fix

A middleware on the API router defaults `Cache-Control: no-store` for `application/json` responses that set no policy of their own. Binary responses keep their explicit policies — verified live: analysis JSON now `no-store`, generated preview PNGs still `max-age=86400`. Unit tests cover the default, the explicit-policy passthrough, and binary exemption.

The desktop app picks this up at its next release; the web UI benefits immediately on deploy.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (721 passed) · live header verification on both endpoint classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)