### PR TITLE
Match filter names by identity, not by raw string

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -77,6 +77,11 @@
 
 ## Fixed
 
+- Filter names that differ only by case or whitespace ("Ha" beside "HA")
+  no longer split one physical filter into separate quality-comparison
+  groups, and filter selections match all variants. Display keeps the name
+  as the camera wrote it.
+
 - The same image can no longer show different quality scores in different
   views inside the desktop app. Analysis responses carried no cache policy,
   so the embedding webview could serve one view's request from its own HTTP

--- a/src/commands/export/mod.rs
+++ b/src/commands/export/mod.rs
@@ -192,7 +192,7 @@ pub fn plan_export(
             continue;
         }
         if let Some(wanted) = &options.filter_name
-            && !image.filter_name.eq_ignore_ascii_case(wanted)
+            && !crate::utils::filter_names_match(&image.filter_name, wanted)
         {
             continue;
         }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -4031,9 +4031,9 @@ pub async fn analyze_sequence(
             target_ids
                 .as_ref()
                 .is_none_or(|target_ids| target_ids.contains(&image.target_id))
-                && filter_name
-                    .as_ref()
-                    .is_none_or(|filter| image.filter_name == *filter)
+                && filter_name.as_ref().is_none_or(|filter| {
+                    crate::utils::filter_names_match(&image.filter_name, filter)
+                })
         }) {
             expected_by_image.insert(
                 image.0.id,
@@ -4100,6 +4100,8 @@ pub async fn analyze_sequence(
             std::collections::HashMap::new();
         let mut entries_by_group: std::collections::HashMap<(i32, String, String), Vec<_>> =
             std::collections::HashMap::new();
+        let mut display_filter_names: std::collections::HashMap<(i32, String, String), String> =
+            std::collections::HashMap::new();
         for (img, _project_name, target_name) in &images_data {
             let mut metrics =
                 extract_metrics_from_metadata(img.id, &img.metadata, img.acquired_date);
@@ -4111,7 +4113,17 @@ pub async fn analyze_sequence(
                 &astrometry_evidence,
                 expected_by_image.get(&img.id).copied().flatten(),
             );
-            let group = (img.target_id, target_name.clone(), img.filter_name.clone());
+            // Key on the normalized filter so case or whitespace variants of
+            // one physical filter form ONE comparison cohort; the raw name
+            // of the group's first frame stays as the display name.
+            let group = (
+                img.target_id,
+                target_name.clone(),
+                crate::utils::normalized_filter_name(&img.filter_name),
+            );
+            display_filter_names
+                .entry(group.clone())
+                .or_insert_with(|| img.filter_name.clone());
             entries_by_group
                 .entry(group.clone())
                 .or_default()
@@ -4122,16 +4134,19 @@ pub async fn analyze_sequence(
         let mut all_sequences = Vec::new();
         let mut target_filter_rollups = Vec::new();
         for ((target_id, target_name, filter), mut metrics) in by_group {
-            if let Some(entries) =
-                entries_by_group.get(&(target_id, target_name.clone(), filter.clone()))
-            {
+            let key = (target_id, target_name.clone(), filter.clone());
+            if let Some(entries) = entries_by_group.get(&key) {
                 merge_photometric_signals(&mut metrics, entries, session_gap_minutes);
             }
+            let display_filter = display_filter_names
+                .get(&key)
+                .cloned()
+                .unwrap_or_else(|| filter.clone());
             let (scored, rollup) = analyzer.analyze_with_target_filter_rollup(
                 &metrics,
                 target_id,
                 &target_name,
-                &filter,
+                &display_filter,
             );
             all_sequences.extend(scored);
             if let Some(rollup) = rollup {
@@ -4209,7 +4224,7 @@ pub async fn get_image_quality(
             .into_iter()
             .filter(|(img, _, _)| {
                 img.target_id == target_image.target_id
-                    && img.filter_name == target_image.filter_name
+                    && crate::utils::filter_names_match(&img.filter_name, &target_image.filter_name)
             })
             .collect();
         let mut resolver =
@@ -4567,7 +4582,7 @@ async fn start_spatial_scan_with_priority(
                 && req
                     .filter_name
                     .as_ref()
-                    .is_none_or(|f| img.filter_name == *f)
+                    .is_none_or(|f| crate::utils::filter_names_match(&img.filter_name, f))
         }) {
             let expected = resolver
                 .expected_for_grading(&conn, &img)
@@ -4931,7 +4946,7 @@ pub async fn get_spatial_scan_progress(
             query
                 .filter_name
                 .as_ref()
-                .is_none_or(|filter| image.filter_name == *filter)
+                .is_none_or(|filter| crate::utils::filter_names_match(&image.filter_name, filter))
         }) {
             let Some(filename) = filename_from_metadata(&image.metadata) else {
                 continue;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,20 @@ pub fn truncate_string(s: &str, max_len: usize) -> String {
     }
 }
 
+/// Filter names as written by N.I.N.A. are free text; profile edits leave
+/// catalogs with "Ha" beside "HA" beside "HA ". Grouping or matching on the
+/// raw string silently splits one physical filter into several comparison
+/// cohorts, so every filter comparison and grouping key goes through here.
+/// Display keeps the raw name; only identity is normalized.
+pub fn normalized_filter_name(name: &str) -> String {
+    name.trim().to_ascii_uppercase()
+}
+
+/// Whether two filter names refer to the same physical filter.
+pub fn filter_names_match(left: &str, right: &str) -> bool {
+    normalized_filter_name(left) == normalized_filter_name(right)
+}
+
 pub fn extract_filename(metadata: &str) -> Option<String> {
     let json: serde_json::Value = serde_json::from_str(metadata).ok()?;
     json.get("FileName").and_then(|f| f.as_str()).map(|path| {
@@ -15,6 +29,19 @@ pub fn extract_filename(metadata: &str) -> Option<String> {
             .unwrap_or(path)
             .to_string()
     })
+}
+
+#[cfg(test)]
+mod filter_name_tests {
+    use super::*;
+
+    #[test]
+    fn variants_of_one_filter_match() {
+        assert!(filter_names_match("Ha", "HA"));
+        assert!(filter_names_match(" HA ", "ha"));
+        assert!(!filter_names_match("HA", "OIII"));
+        assert_eq!(normalized_filter_name(" Ha "), "HA");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Follow-up to the score-consistency audit (#340): the one remaining silent-divergence mechanism was filter-name identity.

Filter names are free text from N.I.N.A., and profile edits leave catalogs with `"Ha"` beside `"HA"` beside `"HA "`. Sequence analysis grouped and matched on the raw string, so one physical filter could split into **separate comparison cohorts with independent statistics** — visually same-filter images scoring against different baselines — and a filter selection silently omitted the other variants. Export, inconsistently, already matched case-insensitively (but did not trim).

One normalization (`normalized_filter_name`: trim + ASCII case fold, with a `filter_names_match` predicate) now backs every filter comparison and grouping key: sequence grouping, the analysis `filter_name` parameter, the per-image cohort, the spatial-scan and statistics scopes, and export. Display names keep the raw string as the camera wrote it (first-seen variant per group).

Deliberately untouched: stack-preview channel grouping still keys on the raw filter name — merging variants there would re-key stack jobs and channels, forcing restacks; worth doing separately with a cache-version bump if mixed-case filters show up in stack channels in practice.

## Verification

Live fixture with 20 of 101 HA frames flipped to `"Ha"`: analysis returns **one** 101-frame HA cohort (previously an 81/20 split), and `filter_name=ha` matches all 101. Unit tests cover the normalization and predicate.

## Checks run locally

`cargo fmt --check` · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo test` (722 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)