### PR TITLE
Grade a grid selection in one request and poll idle status slowly

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -82,6 +82,17 @@
   editor stay visually connected, so paths, remote access, and export settings
   have a clear database context.
 
+- Rejecting or accepting a large grid selection is now one request and one
+  database transaction instead of two HTTP round trips per image, so
+  grading thousands of frames finishes in about a second instead of
+  minutes of "Processing". Undo and redo restore the whole selection in
+  one request the same way.
+
+- An idle grid no longer polls the server every second. The cache and
+  quality status widgets ask fast only while a refresh, scan, or backfill
+  is running, drop to a slow heartbeat otherwise, and stop entirely while
+  the window is in the background.
+
 - Remote sync export responses now carry an `X-Content-SHA256` header with
   the SHA-256 of the exact response body, so the N.I.N.A. plugin can verify
   a pulled bundle without re-serializing it. The in-bundle `payload_sha256`

--- a/src/db.rs
+++ b/src/db.rs
@@ -1499,6 +1499,46 @@ mod tests {
     }
 
     #[test]
+    fn batch_grading_updates_mixed_statuses_in_one_transaction() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE acquiredimage (
+                Id INTEGER PRIMARY KEY, projectId INTEGER NOT NULL,
+                targetId INTEGER NOT NULL, acquireddate INTEGER,
+                filtername TEXT NOT NULL, gradingStatus INTEGER NOT NULL,
+                metadata TEXT NOT NULL, rejectreason TEXT, profileId TEXT
+             );
+             INSERT INTO acquiredimage VALUES
+                (1, 1, 10, 100, 'R', 0, '{}', NULL, 'p'),
+                (2, 1, 10, 200, 'G', 1, '{}', NULL, 'p'),
+                (3, 1, 10, 300, 'B', 2, '{}', 'Clouds', 'p');",
+        )
+        .unwrap();
+
+        let db = Database::new(&conn);
+        // The previous grades a batch handler returns for undo state.
+        let before = db.get_images_by_ids(&[1, 2, 3]).unwrap();
+        assert_eq!(before.len(), 3);
+
+        // Mixed statuses in one call — the shape an undo restore sends.
+        db.batch_update_grading_status(&[
+            (1, GradingStatus::Rejected, Some("Poor stars".to_string())),
+            (2, GradingStatus::Rejected, Some("Poor stars".to_string())),
+            (3, GradingStatus::Accepted, None),
+        ])
+        .unwrap();
+
+        let after = db.get_images_by_ids(&[1, 2, 3]).unwrap();
+        let by_id: std::collections::HashMap<i32, _> =
+            after.into_iter().map(|image| (image.id, image)).collect();
+        assert_eq!(by_id[&1].grading_status, 2);
+        assert_eq!(by_id[&1].reject_reason.as_deref(), Some("Poor stars"));
+        assert_eq!(by_id[&2].grading_status, 2);
+        assert_eq!(by_id[&3].grading_status, 1);
+        assert_eq!(by_id[&3].reject_reason, None);
+    }
+
+    #[test]
     fn recent_images_are_limited_and_sorted_per_project() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -215,6 +215,28 @@ pub struct UpdateGradeRequest {
     pub reason: Option<String>,
 }
 
+/// One grade assignment inside a batch. Entries may carry different
+/// statuses so an undo can restore a mixed selection in one request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchGradeEntry {
+    pub image_id: i32,
+    pub status: String, // "accepted", "rejected", "pending"
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchGradeRequest {
+    pub updates: Vec<BatchGradeEntry>,
+}
+
+/// The grades the batch replaced, so a client can record undo state
+/// without fetching every image first.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BatchGradeResponse {
+    pub updated: usize,
+    pub previous: Vec<BatchGradeEntry>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StarDetectionResponse {
     pub detected_stars: usize,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -2855,6 +2855,76 @@ pub async fn update_image_grade(
     Ok(Json(ApiResponse::success(())))
 }
 
+fn parse_grading_status(status: &str) -> Result<GradingStatus, AppError> {
+    match status {
+        "pending" => Ok(GradingStatus::Pending),
+        "accepted" => Ok(GradingStatus::Accepted),
+        "rejected" => Ok(GradingStatus::Rejected),
+        _ => Err(AppError::BadRequest(format!("Invalid status: {status}"))),
+    }
+}
+
+fn grading_status_label(status: i32) -> &'static str {
+    match status {
+        1 => "accepted",
+        2 => "rejected",
+        _ => "pending",
+    }
+}
+
+/// Grade many images in one request and one database transaction. A grid
+/// selection of thousands of frames was previously one HTTP round trip and
+/// one SQLite write transaction per image. Returns the grades it replaced
+/// so the client records undo state without fetching every image first.
+pub async fn batch_update_image_grades(
+    ctx: DbContext,
+    Json(request): Json<BatchGradeRequest>,
+) -> Result<Json<ApiResponse<BatchGradeResponse>>, AppError> {
+    const MAX_BATCH: usize = 20_000;
+    if request.updates.is_empty() {
+        return Err(AppError::BadRequest("No updates in batch".to_string()));
+    }
+    if request.updates.len() > MAX_BATCH {
+        return Err(AppError::BadRequest(format!(
+            "Batch exceeds {MAX_BATCH} images; split the request"
+        )));
+    }
+    let mut updates = Vec::with_capacity(request.updates.len());
+    for entry in &request.updates {
+        updates.push((
+            entry.image_id,
+            parse_grading_status(&entry.status)?,
+            entry.reason.clone(),
+        ));
+    }
+
+    let conn = ctx.db();
+    let conn = conn.lock().map_err(AppError::db)?;
+    let db = Database::new(&conn);
+
+    // Record what the batch replaces before writing. Chunk the reads to
+    // stay far below SQLite's bound-variable limit.
+    let ids: Vec<i32> = updates.iter().map(|(id, _, _)| *id).collect();
+    let mut previous = Vec::with_capacity(ids.len());
+    for chunk in ids.chunks(500) {
+        for image in db.get_images_by_ids(chunk).map_err(AppError::db)? {
+            previous.push(BatchGradeEntry {
+                image_id: image.id,
+                status: grading_status_label(image.grading_status).to_string(),
+                reason: image.reject_reason.clone(),
+            });
+        }
+    }
+
+    db.batch_update_grading_status(&updates)
+        .map_err(AppError::db)?;
+
+    Ok(Json(ApiResponse::success(BatchGradeResponse {
+        updated: updates.len(),
+        previous,
+    })))
+}
+
 /// Shared DB lookup for the image handlers: the acquired-image row, the FITS
 /// basename (from `metadata.FileName`), and the target name.
 fn resolve_image_meta(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -484,6 +484,7 @@ async fn run_server_internal(
             "/images/{image_id}/grade",
             put(handlers::update_image_grade),
         )
+        .route("/images/grade", post(handlers::batch_update_image_grades))
         .route("/analysis/sequence", get(handlers::analyze_sequence))
         .route(
             "/analysis/image/{image_id}",

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -10,6 +10,8 @@ import type {
   TargetNavigation,
   Image,
   ImageQuery,
+  BatchGradeEntry,
+  BatchGradeResponse,
   UpdateGradeRequest,
   StarDetectionResponse,
   PreviewOptions,
@@ -1096,6 +1098,21 @@ export const apiClient = {
   ): Promise<void> => {
     const apiInstance = await getApi();
     await apiInstance.put(dbPath(dbId, `/images/${imageId}/grade`), request);
+  },
+
+  /** Grade many images in one request and one server transaction. Returns
+   * the grades it replaced so callers can record undo state without a
+   * request per image. */
+  batchUpdateImageGrades: async (
+    dbId: string,
+    updates: BatchGradeEntry[]
+  ): Promise<BatchGradeResponse> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<BatchGradeResponse>>(
+      dbPath(dbId, '/images/grade'),
+      { updates }
+    );
+    return data.data!;
   },
 
   getStarDetection: async (dbId: string, imageId: number): Promise<StarDetectionResponse> => {

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -261,6 +261,20 @@ export interface UpdateGradeRequest {
   reason?: string;
 }
 
+/** One grade assignment inside a batch; entries may carry different
+ * statuses so an undo can restore a mixed selection in one request. */
+export interface BatchGradeEntry {
+  image_id: number;
+  status: 'pending' | 'accepted' | 'rejected';
+  reason?: string | null;
+}
+
+export interface BatchGradeResponse {
+  updated: number;
+  /** The grades the batch replaced, for undo state. */
+  previous: BatchGradeEntry[];
+}
+
 export interface PreviewOptions {
   size?: 'screen' | 'large' | 'original';
   stretch?: boolean;

--- a/static/src/components/AggregatedCacheStatus.tsx
+++ b/static/src/components/AggregatedCacheStatus.tsx
@@ -40,8 +40,11 @@ export default function AggregatedCacheStatus({
     queries: databases.map((db) => ({
       queryKey: ['db', db.id, 'cache-progress'] as const,
       queryFn: () => apiClient.getCacheProgress(db.id),
-      refetchInterval: 1000,
-      refetchIntervalInBackground: true,
+      // Fast only while a refresh runs; a quiet server needs a slow
+      // heartbeat, not a request per second per database.
+      refetchInterval: (query: { state: { data?: CacheRefreshProgress } }) =>
+        query.state.data?.is_refreshing ? 1000 : 10_000,
+      refetchIntervalInBackground: false,
     })),
   });
   const qualityScanQueries = useQueries({
@@ -50,7 +53,7 @@ export default function AggregatedCacheStatus({
       queryFn: () => apiClient.getSpatialScanStatus(db.id),
       refetchInterval: (query: { state: { data?: SpatialScanStatus } }) =>
         query.state.data?.progress.running ? 1000 : false,
-      refetchIntervalInBackground: true,
+      refetchIntervalInBackground: false,
     })),
   });
   const qualityBackfillQueries = useQueries({
@@ -59,7 +62,7 @@ export default function AggregatedCacheStatus({
       queryFn: () => apiClient.getQualityBackfillStatus(db.id),
       refetchInterval: (query: { state: { data?: QualityBackfillStatus } }) =>
         query.state.data?.progress.running ? 1000 : false,
-      refetchIntervalInBackground: true,
+      refetchIntervalInBackground: false,
     })),
   });
 

--- a/static/src/components/CacheRefreshStatus.tsx
+++ b/static/src/components/CacheRefreshStatus.tsx
@@ -32,8 +32,11 @@ export default function CacheRefreshStatus({ className = '' }: CacheRefreshStatu
     queryKey: ['db', dbId, 'cache-progress'],
     queryFn: () => apiClient.getCacheProgress(dbId!),
     enabled: !!dbId,
-    refetchInterval: 1000, // Poll every second
-    refetchIntervalInBackground: true,
+    // Fast only while a refresh runs; otherwise a slow heartbeat is enough
+    // to notice a server-initiated refresh starting.
+    refetchInterval: (query) =>
+      query.state.data?.is_refreshing ? 1000 : 10_000,
+    refetchIntervalInBackground: false,
   });
 
   // Track recent directories for smart truncation

--- a/static/src/components/StackColorPreviewPanel.tsx
+++ b/static/src/components/StackColorPreviewPanel.tsx
@@ -17,7 +17,7 @@ import {
 } from './stackColorProcessing';
 import { isColorStackSkyOriented } from './stackOrientation';
 import { cropLabels, cropOrder, describeCrop, offCenterChannels } from './stackColorCrop';
-import { useStackActivity } from '../hooks/useStackActivity';
+import { STACK_ACTIVITY_QUERY_KEY, useStackActivity } from '../hooks/useStackActivity';
 
 interface StackColorPreviewPanelProps {
   dbId: string;
@@ -401,6 +401,7 @@ export default function StackColorPreviewPanel({
       setWatchedJobIds((current) =>
         current.includes(job.job_id) ? current : [...current, job.job_id]
       );
+      queryClient.invalidateQueries({ queryKey: STACK_ACTIVITY_QUERY_KEY });
       if (terminalStates.has(job.state)) {
         queryClient.invalidateQueries({
           queryKey: catalogQueryKey(dbId, projectId, sourceRevision),

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -16,7 +16,7 @@ import StackColorPreviewPanel from './StackColorPreviewPanel';
 import StackStretchControls from './StackStretchControls';
 import { isSkyOriented } from './stackOrientation';
 import { useAccess } from '../auth/access';
-import { useStackActivity } from '../hooks/useStackActivity';
+import { STACK_ACTIVITY_QUERY_KEY, useStackActivity } from '../hooks/useStackActivity';
 
 type StackCandidateImage = Pick<
   Image,
@@ -319,6 +319,7 @@ export default function StackPreviewPanel({
       setWatchedJobIds((current) =>
         current.includes(job.job_id) ? current : [...current, job.job_id]
       );
+      queryClient.invalidateQueries({ queryKey: STACK_ACTIVITY_QUERY_KEY });
       if (terminalStates.has(job.state)) {
         queryClient.invalidateQueries({ queryKey: latestStackQueryKey(dbId, projectId) });
       }

--- a/static/src/components/__tests__/SequenceView.test.tsx
+++ b/static/src/components/__tests__/SequenceView.test.tsx
@@ -124,6 +124,22 @@ function setupDefaultHandlers() {
         status: 'ready',
       });
     }),
+    http.post('/api/db/:dbId/images/grade', async ({ request }) => {
+      const body = await request.json() as { updates: Array<{ image_id: number }> };
+      return HttpResponse.json({
+        success: true,
+        data: {
+          updated: body.updates.length,
+          previous: body.updates.map((u) => ({
+            image_id: u.image_id,
+            status: 'pending',
+            reason: null,
+          })),
+        },
+        error: null,
+        status: 'ready',
+      });
+    }),
   );
 }
 
@@ -893,11 +909,19 @@ describe('SequenceView: multi-session', () => {
     setupMultiSessionHandlers();
     const gradedImageIds: string[] = [];
     server.use(
-      http.put('/api/db/:dbId/images/:imageId/grade', ({ params }) => {
-        gradedImageIds.push(params.imageId as string);
+      http.post('/api/db/:dbId/images/grade', async ({ request }) => {
+        const body = await request.json() as { updates: Array<{ image_id: number }> };
+        body.updates.forEach((u) => gradedImageIds.push(String(u.image_id)));
         return HttpResponse.json({
           success: true,
-          data: null,
+          data: {
+            updated: body.updates.length,
+            previous: body.updates.map((u) => ({
+              image_id: u.image_id,
+              status: 'pending',
+              reason: null,
+            })),
+          },
           error: null,
           status: 'ready',
         });
@@ -1037,14 +1061,21 @@ describe('SequenceView: batch operations', () => {
       }),
     );
 
-    const gradeRequests: Array<{ imageId: string; body: unknown }> = [];
+    const gradeRequests: Array<{ updates: Array<{ image_id: number; status: string }> }> = [];
     server.use(
-      http.put('/api/db/:dbId/images/:imageId/grade', async ({ params, request }) => {
-        const body = await request.json();
-        gradeRequests.push({ imageId: params.imageId as string, body });
+      http.post('/api/db/:dbId/images/grade', async ({ request }) => {
+        const body = await request.json() as { updates: Array<{ image_id: number; status: string }> };
+        gradeRequests.push(body);
         return HttpResponse.json({
           success: true,
-          data: null,
+          data: {
+            updated: body.updates.length,
+            previous: body.updates.map((u) => ({
+              image_id: u.image_id,
+              status: 'pending',
+              reason: null,
+            })),
+          },
           error: null,
           status: 'ready',
         });
@@ -1072,14 +1103,13 @@ describe('SequenceView: batch operations', () => {
     expect(gradeRequests).toHaveLength(0);
     await user.click(screen.getByText(/Reject selected \(2\)/));
 
-    // Wait for the grade API calls to be made
+    // One batch request carries both frames.
     await waitFor(() => {
-      expect(gradeRequests.length).toBe(2);
+      expect(gradeRequests.length).toBe(1);
     });
-
-    // Verify the grade requests were for rejection
-    gradeRequests.forEach(req => {
-      expect((req.body as Record<string, unknown>).status).toBe('rejected');
+    expect(gradeRequests[0].updates).toHaveLength(2);
+    gradeRequests[0].updates.forEach(update => {
+      expect(update.status).toBe('rejected');
     });
   });
 

--- a/static/src/hooks/useGrading.ts
+++ b/static/src/hooks/useGrading.ts
@@ -16,48 +16,10 @@ export function useGrading(dbId: string, options: UseGradingOptions = {}) {
   const undoRedo = useUndoRedo(dbId);
   const { canWrite } = useAccess();
 
-  // Single image grading mutation
-  const singleGradeMutation = useMutation({
-    mutationFn: async ({ imageId, request, recordHistory = true }: {
-      imageId: number;
-      request: UpdateGradeRequest;
-      recordHistory?: boolean;
-    }) => {
-      if (!canWrite) throw new Error('This account has read-only access');
-      // Record action before applying if history tracking is enabled
-      let actionId: string | null = null;
-      if (recordHistory) {
-        actionId = await undoRedo.recordAction(
-          [imageId],
-          request.status,
-          request.reason,
-          `${request.status} image`
-        );
-      }
-
-      // Apply the grading change
-      await apiClient.updateImageGrade(dbId, imageId, request);
-
-      return { imageId, actionId };
-    },
-    onSuccess: (_, variables) => {
-      // Invalidate queries
-      queryClient.invalidateQueries({ queryKey: ['db', dbId, 'image', variables.imageId] });
-      queryClient.invalidateQueries({ queryKey: ['db', dbId, 'all-images'] });
-
-      if (onSuccess) {
-        onSuccess([variables.imageId], variables.request.status);
-      }
-    },
-    onError: (error: Error, variables) => {
-      console.error('Single grade failed:', error);
-      if (onError) {
-        onError(error, [variables.imageId]);
-      }
-    },
-  });
-
-  // Batch grading mutation
+  // One mutation serves any selection size: a single request and a single
+  // server transaction. The response carries the grades it replaced, so
+  // undo state costs no extra requests either — grading 2000 images was
+  // previously ~4000 HTTP round trips (a state fetch and a write each).
   const batchGradeMutation = useMutation({
     mutationFn: async ({ imageIds, request, recordHistory = true }: {
       imageIds: number[];
@@ -65,31 +27,35 @@ export function useGrading(dbId: string, options: UseGradingOptions = {}) {
       recordHistory?: boolean;
     }) => {
       if (!canWrite) throw new Error('This account has read-only access');
-      // Record action before applying if history tracking is enabled
-      let actionId: string | null = null;
-      if (recordHistory) {
-        actionId = await undoRedo.recordAction(
-          imageIds,
-          request.status,
-          request.reason,
-          `${request.status} ${imageIds.length} images`
-        );
-      }
-
-      // Apply the grading changes
-      const promises = imageIds.map((imageId) =>
-        apiClient.updateImageGrade(dbId, imageId, request)
+      const response = await apiClient.batchUpdateImageGrades(
+        dbId,
+        imageIds.map((imageId) => ({
+          image_id: imageId,
+          status: request.status,
+          reason: request.reason,
+        }))
       );
 
-      await Promise.all(promises);
+      let actionId: string | null = null;
+      if (recordHistory) {
+        actionId = undoRedo.pushAction(
+          imageIds,
+          response.previous.map((entry) => ({
+            imageId: entry.image_id,
+            previousStatus: entry.status,
+            previousReason: entry.reason ?? undefined,
+          })),
+          request.status,
+          request.reason,
+          `${request.status} ${imageIds.length === 1 ? 'image' : `${imageIds.length} images`}`
+        );
+      }
 
       return { imageIds, actionId };
     },
     onSuccess: (_, variables) => {
-      // Invalidate queries for all affected images
-      variables.imageIds.forEach((imageId) => {
-        queryClient.invalidateQueries({ queryKey: ['db', dbId, 'image', imageId] });
-      });
+      // One prefix invalidation covers every per-image detail query.
+      queryClient.invalidateQueries({ queryKey: ['db', dbId, 'image'] });
       queryClient.invalidateQueries({ queryKey: ['db', dbId, 'all-images'] });
 
       if (onSuccess) {
@@ -106,17 +72,17 @@ export function useGrading(dbId: string, options: UseGradingOptions = {}) {
 
   // Convenience functions
   const gradeImage = useCallback((
-    imageId: number, 
+    imageId: number,
     status: 'accepted' | 'rejected' | 'pending',
     reason?: string,
     recordHistory: boolean = true
   ) => {
-    return singleGradeMutation.mutateAsync({
-      imageId,
+    return batchGradeMutation.mutateAsync({
+      imageIds: [imageId],
       request: { status, reason },
       recordHistory,
     });
-  }, [singleGradeMutation]);
+  }, [batchGradeMutation]);
 
   const gradeBatch = useCallback((
     imageIds: number[], 
@@ -145,7 +111,7 @@ export function useGrading(dbId: string, options: UseGradingOptions = {}) {
     }
   }, [gradeImage, gradeBatch]);
 
-  const isLoading = singleGradeMutation.isPending || batchGradeMutation.isPending || undoRedo.isProcessing;
+  const isLoading = batchGradeMutation.isPending || undoRedo.isProcessing;
   const undo = useCallback(
     () => canWrite ? undoRedo.undo() : Promise.resolve(false),
     [canWrite, undoRedo],
@@ -178,8 +144,7 @@ export function useGrading(dbId: string, options: UseGradingOptions = {}) {
     getLastAction: undoRedo.getLastAction,
     getNextRedoAction: undoRedo.getNextRedoAction,
     
-    // Raw mutations (for advanced usage)
-    singleGradeMutation,
+    // Raw mutation (for advanced usage)
     batchGradeMutation,
     
     // History (for debugging)

--- a/static/src/hooks/useStackActivity.ts
+++ b/static/src/hooks/useStackActivity.ts
@@ -12,8 +12,11 @@ export function useStackActivity() {
   const query = useQuery<StackActivity>({
     queryKey: STACK_ACTIVITY_QUERY_KEY,
     queryFn: () => apiClient.getStackActivity(),
-    refetchInterval: (query) => (query.state.data?.active.length ? 1000 : 3000),
-    refetchIntervalInBackground: true,
+    // Fast only while a build runs. Starting one here invalidates this
+    // query, so the idle poll exists to notice jobs another client began —
+    // a few seconds' lag is fine, and the endpoint is an in-memory list.
+    refetchInterval: (query) => (query.state.data?.active.length ? 1000 : 5_000),
+    refetchIntervalInBackground: false,
   });
   return {
     active: query.data?.active ?? [],

--- a/static/src/hooks/useUndoRedo.ts
+++ b/static/src/hooks/useUndoRedo.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 
@@ -29,129 +29,77 @@ export function useUndoRedo(dbId: string, options: UseUndoRedoOptions = {}) {
   const [redoStack, setRedoStack] = useState<GradingAction[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
 
-  // Keep track of current action ID to prevent duplicate tracking
-  const currentActionId = useRef<string | null>(null);
-
   const generateActionId = () => {
     return Date.now().toString(36) + Math.random().toString(36).substr(2);
   };
 
-  const getCurrentImageState = useCallback(
-    async (imageId: number) => {
-      try {
-        const image = await apiClient.getImage(dbId, imageId);
-        return {
-          status:
-            image.grading_status === 0
-              ? ('pending' as const)
-              : image.grading_status === 1
-                ? ('accepted' as const)
-                : ('rejected' as const),
-          reason: image.reject_reason || undefined,
-        };
-      } catch (error) {
-        console.warn(`Failed to get current state for image ${imageId}:`, error);
-        return null;
-      }
-    },
-    [dbId]
-  );
+  const invalidateGrades = useCallback(() => {
+    // One prefix invalidation covers every per-image detail query; a loop
+    // of per-id invalidations over a large selection is pure overhead.
+    queryClient.invalidateQueries({ queryKey: ['db', dbId, 'image'] });
+    queryClient.invalidateQueries({ queryKey: ['db', dbId, 'all-images'] });
+  }, [dbId, queryClient]);
 
-  const recordAction = useCallback(async (
+  /** Record an applied action. The caller supplies the previous grades —
+   * the batch grade endpoint returns them — so recording costs no
+   * requests. */
+  const pushAction = useCallback((
     imageIds: number[],
+    previousStates: GradingAction['previousStates'],
     newStatus: 'accepted' | 'rejected' | 'pending',
     newReason?: string,
     description?: string
   ) => {
-    if (isProcessing) return null;
-
+    if (previousStates.length === 0) return null;
     const actionId = generateActionId();
-    currentActionId.current = actionId;
+    const action: GradingAction = {
+      id: actionId,
+      type: imageIds.length > 1 ? 'batch' : 'single',
+      timestamp: Date.now(),
+      description: description || (
+        imageIds.length > 1
+          ? `${newStatus} ${imageIds.length} images`
+          : `${newStatus} 1 image`
+      ),
+      imageIds,
+      previousStates,
+      newStatus,
+      newReason,
+    };
 
-    try {
-      // Get previous states for all images
-      const previousStatesPromises = imageIds.map(async (imageId) => {
-        const currentState = await getCurrentImageState(imageId);
-        if (!currentState) return null;
-        
-        return {
-          imageId,
-          previousStatus: currentState.status,
-          previousReason: currentState.reason,
-        };
-      });
-
-      const previousStates = (await Promise.all(previousStatesPromises))
-        .filter((state): state is NonNullable<typeof state> => state !== null);
-
-      if (previousStates.length === 0) {
-        console.warn('No previous states found, skipping action recording');
-        return null;
+    setUndoStack(prev => {
+      const newStack = [...prev, action];
+      if (newStack.length > maxHistorySize) {
+        return newStack.slice(-maxHistorySize);
       }
+      return newStack;
+    });
+    setRedoStack([]); // Clear redo stack when new action is recorded
 
-      const action: GradingAction = {
-        id: actionId,
-        type: imageIds.length > 1 ? 'batch' : 'single',
-        timestamp: Date.now(),
-        description: description || (
-          imageIds.length > 1
-            ? `${newStatus} ${imageIds.length} images`
-            : `${newStatus} 1 image`
-        ),
-        imageIds,
-        previousStates,
-        newStatus,
-        newReason,
-      };
-
-      // Add to undo stack and clear redo stack
-      setUndoStack(prev => {
-        const newStack = [...prev, action];
-        // Limit stack size
-        if (newStack.length > maxHistorySize) {
-          return newStack.slice(-maxHistorySize);
-        }
-        return newStack;
-      });
-
-      setRedoStack([]); // Clear redo stack when new action is recorded
-
-      return actionId;
-    } catch (error) {
-      console.error('Failed to record action:', error);
-      return null;
-    } finally {
-      currentActionId.current = null;
-    }
-  }, [isProcessing, maxHistorySize, getCurrentImageState]);
+    return actionId;
+  }, [maxHistorySize]);
 
   const undo = useCallback(async () => {
     if (undoStack.length === 0 || isProcessing) return false;
 
     setIsProcessing(true);
-    
+
     try {
       const action = undoStack[undoStack.length - 1];
-      
-      // Restore previous states for all images in the action
-      const promises = action.previousStates.map(({ imageId, previousStatus, previousReason }) =>
-        apiClient.updateImageGrade(dbId, imageId, {
+
+      // One request restores the whole action, mixed statuses included.
+      await apiClient.batchUpdateImageGrades(
+        dbId,
+        action.previousStates.map(({ imageId, previousStatus, previousReason }) => ({
+          image_id: imageId,
           status: previousStatus,
           reason: previousReason,
-        })
+        }))
       );
 
-      await Promise.all(promises);
-
-      // Update stacks
       setUndoStack((prev) => prev.slice(0, -1));
       setRedoStack((prev) => [action, ...prev]);
-
-      // Invalidate queries for affected images
-      action.imageIds.forEach((imageId) => {
-        queryClient.invalidateQueries({ queryKey: ['db', dbId, 'image', imageId] });
-      });
-      queryClient.invalidateQueries({ queryKey: ['db', dbId, 'all-images'] });
+      invalidateGrades();
 
       return true;
     } catch (error) {
@@ -160,35 +108,28 @@ export function useUndoRedo(dbId: string, options: UseUndoRedoOptions = {}) {
     } finally {
       setIsProcessing(false);
     }
-  }, [dbId, undoStack, isProcessing, queryClient]);
+  }, [dbId, undoStack, isProcessing, invalidateGrades]);
 
   const redo = useCallback(async () => {
     if (redoStack.length === 0 || isProcessing) return false;
 
     setIsProcessing(true);
-    
+
     try {
       const action = redoStack[0];
-      
-      // Reapply the action to all images
-      const promises = action.imageIds.map((imageId) =>
-        apiClient.updateImageGrade(dbId, imageId, {
+
+      await apiClient.batchUpdateImageGrades(
+        dbId,
+        action.imageIds.map((imageId) => ({
+          image_id: imageId,
           status: action.newStatus,
           reason: action.newReason,
-        })
+        }))
       );
 
-      await Promise.all(promises);
-
-      // Update stacks
       setRedoStack((prev) => prev.slice(1));
       setUndoStack((prev) => [...prev, action]);
-
-      // Invalidate queries for affected images
-      action.imageIds.forEach((imageId) => {
-        queryClient.invalidateQueries({ queryKey: ['db', dbId, 'image', imageId] });
-      });
-      queryClient.invalidateQueries({ queryKey: ['db', dbId, 'all-images'] });
+      invalidateGrades();
 
       return true;
     } catch (error) {
@@ -197,7 +138,7 @@ export function useUndoRedo(dbId: string, options: UseUndoRedoOptions = {}) {
     } finally {
       setIsProcessing(false);
     }
-  }, [dbId, redoStack, isProcessing, queryClient]);
+  }, [dbId, redoStack, isProcessing, invalidateGrades]);
 
   const clearHistory = useCallback(() => {
     setUndoStack([]);
@@ -217,22 +158,22 @@ export function useUndoRedo(dbId: string, options: UseUndoRedoOptions = {}) {
 
   return {
     // Actions
-    recordAction,
+    pushAction,
     undo,
     redo,
     clearHistory,
-    
+
     // State
     canUndo,
     canRedo,
     isProcessing,
     undoStackSize: undoStack.length,
     redoStackSize: redoStack.length,
-    
+
     // Getters
     getLastAction,
     getNextRedoAction,
-    
+
     // History (for debugging/display)
     undoStack: [...undoStack], // Return copy to prevent external mutation
     redoStack: [...redoStack],


### PR DESCRIPTION
Fixes two performance problems from real use.

**Rejecting 2,000 images spun "Processing" for minutes.** Every image in a selection cost two HTTP round trips — a GET to record undo state, then a PUT that was its own SQLite write transaction — so a 2,000-frame rejection was ~4,000 requests squeezed through the browser's per-host connection limit.

A new `POST /api/db/{db}/images/grade` endpoint applies the whole batch in one database transaction (over the existing `batch_update_grading_status`) and returns the grades it replaced, so the client records undo state straight from the response. Entries carry independent statuses, which lets undo restore a mixed selection in the same single request. The frontend routes single grades, batches, undo, and redo through it, and replaces the per-image query-invalidation loop with one prefix invalidation. Capped at 20,000 entries per request; state reads chunk at 500 ids.

**An idle grid polled the server every second.** Measured headlessly on an idle grid over 15 s: 15 `cache-progress` requests (per database) and 5 `stack-activity`. The status widgets now poll fast only while a refresh/scan/backfill runs, drop to a 10 s heartbeat when quiet (5 s for the in-memory stack-activity list), and stop in background windows. Starting a stack invalidates the shared activity query, so the header still updates immediately; the adoption path (job started by another client) keeps its ≤5 s pickup, which the existing adopt test enforces.

Verified headlessly on the clean-room database: selecting all 97 grid cards and pressing `x` issues exactly one `POST /images/grade` (200), and Ctrl+Z restores with exactly one request; idle traffic dropped from 20 requests/15 s to 5. Checks: `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (724, including a new mixed-status batch transaction test), `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (283, grading tests updated to the batch endpoint), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)