### PR TITLE
Keep database editing with its selected catalog

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -77,6 +77,11 @@
 
 ## Fixed
 
+- Editing a configured database now opens its settings directly beneath that
+  database instead of below the full database list. The selected row and named
+  editor stay visually connected, so paths, remote access, and export settings
+  have a clear database context.
+
 - Remote sync export responses now carry an `X-Content-SHA256` header with
   the SHA-256 of the exact response body, so the N.I.N.A. plugin can verify
   a pulled bundle without re-serializing it. The in-bundle `payload_sha256`

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -444,16 +444,25 @@
   background-color: var(--color-success-hover);
 }
 /* B5/F3: multi-DB list rows */
+.tauri-settings .db-entry {
+  margin-bottom: 8px;
+  overflow: hidden;
+  border: 1px solid var(--color-border, #444);
+  border-radius: 4px;
+  background-color: var(--color-bg-input, rgba(255, 255, 255, 0.02));
+}
+
+.tauri-settings .db-entry.editing {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 1px var(--color-primary-alpha-30);
+}
+
 .tauri-settings .db-row {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 12px;
   padding: 10px 12px;
-  border: 1px solid var(--color-border, #444);
-  border-radius: 4px;
-  margin-bottom: 8px;
-  background-color: var(--color-bg-input, rgba(255, 255, 255, 0.02));
 }
 
 .tauri-settings .db-row-main {
@@ -486,6 +495,41 @@
 .tauri-settings .db-row-actions .remove-button {
   width: auto;
   padding: 4px 10px;
+}
+
+.tauri-settings .db-row-editor {
+  padding: 20px;
+  border-top: 1px solid var(--color-primary-alpha-30);
+  background-color: var(--color-bg-secondary);
+}
+
+.tauri-settings .db-editor-heading {
+  margin-bottom: 20px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--color-border-secondary);
+}
+
+.tauri-settings .db-editor-context {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--color-primary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.tauri-settings .db-editor-heading h3 {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.tauri-settings .db-row-editor .database-config {
+  margin-bottom: 18px;
+}
+
+.tauri-settings .db-row-editor .modal-buttons {
+  margin-top: 20px;
 }
 
 .tauri-settings .muted {
@@ -763,6 +807,18 @@
 }
 
 @media (max-width: 760px) {
+  .tauri-settings .db-row {
+    flex-direction: column;
+  }
+
+  .tauri-settings .db-row-actions {
+    justify-content: flex-start;
+  }
+
+  .tauri-settings .db-row-editor {
+    padding: 16px 12px;
+  }
+
   .tauri-settings .scheduler-sync-operation,
   .tauri-settings .scheduler-sync-endpoints {
     grid-template-columns: 1fr;

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -601,6 +601,7 @@ export default function TauriSettings({
         queryClient.invalidateQueries({ queryKey: ['databases'] });
         queryClient.invalidateQueries({ queryKey: ['db', entry.id] });
         await reload();
+        if (editingId === entry.id) resetForm();
         setStatusMessage(`Removed ${entry.name}.`);
       } else {
         setStatusMessage('Remove failed.');
@@ -679,6 +680,274 @@ export default function TauriSettings({
     const next = visibleTabs[(index + step + visibleTabs.length) % visibleTabs.length];
     setActiveTab(next.id);
     document.getElementById(`settings-tab-${next.id}`)?.focus();
+  };
+
+  const renderDatabaseForm = (entry: DbEntry | null) => {
+    const editorHeadingId = entry ? `database-editor-heading-${entry.id}` : undefined;
+
+    return (
+      <section
+        className={entry ? 'db-row-editor' : 'settings-section'}
+        aria-labelledby={editorHeadingId}
+      >
+        {entry ? (
+          <div className="db-editor-heading">
+            <span className="db-editor-context">Editing database</span>
+            <h3 id={editorHeadingId}>
+              {entry.name} <code className="db-row-slug">{entry.id}</code>
+            </h3>
+          </div>
+        ) : (
+          <h3>{createMode ? 'New Database from Images' : 'Add Database'}</h3>
+        )}
+
+        {createMode && (
+          <p className="muted">
+            Creates a brand-new Target Scheduler database and imports the
+            selected folders. Each target gets its own project. Nearby,
+            similarly dated panels with matching panel names share a
+            mosaic project. You can rename or reorganize them afterwards.
+            The import reads headers only; pixel-based quality work is a
+            separate option below.
+          </p>
+        )}
+
+        <div className="database-config">
+          <label>Display name (optional):</label>
+          <input
+            type="text"
+            value={formName}
+            onChange={(e) => setFormName(e.target.value)}
+            placeholder={
+              createMode
+                ? 'e.g. 2026 Archive (defaults to "Imported Images")'
+                : 'e.g. Imaging Rig (defaults to filename)'
+            }
+            className="file-path-input"
+          />
+        </div>
+
+        {!createMode && (
+          <div className="database-config">
+            <label>N.I.N.A. Database File:</label>
+            <div className="file-input-group">
+              <input
+                type="text"
+                value={formDbPath}
+                onChange={(e) => setFormDbPath(e.target.value)}
+                placeholder="Select or enter database path"
+                className="file-path-input"
+              />
+              <button onClick={handlePickDbPath} className="browse-button">
+                Browse…
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="database-config">
+          <label>Image Directories:</label>
+          {isTauri ? (
+            <button onClick={handleAddImageDir} className="add-directory-button">
+              + Add Image Directory
+            </button>
+          ) : (
+            <div className="file-input-group">
+              <input
+                type="text"
+                value={pendingImageDir}
+                onChange={(e) => setPendingImageDir(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAddManualImageDir();
+                  }
+                }}
+                placeholder="Type an absolute path and press Add"
+                className="file-path-input"
+              />
+              <button
+                onClick={handleAddManualImageDir}
+                className="browse-button"
+                disabled={!pendingImageDir.trim()}
+              >
+                Add
+              </button>
+            </div>
+          )}
+          {formImageDirs.length > 0 && (
+            <div className="image-directories">
+              {formImageDirs.map((dir, index) => (
+                <div key={dir} className="image-directory-item">
+                  <span>📂 {dir}</span>
+                  <button
+                    onClick={() => handleRemoveImageDir(index)}
+                    className="remove-button"
+                    title="Remove directory"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {editingId && (
+          <div className="database-config">
+            <label htmlFor="remote-upload-token">Remote API key:</label>
+            <div className="remote-upload-token-row">
+              <input
+                id="remote-upload-token"
+                type={formRemoteUploadTokenRevealed ? 'text' : 'password'}
+                value={formRemoteUploadToken}
+                onChange={(event) => {
+                  setFormRemoteUploadToken(event.target.value);
+                  setFormRemoteUploadTokenCopyState('idle');
+                }}
+                placeholder={
+                  formRemoteUploadTokenConfigured
+                    ? 'Unchanged'
+                    : 'At least 24 characters'
+                }
+                className="file-path-input"
+                autoComplete="new-password"
+              />
+              <button
+                type="button"
+                onClick={handleGenerateRemoteUploadToken}
+                className="browse-button"
+              >
+                Generate
+              </button>
+              {formRemoteUploadTokenRevealed &&
+                formRemoteUploadToken.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={handleCopyRemoteUploadToken}
+                    className="browse-button"
+                  >
+                    {formRemoteUploadTokenCopyState === 'copied'
+                      ? 'Copied'
+                      : 'Copy'}
+                  </button>
+                )}
+            </div>
+            {formRemoteUploadTokenRevealed && (
+              <small
+                className={`remote-upload-token-notice ${
+                  formRemoteUploadTokenCopyState === 'failed' ? 'error' : ''
+                }`}
+                role="status"
+              >
+                {formRemoteUploadTokenCopyState === 'failed'
+                  ? 'Copy failed. Select and copy the key manually.'
+                  : 'Copy this key now. It will not be shown again after saving.'}
+              </small>
+            )}
+            <label className="quality-analysis-option">
+              <input
+                type="checkbox"
+                checked={formRemoteSyncEnabled}
+                onChange={(event) =>
+                  setFormRemoteSyncEnabled(event.target.checked)
+                }
+              />
+              <span>
+                <strong>Accept remote scheduler sync</strong>
+                <small>
+                  Lets a holder of this key merge projects, targets,
+                  plans, and grades into this database.
+                </small>
+              </span>
+            </label>
+            <label className="quality-analysis-option">
+              <input
+                type="checkbox"
+                checked={formRemoteUploadEnabled}
+                onChange={(event) =>
+                  setFormRemoteUploadEnabled(event.target.checked)
+                }
+              />
+              <span>
+                <strong>Accept remote image uploads</strong>
+              </span>
+            </label>
+            <label htmlFor="server-export-directory">
+              Server export directory:
+            </label>
+            <input
+              id="server-export-directory"
+              type="text"
+              className="file-path-input"
+              placeholder="Absolute server path; empty disables server export"
+              title="Exports triggered from the Overview land here (reflinked where the filesystem supports it). Leave empty to offer the archive download instead."
+              value={formExportDir}
+              onChange={(event) => setFormExportDir(event.target.value)}
+            />
+            {formRemoteUploadEnabled && (
+              <>
+                <label htmlFor="remote-upload-directory">Receive directory:</label>
+                <select
+                  id="remote-upload-directory"
+                  value={formRemoteUploadDir}
+                  onChange={(event) => setFormRemoteUploadDir(event.target.value)}
+                  className="file-path-input"
+                >
+                  <option value="">Select an image directory</option>
+                  {formImageDirs.map((directory) => (
+                    <option key={directory} value={directory}>
+                      {directory}
+                    </option>
+                  ))}
+                </select>
+              </>
+            )}
+          </div>
+        )}
+
+        {createMode && (
+          <label className="quality-analysis-option">
+            <input
+              type="checkbox"
+              checked={createAnalyzeQuality}
+              onChange={(event) => setCreateAnalyzeQuality(event.target.checked)}
+            />
+            <span>
+              <strong>Queue background quality analysis</strong>
+              <small>
+                Reads every image to measure stars, background, clouds, obstructions,
+                and pointing. This can take a long time, especially in a debug build.
+                You can run it later from this database&apos;s settings.
+              </small>
+            </span>
+          </label>
+        )}
+
+        <div className="modal-buttons">
+          <button
+            onClick={resetForm}
+            className="cancel-button"
+            disabled={isApplying}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSaveForm}
+            className="save-button"
+            disabled={
+              (createMode ? formImageDirs.length === 0 : !formDbPath.trim()) || isApplying
+            }
+          >
+            {createMode
+              ? 'Create & Import'
+              : editingId
+                ? 'Save Changes'
+                : 'Add Database'}
+          </button>
+        </div>
+      </section>
+    );
   };
 
   return (
@@ -789,61 +1058,76 @@ export default function TauriSettings({
               </div>
             )}
 
-            {databases.map((entry) => (
-              <div key={entry.id} className="db-row">
-                <div className="db-row-main">
-                  <div className="db-row-title">
-                    <strong>{entry.name}</strong>{' '}
-                    <code className="db-row-slug">{entry.id}</code>
-                  </div>
-                  <div className="path-info">{entry.db_path}</div>
-                  {entry.image_dirs.length > 0 && (
-                    <div className="path-info muted">
-                      {entry.image_dirs.join(', ')}
+            {databases.map((entry) => {
+              const isEditing = showAddForm && editingId === entry.id;
+              const editorId = `database-editor-${entry.id}`;
+
+              return (
+                <section
+                  key={entry.id}
+                  className={`db-entry${isEditing ? ' editing' : ''}`}
+                  aria-labelledby={`database-heading-${entry.id}`}
+                >
+                  <div className="db-row">
+                    <div className="db-row-main">
+                      <div className="db-row-title">
+                        <strong id={`database-heading-${entry.id}`}>{entry.name}</strong>{' '}
+                        <code className="db-row-slug">{entry.id}</code>
+                      </div>
+                      <div className="path-info">{entry.db_path}</div>
+                      {entry.image_dirs.length > 0 && (
+                        <div className="path-info muted">
+                          {entry.image_dirs.join(', ')}
+                        </div>
+                      )}
+                      {entry.remote_image_upload?.enabled && (
+                        <div className="path-info muted">
+                          Remote receive: {entry.remote_image_upload.image_dir}
+                        </div>
+                      )}
+                      <CalibrationLibrarySummary
+                        dbId={entry.id}
+                        dbName={entry.name}
+                        canManage={managementAllowed}
+                        onImport={() => handleImport(entry)}
+                      />
+                      <QualityBackfillControls dbId={entry.id} />
                     </div>
-                  )}
-                  {entry.remote_image_upload?.enabled && (
-                    <div className="path-info muted">
-                      Remote receive: {entry.remote_image_upload.image_dir}
-                    </div>
-                  )}
-                  <CalibrationLibrarySummary
-                    dbId={entry.id}
-                    dbName={entry.name}
-                    canManage={managementAllowed}
-                    onImport={() => handleImport(entry)}
-                  />
-                  <QualityBackfillControls dbId={entry.id} />
-                </div>
-                {managementAllowed && (
-                  <div className="db-row-actions">
-                    <button
-                      className="browse-button"
-                      onClick={() => handleImport(entry)}
-                      disabled={isApplying || (importRunning && importDbId === entry.id)}
-                      title="Scan this database's image directories and import new frames"
-                    >
-                      {importRunning && importDbId === entry.id ? 'Importing…' : 'Import'}
-                    </button>
-                    <button
-                      className="browse-button"
-                      onClick={() => startEdit(entry)}
-                      disabled={isApplying}
-                    >
-                      Edit
-                    </button>
-                    <button
-                      className="remove-button"
-                      onClick={() => handleRemove(entry)}
-                      disabled={isApplying}
-                      title="Remove this database"
-                    >
-                      Remove
-                    </button>
+                    {managementAllowed && (
+                      <div className="db-row-actions">
+                        <button
+                          className="browse-button"
+                          onClick={() => handleImport(entry)}
+                          disabled={isApplying || (importRunning && importDbId === entry.id)}
+                          title="Scan this database's image directories and import new frames"
+                        >
+                          {importRunning && importDbId === entry.id ? 'Importing…' : 'Import'}
+                        </button>
+                        <button
+                          className="browse-button"
+                          onClick={() => startEdit(entry)}
+                          disabled={isApplying}
+                          aria-label={`Edit ${entry.name}`}
+                          aria-expanded={isEditing}
+                          aria-controls={isEditing ? editorId : undefined}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          className="remove-button"
+                          onClick={() => handleRemove(entry)}
+                          disabled={isApplying}
+                          title="Remove this database"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            ))}
+                  {isEditing && <div id={editorId}>{renderDatabaseForm(entry)}</div>}
+                </section>
+              );
+            })}
 
             {/* With no databases yet the welcome banner carries these same two
                 actions, so rendering them here too would just duplicate them. */}
@@ -1084,263 +1368,7 @@ export default function TauriSettings({
             )}
           </div>
 
-          {managementAllowed && showAddForm && (
-            <div className="settings-section">
-              <h3>
-                {createMode
-                  ? 'New Database from Images'
-                  : editingId
-                    ? 'Edit Database'
-                    : 'Add Database'}
-              </h3>
-
-              {createMode && (
-                <p className="muted">
-                  Creates a brand-new Target Scheduler database and imports the
-                  selected folders. Each target gets its own project. Nearby,
-                  similarly dated panels with matching panel names share a
-                  mosaic project. You can rename or reorganize them afterwards.
-                  The import reads headers only; pixel-based quality work is a
-                  separate option below.
-                </p>
-              )}
-
-              <div className="database-config">
-                <label>Display name (optional):</label>
-                <input
-                  type="text"
-                  value={formName}
-                  onChange={(e) => setFormName(e.target.value)}
-                  placeholder={
-                    createMode
-                      ? 'e.g. 2026 Archive (defaults to "Imported Images")'
-                      : 'e.g. Imaging Rig (defaults to filename)'
-                  }
-                  className="file-path-input"
-                />
-              </div>
-
-              {!createMode && (
-                <div className="database-config">
-                  <label>N.I.N.A. Database File:</label>
-                  <div className="file-input-group">
-                    <input
-                      type="text"
-                      value={formDbPath}
-                      onChange={(e) => setFormDbPath(e.target.value)}
-                      placeholder="Select or enter database path"
-                      className="file-path-input"
-                    />
-                    <button onClick={handlePickDbPath} className="browse-button">
-                      Browse…
-                    </button>
-                  </div>
-                </div>
-              )}
-
-              <div className="database-config">
-                <label>Image Directories:</label>
-                {isTauri ? (
-                  <button onClick={handleAddImageDir} className="add-directory-button">
-                    + Add Image Directory
-                  </button>
-                ) : (
-                  <div className="file-input-group">
-                    <input
-                      type="text"
-                      value={pendingImageDir}
-                      onChange={(e) => setPendingImageDir(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault();
-                          handleAddManualImageDir();
-                        }
-                      }}
-                      placeholder="Type an absolute path and press Add"
-                      className="file-path-input"
-                    />
-                    <button
-                      onClick={handleAddManualImageDir}
-                      className="browse-button"
-                      disabled={!pendingImageDir.trim()}
-                    >
-                      Add
-                    </button>
-                  </div>
-                )}
-                {formImageDirs.length > 0 && (
-                  <div className="image-directories">
-                    {formImageDirs.map((dir, index) => (
-                      <div key={dir} className="image-directory-item">
-                        <span>📂 {dir}</span>
-                        <button
-                          onClick={() => handleRemoveImageDir(index)}
-                          className="remove-button"
-                          title="Remove directory"
-                        >
-                          ×
-                        </button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              {editingId && (
-                <div className="database-config">
-                  <label htmlFor="remote-upload-token">Remote API key:</label>
-                  <div className="remote-upload-token-row">
-                    <input
-                      id="remote-upload-token"
-                      type={formRemoteUploadTokenRevealed ? 'text' : 'password'}
-                      value={formRemoteUploadToken}
-                      onChange={(event) => {
-                        setFormRemoteUploadToken(event.target.value);
-                        setFormRemoteUploadTokenCopyState('idle');
-                      }}
-                      placeholder={
-                        formRemoteUploadTokenConfigured
-                          ? 'Unchanged'
-                          : 'At least 24 characters'
-                      }
-                      className="file-path-input"
-                      autoComplete="new-password"
-                    />
-                    <button
-                      type="button"
-                      onClick={handleGenerateRemoteUploadToken}
-                      className="browse-button"
-                    >
-                      Generate
-                    </button>
-                    {formRemoteUploadTokenRevealed &&
-                      formRemoteUploadToken.length > 0 && (
-                        <button
-                          type="button"
-                          onClick={handleCopyRemoteUploadToken}
-                          className="browse-button"
-                        >
-                          {formRemoteUploadTokenCopyState === 'copied'
-                            ? 'Copied'
-                            : 'Copy'}
-                        </button>
-                      )}
-                  </div>
-                  {formRemoteUploadTokenRevealed && (
-                    <small
-                      className={`remote-upload-token-notice ${
-                        formRemoteUploadTokenCopyState === 'failed' ? 'error' : ''
-                      }`}
-                      role="status"
-                    >
-                      {formRemoteUploadTokenCopyState === 'failed'
-                        ? 'Copy failed. Select and copy the key manually.'
-                        : 'Copy this key now. It will not be shown again after saving.'}
-                    </small>
-                  )}
-                  <label className="quality-analysis-option">
-                    <input
-                      type="checkbox"
-                      checked={formRemoteSyncEnabled}
-                      onChange={(event) =>
-                        setFormRemoteSyncEnabled(event.target.checked)
-                      }
-                    />
-                    <span>
-                      <strong>Accept remote scheduler sync</strong>
-                      <small>
-                        Lets a holder of this key merge projects, targets,
-                        plans, and grades into this database.
-                      </small>
-                    </span>
-                  </label>
-                  <label className="quality-analysis-option">
-                    <input
-                      type="checkbox"
-                      checked={formRemoteUploadEnabled}
-                      onChange={(event) =>
-                        setFormRemoteUploadEnabled(event.target.checked)
-                      }
-                    />
-                    <span>
-                      <strong>Accept remote image uploads</strong>
-                    </span>
-                  </label>
-                  <label htmlFor="server-export-directory">
-                    Server export directory:
-                  </label>
-                  <input
-                    id="server-export-directory"
-                    type="text"
-                    className="file-path-input"
-                    placeholder="Absolute server path; empty disables server export"
-                    title="Exports triggered from the Overview land here (reflinked where the filesystem supports it). Leave empty to offer the archive download instead."
-                    value={formExportDir}
-                    onChange={(event) => setFormExportDir(event.target.value)}
-                  />
-                  {formRemoteUploadEnabled && (
-                    <>
-                      <label htmlFor="remote-upload-directory">Receive directory:</label>
-                      <select
-                        id="remote-upload-directory"
-                        value={formRemoteUploadDir}
-                        onChange={(event) => setFormRemoteUploadDir(event.target.value)}
-                        className="file-path-input"
-                      >
-                        <option value="">Select an image directory</option>
-                        {formImageDirs.map((directory) => (
-                          <option key={directory} value={directory}>
-                            {directory}
-                          </option>
-                        ))}
-                      </select>
-                    </>
-                  )}
-                </div>
-              )}
-
-              {createMode && (
-                <label className="quality-analysis-option">
-                  <input
-                    type="checkbox"
-                    checked={createAnalyzeQuality}
-                    onChange={(event) => setCreateAnalyzeQuality(event.target.checked)}
-                  />
-                  <span>
-                    <strong>Queue background quality analysis</strong>
-                    <small>
-                      Reads every image to measure stars, background, clouds, obstructions,
-                      and pointing. This can take a long time, especially in a debug build.
-                      You can run it later from this database&apos;s settings.
-                    </small>
-                  </span>
-                </label>
-              )}
-
-              <div className="modal-buttons">
-                <button
-                  onClick={resetForm}
-                  className="cancel-button"
-                  disabled={isApplying}
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleSaveForm}
-                  className="save-button"
-                  disabled={
-                    (createMode ? formImageDirs.length === 0 : !formDbPath.trim()) || isApplying
-                  }
-                >
-                  {createMode
-                    ? 'Create & Import'
-                    : editingId
-                      ? 'Save Changes'
-                      : 'Add Database'}
-                </button>
-              </div>
-            </div>
-          )}
+          {managementAllowed && showAddForm && !editingId && renderDatabaseForm(null)}
           </>
           )}
 

--- a/static/src/components/__tests__/TauriSettings.test.tsx
+++ b/static/src/components/__tests__/TauriSettings.test.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { server } from '../../test/msw-server';
 import { AccessContext } from '../../auth/access';
 import type { AuthUserSummary } from '../../api/types';
@@ -318,7 +318,7 @@ describe('TauriSettings import state', () => {
     });
 
     expect(await screen.findByText('Remote receive: /images/remote')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Remote catalog' }));
     expect(
       screen.getByRole('checkbox', { name: 'Accept remote image uploads' })
     ).toBeChecked();
@@ -336,6 +336,107 @@ describe('TauriSettings import state', () => {
       screen.getByText('Copy this key now. It will not be shown again after saving.')
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Copy' })).toBeEnabled();
+  });
+
+  it('keeps the editor with the selected database in a multi-database list', async () => {
+    server.use(
+      http.get('/api/info', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            version: 'test',
+            cache_directory: '/tmp/cache',
+            allow_database_management: true,
+          },
+          error: null,
+          status: 'ready',
+        })
+      ),
+      http.get('/api/databases', () =>
+        HttpResponse.json({
+          success: true,
+          data: [
+            {
+              id: 'c925',
+              name: 'C925',
+              database_path: '/tmp/c925.sqlite',
+              image_directories: ['/images/c925'],
+            },
+            {
+              id: 'ultracat',
+              name: 'Ultra Cat',
+              database_path: '/tmp/ultracat.sqlite',
+              image_directories: ['/images/ultracat'],
+            },
+          ],
+          error: null,
+          status: 'ready',
+        })
+      ),
+      http.get('/api/db/:dbId/import', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            started: false,
+            progress: {
+              running: false,
+              stage: '',
+              image_dirs: [],
+              total_files: 0,
+              scanned_files: 0,
+              outcome: null,
+              started_at: null,
+              finished_at: null,
+              error: null,
+            },
+          },
+          error: null,
+          status: 'ready',
+        })
+      ),
+      http.delete('/api/databases/:dbId', () =>
+        HttpResponse.json({
+          success: true,
+          data: { removed: true },
+          error: null,
+          status: 'ready',
+        })
+      )
+    );
+
+    render(<TauriSettings isOpen onClose={() => undefined} />, {
+      wrapper: createWrapper(),
+    });
+
+    const c925 = await screen.findByRole('region', { name: 'C925' });
+    const ultraCat = screen.getByRole('region', { name: 'Ultra Cat' });
+
+    fireEvent.click(within(c925).getByRole('button', { name: 'Edit C925' }));
+
+    expect(within(c925).getByText('Editing database')).toBeInTheDocument();
+    expect(within(c925).getByRole('heading', { name: 'C925 c925' })).toBeInTheDocument();
+    expect(within(c925).getByRole('button', { name: 'Edit C925' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(within(ultraCat).queryByText('Editing database')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      within(ultraCat).getByRole('button', { name: 'Edit Ultra Cat' })
+    );
+
+    expect(within(c925).queryByText('Editing database')).not.toBeInTheDocument();
+    expect(within(ultraCat).getByText('Editing database')).toBeInTheDocument();
+    expect(
+      within(ultraCat).getByRole('heading', { name: 'Ultra Cat ultracat' })
+    ).toBeInTheDocument();
+
+    const confirmRemove = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    fireEvent.click(within(ultraCat).getByRole('button', { name: 'Remove' }));
+    confirmRemove.mockRestore();
+
+    expect(await screen.findByRole('button', { name: '+ Add Database' })).toBeEnabled();
+    expect(screen.queryByText('Editing database')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- render database editing controls directly beneath the selected database
- highlight and name the active database context, with responsive and accessible relationships
- clear the inline editor when its database is removed

## Validation
- `npm run lint`
- `npm test` (61 files, 284 tests)
- `npm run build`
- live local PSF Guard validation with two copied scheduler databases at 1440x1000 and 390x844
- browser console check (no warnings or errors)
- `git diff --check`

## Review
Reviewed the final diff for edit/add flow regressions, database switching, removal state, responsive overflow, and accessibility. No remaining findings.