### PR TITLE
Show both score-basis chips on every card, with icon toggles

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -83,10 +83,11 @@
   could score 1.0 against itself while scoring far lower against the whole
   filter. The grid (and the detail panel) now use the same basis the
   Sequence view displays, and the badge tooltip names it. When both bases
-  disagree, a second smaller chip shows the other one, colored on the same
-  scale as the badge; its tooltip names the comparison group. A "2nd
-  score" box in the grid and Sequence toolbars hides the chip that view
-  shows; the choice is remembered per chip type and shared across views.
+  smaller chips below the badge always carry both bases: a crescent marks
+  the night-session score, stacked layers mark the all-sessions score,
+  both colored on the badge's scale. The chips never appear or vanish
+  between views; two icon checkboxes in the grid and Sequence toolbars
+  turn each one off, remembered and shared across views.
 
 - Filter names that differ only by case or whitespace ("Ha" beside "HA")
   no longer split one physical filter into separate quality-comparison

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -83,10 +83,10 @@
   could score 1.0 against itself while scoring far lower against the whole
   filter. The grid (and the detail panel) now use the same basis the
   Sequence view displays, and the badge tooltip names it. When both bases
-  disagree, a second smaller chip shows the other one, labeled "night" or
-  "all" so each number says what it is relative to. Chip toggles in the
-  grid and Sequence toolbars turn each chip type off separately; the
-  choice is shared across both views and remembered.
+  disagree, a second smaller chip shows the other one, colored on the same
+  scale as the badge; its tooltip names the comparison group. A "2nd
+  score" box in the grid and Sequence toolbars hides the chip that view
+  shows; the choice is remembered per chip type and shared across views.
 
 - Filter names that differ only by case or whitespace ("Ha" beside "HA")
   no longer split one physical filter into separate quality-comparison

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3447,11 +3447,41 @@
   align-self: flex-start;
 }
 
-.quality-badge.quality-badge-secondary {
-  top: 2.35rem;
-  font-size: 0.68rem;
-  opacity: 0.75;
+.score-chip-stack {
+  position: absolute;
+  top: 2.2rem;
+  right: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+  z-index: 5;
+}
+
+.score-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  color: white;
+  text-shadow: 0 1px 2px rgb(0 0 0 / 50%);
+  opacity: 0.85;
   box-shadow: inset 0 0 0 1px rgb(0 0 0 / 35%);
+}
+
+.score-chip-icon {
+  width: 0.7rem;
+  height: 0.7rem;
+  flex: none;
+  filter: drop-shadow(0 1px 1px rgb(0 0 0 / 40%));
+}
+
+/* Keep the chips clear of the selection marker, like the badge above. */
+.image-card-wrapper.multi-selected .score-chip-stack {
+  right: 40px;
 }
 
 .secondary-score-toggle {
@@ -3474,6 +3504,12 @@
 .secondary-score-toggle input {
   cursor: pointer;
   margin: 0;
+}
+
+.secondary-score-toggle .score-chip-icon {
+  width: 0.85rem;
+  height: 0.85rem;
+  filter: none;
 }
 
 .server-export-status {

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3450,10 +3450,8 @@
 .quality-badge.quality-badge-secondary {
   top: 2.35rem;
   font-size: 0.68rem;
-  opacity: 0.85;
-  background-color: var(--color-bg-secondary, #333) !important;
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border, #555);
+  opacity: 0.75;
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 35%);
 }
 
 .secondary-score-toggle {

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -753,7 +753,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                 </select>
               </div>
 
-              <SecondaryScoreToggle chipScope="capture_sequence" className="compact" />
+              <SecondaryScoreToggle className="compact" />
             </div>
             
             {/* Undo/Redo Toolbar */}
@@ -951,14 +951,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                             image={image}
                             quality={quality.qualityByImage.get(image.id)}
                             qualityScoreScope={quality.scopeByImage.get(image.id)}
-                            secondaryScore={
-                              quality.sessionScoreByImage.has(image.id)
-                                ? {
-                                    score: quality.sessionScoreByImage.get(image.id)!,
-                                    scope: 'capture_sequence',
-                                  }
-                                : undefined
-                            }
+                            basisScores={quality.basisScoresByImage.get(image.id)}
                             qualityPresentation="compact"
                             isSelected={
                               selectedImages.has(image.id) ||

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -752,6 +752,8 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                   }
                 </select>
               </div>
+
+              <SecondaryScoreToggle chipScope="capture_sequence" className="compact" />
             </div>
             
             {/* Undo/Redo Toolbar */}
@@ -820,7 +822,6 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                 canWrite={grading.canWrite}
                 className="toolbar-button compact quality-scan-button"
               />
-              <SecondaryScoreToggle className="compact" />
             </div>
             
             <div className="stats-section">

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -153,9 +153,11 @@ export default function ImageCard({
             Math.round(quality.quality_score * 100) && (
             <div
               className="quality-badge quality-badge-secondary"
+              style={{
+                backgroundColor: qualityColor(secondaryScore.score),
+              }}
               title={secondaryScoreDescription(secondaryScore.score, secondaryScore.scope)}
             >
-              {secondaryScore.scope === 'capture_sequence' ? 'night' : 'all'}{' '}
               {(secondaryScore.score * 100).toFixed(0)}
             </div>
           )}

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -8,12 +8,14 @@ import { useColorPreview } from '../hooks/useColorPreview';
 import { useDisplayPreferences } from '../hooks/useDisplayPreferences';
 import { ensurePreviewReady } from '../hooks/previewPoll';
 import {
+  type BasisScores,
+  basisChipDescription,
   qualityScoreBasis,
   qualityScoreDescription,
   type QualityScoreScope,
-  secondaryScoreDescription,
 } from '../utils/qualityScore';
 import QualityReasonPopover from './QualityReasonPopover';
+import { LayersIcon, MoonIcon } from './ScoreChipIcons';
 
 export interface ImageCardProps {
   dbId: string;
@@ -23,10 +25,10 @@ export interface ImageCardProps {
   onDoubleClick: () => void;
   quality?: ImageQualityResult;
   qualityScoreScope?: QualityScoreScope;
-  /** The same frame's score under the OTHER comparison basis, when it
-   * exists — session-relative when the badge is all-sessions, and the
-   * reverse. Rendered as a smaller chip when the rounded values differ. */
-  secondaryScore?: { score: number; scope: QualityScoreScope };
+  /** Every basis score the frame has. Both chips render whenever their
+   * score exists and their toggle is on — never hidden for matching the
+   * badge, so the same frame keeps the same chips in every view. */
+  basisScores?: BasisScores;
   qualityPresentation?: 'full' | 'compact';
   lazyPreview?: boolean;
   selectionEffects?: boolean;
@@ -41,7 +43,7 @@ export default function ImageCard({
   onDoubleClick,
   quality,
   qualityScoreScope = 'capture_sequence',
-  secondaryScore,
+  basisScores,
   qualityPresentation = 'full',
   lazyPreview = false,
   selectionEffects = true,
@@ -144,23 +146,34 @@ export default function ImageCard({
             {(quality.quality_score * 100).toFixed(0)}
           </div>
         )}
-        {quality &&
-          secondaryScore &&
-          (secondaryScore.scope === 'capture_sequence'
-            ? showNightChip
-            : showAllChip) &&
-          Math.round(secondaryScore.score * 100) !==
-            Math.round(quality.quality_score * 100) && (
-            <div
-              className="quality-badge quality-badge-secondary"
-              style={{
-                backgroundColor: qualityColor(secondaryScore.score),
-              }}
-              title={secondaryScoreDescription(secondaryScore.score, secondaryScore.scope)}
-            >
-              {(secondaryScore.score * 100).toFixed(0)}
-            </div>
-          )}
+        {quality && basisScores && (showNightChip || showAllChip) && (
+          <div className="score-chip-stack">
+            {showNightChip && (
+              <div
+                className="score-chip"
+                style={{
+                  backgroundColor: qualityColor(basisScores.night),
+                }}
+                title={basisChipDescription(basisScores.night, 'capture_sequence')}
+              >
+                <MoonIcon />
+                {(basisScores.night * 100).toFixed(0)}
+              </div>
+            )}
+            {showAllChip && basisScores.all != null && (
+              <div
+                className="score-chip"
+                style={{
+                  backgroundColor: qualityColor(basisScores.all),
+                }}
+                title={basisChipDescription(basisScores.all, 'target_filter')}
+              >
+                <LayersIcon />
+                {(basisScores.all * 100).toFixed(0)}
+              </div>
+            )}
+          </div>
+        )}
         {quality?.category && (
           <div className="category-label">
             {formatCategory(quality.category)}

--- a/static/src/components/ScoreChipIcons.tsx
+++ b/static/src/components/ScoreChipIcons.tsx
@@ -1,0 +1,33 @@
+/** Icons that identify the two score bases without words: a crescent for
+ * the night-session chip, stacked layers for the all-sessions chip. */
+
+export function MoonIcon() {
+  return (
+    <svg
+      className="score-chip-icon"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M20.6 14.5A8.6 8.6 0 0 1 9.5 3.4 9 9 0 1 0 20.6 14.5z" />
+    </svg>
+  );
+}
+
+export function LayersIcon() {
+  return (
+    <svg
+      className="score-chip-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.4"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3 3 8l9 5 9-5-9-5z" fill="currentColor" stroke="none" />
+      <path d="m4.5 12.5 7.5 4.2 7.5-4.2" />
+      <path d="m4.5 17 7.5 4.2 7.5-4.2" />
+    </svg>
+  );
+}

--- a/static/src/components/SecondaryScoreToggle.tsx
+++ b/static/src/components/SecondaryScoreToggle.tsx
@@ -2,48 +2,43 @@ import {
   setDisplayPreferences,
   useDisplayPreferences,
 } from '../hooks/useDisplayPreferences';
-import type { QualityScoreScope } from '../utils/qualityScore';
+import { LayersIcon, MoonIcon } from './ScoreChipIcons';
 
 /**
- * Quick toggle for the second score chip. Each view shows one chip type —
- * the basis its main badge is NOT using — so the box binds to that type
- * and flipping it always changes the cards in front of the user. The
- * per-type choice persists, shared by every view that shows that type.
+ * Quick toggles for the two score chips on cards, labeled with the same
+ * icons the chips carry. One shared preference: flipping a box changes
+ * the grid, the Sequence view, and the detail panel together.
  */
-export default function SecondaryScoreToggle({
-  chipScope,
-  className,
-}: {
-  /** The comparison basis the chips in this view carry. */
-  chipScope: QualityScoreScope;
-  className?: string;
-}) {
+export default function SecondaryScoreToggle({ className }: { className?: string }) {
   const preferences = useDisplayPreferences();
-  const checked =
-    chipScope === 'capture_sequence'
-      ? preferences.showNightChip
-      : preferences.showAllChip;
-  const title =
-    chipScope === 'capture_sequence'
-      ? 'Show a second smaller chip with the score relative to the frame’s own session'
-      : 'Show a second smaller chip with the score relative to every stack candidate for the filter';
   return (
-    <label
-      className={`secondary-score-toggle${className ? ` ${className}` : ''}`}
-      title={title}
-    >
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(event) =>
-          setDisplayPreferences(
-            chipScope === 'capture_sequence'
-              ? { ...preferences, showNightChip: event.target.checked }
-              : { ...preferences, showAllChip: event.target.checked },
-          )
-        }
-      />
-      2nd score
-    </label>
+    <div className={`secondary-score-toggle${className ? ` ${className}` : ''}`}>
+      <label title="Show the night-session score chip: the frame compared within its own capture session">
+        <input
+          type="checkbox"
+          checked={preferences.showNightChip}
+          onChange={(event) =>
+            setDisplayPreferences({
+              ...preferences,
+              showNightChip: event.target.checked,
+            })
+          }
+        />
+        <MoonIcon />
+      </label>
+      <label title="Show the all-sessions score chip: the frame compared across every stack candidate for its filter">
+        <input
+          type="checkbox"
+          checked={preferences.showAllChip}
+          onChange={(event) =>
+            setDisplayPreferences({
+              ...preferences,
+              showAllChip: event.target.checked,
+            })
+          }
+        />
+        <LayersIcon />
+      </label>
+    </div>
   );
 }

--- a/static/src/components/SecondaryScoreToggle.tsx
+++ b/static/src/components/SecondaryScoreToggle.tsx
@@ -2,43 +2,48 @@ import {
   setDisplayPreferences,
   useDisplayPreferences,
 } from '../hooks/useDisplayPreferences';
+import type { QualityScoreScope } from '../utils/qualityScore';
 
 /**
- * Quick toggles for the second score chip on cards, one per chip type.
- * One shared preference: flipping a box here changes the grid, the
- * Sequence view, and the detail panel together.
+ * Quick toggle for the second score chip. Each view shows one chip type —
+ * the basis its main badge is NOT using — so the box binds to that type
+ * and flipping it always changes the cards in front of the user. The
+ * per-type choice persists, shared by every view that shows that type.
  */
-export default function SecondaryScoreToggle({ className }: { className?: string }) {
+export default function SecondaryScoreToggle({
+  chipScope,
+  className,
+}: {
+  /** The comparison basis the chips in this view carry. */
+  chipScope: QualityScoreScope;
+  className?: string;
+}) {
   const preferences = useDisplayPreferences();
+  const checked =
+    chipScope === 'capture_sequence'
+      ? preferences.showNightChip
+      : preferences.showAllChip;
+  const title =
+    chipScope === 'capture_sequence'
+      ? 'Show a second smaller chip with the score relative to the frame’s own session'
+      : 'Show a second smaller chip with the score relative to every stack candidate for the filter';
   return (
-    <div className={`secondary-score-toggle${className ? ` ${className}` : ''}`}>
-      <span className="secondary-score-toggle-label">Chips:</span>
-      <label title='Show the "night <score>" chip — how the frame ranks within its own session — when the main badge is the all-sessions score'>
-        <input
-          type="checkbox"
-          checked={preferences.showNightChip}
-          onChange={(event) =>
-            setDisplayPreferences({
-              ...preferences,
-              showNightChip: event.target.checked,
-            })
-          }
-        />
-        night
-      </label>
-      <label title='Show the "all <score>" chip — how the frame ranks against every stack candidate for its filter — when the main badge is a single session score'>
-        <input
-          type="checkbox"
-          checked={preferences.showAllChip}
-          onChange={(event) =>
-            setDisplayPreferences({
-              ...preferences,
-              showAllChip: event.target.checked,
-            })
-          }
-        />
-        all
-      </label>
-    </div>
+    <label
+      className={`secondary-score-toggle${className ? ` ${className}` : ''}`}
+      title={title}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) =>
+          setDisplayPreferences(
+            chipScope === 'capture_sequence'
+              ? { ...preferences, showNightChip: event.target.checked }
+              : { ...preferences, showAllChip: event.target.checked },
+          )
+        }
+      />
+      2nd score
+    </label>
   );
 }

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -35,6 +35,7 @@ import {
 import { thumbnailGridColumns } from '../utils/thumbnailSizing';
 import SecondaryScoreToggle from './SecondaryScoreToggle';
 import {
+  type BasisScores,
   qualityScoreDescription,
   type QualityScoreScope,
 } from '../utils/qualityScore';
@@ -293,30 +294,31 @@ export default function SequenceView() {
   }, [requestedScoreScope, sequenceChoices, urlCurrentImageId]);
   const activeSequence = activeChoice?.sequence;
   const activeScoreScope: QualityScoreScope = activeChoice?.scoreScope ?? 'capture_sequence';
-  // The same frame's score under the OTHER basis, for the secondary badge:
-  // session score while viewing All sessions, rollup score while viewing a
-  // single session. Only filters with several sessions have two bases.
-  const otherBasisScoreByImage = useMemo(() => {
-    const map = new Map<number, number>();
-    if (!activeChoice) return map;
-    const filter = activeChoice.sequence.filter_name;
-    const sessionCount = sequences.filter(
-      sequence => sequence.filter_name === filter,
-    ).length;
-    if (sessionCount <= 1) return map;
-    if (activeScoreScope === 'target_filter') {
-      for (const sequence of sequences) {
-        if (sequence.filter_name !== filter) continue;
-        for (const image of sequence.images) map.set(image.image_id, image.quality_score);
+  // Every basis score per frame, for the always-on chips: the session
+  // score, and the all-sessions score for filters with several sessions.
+  // Built for every filter in view so the chips never depend on which
+  // session strip is selected.
+  const basisScoresByImage = useMemo(() => {
+    const map = new Map<number, BasisScores>();
+    const sessionsPerFilter = new Map<string, number>();
+    for (const sequence of sequences) {
+      sessionsPerFilter.set(
+        sequence.filter_name,
+        (sessionsPerFilter.get(sequence.filter_name) ?? 0) + 1,
+      );
+      for (const image of sequence.images) {
+        map.set(image.image_id, { night: image.quality_score });
       }
-    } else {
-      const rollup = rollups.find(entry => entry.filter_name === filter);
-      for (const score of rollup?.images ?? []) map.set(score.image_id, score.quality_score);
+    }
+    for (const rollup of rollups) {
+      if ((sessionsPerFilter.get(rollup.filter_name) ?? 0) <= 1) continue;
+      for (const score of rollup.images) {
+        const entry = map.get(score.image_id);
+        if (entry) entry.all = score.quality_score;
+      }
     }
     return map;
-  }, [activeChoice, activeScoreScope, rollups, sequences]);
-  const otherBasisScope: QualityScoreScope =
-    activeScoreScope === 'target_filter' ? 'capture_sequence' : 'target_filter';
+  }, [rollups, sequences]);
   const unavailableImageCount = activeChoice?.unavailableImageCount ?? 0;
   const activeImageId = useMemo(() => {
     if (!activeSequence || activeSequence.images.length === 0) return null;
@@ -774,7 +776,7 @@ export default function SequenceView() {
             <span className="threshold-value">{threshold.toFixed(2)}</span>
           </div>
           <ScoringPenaltyControl />
-          <SecondaryScoreToggle chipScope={otherBasisScope} />
+          <SecondaryScoreToggle />
           <div className="selection-preset-control">
             <label htmlFor="sequence-select-preset">Select:</label>
             <select
@@ -916,8 +918,7 @@ export default function SequenceView() {
                 dbId={dbId!}
                 images={activeSequence.images}
                 scoreScope={activeScoreScope}
-                otherBasisScoreByImage={otherBasisScoreByImage}
-                otherBasisScope={otherBasisScope}
+                basisScoresByImage={basisScoresByImage}
                 imageMap={imageMap}
                 projectId={projectId!}
                 targetId={activeSequence.target_id}
@@ -1145,8 +1146,7 @@ const SequenceStrip = memo(function SequenceStrip({
   dbId,
   images,
   scoreScope,
-  otherBasisScoreByImage,
-  otherBasisScope,
+  basisScoresByImage,
   imageMap,
   projectId,
   targetId,
@@ -1163,8 +1163,7 @@ const SequenceStrip = memo(function SequenceStrip({
   dbId: string;
   images: ImageQualityResult[];
   scoreScope: QualityScoreScope;
-  otherBasisScoreByImage: ReadonlyMap<number, number>;
-  otherBasisScope: QualityScoreScope;
+  basisScoresByImage: ReadonlyMap<number, BasisScores>;
   imageMap: ReadonlyMap<number, Image>;
   projectId: number;
   targetId: number;
@@ -1230,14 +1229,7 @@ const SequenceStrip = memo(function SequenceStrip({
             image={image}
             quality={quality}
             qualityScoreScope={scoreScope}
-            secondaryScore={
-              otherBasisScoreByImage.has(quality.image_id)
-                ? {
-                    score: otherBasisScoreByImage.get(quality.image_id)!,
-                    scope: otherBasisScope,
-                  }
-                : undefined
-            }
+            basisScores={basisScoresByImage.get(quality.image_id)}
             isSelected={selectedImages.has(quality.image_id)}
             onClick={(event) => onSelect(quality.image_id, event)}
             onDoubleClick={() => onOpen(quality.image_id)}

--- a/static/src/components/SequenceView.tsx
+++ b/static/src/components/SequenceView.tsx
@@ -774,7 +774,7 @@ export default function SequenceView() {
             <span className="threshold-value">{threshold.toFixed(2)}</span>
           </div>
           <ScoringPenaltyControl />
-          <SecondaryScoreToggle />
+          <SecondaryScoreToggle chipScope={otherBasisScope} />
           <div className="selection-preset-control">
             <label htmlFor="sequence-select-preset">Select:</label>
             <select

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -225,7 +225,7 @@ describe('SequenceView: rendering states', () => {
     await waitFor(() => {
       expect(new URLSearchParams(search).get('target')).toBe('1');
     });
-    expect(await screen.findByText('82')).toBeInTheDocument();
+    expect((await screen.findAllByText('82')).length).toBeGreaterThan(0);
   });
 
   it('uses the current Grid image to choose a target', async () => {
@@ -428,8 +428,11 @@ describe('SequenceView: quality display', () => {
 
     await waitFor(() => {
       // Quality badges show percentage (e.g., "82" for 0.82)
-      expect(screen.getByText('82')).toBeInTheDocument();
+      expect(screen.getAllByText('82').length).toBeGreaterThan(0);
     });
+    // The night chip renders beside the badge even when both show the
+    // same value: chips never appear or vanish between views.
+    expect(document.querySelectorAll('.score-chip').length).toBeGreaterThan(0);
   });
 
   it('renders timeline text without non-uniform SVG scaling', async () => {
@@ -514,7 +517,7 @@ describe('SequenceView: interactions', () => {
     render(<SequenceView />, { wrapper: createWrapper('/sequence?db=test&project=1&target=1') });
 
     await waitFor(() => {
-      expect(screen.getByText('82')).toBeInTheDocument();
+      expect(screen.getAllByText('82').length).toBeGreaterThan(0);
     });
 
     // Find image cards and click one
@@ -547,7 +550,7 @@ describe('SequenceView: interactions', () => {
       </Wrapper>
     );
 
-    await screen.findByText('82');
+    await screen.findAllByText('82');
     const size = screen.getByLabelText('Size:');
     expect(size).toHaveValue('150');
 

--- a/static/src/hooks/useSequenceAnalysis.ts
+++ b/static/src/hooks/useSequenceAnalysis.ts
@@ -7,7 +7,7 @@ import type {
   SequenceAnalysisRequest,
 } from '../api/types';
 import { useState, useCallback } from 'react';
-import type { QualityScoreScope } from '../utils/qualityScore';
+import type { BasisScores, QualityScoreScope } from '../utils/qualityScore';
 import {
   penaltyKeyOf,
   penaltyParamsOf,
@@ -113,9 +113,10 @@ export function useScopedQuality(
   // entry — category, pointing, and overlays stay intact.
   const qualityByImage = new Map<number, ImageQualityResult>();
   const scopeByImage = new Map<number, QualityScoreScope>();
-  // Where the badge shows the all-sessions score, the frame's own
-  // session-relative score is kept here for the secondary chip.
-  const sessionScoreByImage = new Map<number, number>();
+  // Every basis score the frame has, for the always-on chips: the
+  // session-relative score, and the all-sessions score for filters with
+  // several sessions.
+  const basisScoresByImage = new Map<number, BasisScores>();
   const sessionsPerFilter = new Map<string, number>();
   for (const sequence of query.data?.sequences ?? []) {
     const key = `${sequence.target_id}:${sequence.filter_name}`;
@@ -123,6 +124,7 @@ export function useScopedQuality(
     for (const quality of sequence.images) {
       qualityByImage.set(quality.image_id, quality);
       scopeByImage.set(quality.image_id, 'capture_sequence');
+      basisScoresByImage.set(quality.image_id, { night: quality.quality_score });
     }
   }
   for (const rollup of query.data?.target_filter_rollups ?? []) {
@@ -132,7 +134,10 @@ export function useScopedQuality(
     for (const score of rollup.images) {
       const session = qualityByImage.get(score.image_id);
       if (!session) continue;
-      sessionScoreByImage.set(score.image_id, session.quality_score);
+      basisScoresByImage.set(score.image_id, {
+        night: session.quality_score,
+        all: score.quality_score,
+      });
       qualityByImage.set(score.image_id, {
         ...session,
         quality_score: score.quality_score,
@@ -146,7 +151,7 @@ export function useScopedQuality(
   return {
     qualityByImage,
     scopeByImage,
-    sessionScoreByImage,
+    basisScoresByImage,
     isLoading: query.isLoading,
     error: query.error,
   };

--- a/static/src/utils/qualityScore.ts
+++ b/static/src/utils/qualityScore.ts
@@ -28,10 +28,18 @@ export function qualityScoreDescription(
   return `${basis}: ${score}. Compared with ${comparison}. ${evidence}`;
 }
 
-/** Tooltip for the smaller second badge showing the other comparison basis. */
-export function secondaryScoreDescription(score: number, scope: QualityScoreScope): string {
+/** Every comparison basis a frame is scored under. `all` exists only when
+ * the target/filter has more than one session to compare across. */
+export interface BasisScores {
+  night: number;
+  all?: number;
+}
+
+/** Tooltip for a basis chip. The chips render on every card so the same
+ * frame never gains or loses one between views. */
+export function basisChipDescription(score: number, scope: QualityScoreScope): string {
   const value = `${Math.round(score * 100)}%`;
   return scope === 'capture_sequence'
-    ? `Within its own capture session: ${value}. A small session can flatter a frame; the main badge compares across every session of this filter.`
-    : `Across all target/filter stack candidates: ${value}. The main badge compares within the selected capture session.`;
+    ? `Night session score: ${value}, compared within the frame's own capture session. A small session can flatter a frame.`
+    : `All-sessions score: ${value}, compared across every stack candidate for this filter.`;
 }


### PR DESCRIPTION
Follow-up to #344, from screenshot feedback on the deployed UI.

**Chip appearance.** The chip drops its "night"/"all" word and takes the same color scale as the main badge, so both read as the same kind of number. Size, position, and an inset outline mark it as secondary; its tooltip still names the comparison group.

**One toggle per view.** The night/all checkbox pair looked broken: a view only ever shows one chip type, so one box never changed anything visible, and "all" read as "all chips." Each view now shows a single **2nd score** box bound to the chip type that view displays — beside the Group control in the grid, beside Penalties in Sequence. The per-type preference stays underneath, remembered and shared across views showing the same type.

Verified headlessly on the clean-room database: the grid box is visible next to Group and removes/restores its 58 chips; a single-night Sequence view's box removes/restores its all-sessions chips; chip backgrounds computed as the badge's green at the same thresholds. Checks run locally: `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (283 passed), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)