### PR TITLE
Per-type quick toggles for the second score chip

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -84,7 +84,9 @@
   filter. The grid (and the detail panel) now use the same basis the
   Sequence view displays, and the badge tooltip names it. When both bases
   disagree, a second smaller chip shows the other one, labeled "night" or
-  "all" so each number says what it is relative to.
+  "all" so each number says what it is relative to. A "2nd score" toggle in
+  the grid and Sequence toolbars turns the chip off; the choice is shared
+  across both views and remembered.
 
 - Filter names that differ only by case or whitespace ("Ha" beside "HA")
   no longer split one physical filter into separate quality-comparison

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -84,9 +84,9 @@
   filter. The grid (and the detail panel) now use the same basis the
   Sequence view displays, and the badge tooltip names it. When both bases
   disagree, a second smaller chip shows the other one, labeled "night" or
-  "all" so each number says what it is relative to. A "2nd score" toggle in
-  the grid and Sequence toolbars turns the chip off; the choice is shared
-  across both views and remembered.
+  "all" so each number says what it is relative to. Chip toggles in the
+  grid and Sequence toolbars turn each chip type off separately; the
+  choice is shared across both views and remembered.
 
 - Filter names that differ only by case or whitespace ("Ha" beside "HA")
   no longer split one physical filter into separate quality-comparison

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3459,12 +3459,18 @@
 .secondary-score-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.55rem;
   font-size: 0.82rem;
   color: var(--color-text-muted);
   white-space: nowrap;
-  cursor: pointer;
   user-select: none;
+}
+
+.secondary-score-toggle label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  cursor: pointer;
 }
 
 .secondary-score-toggle input {

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3456,6 +3456,22 @@
   border: 1px solid var(--color-border, #555);
 }
 
+.secondary-score-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+
+.secondary-score-toggle input {
+  cursor: pointer;
+  margin: 0;
+}
+
 .server-export-status {
   font-size: 0.82rem;
   color: var(--color-text-muted);

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -40,6 +40,7 @@ import {
 } from '../utils/gridNavigation';
 import { thumbnailGridColumns } from '../utils/thumbnailSizing';
 import { useScopedQuality } from '../hooks/useSequenceAnalysis';
+import SecondaryScoreToggle from './SecondaryScoreToggle';
 
 interface GroupedImageGridProps {
   useLazyImages?: boolean;
@@ -819,6 +820,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                 canWrite={grading.canWrite}
                 className="toolbar-button compact quality-scan-button"
               />
+              <SecondaryScoreToggle className="compact" />
             </div>
             
             <div className="stats-section">

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -48,7 +48,7 @@ export default function ImageCard({
   className = '',
 }: ImageCardProps) {
   const color = useColorPreview();
-  const { showSecondaryScore } = useDisplayPreferences();
+  const { showNightChip, showAllChip } = useDisplayPreferences();
   const shouldDeferPreview = lazyPreview && typeof IntersectionObserver !== 'undefined';
   const { ref: inViewRef, inView } = useInView({
     threshold: 0,
@@ -145,8 +145,10 @@ export default function ImageCard({
           </div>
         )}
         {quality &&
-          showSecondaryScore &&
           secondaryScore &&
+          (secondaryScore.scope === 'capture_sequence'
+            ? showNightChip
+            : showAllChip) &&
           Math.round(secondaryScore.score * 100) !==
             Math.round(quality.quality_score * 100) && (
             <div

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -5,6 +5,7 @@ import { GradingStatus } from '../api/types';
 import { apiClient } from '../api/client';
 import PreviewImage from './PreviewImage';
 import { useColorPreview } from '../hooks/useColorPreview';
+import { useDisplayPreferences } from '../hooks/useDisplayPreferences';
 import { ensurePreviewReady } from '../hooks/previewPoll';
 import {
   qualityScoreBasis,
@@ -47,6 +48,7 @@ export default function ImageCard({
   className = '',
 }: ImageCardProps) {
   const color = useColorPreview();
+  const { showSecondaryScore } = useDisplayPreferences();
   const shouldDeferPreview = lazyPreview && typeof IntersectionObserver !== 'undefined';
   const { ref: inViewRef, inView } = useInView({
     threshold: 0,
@@ -143,6 +145,7 @@ export default function ImageCard({
           </div>
         )}
         {quality &&
+          showSecondaryScore &&
           secondaryScore &&
           Math.round(secondaryScore.score * 100) !==
             Math.round(quality.quality_score * 100) && (

--- a/static/src/components/SecondaryScoreToggle.tsx
+++ b/static/src/components/SecondaryScoreToggle.tsx
@@ -1,0 +1,31 @@
+import {
+  setDisplayPreferences,
+  useDisplayPreferences,
+} from '../hooks/useDisplayPreferences';
+
+/**
+ * Quick toggle for the second score chip on cards. One shared preference:
+ * flipping it here changes the grid, the Sequence view, and the detail
+ * panel together.
+ */
+export default function SecondaryScoreToggle({ className }: { className?: string }) {
+  const preferences = useDisplayPreferences();
+  return (
+    <label
+      className={`secondary-score-toggle${className ? ` ${className}` : ''}`}
+      title='Show the other score basis ("night" vs "all") as a second chip when it disagrees with the main badge'
+    >
+      <input
+        type="checkbox"
+        checked={preferences.showSecondaryScore}
+        onChange={(event) =>
+          setDisplayPreferences({
+            ...preferences,
+            showSecondaryScore: event.target.checked,
+          })
+        }
+      />
+      2nd score
+    </label>
+  );
+}

--- a/static/src/components/SecondaryScoreToggle.tsx
+++ b/static/src/components/SecondaryScoreToggle.tsx
@@ -4,28 +4,41 @@ import {
 } from '../hooks/useDisplayPreferences';
 
 /**
- * Quick toggle for the second score chip on cards. One shared preference:
- * flipping it here changes the grid, the Sequence view, and the detail
- * panel together.
+ * Quick toggles for the second score chip on cards, one per chip type.
+ * One shared preference: flipping a box here changes the grid, the
+ * Sequence view, and the detail panel together.
  */
 export default function SecondaryScoreToggle({ className }: { className?: string }) {
   const preferences = useDisplayPreferences();
   return (
-    <label
-      className={`secondary-score-toggle${className ? ` ${className}` : ''}`}
-      title='Show the other score basis ("night" vs "all") as a second chip when it disagrees with the main badge'
-    >
-      <input
-        type="checkbox"
-        checked={preferences.showSecondaryScore}
-        onChange={(event) =>
-          setDisplayPreferences({
-            ...preferences,
-            showSecondaryScore: event.target.checked,
-          })
-        }
-      />
-      2nd score
-    </label>
+    <div className={`secondary-score-toggle${className ? ` ${className}` : ''}`}>
+      <span className="secondary-score-toggle-label">Chips:</span>
+      <label title='Show the "night <score>" chip — how the frame ranks within its own session — when the main badge is the all-sessions score'>
+        <input
+          type="checkbox"
+          checked={preferences.showNightChip}
+          onChange={(event) =>
+            setDisplayPreferences({
+              ...preferences,
+              showNightChip: event.target.checked,
+            })
+          }
+        />
+        night
+      </label>
+      <label title='Show the "all <score>" chip — how the frame ranks against every stack candidate for its filter — when the main badge is a single session score'>
+        <input
+          type="checkbox"
+          checked={preferences.showAllChip}
+          onChange={(event) =>
+            setDisplayPreferences({
+              ...preferences,
+              showAllChip: event.target.checked,
+            })
+          }
+        />
+        all
+      </label>
+    </div>
   );
 }

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -33,6 +33,7 @@ import {
   type GridNavigationDirection,
 } from '../utils/gridNavigation';
 import { thumbnailGridColumns } from '../utils/thumbnailSizing';
+import SecondaryScoreToggle from './SecondaryScoreToggle';
 import {
   qualityScoreDescription,
   type QualityScoreScope,
@@ -773,6 +774,7 @@ export default function SequenceView() {
             <span className="threshold-value">{threshold.toFixed(2)}</span>
           </div>
           <ScoringPenaltyControl />
+          <SecondaryScoreToggle />
           <div className="selection-preset-control">
             <label htmlFor="sequence-select-preset">Select:</label>
             <select

--- a/static/src/hooks/__tests__/useDisplayPreferences.test.tsx
+++ b/static/src/hooks/__tests__/useDisplayPreferences.test.tsx
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  setDisplayPreferences,
+  useDisplayPreferences,
+} from '../useDisplayPreferences';
+
+describe('display preferences', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem('psf-guard.display-preferences');
+    setDisplayPreferences({ showSecondaryScore: true });
+  });
+
+  it('defaults to showing the secondary score chip', () => {
+    const { result } = renderHook(() => useDisplayPreferences());
+    expect(result.current.showSecondaryScore).toBe(true);
+  });
+
+  it('updates every subscriber when one toggle flips', () => {
+    // Two hook instances stand in for the grid toolbar and the Sequence
+    // toolbar: one shared preference, so flipping either flips both.
+    const grid = renderHook(() => useDisplayPreferences());
+    const sequence = renderHook(() => useDisplayPreferences());
+    act(() => {
+      setDisplayPreferences({ showSecondaryScore: false });
+    });
+    expect(grid.result.current.showSecondaryScore).toBe(false);
+    expect(sequence.result.current.showSecondaryScore).toBe(false);
+  });
+
+  it('persists the choice to localStorage', () => {
+    act(() => {
+      setDisplayPreferences({ showSecondaryScore: false });
+    });
+    expect(
+      JSON.parse(window.localStorage.getItem('psf-guard.display-preferences')!),
+    ).toEqual({ showSecondaryScore: false });
+  });
+
+  it('falls back to the default on malformed stored values', () => {
+    setDisplayPreferences({
+      showSecondaryScore: 'yes' as unknown as boolean,
+    });
+    const { result } = renderHook(() => useDisplayPreferences());
+    expect(result.current.showSecondaryScore).toBe(true);
+  });
+});

--- a/static/src/hooks/__tests__/useDisplayPreferences.test.tsx
+++ b/static/src/hooks/__tests__/useDisplayPreferences.test.tsx
@@ -8,12 +8,21 @@ import {
 describe('display preferences', () => {
   beforeEach(() => {
     window.localStorage.removeItem('psf-guard.display-preferences');
-    setDisplayPreferences({ showSecondaryScore: true });
+    setDisplayPreferences({ showNightChip: true, showAllChip: true });
   });
 
-  it('defaults to showing the secondary score chip', () => {
+  it('defaults to showing both chip types', () => {
     const { result } = renderHook(() => useDisplayPreferences());
-    expect(result.current.showSecondaryScore).toBe(true);
+    expect(result.current).toEqual({ showNightChip: true, showAllChip: true });
+  });
+
+  it('toggles each chip type independently', () => {
+    act(() => {
+      setDisplayPreferences({ showNightChip: false, showAllChip: true });
+    });
+    const { result } = renderHook(() => useDisplayPreferences());
+    expect(result.current.showNightChip).toBe(false);
+    expect(result.current.showAllChip).toBe(true);
   });
 
   it('updates every subscriber when one toggle flips', () => {
@@ -22,26 +31,41 @@ describe('display preferences', () => {
     const grid = renderHook(() => useDisplayPreferences());
     const sequence = renderHook(() => useDisplayPreferences());
     act(() => {
-      setDisplayPreferences({ showSecondaryScore: false });
+      setDisplayPreferences({ showNightChip: true, showAllChip: false });
     });
-    expect(grid.result.current.showSecondaryScore).toBe(false);
-    expect(sequence.result.current.showSecondaryScore).toBe(false);
+    expect(grid.result.current.showAllChip).toBe(false);
+    expect(sequence.result.current.showAllChip).toBe(false);
   });
 
   it('persists the choice to localStorage', () => {
     act(() => {
-      setDisplayPreferences({ showSecondaryScore: false });
+      setDisplayPreferences({ showNightChip: false, showAllChip: false });
     });
     expect(
       JSON.parse(window.localStorage.getItem('psf-guard.display-preferences')!),
-    ).toEqual({ showSecondaryScore: false });
+    ).toEqual({ showNightChip: false, showAllChip: false });
   });
 
   it('falls back to the default on malformed stored values', () => {
     setDisplayPreferences({
-      showSecondaryScore: 'yes' as unknown as boolean,
+      showNightChip: 'yes' as unknown as boolean,
+      showAllChip: true,
     });
     const { result } = renderHook(() => useDisplayPreferences());
-    expect(result.current.showSecondaryScore).toBe(true);
+    expect(result.current.showNightChip).toBe(true);
+  });
+
+  it('honors the earlier single-switch stored form', () => {
+    // A browser that stored the one-switch build's "off" keeps both chips
+    // off after upgrading rather than silently turning them back on.
+    window.localStorage.setItem(
+      'psf-guard.display-preferences',
+      JSON.stringify({ showSecondaryScore: false }),
+    );
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'psf-guard.display-preferences' }),
+    );
+    const { result } = renderHook(() => useDisplayPreferences());
+    expect(result.current).toEqual({ showNightChip: false, showAllChip: false });
   });
 });

--- a/static/src/hooks/useDisplayPreferences.ts
+++ b/static/src/hooks/useDisplayPreferences.ts
@@ -6,24 +6,40 @@ import { useSyncExternalStore } from 'react';
  * never disagree about what a card shows.
  */
 export interface DisplayPreferences {
-  /** Show the smaller labeled chip with the other score basis ("night" or
-   * "all") when it disagrees with the main badge. */
-  showSecondaryScore: boolean;
+  /** Show the smaller "night <score>" chip — the per-session basis shown
+   * when the main badge is the all-sessions score. */
+  showNightChip: boolean;
+  /** Show the smaller "all <score>" chip — the all-sessions basis shown
+   * when the main badge is a single session's score. */
+  showAllChip: boolean;
 }
 
 const STORAGE_KEY = 'psf-guard.display-preferences';
-const DEFAULTS: DisplayPreferences = { showSecondaryScore: true };
+const DEFAULTS: DisplayPreferences = { showNightChip: true, showAllChip: true };
 
 type Listener = () => void;
 
 const listeners = new Set<Listener>();
 
-function sanitize(parsed: Partial<DisplayPreferences>): DisplayPreferences {
+interface StoredPreferences extends Partial<DisplayPreferences> {
+  /** Earlier builds stored one switch for both chip types. */
+  showSecondaryScore?: boolean;
+}
+
+function sanitize(parsed: StoredPreferences): DisplayPreferences {
+  const legacy =
+    typeof parsed.showSecondaryScore === 'boolean'
+      ? parsed.showSecondaryScore
+      : undefined;
   return {
-    showSecondaryScore:
-      typeof parsed.showSecondaryScore === 'boolean'
-        ? parsed.showSecondaryScore
-        : DEFAULTS.showSecondaryScore,
+    showNightChip:
+      typeof parsed.showNightChip === 'boolean'
+        ? parsed.showNightChip
+        : legacy ?? DEFAULTS.showNightChip,
+    showAllChip:
+      typeof parsed.showAllChip === 'boolean'
+        ? parsed.showAllChip
+        : legacy ?? DEFAULTS.showAllChip,
   };
 }
 
@@ -31,7 +47,7 @@ function readStored(): DisplayPreferences {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return { ...DEFAULTS };
-    return sanitize(JSON.parse(raw) as Partial<DisplayPreferences>);
+    return sanitize(JSON.parse(raw) as StoredPreferences);
   } catch {
     return { ...DEFAULTS };
   }

--- a/static/src/hooks/useDisplayPreferences.ts
+++ b/static/src/hooks/useDisplayPreferences.ts
@@ -1,0 +1,76 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Card display choices shared by every surface that renders an ImageCard.
+ * One preference, not one per view: the grid and the Sequence view must
+ * never disagree about what a card shows.
+ */
+export interface DisplayPreferences {
+  /** Show the smaller labeled chip with the other score basis ("night" or
+   * "all") when it disagrees with the main badge. */
+  showSecondaryScore: boolean;
+}
+
+const STORAGE_KEY = 'psf-guard.display-preferences';
+const DEFAULTS: DisplayPreferences = { showSecondaryScore: true };
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+function sanitize(parsed: Partial<DisplayPreferences>): DisplayPreferences {
+  return {
+    showSecondaryScore:
+      typeof parsed.showSecondaryScore === 'boolean'
+        ? parsed.showSecondaryScore
+        : DEFAULTS.showSecondaryScore,
+  };
+}
+
+function readStored(): DisplayPreferences {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULTS };
+    return sanitize(JSON.parse(raw) as Partial<DisplayPreferences>);
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+let current = readStored();
+
+// A second tab writes the same localStorage key: adopt its value so two
+// windows show the same cards the same way.
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    current = readStored();
+    listeners.forEach((listener) => listener());
+  });
+}
+
+export function setDisplayPreferences(next: DisplayPreferences): void {
+  current = sanitize(next);
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(current));
+  } catch {
+    // Keep the in-memory preference even when it cannot be persisted.
+  }
+  listeners.forEach((listener) => listener());
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function snapshot(): DisplayPreferences {
+  return current;
+}
+
+/** Subscribe to the shared preference. Returns the current snapshot. */
+export function useDisplayPreferences(): DisplayPreferences {
+  return useSyncExternalStore(subscribe, snapshot);
+}


### PR DESCRIPTION
Follow-up to #343. The second score chip gets user control: a **Chips: night / all** checkbox pair in the grid toolbar and the Sequence review row.

- **night** shows or hides the per-session chip (seen where the main badge is the all-sessions score).
- **all** shows or hides the all-sessions chip (seen where the main badge is a single session's score).

One shared preference backs every toggle, stored in localStorage and synced across tabs, so the grid and the Sequence view always show cards the same way. Defaults keep both chips on; a stored "off" from the interim single-switch build maps onto both boxes.

Verified headlessly against the clean-room two-session database: turning **night** off removes the grid's 58 chips while a single-night Sequence view keeps its `all` chips; turning **all** off removes those; re-checking restores both, and checkbox state carries across views and reloads. Checks run locally: `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (283 passed, including new tests for independent toggling and the legacy mapping), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)