### PR TITLE
Review ergonomics: grade-advance preference, Shift+arrow select, visible status under selection

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -75,6 +75,16 @@
   filesystem supports it, copying where it does not. No database-management
   grant needed: consent was given when the directory was configured.
 
+- Review ergonomics: a **Review** tab in Settings holds browser-local
+  preferences, starting with whether grading moves to the next image
+  (holding Shift while grading does the opposite for that one grade) and
+  the two score-chip toggles. Shift+arrow extends the grid selection from
+  the keyboard like Shift+click does with the mouse. A selected card now
+  keeps its accepted/rejected border color, with selection shown as an
+  outer ring and checkmark. Selecting many images no longer queues a
+  full-size preview generation per selected frame — only the keyboard
+  cursor's image preloads.
+
 ## Fixed
 
 - Editing a configured database now opens its settings directly beneath that

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3288,9 +3288,11 @@
   position: relative;
 }
 
+/* Selection shows as an outer ring, checkmark, and inset — the border
+ * itself keeps the accept/reject status color, so a selected card still
+ * reads as accepted or rejected at a glance. */
 .image-card-wrapper.multi-selected .image-card {
-  border-color: var(--color-warning);
-  box-shadow: 0 0 0 2px var(--color-warning-alpha-40);
+  box-shadow: 0 0 0 2px var(--color-warning);
   transform: scale(0.98);
 }
 

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -40,6 +40,7 @@ import {
 } from '../utils/gridNavigation';
 import { thumbnailGridColumns } from '../utils/thumbnailSizing';
 import { useScopedQuality } from '../hooks/useSequenceAnalysis';
+import { useDisplayPreferences } from '../hooks/useDisplayPreferences';
 import SecondaryScoreToggle from './SecondaryScoreToggle';
 
 interface GroupedImageGridProps {
@@ -81,6 +82,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
 
   // Initialize grading system with undo/redo
   const grading = useGrading(dbId!);
+  const { advanceOnGrade } = useDisplayPreferences();
   const [lastSelectedImageId, setLastSelectedImageId] = useState<number | null>(null);
   const selectionAnchorIdRef = useRef<number | null>(null);
   const selectionBaseIdsRef = useRef<Set<number>>(new Set());
@@ -392,6 +394,50 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
     setCurrentImageId,
   ]);
 
+  // Shift+arrow: move the cursor and select everything between the anchor
+  // and the new cursor, exactly like shift+click on the destination card.
+  const extendSelection = useCallback((direction: GridNavigationDirection) => {
+    const currentImageId = activeImageIdRef.current;
+    const currentIndex = currentImageId == null
+      ? -1
+      : flatImages.findIndex(image => image.id === currentImageId);
+    if (currentIndex === -1) return;
+
+    const newIndex = findGridNavigationIndex(
+      flatImages,
+      currentIndex,
+      direction,
+      image => containerRef.current
+        ?.querySelector<HTMLElement>(`[data-image-id="${image.id}"]`)
+        ?.getBoundingClientRect() ?? null,
+    );
+    if (newIndex === currentIndex) return;
+
+    const storedAnchorId = selectionAnchorIdRef.current;
+    const anchorId = storedAnchorId !== null && flatImages.some(
+      image => image.id === storedAnchorId,
+    ) ? storedAnchorId : currentImageId;
+    selectionAnchorIdRef.current = anchorId;
+    const anchorIndex = flatImages.findIndex(image => image.id === anchorId);
+    const [minIndex, maxIndex] = [
+      Math.min(anchorIndex, newIndex),
+      Math.max(anchorIndex, newIndex),
+    ];
+    const next = new Set(selectionBaseIdsRef.current);
+    for (let i = minIndex; i <= maxIndex; i++) {
+      next.add(flatImages[i].id);
+    }
+    setSelectedImages(next);
+
+    const newImage = flatImages[newIndex];
+    activeImageIdRef.current = newImage.id;
+    setCurrentImageId(newImage.id);
+    requestAnimationFrame(() => {
+      containerRef.current?.querySelector(`[data-image-id="${newImage.id}"]`)
+        ?.scrollIntoView({ block: 'nearest' });
+    });
+  }, [flatImages, setCurrentImageId, setSelectedImages]);
+
   const toggleCurrentImageSelection = useCallback(() => {
     const currentImageId = activeImageIdRef.current;
     if (currentImageId === null) return;
@@ -410,18 +456,22 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
     });
   }, [setSelectedImages]);
 
-  const gradeImage = useCallback(async (status: 'accepted' | 'rejected' | 'pending') => {
+  const gradeImage = useCallback(async (
+    status: 'accepted' | 'rejected' | 'pending',
+    shiftHeld = false,
+  ) => {
     const currentImageId = activeImageIdRef.current;
     if (!currentImageId || !grading.canWrite) return;
 
     try {
       await grading.gradeImage(currentImageId, status);
-      // Auto-advance to next image
-      setTimeout(() => navigateImages('next'), 100);
+      // Advance per preference; Shift does the opposite for this grade.
+      const advance = shiftHeld ? !advanceOnGrade : advanceOnGrade;
+      if (advance) setTimeout(() => navigateImages('next'), 100);
     } catch (error) {
       console.error('Failed to grade image:', error);
     }
-  }, [grading, navigateImages]);
+  }, [grading, navigateImages, advanceOnGrade]);
 
   const toggleGroup = useCallback((filterName: string) => {
     setExpandedGroups(() => {
@@ -627,33 +677,57 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
     [navigateImages, onLiveGridRoute],
   );
   useHotkeys(
+    'shift+right',
+    () => onLiveGridRoute(() => extendSelection('next')),
+    gridArrowHotkeyOptions,
+    [extendSelection, onLiveGridRoute],
+  );
+  useHotkeys(
+    'shift+left',
+    () => onLiveGridRoute(() => extendSelection('prev')),
+    gridArrowHotkeyOptions,
+    [extendSelection, onLiveGridRoute],
+  );
+  useHotkeys(
+    'shift+down',
+    () => onLiveGridRoute(() => extendSelection('down')),
+    gridArrowHotkeyOptions,
+    [extendSelection, onLiveGridRoute],
+  );
+  useHotkeys(
+    'shift+up',
+    () => onLiveGridRoute(() => extendSelection('up')),
+    gridArrowHotkeyOptions,
+    [extendSelection, onLiveGridRoute],
+  );
+  useHotkeys(
     'space',
     () => onLiveGridRoute(toggleCurrentImageSelection),
     gridArrowHotkeyOptions,
     [toggleCurrentImageSelection, onLiveGridRoute],
   );
-  useHotkeys('a', () => {
+  useHotkeys('a,shift+a', (event) => {
     if (!isLiveGridRoute()) return;
     if (selectedImages.size > 1) {
       gradeBatch('accepted');
     } else {
-      gradeImage('accepted');
+      gradeImage('accepted', event.shiftKey);
     }
   }, gridHotkeyOptions, [gradeImage, gradeBatch, selectedImages.size, isLiveGridRoute]);
-  useHotkeys('x', () => {
+  useHotkeys('x,shift+x', (event) => {
     if (!isLiveGridRoute()) return;
     if (selectedImages.size > 1) {
       gradeBatch('rejected');
     } else {
-      gradeImage('rejected');
+      gradeImage('rejected', event.shiftKey);
     }
   }, gridHotkeyOptions, [gradeImage, gradeBatch, selectedImages.size, isLiveGridRoute]);
-  useHotkeys('u', () => {
+  useHotkeys('u,shift+u', (event) => {
     if (!isLiveGridRoute()) return;
     if (selectedImages.size > 1) {
       gradeBatch('pending');
     } else {
-      gradeImage('pending');
+      gradeImage('pending', event.shiftKey);
     }
   }, gridHotkeyOptions, [gradeImage, gradeBatch, selectedImages.size, isLiveGridRoute]);
   useHotkeys('enter', () => {
@@ -957,6 +1031,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
                               selectedImages.has(image.id) ||
                               image.id === activeImageId
                             }
+                            selectionEffects={image.id === activeImageId}
                             onClick={(event) => handleImageSelection(image.id, event)}
                             onDoubleClick={() => navigateToDetail(image.id)}
                           />

--- a/static/src/components/ImageCard.tsx
+++ b/static/src/components/ImageCard.tsx
@@ -63,8 +63,10 @@ export default function ImageCard({
     inViewRef(node);
   }, [inViewRef]);
 
-  // Preload full size image when selected (for quick detail view opening).
-  // Warms the interactive queue so the 'large' preview is generated if needed.
+  // Preload the full-size image for quick detail-view opening. Callers must
+  // enable this only for the keyboard-cursor card: preloading every card in
+  // a multi-selection would enqueue a large-preview generation per selected
+  // image (select-all on a big grid meant thousands of queued jobs).
   useEffect(() => {
     if (selectionEffects && isSelected && image.id) {
       void ensurePreviewReady(

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -33,7 +33,7 @@ interface ImageDetailViewProps {
   onClose: () => void;
   onNext: () => void;
   onPrevious: () => void;
-  onGrade: (status: 'accepted' | 'rejected' | 'pending') => void;
+  onGrade: (status: 'accepted' | 'rejected' | 'pending', shiftHeld?: boolean) => void;
   adjacentImageIds?: { next: number[]; previous: number[] };
   // Optional grading system for undo/redo (passed from parent)
   grading?: {
@@ -265,9 +265,9 @@ export default function ImageDetailView({
   useHotkeys('j,left', () => {
     onPrevious(); // J/Left goes to older image (lower index in oldest-first sort)
   }, { enableOnFormTags: true }, [onPrevious]);
-  useHotkeys('a', () => onGrade('accepted'), [onGrade]);
-  useHotkeys('x', () => onGrade('rejected'), [onGrade]);
-  useHotkeys('u', () => onGrade('pending'), [onGrade]);
+  useHotkeys('a,shift+a', (event) => onGrade('accepted', event.shiftKey), [onGrade]);
+  useHotkeys('x,shift+x', (event) => onGrade('rejected', event.shiftKey), [onGrade]);
+  useHotkeys('u,shift+u', (event) => onGrade('pending', event.shiftKey), [onGrade]);
   useHotkeys('s', () => {
     setShowStars(s => !s);
     setShowPsf(false); // Turn off PSF when showing stars
@@ -841,21 +841,21 @@ export default function ImageDetailView({
             <div className="detail-actions">
               <button 
                 className="action-button accept" 
-                onClick={() => onGrade('accepted')}
+                onClick={(event) => onGrade('accepted', event.shiftKey)}
                 disabled={grading ? !grading.canWrite : false}
               >
                 Accept (A)
               </button>
               <button 
                 className="action-button reject" 
-                onClick={() => onGrade('rejected')}
+                onClick={(event) => onGrade('rejected', event.shiftKey)}
                 disabled={grading ? !grading.canWrite : false}
               >
                 Reject (X)
               </button>
               <button 
                 className="action-button pending" 
-                onClick={() => onGrade('pending')}
+                onClick={(event) => onGrade('pending', event.shiftKey)}
                 disabled={grading ? !grading.canWrite : false}
               >
                 Unmark (U)

--- a/static/src/components/MainView.tsx
+++ b/static/src/components/MainView.tsx
@@ -5,6 +5,7 @@ import ImageDetailView from './ImageDetailView';
 import ImageComparisonView from './ImageComparisonView';
 import { useImageNavigation } from '../hooks/useImageNavigation';
 import { useGrading } from '../hooks/useGrading';
+import { useDisplayPreferences } from '../hooks/useDisplayPreferences';
 import { imageDetailReturnView } from '../utils/imageDetailRoutes';
 
 export default function MainView() {
@@ -32,14 +33,19 @@ export default function MainView() {
   // Navigation and grading hooks for overlays
   const navigation = useImageNavigation(imageId || rightImageId);
   const grading = useGrading(dbId!);
+  const { advanceOnGrade } = useDisplayPreferences();
 
-  const handleGrade = async (status: 'accepted' | 'rejected' | 'pending') => {
+  const handleGrade = async (
+    status: 'accepted' | 'rejected' | 'pending',
+    shiftHeld = false,
+  ) => {
     if (!imageId || !grading.canWrite) return;
-    
+
     try {
       await grading.gradeImage(imageId, status);
-      // Auto-advance to next image after grading
-      if (navigation.canGoNext) {
+      // Advance per preference; Shift does the opposite for this grade.
+      const advance = shiftHeld ? !advanceOnGrade : advanceOnGrade;
+      if (advance && navigation.canGoNext) {
         setTimeout(() => navigation.goToNext(), 100);
       }
     } catch (error) {

--- a/static/src/components/ReviewPreferences.tsx
+++ b/static/src/components/ReviewPreferences.tsx
@@ -1,0 +1,66 @@
+import {
+  setDisplayPreferences,
+  useDisplayPreferences,
+} from '../hooks/useDisplayPreferences';
+import { LayersIcon, MoonIcon } from './ScoreChipIcons';
+
+/**
+ * Review behavior preferences. Stored in this browser and shared by the
+ * grid, the Sequence view, and the detail view, so every surface behaves
+ * the same way.
+ */
+export default function ReviewPreferences() {
+  const preferences = useDisplayPreferences();
+  const set = (patch: Partial<typeof preferences>) =>
+    setDisplayPreferences({ ...preferences, ...patch });
+
+  return (
+    <div className="review-preferences">
+      <h3>Grading</h3>
+      <label className="review-preference">
+        <input
+          type="checkbox"
+          checked={preferences.advanceOnGrade}
+          onChange={(event) => set({ advanceOnGrade: event.target.checked })}
+        />
+        <span>
+          Move to the next image after accept, reject, or pending
+          <small>
+            Holding Shift while grading does the opposite of this setting for
+            that one grade.
+          </small>
+        </span>
+      </label>
+
+      <h3>Score chips</h3>
+      <label className="review-preference">
+        <input
+          type="checkbox"
+          checked={preferences.showNightChip}
+          onChange={(event) => set({ showNightChip: event.target.checked })}
+        />
+        <span>
+          <MoonIcon /> Night-session score chip
+          <small>How the frame ranks within its own capture session.</small>
+        </span>
+      </label>
+      <label className="review-preference">
+        <input
+          type="checkbox"
+          checked={preferences.showAllChip}
+          onChange={(event) => set({ showAllChip: event.target.checked })}
+        />
+        <span>
+          <LayersIcon /> All-sessions score chip
+          <small>
+            How the frame ranks against every stack candidate for its filter.
+          </small>
+        </span>
+      </label>
+
+      <p className="review-preferences-note">
+        These preferences live in this browser and apply immediately.
+      </p>
+    </div>
+  );
+}

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -1529,3 +1529,50 @@
     flex-direction: column;
   }
 }
+
+.review-preferences {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  max-width: 34rem;
+}
+
+.review-preferences h3 {
+  margin: 0.4rem 0 0;
+  font-size: 0.95rem;
+}
+
+.review-preference {
+  display: flex;
+  gap: 0.6rem;
+  align-items: flex-start;
+  cursor: pointer;
+}
+
+.review-preference input {
+  margin-top: 0.2rem;
+  cursor: pointer;
+}
+
+.review-preference span {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.review-preference small {
+  color: var(--color-text-muted);
+}
+
+.review-preference .score-chip-icon {
+  width: 0.85rem;
+  height: 0.85rem;
+  vertical-align: middle;
+  margin-right: 0.25rem;
+}
+
+.review-preferences-note {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  margin: 0.4rem 0 0;
+}

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -11,6 +11,7 @@ import type { DbEntry, DbRegistry } from '../utils/tauri';
 import { apiClient } from '../api/client';
 import { useAccess } from '../auth/access';
 import type { SettingsIntent } from '../utils/settingsIntent';
+import ReviewPreferences from './ReviewPreferences';
 import type { DatabaseSummary } from '../api/types';
 import { describeImportProgress, useImportJob } from '../hooks/useImportJob';
 import { starMetadataFillEnabled } from '../hooks/useStarMetadataFill';
@@ -26,7 +27,7 @@ import './TauriSettings.css';
 /**
  * Settings groups unrelated jobs into named tabs so each stays easy to find.
  */
-type SettingsTab = 'databases' | 'catalogs' | 'sync' | 'setups' | 'users';
+type SettingsTab = 'databases' | 'catalogs' | 'sync' | 'setups' | 'review' | 'users';
 
 interface TauriSettingsProps {
   isOpen: boolean;
@@ -661,6 +662,8 @@ export default function TauriSettings({
     // Setups are global display parameters, not filesystem paths, so the tab
     // is not management-gated.
     { id: 'setups', label: 'Setups' },
+    // Review preferences are stored in this browser, so no gate either.
+    { id: 'review', label: 'Review' },
     ...(!isTauri && access.status.authentication_required
       ? ([{ id: 'users', label: 'Users' }] as const)
       : []),
@@ -987,6 +990,7 @@ export default function TauriSettings({
           id={`settings-panel-${currentTab}`}
           aria-labelledby={`settings-tab-${currentTab}`}
         >
+          {currentTab === 'review' && <ReviewPreferences />}
           {currentTab === 'databases' && (
           <>
           {!hasDatabases && managementAllowed && (

--- a/static/src/hooks/__tests__/useDisplayPreferences.test.tsx
+++ b/static/src/hooks/__tests__/useDisplayPreferences.test.tsx
@@ -8,17 +8,21 @@ import {
 describe('display preferences', () => {
   beforeEach(() => {
     window.localStorage.removeItem('psf-guard.display-preferences');
-    setDisplayPreferences({ showNightChip: true, showAllChip: true });
+    setDisplayPreferences({ showNightChip: true, showAllChip: true, advanceOnGrade: true });
   });
 
-  it('defaults to showing both chip types', () => {
+  it('defaults to showing both chip types and advancing after a grade', () => {
     const { result } = renderHook(() => useDisplayPreferences());
-    expect(result.current).toEqual({ showNightChip: true, showAllChip: true });
+    expect(result.current).toEqual({
+      showNightChip: true,
+      showAllChip: true,
+      advanceOnGrade: true,
+    });
   });
 
   it('toggles each chip type independently', () => {
     act(() => {
-      setDisplayPreferences({ showNightChip: false, showAllChip: true });
+      setDisplayPreferences({ showNightChip: false, showAllChip: true, advanceOnGrade: true });
     });
     const { result } = renderHook(() => useDisplayPreferences());
     expect(result.current.showNightChip).toBe(false);
@@ -31,7 +35,7 @@ describe('display preferences', () => {
     const grid = renderHook(() => useDisplayPreferences());
     const sequence = renderHook(() => useDisplayPreferences());
     act(() => {
-      setDisplayPreferences({ showNightChip: true, showAllChip: false });
+      setDisplayPreferences({ showNightChip: true, showAllChip: false, advanceOnGrade: true });
     });
     expect(grid.result.current.showAllChip).toBe(false);
     expect(sequence.result.current.showAllChip).toBe(false);
@@ -39,17 +43,18 @@ describe('display preferences', () => {
 
   it('persists the choice to localStorage', () => {
     act(() => {
-      setDisplayPreferences({ showNightChip: false, showAllChip: false });
+      setDisplayPreferences({ showNightChip: false, showAllChip: false, advanceOnGrade: false });
     });
     expect(
       JSON.parse(window.localStorage.getItem('psf-guard.display-preferences')!),
-    ).toEqual({ showNightChip: false, showAllChip: false });
+    ).toEqual({ showNightChip: false, showAllChip: false, advanceOnGrade: false });
   });
 
   it('falls back to the default on malformed stored values', () => {
     setDisplayPreferences({
       showNightChip: 'yes' as unknown as boolean,
       showAllChip: true,
+      advanceOnGrade: true,
     });
     const { result } = renderHook(() => useDisplayPreferences());
     expect(result.current.showNightChip).toBe(true);
@@ -66,6 +71,7 @@ describe('display preferences', () => {
       new StorageEvent('storage', { key: 'psf-guard.display-preferences' }),
     );
     const { result } = renderHook(() => useDisplayPreferences());
-    expect(result.current).toEqual({ showNightChip: false, showAllChip: false });
+    expect(result.current.showNightChip).toBe(false);
+    expect(result.current.showAllChip).toBe(false);
   });
 });

--- a/static/src/hooks/useDisplayPreferences.ts
+++ b/static/src/hooks/useDisplayPreferences.ts
@@ -12,10 +12,17 @@ export interface DisplayPreferences {
   /** Show the smaller "all <score>" chip — the all-sessions basis shown
    * when the main badge is a single session's score. */
   showAllChip: boolean;
+  /** Move to the next image after accept/reject/pending. Holding Shift
+   * while grading does the opposite of this setting for that one grade. */
+  advanceOnGrade: boolean;
 }
 
 const STORAGE_KEY = 'psf-guard.display-preferences';
-const DEFAULTS: DisplayPreferences = { showNightChip: true, showAllChip: true };
+const DEFAULTS: DisplayPreferences = {
+  showNightChip: true,
+  showAllChip: true,
+  advanceOnGrade: true,
+};
 
 type Listener = () => void;
 
@@ -40,6 +47,10 @@ function sanitize(parsed: StoredPreferences): DisplayPreferences {
       typeof parsed.showAllChip === 'boolean'
         ? parsed.showAllChip
         : legacy ?? DEFAULTS.showAllChip,
+    advanceOnGrade:
+      typeof parsed.advanceOnGrade === 'boolean'
+        ? parsed.advanceOnGrade
+        : DEFAULTS.advanceOnGrade,
   };
 }
 


### PR DESCRIPTION
Four review-flow refinements from feedback, plus one optimization of the same class as #348.

- **Advance-on-grade preference.** A new **Review** tab in Settings (browser-local, ungated) controls whether accept/reject/pending moves to the next image — in the grid and the detail view. Holding Shift while grading does the opposite of the setting for that one grade. The score-chip toggles join the same tab.
- **Shift+arrow range select.** The grid selection extends from the keyboard with the same anchor semantics as Shift+click.
- **Status visible under selection.** A multi-selected card keeps its accepted/rejected border color; selection reads as an outer ring, checkmark, and inset instead of replacing the border.
- **Selection no longer floods the preview queue.** Every selected card preloaded its full-size preview, so select-all on a big grid queued thousands of large-preview generations and kept the generation-status poller running for minutes. Only the keyboard cursor's image preloads — the one a detail view would open.

Verified headlessly on the clean-room database: Shift+ArrowRight×2 + Shift+ArrowDown selects 7 cards; `x` grades and moves the cursor while `Shift+X` grades in place; a rejected card selected via Ctrl+click keeps its red border (computed `rgb(244,67,54)`) inside the orange ring; select-all produces 0 generation-status posts (previously a 44-post flood); the Review tab renders with working checkboxes. Checks: `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (284), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)