### PR TITLE
Show the same score basis in the grid as the Sequence view

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -77,6 +77,13 @@
 
 ## Fixed
 
+- The grid and the Sequence view now show the same quality score for the
+  same image. The Sequence view defaults to the all-sessions score, but the
+  grid badge was built from per-session scores — a frame in a small session
+  could score 1.0 against itself while scoring far lower against the whole
+  filter. The grid (and the detail panel) now use the same basis the
+  Sequence view displays, and the badge tooltip names it.
+
 - Filter names that differ only by case or whitespace ("Ha" beside "HA")
   no longer split one physical filter into separate quality-comparison
   groups, and filter selections match all variants. Display keeps the name

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3447,6 +3447,15 @@
   align-self: flex-start;
 }
 
+.quality-badge-secondary {
+  top: 2.2rem;
+  font-size: 0.68rem;
+  opacity: 0.85;
+  background-color: var(--color-bg-secondary, #333) !important;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border, #555);
+}
+
 .server-export-status {
   font-size: 0.82rem;
   color: var(--color-text-muted);

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -947,6 +947,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                             dbId={dbId!}
                             image={image}
                             quality={quality.qualityByImage.get(image.id)}
+                            qualityScoreScope={quality.scopeByImage.get(image.id)}
                             qualityPresentation="compact"
                             isSelected={
                               selectedImages.has(image.id) ||

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -948,6 +948,14 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                             image={image}
                             quality={quality.qualityByImage.get(image.id)}
                             qualityScoreScope={quality.scopeByImage.get(image.id)}
+                            secondaryScore={
+                              quality.sessionScoreByImage.has(image.id)
+                                ? {
+                                    score: quality.sessionScoreByImage.get(image.id)!,
+                                    scope: 'capture_sequence',
+                                  }
+                                : undefined
+                            }
                             qualityPresentation="compact"
                             isSelected={
                               selectedImages.has(image.id) ||

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -10,6 +10,7 @@ import {
   qualityScoreBasis,
   qualityScoreDescription,
   type QualityScoreScope,
+  secondaryScoreDescription,
 } from '../utils/qualityScore';
 import QualityReasonPopover from './QualityReasonPopover';
 
@@ -21,6 +22,10 @@ export interface ImageCardProps {
   onDoubleClick: () => void;
   quality?: ImageQualityResult;
   qualityScoreScope?: QualityScoreScope;
+  /** The same frame's score under the OTHER comparison basis, when it
+   * exists — session-relative when the badge is all-sessions, and the
+   * reverse. Rendered as a smaller chip when the rounded values differ. */
+  secondaryScore?: { score: number; scope: QualityScoreScope };
   qualityPresentation?: 'full' | 'compact';
   lazyPreview?: boolean;
   selectionEffects?: boolean;
@@ -35,6 +40,7 @@ export default function ImageCard({
   onDoubleClick,
   quality,
   qualityScoreScope = 'capture_sequence',
+  secondaryScore,
   qualityPresentation = 'full',
   lazyPreview = false,
   selectionEffects = true,
@@ -136,6 +142,17 @@ export default function ImageCard({
             {(quality.quality_score * 100).toFixed(0)}
           </div>
         )}
+        {quality &&
+          secondaryScore &&
+          Math.round(secondaryScore.score * 100) !==
+            Math.round(quality.quality_score * 100) && (
+            <div
+              className="quality-badge quality-badge-secondary"
+              title={secondaryScoreDescription(secondaryScore.score, secondaryScore.scope)}
+            >
+              {(secondaryScore.score * 100).toFixed(0)}
+            </div>
+          )}
         {quality?.category && (
           <div className="category-label">
             {formatCategory(quality.category)}

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -292,6 +292,30 @@ export default function SequenceView() {
   }, [requestedScoreScope, sequenceChoices, urlCurrentImageId]);
   const activeSequence = activeChoice?.sequence;
   const activeScoreScope: QualityScoreScope = activeChoice?.scoreScope ?? 'capture_sequence';
+  // The same frame's score under the OTHER basis, for the secondary badge:
+  // session score while viewing All sessions, rollup score while viewing a
+  // single session. Only filters with several sessions have two bases.
+  const otherBasisScoreByImage = useMemo(() => {
+    const map = new Map<number, number>();
+    if (!activeChoice) return map;
+    const filter = activeChoice.sequence.filter_name;
+    const sessionCount = sequences.filter(
+      sequence => sequence.filter_name === filter,
+    ).length;
+    if (sessionCount <= 1) return map;
+    if (activeScoreScope === 'target_filter') {
+      for (const sequence of sequences) {
+        if (sequence.filter_name !== filter) continue;
+        for (const image of sequence.images) map.set(image.image_id, image.quality_score);
+      }
+    } else {
+      const rollup = rollups.find(entry => entry.filter_name === filter);
+      for (const score of rollup?.images ?? []) map.set(score.image_id, score.quality_score);
+    }
+    return map;
+  }, [activeChoice, activeScoreScope, rollups, sequences]);
+  const otherBasisScope: QualityScoreScope =
+    activeScoreScope === 'target_filter' ? 'capture_sequence' : 'target_filter';
   const unavailableImageCount = activeChoice?.unavailableImageCount ?? 0;
   const activeImageId = useMemo(() => {
     if (!activeSequence || activeSequence.images.length === 0) return null;
@@ -890,6 +914,8 @@ export default function SequenceView() {
                 dbId={dbId!}
                 images={activeSequence.images}
                 scoreScope={activeScoreScope}
+                otherBasisScoreByImage={otherBasisScoreByImage}
+                otherBasisScope={otherBasisScope}
                 imageMap={imageMap}
                 projectId={projectId!}
                 targetId={activeSequence.target_id}
@@ -1117,6 +1143,8 @@ const SequenceStrip = memo(function SequenceStrip({
   dbId,
   images,
   scoreScope,
+  otherBasisScoreByImage,
+  otherBasisScope,
   imageMap,
   projectId,
   targetId,
@@ -1133,6 +1161,8 @@ const SequenceStrip = memo(function SequenceStrip({
   dbId: string;
   images: ImageQualityResult[];
   scoreScope: QualityScoreScope;
+  otherBasisScoreByImage: ReadonlyMap<number, number>;
+  otherBasisScope: QualityScoreScope;
   imageMap: ReadonlyMap<number, Image>;
   projectId: number;
   targetId: number;
@@ -1198,6 +1228,14 @@ const SequenceStrip = memo(function SequenceStrip({
             image={image}
             quality={quality}
             qualityScoreScope={scoreScope}
+            secondaryScore={
+              otherBasisScoreByImage.has(quality.image_id)
+                ? {
+                    score: otherBasisScoreByImage.get(quality.image_id)!,
+                    scope: otherBasisScope,
+                  }
+                : undefined
+            }
             isSelected={selectedImages.has(quality.image_id)}
             onClick={(event) => onSelect(quality.image_id, event)}
             onDoubleClick={() => onOpen(quality.image_id)}

--- a/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
+++ b/static/src/hooks/__tests__/useSequenceAnalysis.test.tsx
@@ -149,6 +149,58 @@ describe('useImageQuality', () => {
 });
 
 describe('useScopedQuality', () => {
+  it('prefers the all-sessions rollup score over the per-session score', async () => {
+    // A small session can normalize against itself and score 1.0 while the
+    // target/filter rollup — the basis the Sequence view shows by default —
+    // scores the same frame far lower. The grid must show the same basis.
+    const base = normalFixture.data.sequences[0].images[0];
+    const fixture = {
+      success: true,
+      data: {
+        sequences: [
+          {
+            ...normalFixture.data.sequences[0],
+            images: [{ ...base, image_id: 1, quality_score: 1.0 }],
+          },
+          {
+            ...normalFixture.data.sequences[0],
+            images: [{ ...base, image_id: 2, quality_score: 0.9 }],
+          },
+        ],
+        target_filter_rollups: [
+          {
+            target_id: normalFixture.data.sequences[0].target_id,
+            target_name: 'T',
+            filter_name: normalFixture.data.sequences[0].filter_name,
+            image_count: 1,
+            unavailable_image_count: 1,
+            summary: null,
+            session_start: null,
+            session_end: null,
+            images: [{ ...base, image_id: 1, quality_score: 0.83 }],
+          },
+        ],
+      },
+      error: null,
+    };
+    server.use(
+      http.get('/api/db/:dbId/analysis/sequence', () => HttpResponse.json(fixture)),
+    );
+
+    const { result } = renderHook(() => useScopedQuality('test', 7, undefined), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current.qualityByImage.size).toBe(2);
+    });
+
+    expect(result.current.qualityByImage.get(1)?.quality_score).toBe(0.83);
+    expect(result.current.scopeByImage.get(1)).toBe('target_filter');
+    // A frame the rollup could not include keeps its per-session score.
+    expect(result.current.qualityByImage.get(2)?.quality_score).toBe(0.9);
+    expect(result.current.scopeByImage.get(2)).toBe('capture_sequence');
+  });
+
   it('loads one project analysis and indexes results by image', async () => {
     let requests = 0;
     let projectId: string | null = null;

--- a/static/src/hooks/useSequenceAnalysis.ts
+++ b/static/src/hooks/useSequenceAnalysis.ts
@@ -7,6 +7,7 @@ import type {
   SequenceAnalysisRequest,
 } from '../api/types';
 import { useState, useCallback } from 'react';
+import type { QualityScoreScope } from '../utils/qualityScore';
 import {
   penaltyKeyOf,
   penaltyParamsOf,
@@ -103,15 +104,44 @@ export function useScopedQuality(
     staleTime: 60000,
   });
 
+  // Show the same score basis the Sequence view shows by default: the
+  // all-sessions (target/filter) rollup for filters with several sessions,
+  // the per-session score otherwise. Building the map from sessions alone
+  // made the grid badge disagree with the Sequence view for any frame
+  // whose small session normalized against itself. The rollup entry
+  // carries only the score fields, so it overlays a copy of the session
+  // entry — category, pointing, and overlays stay intact.
   const qualityByImage = new Map<number, ImageQualityResult>();
+  const scopeByImage = new Map<number, QualityScoreScope>();
+  const sessionsPerFilter = new Map<string, number>();
   for (const sequence of query.data?.sequences ?? []) {
+    const key = `${sequence.target_id}:${sequence.filter_name}`;
+    sessionsPerFilter.set(key, (sessionsPerFilter.get(key) ?? 0) + 1);
     for (const quality of sequence.images) {
       qualityByImage.set(quality.image_id, quality);
+      scopeByImage.set(quality.image_id, 'capture_sequence');
+    }
+  }
+  for (const rollup of query.data?.target_filter_rollups ?? []) {
+    if ((sessionsPerFilter.get(`${rollup.target_id}:${rollup.filter_name}`) ?? 0) <= 1) {
+      continue;
+    }
+    for (const score of rollup.images) {
+      const session = qualityByImage.get(score.image_id);
+      if (!session) continue;
+      qualityByImage.set(score.image_id, {
+        ...session,
+        quality_score: score.quality_score,
+        normalized_metrics: score.normalized_metrics,
+        details: score.details,
+      });
+      scopeByImage.set(score.image_id, 'target_filter');
     }
   }
 
   return {
     qualityByImage,
+    scopeByImage,
     isLoading: query.isLoading,
     error: query.error,
   };

--- a/static/src/hooks/useSequenceAnalysis.ts
+++ b/static/src/hooks/useSequenceAnalysis.ts
@@ -113,6 +113,9 @@ export function useScopedQuality(
   // entry — category, pointing, and overlays stay intact.
   const qualityByImage = new Map<number, ImageQualityResult>();
   const scopeByImage = new Map<number, QualityScoreScope>();
+  // Where the badge shows the all-sessions score, the frame's own
+  // session-relative score is kept here for the secondary chip.
+  const sessionScoreByImage = new Map<number, number>();
   const sessionsPerFilter = new Map<string, number>();
   for (const sequence of query.data?.sequences ?? []) {
     const key = `${sequence.target_id}:${sequence.filter_name}`;
@@ -129,6 +132,7 @@ export function useScopedQuality(
     for (const score of rollup.images) {
       const session = qualityByImage.get(score.image_id);
       if (!session) continue;
+      sessionScoreByImage.set(score.image_id, session.quality_score);
       qualityByImage.set(score.image_id, {
         ...session,
         quality_score: score.quality_score,
@@ -142,6 +146,7 @@ export function useScopedQuality(
   return {
     qualityByImage,
     scopeByImage,
+    sessionScoreByImage,
     isLoading: query.isLoading,
     error: query.error,
   };

--- a/static/src/utils/qualityScore.ts
+++ b/static/src/utils/qualityScore.ts
@@ -27,3 +27,11 @@ export function qualityScoreDescription(
     : 'It uses catalog metrics only and is not proof of image damage.';
   return `${basis}: ${score}. Compared with ${comparison}. ${evidence}`;
 }
+
+/** Tooltip for the smaller second badge showing the other comparison basis. */
+export function secondaryScoreDescription(score: number, scope: QualityScoreScope): string {
+  const value = `${Math.round(score * 100)}%`;
+  return scope === 'capture_sequence'
+    ? `Within its own capture session: ${value}. A small session can flatter a frame; the main badge compares across every session of this filter.`
+    : `Across all target/filter stack candidates: ${value}. The main badge compares within the selected capture session.`;
+}


### PR DESCRIPTION
Root cause of the "images in grid view and sequence view have entirely different quality scores" report, found by the clean-room reproduction: blank DB → import two real nights (97 frames) → quality scan → render both views headlessly.

## The two bases

`/analysis/sequence` returns two scorings: **per-session** (`sequences`) and the **all-sessions target/filter rollup** (`target_filter_rollups`). The Sequence view defaults to the rollup ("All sessions"); the grid's `qualityByImage` was built from sessions only. A frame in a small session — e.g. a 2-frame pair before a break — normalizes against itself and scores **1.0** per-session while the rollup scores it **0.83** against the whole filter. Same image, both views "right", different cohorts: the reported 58-vs-82 class exactly. (The webview cache fix in #340 addressed a second, independent divergence mechanism; this was the deterministic one.)

## Fix

`useScopedQuality` (grid badges and the detail panel) now overlays rollup scores onto session entries for filters with more than one session — precisely mirroring the Sequence view's own adaptation, including keeping category/pointing/overlay fields from the session entry and falling back to session scores for frames the rollup could not include. The per-image basis flows into the badge tooltip.

## Verification

Headless render of both views against the reproduction database: **all 30 common cards agree per-image** (previously the 2-frame session showed 100/100 in the grid vs 83/79 in the Sequence view). API-level equality across scopes re-confirmed. New hook test covers rollup preference, the multi-session condition, and session fallback.

## Checks run locally

`npx tsc --noEmit` · `npm run lint` · `npx vitest run` (277 passed) · `npm run build` · headless two-view comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)