### PR TITLE
Keep the secondary score chip below the badge and label it

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -82,7 +82,9 @@
   grid badge was built from per-session scores — a frame in a small session
   could score 1.0 against itself while scoring far lower against the whole
   filter. The grid (and the detail panel) now use the same basis the
-  Sequence view displays, and the badge tooltip names it.
+  Sequence view displays, and the badge tooltip names it. When both bases
+  disagree, a second smaller chip shows the other one, labeled "night" or
+  "all" so each number says what it is relative to.
 
 - Filter names that differ only by case or whitespace ("Ha" beside "HA")
   no longer split one physical filter into separate quality-comparison

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3447,8 +3447,8 @@
   align-self: flex-start;
 }
 
-.quality-badge-secondary {
-  top: 2.2rem;
+.quality-badge.quality-badge-secondary {
+  top: 2.35rem;
   font-size: 0.68rem;
   opacity: 0.85;
   background-color: var(--color-bg-secondary, #333) !important;

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -150,6 +150,7 @@ export default function ImageCard({
               className="quality-badge quality-badge-secondary"
               title={secondaryScoreDescription(secondaryScore.score, secondaryScore.scope)}
             >
+              {secondaryScore.scope === 'capture_sequence' ? 'night' : 'all'}{' '}
               {(secondaryScore.score * 100).toFixed(0)}
             </div>
           )}


### PR DESCRIPTION
Follow-up to #342. Two problems with the dual score badges:

**They drew on top of each other.** The chip's CSS rule sits earlier in `App.css` than the base `.quality-badge` rule, so at equal specificity the base `top: 4px` won and both numbers rendered in the same corner. In the grid this read as one garbled badge, which also made the chip look missing there. A two-class selector (`.quality-badge.quality-badge-secondary`) now wins regardless of rule order.

**Two bare numbers were cryptic.** The chip now carries a one-word label — `night 100` when it shows the per-session score, `all 83` when it shows the all-sessions score — so each number says what it is relative to without hovering.

Verified headlessly against the clean-room two-session database: grid shows 58 labeled chips with zero bounding-box overlaps (`83` / `night 100` etc.), and the Sequence strip shows the identical pairs. Checks run locally: `npm run lint`, `npx vitest run` (277 passed), `npm run build`, `npx tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)