### PR TITLE
Add a sensor tilt inspector, and make PSF fitting actually fit

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -85,7 +85,22 @@
   full-size preview generation per selected frame — only the keyboard
   cursor's image preloads.
 
+- The image detail view gained a **sensor tilt and aberration inspector**
+  (press **I**): a 3x3 mosaic of 1:1 crops from each sensor region with
+  per-region median HFR, eccentricity, star count, and mean star-elongation
+  direction, plus ASTAP-style corner numbers — tilt (softest corner against
+  sharpest) and field curvature (corners against center). Solved frames also
+  show their **field rotation** (and a mirrored flag) in the Sky context
+  panel.
+
 ## Fixed
+
+- Star PSF fitting now actually fits. A sign error in the optimizer made
+  every iteration step uphill, so every fitted PSF kept its initial guess —
+  reported eccentricity was really the star's bounding-box aspect ratio and
+  orientation was always zero. Star detail overlays and the tilt inspector
+  now see converged models; quality scoring is unaffected (it uses
+  N.I.N.A.'s own capture-time values).
 
 - Editing a configured database now opens its settings directly beneath that
   database instead of below the full database list. The selected row and named

--- a/src/psf_fitting.rs
+++ b/src/psf_fitting.rs
@@ -387,10 +387,13 @@ impl LevenbergMarquardt {
                 break;
             }
 
-            // LM update
+            // LM update. The Jacobian here is d(residual)/d(param), so the
+            // descent step solves (JᵀJ + λI)·δ = −Jᵀr; solving for +Jᵀr
+            // walks uphill, every step gets rejected, and the "fit" returns
+            // the initial guess untouched.
             let jt = jacobian.transpose();
             let jtj = &jt * &jacobian;
-            let jtr = &jt * &residuals;
+            let jtr = -(&jt * &residuals);
 
             loop {
                 // Add lambda to diagonal (LM modification)

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -242,6 +242,12 @@ pub struct StarDetectionResponse {
     pub detected_stars: usize,
     pub average_hfr: f64,
     pub average_fwhm: f64,
+    /// Frame dimensions in pixels, so a client can place stars into
+    /// regions (tilt and aberration inspection) without a second lookup.
+    #[serde(default)]
+    pub width: Option<usize>,
+    #[serde(default)]
+    pub height: Option<usize>,
     pub stars: Vec<StarInfo>,
 }
 
@@ -253,6 +259,11 @@ pub struct StarInfo {
     pub fwhm: f64,
     pub brightness: f64,
     pub eccentricity: f64,
+    /// PSF orientation in radians (elongation direction), when a PSF model
+    /// was fitted. The tilt inspector uses the per-region mean direction to
+    /// tell tilt from curvature and astigmatism.
+    #[serde(default)]
+    pub theta: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -3285,7 +3285,7 @@ pub async fn get_image_stars(
     // detector picks a telescope-class preset from the frame's headers, so
     // v1 entries (fixed defaults) are stale for wide/long rigs.
     let cache_key = format!(
-        "stars_v2_{}_{}_{}_{}_{}",
+        "stars_v3_{}_{}_{}_{}_{}",
         image_id,
         image.project_id,
         image.target_id,
@@ -3316,7 +3316,7 @@ pub async fn get_image_stars(
 
     // Move expensive operations to spawn_blocking
     let fits_path_str = fits_path.to_string_lossy().to_string();
-    let (stars, detected_count, average_hfr, average_fwhm) =
+    let (stars, detected_count, average_hfr, average_fwhm, frame_width, frame_height) =
         tokio::task::spawn_blocking(move || {
             // Load FITS file
             let fits = FitsImage::from_file(std::path::Path::new(&fits_path_str))?;
@@ -3335,10 +3335,20 @@ pub async fn get_image_stars(
                 .stars
                 .iter()
                 .map(|star| {
-                    let eccentricity = if let Some(psf) = &star.psf_model {
-                        psf.eccentricity
+                    let (eccentricity, theta) = if let Some(psf) = &star.psf_model {
+                        // Report the MAJOR-axis direction in [0, π): the fit
+                        // may express the same ellipse as either sigma being
+                        // larger, and clients averaging directions must not
+                        // see the two forms 90° apart.
+                        let raw = if psf.sigma_x >= psf.sigma_y {
+                            psf.theta
+                        } else {
+                            psf.theta + std::f64::consts::FRAC_PI_2
+                        };
+                        let major = raw.rem_euclid(std::f64::consts::PI);
+                        (psf.eccentricity, Some(major))
                     } else {
-                        0.0
+                        (0.0, None)
                     };
 
                     StarInfo {
@@ -3348,15 +3358,18 @@ pub async fn get_image_stars(
                         fwhm: star.fwhm,
                         brightness: star.brightness,
                         eccentricity,
+                        theta,
                     }
                 })
                 .collect();
 
-            Ok::<(Vec<StarInfo>, usize, f64, f64), anyhow::Error>((
+            Ok::<(Vec<StarInfo>, usize, f64, f64, usize, usize), anyhow::Error>((
                 stars,
                 detection_result.stars.len(),
                 detection_result.average_hfr,
                 detection_result.average_fwhm,
+                fits.width,
+                fits.height,
             ))
         })
         .await
@@ -3367,6 +3380,8 @@ pub async fn get_image_stars(
         detected_stars: detected_count,
         average_hfr,
         average_fwhm,
+        width: Some(frame_width),
+        height: Some(frame_height),
         stars,
     };
 

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -54,12 +54,17 @@ export interface StarInfo {
   fwhm: number;
   brightness: number;
   eccentricity: number;
+  /** PSF orientation in radians (elongation direction), when fitted. */
+  theta?: number | null;
 }
 
 export interface StarDetectionResponse {
   detected_stars: number;
   average_hfr: number;
   average_fwhm: number;
+  /** Frame dimensions in pixels; absent from pre-v3 cached results. */
+  width?: number | null;
+  height?: number | null;
   stars: StarInfo[];
 }
 

--- a/static/src/components/AstrometryPanel.tsx
+++ b/static/src/components/AstrometryPanel.tsx
@@ -1,4 +1,5 @@
 import type { AstrometryAnalysis, CatalogHit } from '../api/types';
+import { fieldRotation } from '../utils/fieldRotation';
 
 interface AstrometryPanelProps {
   analysis?: AstrometryAnalysis;
@@ -76,6 +77,7 @@ export default function AstrometryPanel({
   }
 
   const solution = analysis.solution;
+  const rotation = solution?.wcs ? fieldRotation(solution.wcs) : null;
   const badge = solution
     ? analysis.mode === 'hinted'
       ? 'Hinted solve'
@@ -141,6 +143,14 @@ export default function AstrometryPanel({
             <>
               <dt>Scale</dt>
               <dd>{solution.pixel_scale_arcsec_per_pixel.toFixed(3)}″/px</dd>
+            </>
+          )}
+          {rotation && (
+            <>
+              <dt>Rotation</dt>
+              <dd title="Direction of celestial north from image up, positive toward image right">
+                {rotation.degrees.toFixed(1)}°{rotation.mirrored ? ' · mirrored' : ''}
+              </dd>
             </>
           )}
           {analysis.pointing && (

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -14,6 +14,7 @@ import AstrometryOverlay from './AstrometryOverlay';
 import SatellitePanel from './SatellitePanel';
 import SatelliteTrackOverlay from './SatelliteTrackOverlay';
 import ImageFileLocation from './ImageFileLocation';
+import TiltInspector from './TiltInspector';
 import { useScopedQuality } from '../hooks/useSequenceAnalysis';
 import QualityAnalysisSummary from './QualityAnalysisSummary';
 import QualityRegionOverlay from './QualityRegionOverlay';
@@ -66,6 +67,7 @@ export default function ImageDetailView({
   const queryClient = useQueryClient();
   const { canCompute } = useAccess();
   const [showStars, setShowStars] = useState(false);
+  const [showTilt, setShowTilt] = useState(false);
   // Shared with the grid and the overview, so a frame does not change
   // appearance on the way into the detail view. On by default; off gives the
   // luminance rendition the grader measures, and a mono frame looks the same
@@ -268,6 +270,7 @@ export default function ImageDetailView({
   useHotkeys('a,shift+a', (event) => onGrade('accepted', event.shiftKey), [onGrade]);
   useHotkeys('x,shift+x', (event) => onGrade('rejected', event.shiftKey), [onGrade]);
   useHotkeys('u,shift+u', (event) => onGrade('pending', event.shiftKey), [onGrade]);
+  useHotkeys('i', () => setShowTilt(current => !current), []);
   useHotkeys('s', () => {
     setShowStars(s => !s);
     setShowPsf(false); // Turn off PSF when showing stars
@@ -886,6 +889,7 @@ export default function ImageDetailView({
                 <span>X Reject</span>
                 <span>U Pending</span>
                 <span>S Stars {showStars ? '✓' : ''}</span>
+                <span>I Tilt {showTilt ? '✓' : ''}</span>
                 <span>P PSF {showPsf ? '✓' : ''}</span>
                 <span>O Sky {showAstrometry && astrometry?.solution ? '✓' : ''}</span>
                 <span>Z Size</span>
@@ -946,6 +950,12 @@ export default function ImageDetailView({
           </div>
         </div>
       </div>
+      <TiltInspector
+        open={showTilt}
+        dbId={dbId}
+        imageId={imageId}
+        onClose={() => setShowTilt(false)}
+      />
     </div>
   );
 }

--- a/static/src/components/TiltInspector.css
+++ b/static/src/components/TiltInspector.css
@@ -1,0 +1,75 @@
+.tilt-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  max-width: 40rem;
+}
+
+.tilt-mosaic {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 4px;
+  justify-content: center;
+}
+
+.tilt-pane {
+  position: relative;
+  border: 2px solid var(--color-border, #555);
+  border-radius: 4px;
+  background-color: var(--color-bg-primary, #111);
+  background-repeat: no-repeat;
+  overflow: hidden;
+}
+
+.tilt-direction {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  color: var(--color-primary, #4da3ff);
+  pointer-events: none;
+}
+
+.tilt-pane-stats {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  gap: 0.6rem;
+  justify-content: center;
+  padding: 2px 4px;
+  font-size: 0.7rem;
+  background: rgb(0 0 0 / 55%);
+  color: white;
+}
+
+.tilt-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 2rem;
+}
+
+.tilt-summary > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.tilt-summary strong {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+.tilt-inspector-muted {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.tilt-inspector-error {
+  color: var(--color-error, #c0392b);
+  margin: 0;
+}

--- a/static/src/components/TiltInspector.tsx
+++ b/static/src/components/TiltInspector.tsx
@@ -1,0 +1,208 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import type { StarDetectionResponse } from '../api/types';
+import { useColorPreview } from '../hooks/useColorPreview';
+import { analyzeCells, tiltSummary, type CellStats } from '../utils/tiltAnalysis';
+import Dialog from './Dialog';
+import './TiltInspector.css';
+
+interface TiltInspectorProps {
+  open: boolean;
+  dbId: string;
+  imageId: number;
+  onClose: () => void;
+}
+
+/** Side of one mosaic pane, in CSS pixels. */
+const PANE_SIZE = 200;
+/** Fraction of the frame's short side each pane crops at 1:1 scale. */
+const CROP_FRACTION = 1 / 6;
+
+function cellLabel(row: number, col: number): string {
+  const vertical = ['Top', 'Middle', 'Bottom'][row];
+  const horizontal = ['left', 'center', 'right'][col];
+  return row === 1 && col === 1 ? 'Center' : `${vertical} ${horizontal}`;
+}
+
+/** Color a cell by how much softer it is than the sharpest cell. */
+function hfrColor(hfr: number | null, bestHfr: number | null): string {
+  if (hfr === null || bestHfr === null || bestHfr <= 0) {
+    return 'var(--color-border, #555)';
+  }
+  const excess = hfr / bestHfr - 1;
+  if (excess < 0.1) return 'var(--color-success)';
+  if (excess < 0.25) return 'var(--color-warning)';
+  return 'var(--color-error)';
+}
+
+/**
+ * Sensor tilt and aberration inspection for one frame: a 3x3 mosaic of 1:1
+ * crops (the corner view PixInsight's aberration inspector gives),
+ * per-region star statistics with elongation direction, and ASTAP-style
+ * corner-HFD tilt numbers. A tilted sensor focuses one side of the frame
+ * ahead of the other, so its signature is a soft corner opposite a sharp
+ * one; evenly soft corners are field curvature instead.
+ */
+export default function TiltInspector({
+  open,
+  dbId,
+  imageId,
+  onClose,
+}: TiltInspectorProps) {
+  const color = useColorPreview();
+  const detection = useQuery<StarDetectionResponse>({
+    queryKey: ['db', dbId, 'stars', imageId],
+    queryFn: () => apiClient.getStarDetection(dbId, imageId),
+    enabled: open,
+    staleTime: Infinity,
+  });
+
+  const data = detection.data;
+  const width = data?.width ?? null;
+  const height = data?.height ?? null;
+  const cells = useMemo<CellStats[] | null>(() => {
+    if (!data || width === null || height === null) return null;
+    return analyzeCells(data.stars, width, height);
+  }, [data, width, height]);
+  const summary = useMemo(() => (cells ? tiltSummary(cells) : null), [cells]);
+  const bestCellHfr = useMemo(() => {
+    if (!cells) return null;
+    const values = cells
+      .map((cell) => cell.medianHfr)
+      .filter((hfr): hfr is number => hfr !== null);
+    return values.length > 0 ? Math.min(...values) : null;
+  }, [cells]);
+
+  // 1:1 crops from the "large" preview via background positioning. The
+  // preview is capped at 2000px on the long side, so scale accordingly.
+  const previewUrl = apiClient.getPreviewUrl(dbId, imageId, {
+    size: 'large',
+    color,
+  });
+  const paneStyle = (row: number, col: number): React.CSSProperties => {
+    if (width === null || height === null) return {};
+    const previewScale = Math.min(1, 2000 / Math.max(width, height));
+    const previewWidth = width * previewScale;
+    const previewHeight = height * previewScale;
+    const cropSide = Math.min(width, height) * CROP_FRACTION * previewScale;
+    const scale = PANE_SIZE / cropSide;
+    const centerX = ((col + 0.5) * previewWidth) / 3;
+    const centerY = ((row + 0.5) * previewHeight) / 3;
+    return {
+      backgroundImage: `url(${JSON.stringify(previewUrl)})`,
+      backgroundSize: `${previewWidth * scale}px ${previewHeight * scale}px`,
+      backgroundPosition: `${-(centerX * scale - PANE_SIZE / 2)}px ${-(
+        centerY * scale -
+        PANE_SIZE / 2
+      )}px`,
+    };
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} title="Sensor tilt and aberration inspection">
+      <div className="tilt-inspector">
+        {detection.isLoading && (
+          <p className="tilt-inspector-muted">Detecting stars…</p>
+        )}
+        {detection.error && (
+          <p className="tilt-inspector-error">
+            {detection.error instanceof Error
+              ? detection.error.message
+              : String(detection.error)}
+          </p>
+        )}
+        {data && (width === null || height === null) && (
+          <p className="tilt-inspector-muted">
+            This frame's star analysis predates region support. Run Analyze
+            Quality again, or reopen after the star cache refreshes.
+          </p>
+        )}
+        {cells && summary && (
+          <>
+            <div className="tilt-mosaic">
+              {cells.map((cell) => (
+                <div
+                  key={`${cell.row}:${cell.col}`}
+                  className="tilt-pane"
+                  style={{
+                    width: PANE_SIZE,
+                    height: PANE_SIZE,
+                    borderColor: hfrColor(cell.medianHfr, bestCellHfr),
+                    ...paneStyle(cell.row, cell.col),
+                  }}
+                  title={cellLabel(cell.row, cell.col)}
+                >
+                  {cell.meanTheta !== null && cell.thetaCoherence > 0.25 && (
+                    <svg
+                      className="tilt-direction"
+                      viewBox="-100 -100 200 200"
+                      aria-hidden="true"
+                    >
+                      <line
+                        x1={-30 * Math.cos(cell.meanTheta)}
+                        y1={-30 * Math.sin(cell.meanTheta)}
+                        x2={30 * Math.cos(cell.meanTheta)}
+                        y2={30 * Math.sin(cell.meanTheta)}
+                        stroke="currentColor"
+                        strokeWidth={1.5 + 2.5 * cell.thetaCoherence}
+                        strokeLinecap="round"
+                        opacity={0.8}
+                      />
+                    </svg>
+                  )}
+                  <div className="tilt-pane-stats">
+                    {cell.medianHfr !== null ? (
+                      <>
+                        <span>HFR {cell.medianHfr.toFixed(2)}</span>
+                        <span>e {cell.medianEccentricity?.toFixed(2) ?? '—'}</span>
+                        <span>{cell.starCount}★</span>
+                      </>
+                    ) : (
+                      <span>no stars</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="tilt-summary">
+              <div>
+                <strong>Tilt</strong>
+                <span>
+                  {summary.tiltPercent !== null
+                    ? `${summary.tiltPercent.toFixed(0)}% — softest ${summary.worstCorner}, sharpest ${summary.bestCorner}`
+                    : 'needs stars in all four corners'}
+                </span>
+              </div>
+              <div>
+                <strong>Field curvature</strong>
+                <span>
+                  {summary.curvaturePercent !== null
+                    ? `corners ${summary.curvaturePercent >= 0 ? '+' : ''}${summary.curvaturePercent.toFixed(0)}% vs center`
+                    : 'needs center and corner stars'}
+                </span>
+              </div>
+              <div>
+                <strong>Center HFR</strong>
+                <span>{summary.centerHfr?.toFixed(2) ?? '—'}</span>
+              </div>
+            </div>
+
+            <p className="tilt-inspector-muted">
+              Panes crop the frame 1:1 at each region's center; borders color
+              by softness against the sharpest region. A line through a pane
+              is the region's mean star-elongation direction (thicker = more
+              aligned). The same direction in every region — center included —
+              is guiding or wind, not optics; directions that only align near
+              the edges point at sensor tilt or astigmatism; soft corners in
+              every direction with a sharp center indicate field curvature.
+              One frame's seeing can mimic any of these — confirm on several
+              frames.
+            </p>
+          </>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/static/src/utils/__tests__/fieldRotation.test.ts
+++ b/static/src/utils/__tests__/fieldRotation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { fieldRotation } from '../fieldRotation';
+import type { WcsSolution } from '@seiza/astro-overlay';
+
+function wcs(cd: [[number, number], [number, number]]): WcsSolution {
+  return { crval: [180, 45], crpix: [100, 100], cd };
+}
+
+const SCALE = 0.001; // deg/px
+
+describe('fieldRotation', () => {
+  it('reports zero for north-up east-left', () => {
+    // +Dec maps to −y (screen up), +RA to −x (screen left).
+    const rotation = fieldRotation(wcs([[-SCALE, 0], [0, -SCALE]]))!;
+    expect(rotation.degrees).toBeCloseTo(0, 6);
+    expect(rotation.mirrored).toBe(false);
+  });
+
+  it('reports a quarter turn when north points right', () => {
+    // +Dec maps to +x: the camera is rotated 90°.
+    const rotation = fieldRotation(wcs([[0, -SCALE], [SCALE, 0]]))!;
+    expect(rotation.degrees).toBeCloseTo(90, 6);
+    expect(rotation.mirrored).toBe(false);
+  });
+
+  it('flags a mirrored field', () => {
+    // North up but east to the RIGHT: parity flipped.
+    const rotation = fieldRotation(wcs([[SCALE, 0], [0, -SCALE]]))!;
+    expect(rotation.degrees).toBeCloseTo(0, 6);
+    expect(rotation.mirrored).toBe(true);
+  });
+
+  it('returns null for a degenerate matrix', () => {
+    expect(fieldRotation(wcs([[0, 0], [0, 0]]))).toBeNull();
+  });
+});

--- a/static/src/utils/__tests__/tiltAnalysis.test.ts
+++ b/static/src/utils/__tests__/tiltAnalysis.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeCells, tiltSummary } from '../tiltAnalysis';
+import type { StarInfo } from '../../api/types';
+
+function star(x: number, y: number, hfr: number, extra: Partial<StarInfo> = {}): StarInfo {
+  return {
+    x,
+    y,
+    hfr,
+    fwhm: hfr * 2,
+    brightness: 1000,
+    eccentricity: 0.2,
+    ...extra,
+  };
+}
+
+/** One star in the middle of every 3x3 cell of a 300x300 frame. */
+function starPerCell(hfrAt: (row: number, col: number) => number): StarInfo[] {
+  const stars: StarInfo[] = [];
+  for (let row = 0; row < 3; row++) {
+    for (let col = 0; col < 3; col++) {
+      stars.push(star(col * 100 + 50, row * 100 + 50, hfrAt(row, col)));
+    }
+  }
+  return stars;
+}
+
+describe('analyzeCells', () => {
+  it('assigns stars to their region and takes medians', () => {
+    const stars = [
+      star(10, 10, 2.0),
+      star(20, 20, 3.0),
+      star(30, 30, 4.0),
+      star(290, 290, 5.0),
+    ];
+    const cells = analyzeCells(stars, 300, 300);
+    const topLeft = cells.find((cell) => cell.row === 0 && cell.col === 0)!;
+    expect(topLeft.starCount).toBe(3);
+    expect(topLeft.medianHfr).toBe(3.0);
+    const bottomRight = cells.find((cell) => cell.row === 2 && cell.col === 2)!;
+    expect(bottomRight.starCount).toBe(1);
+    expect(bottomRight.medianHfr).toBe(5.0);
+    const empty = cells.find((cell) => cell.row === 1 && cell.col === 1)!;
+    expect(empty.starCount).toBe(0);
+    expect(empty.medianHfr).toBeNull();
+  });
+
+  it('averages elongation directions over the axial period', () => {
+    // Orientations near π and near 0 are almost the same axis; a naive
+    // mean would point them perpendicular instead.
+    const stars = [
+      star(10, 10, 2, { theta: 0.05, eccentricity: 0.5 }),
+      star(20, 20, 2, { theta: Math.PI - 0.05, eccentricity: 0.5 }),
+    ];
+    const cells = analyzeCells(stars, 300, 300);
+    const cell = cells.find((c) => c.row === 0 && c.col === 0)!;
+    expect(cell.meanTheta).not.toBeNull();
+    const axisError = Math.min(cell.meanTheta!, Math.PI - cell.meanTheta!);
+    expect(axisError).toBeLessThan(0.01);
+    expect(cell.thetaCoherence).toBeGreaterThan(0.9);
+  });
+
+  it('reports low coherence for random directions', () => {
+    const stars = [0, 1, 2, 3].map((i) =>
+      star(10 + i, 10 + i, 2, { theta: (i * Math.PI) / 4, eccentricity: 0.5 })
+    );
+    const cells = analyzeCells(stars, 300, 300);
+    const cell = cells.find((c) => c.row === 0 && c.col === 0)!;
+    expect(cell.thetaCoherence).toBeLessThan(0.3);
+  });
+});
+
+describe('tiltSummary', () => {
+  it('derives tilt from corner spread against the mean', () => {
+    // One soft corner: classic tilt signature.
+    const cells = analyzeCells(
+      starPerCell((row, col) => (row === 0 && col === 0 ? 3.0 : 2.0)),
+      300,
+      300
+    );
+    const summary = tiltSummary(cells);
+    expect(summary.worstCorner).toBe('top-left');
+    expect(summary.bestCorner).toBeTruthy();
+    expect(summary.tiltPercent).toBeCloseTo(50, 0);
+  });
+
+  it('derives curvature from corners against the center', () => {
+    // All corners equally soft, sharp center: curvature, near-zero tilt.
+    const cells = analyzeCells(
+      starPerCell((row, col) =>
+        (row === 1 && col === 1) ? 2.0 : (row !== 1 && col !== 1) ? 3.0 : 2.5
+      ),
+      300,
+      300
+    );
+    const summary = tiltSummary(cells);
+    expect(summary.tiltPercent).toBeCloseTo(0, 5);
+    expect(summary.curvaturePercent).toBeCloseTo(50, 0);
+  });
+
+  it('refuses a tilt number with an empty corner', () => {
+    const stars = starPerCell(() => 2.0).filter(
+      (candidate) => !(candidate.x < 100 && candidate.y < 100)
+    );
+    const summary = tiltSummary(analyzeCells(stars, 300, 300));
+    expect(summary.tiltPercent).toBeNull();
+    expect(summary.worstCorner).toBeNull();
+  });
+});

--- a/static/src/utils/fieldRotation.ts
+++ b/static/src/utils/fieldRotation.ts
@@ -1,0 +1,34 @@
+import type { WcsSolution } from '@seiza/astro-overlay';
+
+export interface FieldRotation {
+  /** Direction of celestial north measured from image "up", in degrees,
+   * positive toward image right, normalized to (−180, 180]. */
+  degrees: number;
+  /** True when the field is mirrored (east and west swap sides compared
+   * with the sky) — a flat, mirror diagonal, or some OAG paths. */
+  mirrored: boolean;
+}
+
+/**
+ * Camera field rotation from a WCS solve's CD matrix.
+ *
+ * The CD matrix maps pixel offsets to sky offsets; inverting its second
+ * column gives the pixel direction of +Dec (north). The angle of that
+ * vector from screen-up is the field rotation. Parity (the determinant
+ * sign) says whether the frame is mirrored.
+ */
+export function fieldRotation(wcs: WcsSolution): FieldRotation | null {
+  const [[cd11, cd12], [cd21, cd22]] = wcs.cd;
+  const det = cd11 * cd22 - cd12 * cd21;
+  if (!Number.isFinite(det) || det === 0) return null;
+  // inv(CD) · (0, 1): pixel displacement per degree of declination.
+  const northX = -cd12 / det;
+  const northY = cd11 / det;
+  if (northX === 0 && northY === 0) return null;
+  // Screen up is −y; positive angles rotate toward +x (image right).
+  const degrees = (Math.atan2(northX, -northY) * 180) / Math.PI;
+  // Sky convention: with north up, east is to the LEFT. Working the east
+  // vector inv(CD)·(1,0) through image coordinates (y down), that parity
+  // corresponds to a positive determinant; negative means mirrored.
+  return { degrees, mirrored: det < 0 };
+}

--- a/static/src/utils/tiltAnalysis.ts
+++ b/static/src/utils/tiltAnalysis.ts
@@ -1,0 +1,162 @@
+import type { StarInfo } from '../api/types';
+
+/**
+ * Sensor-region star statistics for tilt and aberration inspection.
+ *
+ * The frame divides into a 3x3 grid (the layout ASTAP's HFD inspection and
+ * PixInsight's aberration mosaic both use). Each cell aggregates the stars
+ * detected inside it; the summary compares corner cells against the center
+ * the way ASTAP derives its tilt numbers.
+ */
+
+export interface CellStats {
+  row: number;
+  col: number;
+  starCount: number;
+  medianHfr: number | null;
+  medianEccentricity: number | null;
+  /** Mean elongation direction in radians over [0, π). Orientation is
+   * axial (a star elongated at θ looks the same at θ+π), so this is the
+   * circular mean over doubled angles. Null without fitted PSFs. */
+  meanTheta: number | null;
+  /** Agreement of elongation directions, 0 (random) to 1 (aligned).
+   * Aligned directions across a region point at astigmatism or tilt;
+   * random directions are seeing noise. */
+  thetaCoherence: number;
+}
+
+export interface CornerHfr {
+  corner: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  hfr: number | null;
+}
+
+export interface TiltSummary {
+  centerHfr: number | null;
+  corners: CornerHfr[];
+  /** Median HFR over every cell that has stars. */
+  meanHfr: number | null;
+  /** (worst corner − best corner) / mean HFR, as a percentage. ASTAP's
+   * tilt indicator: one soft corner against a sharp opposite one. */
+  tiltPercent: number | null;
+  /** mean(corners) / center − 1 as a percentage. Uniformly soft corners
+   * with a sharp center indicate field curvature, not tilt. */
+  curvaturePercent: number | null;
+  worstCorner: CornerHfr['corner'] | null;
+  bestCorner: CornerHfr['corner'] | null;
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export function analyzeCells(
+  stars: StarInfo[],
+  width: number,
+  height: number
+): CellStats[] {
+  const cells: CellStats[] = [];
+  for (let row = 0; row < 3; row++) {
+    for (let col = 0; col < 3; col++) {
+      const x0 = (col * width) / 3;
+      const x1 = ((col + 1) * width) / 3;
+      const y0 = (row * height) / 3;
+      const y1 = ((row + 1) * height) / 3;
+      const cellStars = stars.filter(
+        (star) => star.x >= x0 && star.x < x1 && star.y >= y0 && star.y < y1
+      );
+      const withTheta = cellStars.filter(
+        (star): star is StarInfo & { theta: number } =>
+          typeof star.theta === 'number' && star.eccentricity > 0
+      );
+      // Circular mean over doubled angles: orientation has period π.
+      let meanTheta: number | null = null;
+      let thetaCoherence = 0;
+      if (withTheta.length > 0) {
+        let sumCos = 0;
+        let sumSin = 0;
+        for (const star of withTheta) {
+          // Weight by eccentricity: a round star has no direction to vote.
+          sumCos += Math.cos(2 * star.theta) * star.eccentricity;
+          sumSin += Math.sin(2 * star.theta) * star.eccentricity;
+        }
+        const weight = withTheta.reduce((sum, star) => sum + star.eccentricity, 0);
+        const magnitude = Math.hypot(sumCos, sumSin);
+        if (weight > 0 && magnitude > 1e-9) {
+          thetaCoherence = magnitude / weight;
+          let angle = Math.atan2(sumSin, sumCos) / 2;
+          if (angle < 0) angle += Math.PI;
+          meanTheta = angle;
+        }
+      }
+      cells.push({
+        row,
+        col,
+        starCount: cellStars.length,
+        medianHfr: median(cellStars.map((star) => star.hfr)),
+        medianEccentricity: median(cellStars.map((star) => star.eccentricity)),
+        meanTheta,
+        thetaCoherence,
+      });
+    }
+  }
+  return cells;
+}
+
+const CORNER_CELLS: Array<{ corner: CornerHfr['corner']; row: number; col: number }> = [
+  { corner: 'top-left', row: 0, col: 0 },
+  { corner: 'top-right', row: 0, col: 2 },
+  { corner: 'bottom-left', row: 2, col: 0 },
+  { corner: 'bottom-right', row: 2, col: 2 },
+];
+
+export function tiltSummary(cells: CellStats[]): TiltSummary {
+  const cellAt = (row: number, col: number) =>
+    cells.find((cell) => cell.row === row && cell.col === col);
+  const centerHfr = cellAt(1, 1)?.medianHfr ?? null;
+  const corners: CornerHfr[] = CORNER_CELLS.map(({ corner, row, col }) => ({
+    corner,
+    hfr: cellAt(row, col)?.medianHfr ?? null,
+  }));
+  const meanHfr = median(
+    cells.map((cell) => cell.medianHfr).filter((hfr): hfr is number => hfr !== null)
+  );
+
+  const measured = corners.filter(
+    (corner): corner is { corner: CornerHfr['corner']; hfr: number } =>
+      corner.hfr !== null
+  );
+  let tiltPercent: number | null = null;
+  let worstCorner: CornerHfr['corner'] | null = null;
+  let bestCorner: CornerHfr['corner'] | null = null;
+  // Tilt is a differential measure; with corners missing it would compare
+  // a corner against nothing and report noise.
+  if (measured.length === 4 && meanHfr !== null && meanHfr > 0) {
+    const sorted = [...measured].sort((a, b) => a.hfr - b.hfr);
+    bestCorner = sorted[0].corner;
+    worstCorner = sorted[sorted.length - 1].corner;
+    tiltPercent =
+      ((sorted[sorted.length - 1].hfr - sorted[0].hfr) / meanHfr) * 100;
+  }
+
+  let curvaturePercent: number | null = null;
+  if (measured.length === 4 && centerHfr !== null && centerHfr > 0) {
+    const cornerMean =
+      measured.reduce((sum, corner) => sum + corner.hfr, 0) / measured.length;
+    curvaturePercent = (cornerMean / centerHfr - 1) * 100;
+  }
+
+  return {
+    centerHfr,
+    corners,
+    meanHfr,
+    tiltPercent,
+    curvaturePercent,
+    worstCorner,
+    bestCorner,
+  };
+}

--- a/tests/theta_probe.rs
+++ b/tests/theta_probe.rs
@@ -1,0 +1,73 @@
+//! The PSF fitter must actually improve on its initial guess. A sign error
+//! in the Levenberg-Marquardt step once made every step walk uphill, so the
+//! "fit" returned the seed parameters (sigma = bounding box / 3, theta = 0)
+//! and every eccentricity in the stars endpoint was really box aspect ratio.
+
+use psf_guard::psf_fitting::{PSFFitter, PSFType};
+
+fn rotated_gaussian_frame(
+    width: usize,
+    height: usize,
+    cx: f64,
+    cy: f64,
+    sx: f64,
+    sy: f64,
+    theta: f64,
+) -> Vec<u16> {
+    let cos_t = theta.cos();
+    let sin_t = theta.sin();
+    let mut data = vec![100u16; width * height];
+    for y in 0..height {
+        for x in 0..width {
+            let dx = x as f64 - cx;
+            let dy = y as f64 - cy;
+            let xp = dx * cos_t + dy * sin_t;
+            let yp = -dx * sin_t + dy * cos_t;
+            let value =
+                100.0 + 20000.0 * (-(xp * xp / (2.0 * sx * sx) + yp * yp / (2.0 * sy * sy))).exp();
+            data[y * width + x] = value as u16;
+        }
+    }
+    data
+}
+
+#[test]
+fn moffat_fit_recovers_a_rotated_elliptical_star() {
+    let (width, height) = (64usize, 64usize);
+    let (cx, cy) = (32.0, 32.0);
+    let true_theta = 0.6;
+    let data = rotated_gaussian_frame(width, height, cx, cy, 4.0, 2.0, true_theta);
+
+    let fitter = PSFFitter::new(PSFType::Moffat4);
+    let model = fitter
+        .fit_star(&data, width, height, cx, cy, 20.0, 20.0, 100.0, 20100.0)
+        .expect("fit should converge");
+
+    assert!(
+        model.r_squared > 0.98,
+        "fit barely improved on the seed: r²={}",
+        model.r_squared
+    );
+    assert!(
+        model.eccentricity > 0.5,
+        "elongation lost: ecc={}",
+        model.eccentricity
+    );
+    // Compare as axes (period π): the same ellipse can be reported with
+    // either sigma larger and theta rotated a quarter turn.
+    let major = if model.sigma_x >= model.sigma_y {
+        model.theta
+    } else {
+        model.theta + std::f64::consts::FRAC_PI_2
+    }
+    .rem_euclid(std::f64::consts::PI);
+    let diff = (major - true_theta).rem_euclid(std::f64::consts::PI);
+    let axis_error = diff.min(std::f64::consts::PI - diff);
+    assert!(
+        axis_error < 0.05,
+        "major axis off by {axis_error} rad (theta={}, sx={}, sy={})",
+        model.theta,
+        model.sigma_x,
+        model.sigma_y
+    );
+}


### PR DESCRIPTION
Two things, found in this order.

## Sensor tilt and aberration inspector

Press **I** in the image detail view:

![Sensor tilt inspector on an NGC 6543 Ha frame](https://raw.githubusercontent.com/theatrus/psf-guard/pr-assets/tilt-inspector.png)

- A 3×3 mosaic of 1:1 crops from each sensor region — the corner view PixInsight's aberration inspector gives — with per-region median HFR, eccentricity, and star count. Borders color by softness against the sharpest region.
- The thin line in each pane is the region's mean star-elongation direction (weighted circular mean over the axial period, thicker with alignment). The example frame shows the classic guiding signature: the same near-vertical direction in every region including the center — that night's tracking was off, which matches its history. Directions aligning only near the edges point at sensor tilt or astigmatism instead; the in-dialog note explains the reading.
- ASTAP-style corner numbers: **tilt** = (softest − sharpest corner HFR) / mean, shown with which corners; **field curvature** = corners vs center. The example reads 21% tilt, corners −11% vs center.
- Analysis runs client-side from the existing star-detection response, which now carries frame dimensions and each star's fitted PSF orientation (major-axis normalized to [0, π)). Solved frames also show **field rotation** (+ mirrored flag) in the Sky context panel, derived from the WCS CD matrix — with unit tests for the parity conventions.

## PSF fitting never actually fit

Wiring up orientation exposed that every fitted theta was exactly 0.0 — and a synthetic-star probe showed the fitter returning its **initial seed untouched**. The Levenberg–Marquardt step solved `(JᵀJ+λI)δ = +Jᵀr` with a residual Jacobian, i.e. stepped uphill; every step was rejected, λ inflated, and the "fit" gave back sigma = bbox/3, theta = 0. Reported eccentricity has really been bounding-box aspect ratio all along.

One sign fix later, the probe (now a regression test) recovers a rotated elliptical star: Moffat4 theta 0.6001 vs true 0.6, r² 0.996; the test pins r² > 0.98 and axis within 0.05 rad. Real-frame check: theta now spans 0–π across 188 stars where it was uniformly 0.0. The stars cache key bumps to v3. **Quality scoring is unaffected** — it reads N.I.N.A.'s capture-time metrics from image metadata, and every internal consumer (screen-fits, stack previews, import) passes `eccentricity: None`; the fix only improves display surfaces and this feature.

Verified headlessly on the clean-room database (screenshot above from a real 6248×4176 Ha frame). Checks: `cargo fmt`, `clippy -D warnings`, `cargo test` (725, including the new fitter regression), `npx tsc`, `npm run lint`, `npx vitest run` (294, including tilt-analysis and field-rotation math tests), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)