### PR TITLE
Stamp sync export responses with a raw-byte digest header

### DIFF
--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -293,6 +293,15 @@ already covers truncation. The receiver therefore accepts a bundle whose
 digest is absent or stale. Enforcing it would pin one canonical JSON encoding,
 and reordering a single field would then reject every plugin already shipped.
 
+A client that wants an integrity check on a pulled export must not
+re-serialize the bundle and compare against `payload_sha256` — that check
+only passes when the client reproduces the server's JSON writer byte for
+byte, so it fails between implementations by construction. Instead, the
+export endpoints stamp `X-Content-SHA256` on the response: the SHA-256 of
+the exact body bytes sent. Hash the raw body before parsing and compare.
+This mirrors the upload path, where the client sends the same header over
+the raw image bytes.
+
 A bundle must carry the tables its operation acts on — `project`, `target`,
 and `acquiredimage` for grades, `project`/`target`/`exposureplan` for planning,
 and both sets for a merge. Other tables in the operation's set may be omitted;

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -77,6 +77,13 @@
 
 ## Fixed
 
+- Remote sync export responses now carry an `X-Content-SHA256` header with
+  the SHA-256 of the exact response body, so the N.I.N.A. plugin can verify
+  a pulled bundle without re-serializing it. The in-bundle `payload_sha256`
+  stays advisory: checking it requires reproducing the server's JSON writer
+  byte for byte, which is why plugin pulls failed with "bundle digest
+  missing or invalid".
+
 - The grid and the Sequence view now show the same quality score for the
   same image. The Sequence view defaults to the all-sessions score, but the
   grid badge was built from per-session scores — a frame in a small session

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -804,11 +804,33 @@ pub async fn refresh_preview(
     })))
 }
 
+/// Response header carrying the SHA-256 of the exact response body bytes.
+///
+/// The in-bundle `payload_sha256` is a courtesy field a client can only
+/// re-check by reproducing this server's serialization byte for byte, which
+/// no other JSON writer does. A client that wants integrity should hash the
+/// raw body it received and compare it against this header — the same
+/// contract the upload path already uses for `X-Content-SHA256` requests.
+const CONTENT_SHA256_HEADER: &str = "x-content-sha256";
+
+/// Serialize an export envelope once and stamp the digest of those exact
+/// bytes on the response, so a client can verify without re-serializing.
+fn export_response(export: SyncExport) -> Result<Response, AppError> {
+    let body = serde_json::to_vec(&ApiResponse::success(export))
+        .map_err(|error| AppError::InternalError(format!("serializing export: {error}")))?;
+    let digest = digest_hex(&body);
+    Response::builder()
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .header(CONTENT_SHA256_HEADER, digest)
+        .body(axum::body::Body::from(body))
+        .map_err(|error| AppError::InternalError(format!("building export response: {error}")))
+}
+
 pub async fn create_export(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Json(request): Json<CreateExportRequest>,
-) -> Result<Json<ApiResponse<SyncExport>>, AppError> {
+) -> Result<Response, AppError> {
     let catalog = authenticated_catalog(&state, &headers, AuditAction::Export)?;
     require_protocol(request.protocol_version)?;
     require_catalog(&catalog, &request.catalog_id)?;
@@ -857,14 +879,14 @@ pub async fn create_export(
         .remote_exports
         .insert(catalog.id.clone(), export.clone())?;
     audit(AuditOutcome::Ok, Some(&export.export_id), summary);
-    Ok(Json(ApiResponse::success(export)))
+    export_response(export)
 }
 
 pub async fn get_export(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Path(export_id): Path<String>,
-) -> Result<Json<ApiResponse<SyncExport>>, AppError> {
+) -> Result<Response, AppError> {
     let catalog = authenticated_catalog(&state, &headers, AuditAction::Export)?;
     let export = state
         .remote_exports
@@ -876,7 +898,7 @@ pub async fn get_export(
                     .into(),
             )
         })?;
-    Ok(Json(ApiResponse::success(export)))
+    export_response(export)
 }
 
 fn authenticated_catalog(
@@ -1466,6 +1488,31 @@ fn internal(error: impl std::fmt::Display) -> AppError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn export_response_header_matches_the_body_bytes() {
+        // The client hashes the raw body it received and compares it to the
+        // header — the only digest check that survives two JSON writers.
+        let export = SyncExport {
+            export_id: "export-1".into(),
+            state: "ready",
+            bundle: Some(grades_bundle(&grade_tables(), "")),
+            error: None,
+        };
+        let response = export_response(export).unwrap();
+        let header = response
+            .headers()
+            .get(CONTENT_SHA256_HEADER)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(header, digest_hex(&body));
+        assert_eq!(header.len(), 64);
+    }
 
     fn grades_bundle(tables: &str, digest: &str) -> CatalogBundle {
         let json = format!(


### PR DESCRIPTION
Fixes the N.I.N.A. plugin failing every grades pull with "Bundle digest is missing or invalid" (seen against the supergateway master build; the server logged `remote sync Export Ok` for each attempt).

**Root cause.** The plugin verifies a pulled bundle by re-serializing it with System.Text.Json and comparing the hash against `payload_sha256`, which this server computed over its own serde_json bytes. Two JSON writers never agree byte for byte — .NET writes `2026-07-23T12:00:00+00:00` with 7-digit ticks where Rust writes RFC3339 `Z` with variable precision — so the check fails between implementations by construction. The plugin's own test suite even asserts `Assert.False(downloaded.VerifyDigest())` for a server bundle.

**Fix.** The export endpoints (`POST /sync/v1/exports`, `GET /sync/v1/exports/{id}`) now serialize the response envelope once and stamp `X-Content-SHA256` with the SHA-256 of those exact bytes — mirroring the header the upload path already uses in the request direction. A client hashes the raw body it received before parsing and compares; no canonical JSON encoding is pinned. `payload_sha256` stays in the bundle as the advisory courtesy field the protocol documents.

A companion plugin PR moves its verification to the raw response bytes. Until the plugin updates, its pull keeps failing on its own re-serialization check — the plugin change is the user-visible fix; this PR supplies the header it verifies against.

Checks run locally: `cargo fmt -- --check`, `cargo build`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (723 passed, including a new test asserting the header equals the hash of the body bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)