### PR TITLE
Reconcile exposure plan accepted counts wherever grades change

### DIFF
--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -87,7 +87,10 @@ Destination: any writable catalog endpoint.
 
 Copies projects, targets, exposure templates, exposure plans, rule weights,
 captures, and optional stored thumbnails. Matching uses stable GUIDs.
-Destination reviewed grades win. New captures retain the source grade.
+Destination reviewed grades win. New captures retain the source grade. Plan
+`acquired` counts copy from the source; `accepted` counts are recomputed
+from the merged grades, because local decisions can differ from the
+source's counter.
 
 ### Send planning
 
@@ -96,7 +99,10 @@ Source planning fields win. The destination keeps capture history, plan
 
 ### Send grades
 
-Only `gradingStatus` and `rejectreason` change. Images match by stable GUID.
+Only `gradingStatus` and `rejectreason` change on images, and the
+destination's `exposureplan.accepted` counters are recomputed from the
+resulting grades so the scheduler plans against them. Images match by
+stable GUID.
 The source wins. The UI defaults to reviewed grades only, so a Pending source
 row cannot erase a telescope decision by accident. Project, target, and grade
 filters remain available.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -95,6 +95,16 @@
 
 ## Fixed
 
+- Grading now keeps Target Scheduler's exposure plans honest. Every path
+  that changes a grade — the grid and detail views, undo and redo, the
+  CLI regrade and screening commands, grade pushes, and catalog pulls —
+  recomputes `exposureplan.accepted` from the images each plan actually
+  has (linked by `exposureId`, schema v17+). Before, rejecting frames in
+  PSF Guard left the telescope's counters where its own grader put them,
+  so the scheduler under- or over-scheduled that filter. Catalog pulls
+  now also keep the counter derived from the merged grades instead of
+  copying the telescope's value.
+
 - Star PSF fitting now actually fits. A sign error in the optimizer made
   every iteration step uphill, so every fitted PSF kept its initial guess —
   reported eccentricity was really the star's bounding-box aspect ratio and

--- a/src/commands/sync/grades.rs
+++ b/src/commands/sync/grades.rs
@@ -242,6 +242,9 @@ pub(crate) fn sync_grades_in_transaction(
             )
             .context("applying grade update to destination")?;
         }
+        // The destination's Target Scheduler plans against these counters.
+        crate::db::reconcile_accepted_counts(tx)
+            .context("reconciling exposure plan accepted counts")?;
     }
 
     Ok(summary)
@@ -310,6 +313,50 @@ mod tests {
             |r| Ok((r.get(0)?, r.get(1)?)),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn push_reconciles_destination_exposure_plan_accepted_counts() {
+        let src = setup_db(
+            &[
+                (1, 1, Some("g1"), None), // Accepted
+                (2, 2, Some("g2"), Some("clouds")),
+            ],
+            true,
+        );
+        let dest = setup_db(
+            &[
+                (100, 0, Some("g1"), None),
+                (200, 1, Some("g2"), None), // Accepted locally; push rejects it
+            ],
+            true,
+        );
+        // The destination is a live Target Scheduler catalog: images link to
+        // exposure plans whose accepted counter the scheduler plans against.
+        dest.execute_batch(
+            "ALTER TABLE acquiredimage ADD COLUMN exposureId INTEGER DEFAULT 0;
+             CREATE TABLE exposureplan (
+                Id INTEGER PRIMARY KEY, profileId TEXT, exposure REAL,
+                desired INTEGER, acquired INTEGER, accepted INTEGER,
+                targetid INTEGER, exposureTemplateId INTEGER
+             );
+             INSERT INTO exposureplan VALUES (5, 'p', 300, 20, 2, 1, 1, 1);
+             UPDATE acquiredimage SET exposureId = 5;",
+        )
+        .unwrap();
+
+        sync_grades(&src, &dest, &opts()).unwrap();
+
+        // g1 became Accepted and g2 became Rejected: still one accepted image,
+        // but the counter is now derived from the grades, not left stale.
+        let accepted: i64 = dest
+            .query_row("SELECT accepted FROM exposureplan WHERE Id = 5", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(accepted, 1);
+        assert_eq!(grade_of(&dest, "g1"), (1, None));
+        assert_eq!(grade_of(&dest, "g2"), (2, Some("clouds".to_string())));
     }
 
     #[test]

--- a/src/commands/sync/planning.rs
+++ b/src/commands/sync/planning.rs
@@ -86,7 +86,7 @@ pub(crate) fn sync_planning_in_transaction(
         src,
         tx,
         opts.project_filter.as_deref(),
-        true,
+        &["acquired", "accepted"],
         &mut summary.changes,
     )?;
 

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -701,15 +701,21 @@ pub(super) struct StructureSync {
     pub selected_project_ids: Option<HashSet<i64>>,
 }
 
-/// Sync scheduler planning structure in FK order. When `preserve_plan_counts`
 /// is true, existing destination `acquired`/`accepted` counts stay unchanged
-/// and new plans start at zero. This is the safe policy for a local-to-
-/// telescope planning push; a full telescope pull keeps the source counts.
+/// Sync scheduler planning structure in FK order.
+///
+/// `excluded_plan_counts` names exposureplan progress columns the source must
+/// not overwrite. A planning push excludes both `acquired` and `accepted`
+/// (the telescope owns its progress; new plans start at zero). A telescope
+/// pull keeps `acquired` (capture counts are the telescope's) but excludes
+/// `accepted`: local grading decisions win in the merge, so the counter is
+/// recomputed from the merged grades afterwards — copying the telescope's
+/// value would fight that reconciliation on every re-pull.
 pub(super) fn sync_structure(
     src: &Connection,
     tx: &Transaction,
     project_filter: Option<&str>,
-    preserve_plan_counts: bool,
+    excluded_plan_counts: &[&str],
     changes: &mut Vec<String>,
 ) -> Result<StructureSync> {
     let included_projects: Option<HashSet<i64>> = match project_filter {
@@ -761,18 +767,13 @@ pub(super) fn sync_structure(
     )?;
     let tgt_map = tgt.id_map;
 
-    let plan_runtime_counts: &[&str] = if preserve_plan_counts {
-        &["acquired", "accepted"]
-    } else {
-        &[]
-    };
     let plan = upsert_guid_table(
         src,
         tx,
         "exposureplan",
         &[("targetid", &tgt_map), ("exposureTemplateId", &tmpl_map)],
         included_plans.as_ref(),
-        plan_runtime_counts,
+        excluded_plan_counts,
         changes,
     )?;
 
@@ -819,7 +820,7 @@ pub(crate) fn sync_pull_in_transaction(
         src,
         tx,
         opts.project_filter.as_deref(),
-        false,
+        &["accepted"],
         &mut summary.changes,
     )?;
     summary.exposuretemplate = structure.exposuretemplate;
@@ -871,6 +872,12 @@ pub(crate) fn sync_pull_in_transaction(
         unchanged: calibration.frames.unchanged,
         skipped: 0,
     };
+
+    // Pulled rows carry grades; the destination's plans must count them.
+    // Runs inside the transaction so the server's remote-sync apply path
+    // (which manages its own transaction) reconciles too.
+    crate::db::reconcile_accepted_counts(tx)
+        .context("reconciling exposure plan accepted counts")?;
 
     Ok(summary)
 }
@@ -1037,6 +1044,26 @@ mod tests {
         );
         assert_eq!(s.grade_preserved, 1);
         assert_eq!(s.grade_filled, 1);
+    }
+
+    #[test]
+    fn pull_derives_accepted_counts_from_merged_grades() {
+        // The telescope's counter says 8, but only one of its images is
+        // actually Accepted. The pull must not copy the stale counter — the
+        // destination's plans count the grades the merge actually produced.
+        let src = telescope();
+        let dest = empty_local();
+        sync_pull(&src, &dest, &opts()).unwrap();
+
+        let (acquired, accepted): (i64, i64) = dest
+            .query_row(
+                "SELECT acquired, accepted FROM exposureplan WHERE guid='lg'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(acquired, 10, "capture counts stay the telescope's");
+        assert_eq!(accepted, 1, "accepted derives from the merged grades");
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -42,6 +42,38 @@ impl SchemaCapabilities {
     }
 }
 
+/// Recompute `exposureplan.accepted` from the images each plan actually has.
+///
+/// Target Scheduler plans a filter by `desired` vs `accepted`, and it
+/// maintains that counter itself only when its own grader runs. Every place
+/// PSF Guard changes `gradingStatus` — grading endpoints, undo, grade sync,
+/// catalog pulls — must call this afterwards, or the scheduler keeps
+/// planning against counts that no longer match the grades.
+///
+/// Images link to their plan through `acquiredimage.exposureId` (TS schema
+/// v17+). Rows with `exposureId` 0 predate the link and are left out — the
+/// same rows the plugin's own grader cannot attribute. A schema without the
+/// link (or without plans at all) is a no-op. Returns the number of plans
+/// whose counter changed.
+pub fn reconcile_accepted_counts(conn: &Connection) -> Result<usize> {
+    let has_column = |table: &str, column: &str| -> bool {
+        SchemaCapabilities::table_has_column(conn, table, column)
+    };
+    if !has_column("acquiredimage", "exposureId") || !has_column("exposureplan", "accepted") {
+        return Ok(0);
+    }
+    let changed = conn.execute(
+        "UPDATE exposureplan SET accepted = (
+             SELECT COUNT(*) FROM acquiredimage ai
+             WHERE ai.exposureId = exposureplan.Id AND ai.gradingStatus = 1)
+         WHERE IFNULL(accepted, -1) <> (
+             SELECT COUNT(*) FROM acquiredimage ai
+             WHERE ai.exposureId = exposureplan.Id AND ai.gradingStatus = 1)",
+        [],
+    )?;
+    Ok(changed)
+}
+
 /// Database access layer for PSF Guard
 pub struct Database<'a> {
     conn: &'a Connection,
@@ -793,12 +825,15 @@ impl<'a> Database<'a> {
         status: GradingStatus,
         reject_reason: Option<&str>,
     ) -> Result<()> {
-        self.conn.execute(
-            "UPDATE acquiredimage 
-             SET gradingStatus = ?, rejectreason = ? 
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "UPDATE acquiredimage
+             SET gradingStatus = ?, rejectreason = ?
              WHERE Id = ?",
             params![status as i32, reject_reason, image_id],
         )?;
+        reconcile_accepted_counts(&tx)?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -810,13 +845,14 @@ impl<'a> Database<'a> {
 
         for (id, status, reason) in updates {
             tx.execute(
-                "UPDATE acquiredimage 
-                 SET gradingStatus = ?, rejectreason = ? 
+                "UPDATE acquiredimage
+                 SET gradingStatus = ?, rejectreason = ?
                  WHERE Id = ?",
                 params![*status as i32, reason.as_deref(), id],
             )?;
         }
 
+        reconcile_accepted_counts(&tx)?;
         tx.commit()?;
         Ok(())
     }
@@ -1028,6 +1064,7 @@ impl<'a> Database<'a> {
 
         let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
         let count = self.conn.execute(&query, param_refs.as_slice())?;
+        reconcile_accepted_counts(self.conn)?;
 
         Ok(count)
     }
@@ -1506,12 +1543,19 @@ mod tests {
                 Id INTEGER PRIMARY KEY, projectId INTEGER NOT NULL,
                 targetId INTEGER NOT NULL, acquireddate INTEGER,
                 filtername TEXT NOT NULL, gradingStatus INTEGER NOT NULL,
-                metadata TEXT NOT NULL, rejectreason TEXT, profileId TEXT
+                metadata TEXT NOT NULL, rejectreason TEXT, profileId TEXT,
+                exposureId INTEGER DEFAULT 0
              );
+             CREATE TABLE exposureplan (
+                Id INTEGER PRIMARY KEY, profileId TEXT, exposure REAL,
+                desired INTEGER, acquired INTEGER, accepted INTEGER,
+                targetid INTEGER, exposureTemplateId INTEGER
+             );
+             INSERT INTO exposureplan VALUES (7, 'p', 300, 20, 3, 1, 10, 1);
              INSERT INTO acquiredimage VALUES
-                (1, 1, 10, 100, 'R', 0, '{}', NULL, 'p'),
-                (2, 1, 10, 200, 'G', 1, '{}', NULL, 'p'),
-                (3, 1, 10, 300, 'B', 2, '{}', 'Clouds', 'p');",
+                (1, 1, 10, 100, 'R', 0, '{}', NULL, 'p', 7),
+                (2, 1, 10, 200, 'G', 1, '{}', NULL, 'p', 7),
+                (3, 1, 10, 300, 'B', 2, '{}', 'Clouds', 'p', 7);",
         )
         .unwrap();
 
@@ -1536,6 +1580,71 @@ mod tests {
         assert_eq!(by_id[&2].grading_status, 2);
         assert_eq!(by_id[&3].grading_status, 1);
         assert_eq!(by_id[&3].reject_reason, None);
+
+        // Target Scheduler plans against exposureplan.accepted, so grading
+        // must reconcile it: exactly one image (id 3) is now accepted.
+        let accepted: i64 = conn
+            .query_row("SELECT accepted FROM exposureplan WHERE Id = 7", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(accepted, 1);
+
+        // Single-image grading reconciles too.
+        db.update_grading_status(2, GradingStatus::Accepted, None)
+            .unwrap();
+        let accepted: i64 = conn
+            .query_row("SELECT accepted FROM exposureplan WHERE Id = 7", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(accepted, 2);
+    }
+
+    #[test]
+    fn reconciling_accepted_counts_skips_schemas_without_the_link() {
+        // Pre-v17 schema: no exposureId column, nothing to maintain.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE acquiredimage (
+                Id INTEGER PRIMARY KEY, gradingStatus INTEGER NOT NULL
+             );
+             CREATE TABLE exposureplan (Id INTEGER PRIMARY KEY, accepted INTEGER);",
+        )
+        .unwrap();
+        assert_eq!(reconcile_accepted_counts(&conn).unwrap(), 0);
+    }
+
+    #[test]
+    fn reconciling_accepted_counts_leaves_unlinked_legacy_rows_out() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE acquiredimage (
+                Id INTEGER PRIMARY KEY, gradingStatus INTEGER NOT NULL,
+                exposureId INTEGER DEFAULT 0
+             );
+             CREATE TABLE exposureplan (Id INTEGER PRIMARY KEY, accepted INTEGER);
+             INSERT INTO exposureplan VALUES (1, 99), (2, NULL);
+             INSERT INTO acquiredimage VALUES
+                (1, 1, 1), (2, 1, 1), (3, 2, 1),
+                (4, 1, 0),  -- legacy row: accepted but linked to no plan
+                (5, 1, 2);",
+        )
+        .unwrap();
+        let changed = reconcile_accepted_counts(&conn).unwrap();
+        assert_eq!(changed, 2);
+        let plan1: i64 = conn
+            .query_row("SELECT accepted FROM exposureplan WHERE Id = 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let plan2: i64 = conn
+            .query_row("SELECT accepted FROM exposureplan WHERE Id = 2", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(plan1, 2);
+        assert_eq!(plan2, 1);
     }
 
     #[test]


### PR DESCRIPTION
Target Scheduler plans a filter by `desired` vs `accepted`, and it maintains that counter only when its own grader runs. PSF Guard changed `gradingStatus` in many places — grading endpoints, undo/redo, CLI `regrade` and screening, the grade sync push, catalog pulls — and none of them touched `exposureplan.accepted`. Net effect: reject frames in PSF Guard, and the telescope's scheduler still counts them as accepted, under-scheduling that filter (or over-scheduling for grades TS never saw).

**The fix is one idempotent recomputation**, `db::reconcile_accepted_counts`: set each plan's `accepted` to the count of its images with `gradingStatus = 1`, linked by `acquiredimage.exposureId` (TS schema v17+). Legacy rows with `exposureId = 0` stay out — the same rows TS's own grader cannot attribute — and a schema without the link is a no-op. It runs **inside the same transaction** as every grade write:

- single and batch grading updates (`Database::update_grading_status` / `batch_update_grading_status`) — which also covers the web endpoints, undo/redo, `regrade`, and `screen-fits`;
- `reset_grading_status`;
- the grade sync push (`sync_grades_in_transaction`, so the server's remote-sync apply path with its externally managed transaction is covered);
- catalog pulls (`sync_pull_in_transaction`, same reasoning).

**One behavior change surfaced by the idempotence test:** pulls used to copy the telescope's `accepted` counter, which would fight the reconciliation on every re-pull (local grading decisions win in a merge, so the source counter is wrong for the merged state — the fixture telescope claims 8 accepted while its images show 1). Pulls now exclude `accepted` from the copied columns and derive it from the merged grades; `acquired` still copies (capture counts are the telescope's), and the planning push keeps excluding both, unchanged.

The N.I.N.A. plugin's pull path is being fixed separately on the plugin side.

Tests: batch + single grading reconcile a seeded plan; the recomputation skips pre-v17 schemas and leaves unlinked legacy rows out; the grade push reconciles a live destination; a pull derives `accepted=1` from merged grades while keeping the telescope's `acquired=10`; the existing idempotence test now passes with the counter stable across re-pulls. Checks run locally: `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (729 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)