### PR TITLE
Stage pushed bundles in one transaction, and surface parked previews

### DIFF
--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -86,7 +86,9 @@ Source: any catalog endpoint.
 Destination: any writable catalog endpoint.
 
 Copies projects, targets, exposure templates, exposure plans, rule weights,
-captures, and optional stored thumbnails. Matching uses stable GUIDs.
+captures, and optional stored thumbnails. Thumbnails are opt-in on a merge
+export (`include_thumbnails`); they dominate a catalog's size and most
+round trips do not need them. Matching uses stable GUIDs.
 Destination reviewed grades win. New captures retain the source grade. Plan
 `acquired` counts copy from the source; `accepted` counts are recomputed
 from the merged grades, because local decisions can differ from the

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -92,6 +92,13 @@
   sharpest) and field curvature (corners against center). Solved frames also
   show their **field rotation** (and a mirrored flag) in the Sky context
   panel.
+- Data Transfer in Settings now lists every **staged preview** parked on
+  the server — including pushes a remote N.I.N.A. client created and never
+  applied — with its source, operation, change counts, and expiry, plus
+  Apply, Refresh, and Discard actions. Previously only the browser session
+  that created a preview could see it, so a plugin's staged push sat
+  invisible until it expired. Remote preview jobs also report a phase
+  (materializing, then comparing) while they run.
 
 ## Fixed
 
@@ -99,6 +106,15 @@
   handling** setting (off, every 1-7 sessions, target completion, or
   immediate), read and written with the same schema tolerance as the
   other project fields.
+
+- Staging a pushed bundle no longer commits once per row. A large grades
+  push materialized each row in its own SQLite transaction — thousands of
+  journal round-trips, minutes of "preview" — and a failure mid-bundle
+  left a partial snapshot behind. The whole bundle now lands in one
+  transaction on a scratch connection with no fsync cost, and a failure
+  rolls back to an empty snapshot. Merge exports also stopped carrying
+  thumbnail blobs by default: `include_thumbnails` opts in, so a season of
+  previews no longer rides along with every catalog round trip.
 
 - Grading now keeps Target Scheduler's exposure plans honest. Every path
   that changes a grade — the grid and detail views, undo and redo, the

--- a/src/commands/sync/remote.rs
+++ b/src/commands/sync/remote.rs
@@ -157,6 +157,7 @@ async fn push_to(
         &options.local_id,
         operation,
         options.reviewed_only,
+        options.with_image_data,
     )
     .context("building a bundle from the local database")?;
     let rows: usize = bundle.tables.values().map(|table| table.rows.len()).sum();

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -476,6 +476,22 @@ pub struct SchedulerSyncPreviewResponse {
     pub result: SchedulerSyncResponse,
 }
 
+/// One entry of `GET /api/databases/{db_id}/sync/previews`: every unexpired
+/// staged transfer for that catalog, wherever it was created — the UI's own
+/// preview flow or a remote client's push.
+#[derive(Debug, Serialize)]
+pub struct SchedulerSyncPreviewListEntry {
+    pub preview_id: String,
+    /// Operation kind label: "pull", "push_planning", or "push_grades".
+    pub kind: String,
+    /// The peer that produced the staged rows — a configured peer database
+    /// id for UI transfers, or the remote catalog id a plugin sent.
+    pub source: String,
+    pub created_at: i64,
+    pub expires_at: i64,
+    pub result: SchedulerSyncResponse,
+}
+
 /// Body of `POST /api/databases`.
 #[derive(Debug, Deserialize)]
 pub struct AddDatabaseRequest {

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -912,6 +912,75 @@ pub async fn delete_sync_database_preview_route(
     Ok(Json(ApiResponse::success(deleted)))
 }
 
+/// Every unexpired staged transfer for this catalog, wherever it was
+/// created. The UI's own previews live in its session, but a remote
+/// client's push also parks a preview here, and without this listing the
+/// operator has no way to see or act on it.
+pub async fn list_sync_database_previews_route(
+    State(state): State<Arc<AppState>>,
+    Path(db_id): Path<String>,
+) -> Result<Json<ApiResponse<Vec<SchedulerSyncPreviewListEntry>>>, AppError> {
+    let records = state
+        .sync_previews
+        .list(&db_id)
+        .map_err(|error| AppError::InternalError(format!("listing sync previews: {error}")))?;
+    let entries = records
+        .into_iter()
+        .map(|record| SchedulerSyncPreviewListEntry {
+            preview_id: record.id,
+            kind: crate::server::remote_sync::kind_label(record.request.kind).to_string(),
+            source: record.request.peer_db_id,
+            created_at: record.created_at,
+            expires_at: record.expires_at,
+            result: record.result,
+        })
+        .collect();
+    Ok(Json(ApiResponse::success(entries)))
+}
+
+/// Re-run one preview's dry run against the catalog as it stands now, so a
+/// preview gone stale (the fingerprint moved) becomes applicable again
+/// without the remote client re-uploading its bundle.
+pub async fn refresh_sync_database_preview_route(
+    State(state): State<Arc<AppState>>,
+    Path((db_id, preview_id)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<SchedulerSyncPreviewResponse>>, AppError> {
+    // Refresh rewrites a record an apply may be claiming: same lock as apply.
+    let _apply_guard = state.sync_apply_lock.lock().await;
+    let record = state
+        .sync_previews
+        .get(&preview_id)
+        .map_err(|error| AppError::InternalError(format!("loading sync preview: {error}")))?
+        .filter(|record| record.local_db_id == db_id)
+        .ok_or(AppError::NotFound)?;
+    let source_snapshot = state
+        .sync_previews
+        .source_snapshot_path(&record)
+        .map_err(|error| AppError::InternalError(format!("{error:#}")))?;
+    let mut request = record.request.clone();
+    request.dry_run = true;
+    let (result, fingerprint) = execute_scheduler_sync_guarded(
+        &state,
+        &db_id,
+        request,
+        Some(source_snapshot),
+        SyncGuardMode::Preview,
+    )
+    .await?;
+    let fingerprint = fingerprint
+        .ok_or_else(|| AppError::InternalError("preview refresh returned no fingerprint".into()))?;
+    let refreshed = state
+        .sync_previews
+        .refresh(&record, fingerprint, result)
+        .map_err(|error| AppError::InternalError(format!("storing refreshed preview: {error}")))?;
+    Ok(Json(ApiResponse::success(SchedulerSyncPreviewResponse {
+        preview_id: refreshed.id,
+        created_at: refreshed.created_at,
+        expires_at: refreshed.expires_at,
+        result: refreshed.result,
+    })))
+}
+
 /// Apply one unexpired preview after proving that neither catalog changed.
 pub async fn apply_sync_database_preview_route(
     State(state): State<Arc<AppState>>,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -574,8 +574,16 @@ async fn run_server_internal(
             post(handlers::preview_sync_database_route),
         )
         .route(
+            "/databases/{db_id}/sync/previews",
+            get(handlers::list_sync_database_previews_route),
+        )
+        .route(
             "/databases/{db_id}/sync/previews/{preview_id}/apply",
             post(handlers::apply_sync_database_preview_route),
+        )
+        .route(
+            "/databases/{db_id}/sync/previews/{preview_id}/refresh",
+            post(handlers::refresh_sync_database_preview_route),
         )
         .route(
             "/databases/{db_id}/sync/previews/{preview_id}",

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -155,6 +155,12 @@ pub struct CreateExportRequest {
     pub operation: SyncOperation,
     #[serde(default = "default_true")]
     pub reviewed_only: bool,
+    /// Merge exports only: include the `imagedata` thumbnail BLOBs. Off by
+    /// default — thumbnails dominate a catalog's size (a hundred-plus
+    /// megabytes on a season of captures), and a client that wants them
+    /// must ask.
+    #[serde(default)]
+    pub include_thumbnails: bool,
 }
 
 fn default_true() -> bool {
@@ -190,6 +196,11 @@ pub struct SyncPreview {
 pub struct PreviewJob {
     pub job_id: String,
     pub state: &'static str,
+    /// Where a running job currently is: "materializing" (writing the
+    /// bundle snapshot), then "comparing" (dry-run against the catalog).
+    /// Ready and failed jobs carry no phase.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phase: Option<&'static str>,
     pub preview: Option<SyncPreview>,
     pub error: Option<String>,
 }
@@ -241,6 +252,7 @@ impl PreviewJobStore {
         let job = PreviewJob {
             job_id: requested_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
             state: "running",
+            phase: Some("materializing"),
             preview: None,
             error: None,
         };
@@ -264,6 +276,7 @@ impl PreviewJobStore {
         let Some(stored) = entries.get_mut(job_id) else {
             return;
         };
+        stored.job.phase = None;
         match result {
             Ok(preview) => {
                 stored.job.state = "ready";
@@ -273,6 +286,18 @@ impl PreviewJobStore {
                 stored.job.state = "failed";
                 stored.job.error = Some(detail_of(&error));
             }
+        }
+    }
+
+    /// Record where a running job is. Missing or finished jobs are ignored.
+    fn set_phase(&self, job_id: &str, phase: &'static str) {
+        let Ok(mut entries) = self.entries.lock() else {
+            return;
+        };
+        if let Some(stored) = entries.get_mut(job_id)
+            && stored.job.state == "running"
+        {
+            stored.job.phase = Some(phase);
         }
     }
 
@@ -464,8 +489,13 @@ pub async fn create_preview(
         let job_id = job.job_id.clone();
         let background_state = Arc::clone(&state);
         tokio::spawn(async move {
-            let result =
-                create_preview_inner(Arc::clone(&background_state), catalog, request).await;
+            let result = create_preview_inner(
+                Arc::clone(&background_state),
+                catalog,
+                request,
+                Some(job_id.clone()),
+            )
+            .await;
             background_state.remote_preview_jobs.finish(&job_id, result);
         });
         return Ok((
@@ -478,7 +508,7 @@ pub async fn create_preview(
             .into_response());
     }
 
-    let preview = create_preview_inner(state, catalog, request).await?;
+    let preview = create_preview_inner(state, catalog, request, None).await?;
     Ok(Json(ApiResponse::success(preview)).into_response())
 }
 
@@ -486,8 +516,16 @@ async fn create_preview_inner(
     state: Arc<AppState>,
     catalog: Arc<DatabaseContext>,
     request: CreatePreviewRequest,
+    job_id: Option<String>,
 ) -> Result<SyncPreview, AppError> {
+    let started = std::time::Instant::now();
     let operation = request.operation;
+    let row_count: usize = request
+        .bundle
+        .tables
+        .values()
+        .map(|table| table.rows.len())
+        .sum();
     // Copy the identifiers the audit log needs before the bundle moves, so
     // auditing never forces the whole payload to be cloned.
     let bundle_id = request.bundle.bundle_id.clone();
@@ -549,6 +587,15 @@ async fn create_preview_inner(
         state.sync_previews.remove_source_snapshot(&snapshot_file);
         return Err(refuse(format!("invalid catalog bundle: {error:#}")));
     }
+    let materialize_duration = started.elapsed();
+    tracing::info!(
+        "remote sync preview materialized catalog={} bundle={bundle_id}          operation={} rows={row_count} in {materialize_duration:.2?}",
+        catalog.id,
+        operation_label(operation),
+    );
+    if let Some(job_id) = job_id.as_deref() {
+        state.remote_preview_jobs.set_phase(job_id, "comparing");
+    }
 
     let sync_request = scheduler_request(operation, source_id.clone(), true);
     let execution = execute_scheduler_sync_paths(
@@ -590,6 +637,14 @@ async fn create_preview_inner(
         })?;
     let summary = result_summary(&result);
     audit(AuditOutcome::Ok, None, Some(&record.id), summary.clone());
+    tracing::info!(
+        "remote sync preview ready catalog={} bundle={bundle_id} operation={}          rows={row_count} compare={:.2?} total={:.2?} preview={}",
+        catalog.id,
+        operation_label(operation),
+        started.elapsed().saturating_sub(materialize_duration),
+        started.elapsed(),
+        record.id,
+    );
     Ok(SyncPreview {
         preview_id: record.id,
         state: "ready",
@@ -838,6 +893,7 @@ pub async fn create_export(
     let catalog_id = catalog.id.clone();
     let operation = request.operation;
     let reviewed_only = request.reviewed_only;
+    let include_thumbnails = request.include_thumbnails;
     let audit = |outcome, detail: Option<&str>, summary| {
         state.remote_audit.record(
             &catalog.id,
@@ -852,7 +908,13 @@ pub async fn create_export(
         );
     };
     let bundle = match tokio::task::spawn_blocking(move || {
-        export_bundle(&database_path, &catalog_id, operation, reviewed_only)
+        export_bundle(
+            &database_path,
+            &catalog_id,
+            operation,
+            reviewed_only,
+            include_thumbnails,
+        )
     })
     .await
     .map_err(|error| AppError::InternalError(format!("export task failed: {error}")))?
@@ -1045,13 +1107,23 @@ pub(crate) fn materialize_bundle(
     template_path: &FsPath,
     bundle: &CatalogBundle,
 ) -> anyhow::Result<()> {
-    let connection = Connection::open(path)?;
-    connection.execute_batch("PRAGMA journal_mode=DELETE; PRAGMA foreign_keys=OFF;")?;
+    let mut connection = Connection::open(path)?;
+    // The snapshot is scratch state: on a crash it is discarded and the
+    // client re-uploads, so buying durability with fsyncs is pure waste.
+    connection.execute_batch(
+        "PRAGMA journal_mode=DELETE; PRAGMA foreign_keys=OFF; PRAGMA synchronous=OFF;",
+    )?;
+    // One transaction for the whole snapshot. Row inserts outside a
+    // transaction each autocommit — a large grades bundle meant thousands
+    // of journal round-trips — and a failure mid-bundle left a partial
+    // snapshot file behind. Now it is one commit, and an error rolls the
+    // whole materialization back to an empty database.
+    let transaction = connection.transaction()?;
     let mut template = None;
     for table_name in allowed_tables(bundle.operation) {
         if let Some(table) = bundle.tables.get(*table_name) {
-            create_bundle_table(&connection, table_name, table)?;
-            insert_bundle_rows(&connection, table_name, table)?;
+            create_bundle_table(&transaction, table_name, table)?;
+            insert_bundle_rows(&transaction, table_name, table)?;
         } else {
             // An omitted optional table still has to exist for the sync
             // engine to read, so borrow the destination's own DDL. One
@@ -1063,10 +1135,11 @@ pub(crate) fn materialize_bundle(
                 )?);
             }
             let template = template.as_ref().expect("template connection is open");
-            create_empty_table_from_template(&connection, template, table_name)?;
+            create_empty_table_from_template(&transaction, template, table_name)?;
         }
     }
-    connection.pragma_update(None, "user_version", bundle.source.schema_version)?;
+    transaction.pragma_update(None, "user_version", bundle.source.schema_version)?;
+    transaction.commit()?;
     Ok(())
 }
 
@@ -1180,6 +1253,7 @@ pub(crate) fn export_bundle(
     catalog_id: &str,
     operation: SyncOperation,
     reviewed_only: bool,
+    include_thumbnails: bool,
 ) -> anyhow::Result<CatalogBundle> {
     let connection = Connection::open_with_flags(database_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
     let schema_version: i64 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
@@ -1190,6 +1264,12 @@ pub(crate) fn export_bundle(
     let mut tables = BTreeMap::new();
     let mut row_count = 0usize;
     for name in allowed_tables(operation) {
+        // Thumbnails are optional payload, not identity: the receiver's
+        // materializer creates an empty imagedata table and the merge is
+        // additive, so omitting them only skips copying blobs.
+        if *name == "imagedata" && !include_thumbnails {
+            continue;
+        }
         // Only acquiredimage narrows: reviewed_only means "the rows I have
         // actually graded". project and target ride along whole because the
         // grade read joins against them.
@@ -1368,7 +1448,7 @@ pub(crate) fn operation_label(operation: SyncOperation) -> &'static str {
 
 /// The stored preview keeps the engine's own `SchedulerSyncKind`, so map back
 /// to the protocol name the client used.
-fn kind_label(kind: SchedulerSyncKind) -> &'static str {
+pub(crate) fn kind_label(kind: SchedulerSyncKind) -> &'static str {
     match kind {
         SchedulerSyncKind::Pull => "merge",
         SchedulerSyncKind::PushPlanning => "push_planning",
@@ -1488,6 +1568,201 @@ fn internal(error: impl std::fmt::Display) -> AppError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn wire_int(value: i64) -> WireValue {
+        WireValue {
+            kind: WireValueKind::Integer,
+            value: Some(value.to_string()),
+        }
+    }
+
+    fn wire_text(value: &str) -> WireValue {
+        WireValue {
+            kind: WireValueKind::Text,
+            value: Some(value.to_string()),
+        }
+    }
+
+    fn column(name: &str, declared: &str, primary_key: bool) -> BundleColumn {
+        BundleColumn {
+            name: name.to_string(),
+            declared_type: declared.to_string(),
+            not_null: false,
+            primary_key,
+        }
+    }
+
+    /// A grades bundle with `rows` acquiredimage rows, ids taken from `ids`.
+    fn big_grades_bundle(ids: impl Iterator<Item = i64>) -> CatalogBundle {
+        let guid_table = BundleTable {
+            columns: vec![column("guid", "TEXT", false)],
+            rows: vec![BundleRow {
+                values: vec![wire_text("a-guid")],
+            }],
+        };
+        let image_table = BundleTable {
+            columns: vec![
+                column("Id", "INTEGER", true),
+                column("guid", "TEXT", false),
+                column("gradingStatus", "INTEGER", false),
+            ],
+            rows: ids
+                .map(|id| BundleRow {
+                    values: vec![wire_int(id), wire_text(&format!("guid-{id}")), wire_int(1)],
+                })
+                .collect(),
+        };
+        let mut tables = BTreeMap::new();
+        tables.insert("project".to_string(), guid_table.clone());
+        tables.insert("target".to_string(), guid_table);
+        tables.insert("acquiredimage".to_string(), image_table);
+        CatalogBundle {
+            protocol_version: PROTOCOL_VERSION,
+            bundle_id: "bundle-1".to_string(),
+            created_at_utc: "2026-08-18T00:00:00Z".to_string(),
+            operation: SyncOperation::PushGrades,
+            source: CatalogIdentity {
+                id: "source".to_string(),
+                product: "test".to_string(),
+                product_version: "1".to_string(),
+                schema_version: 23,
+            },
+            tables,
+            payload_sha256: None,
+        }
+    }
+
+    fn temp_snapshot(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("psf-guard-materialize-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{name}-{}.sqlite", Uuid::new_v4()));
+        let _ = std::fs::remove_file(&path);
+        path
+    }
+
+    #[test]
+    fn materializes_thousands_of_rows_in_one_transaction() {
+        let bundle = big_grades_bundle(0..5_000);
+        let path = temp_snapshot("bulk");
+        let template = temp_snapshot("template");
+        Connection::open(&template).unwrap();
+
+        let started = std::time::Instant::now();
+        materialize_bundle(&path, &template, &bundle).unwrap();
+        let elapsed = started.elapsed();
+
+        let connection = Connection::open(&path).unwrap();
+        let count: i64 = connection
+            .query_row("SELECT COUNT(*) FROM acquiredimage", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 5_000);
+        let version: i64 = connection
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(version, 23);
+        // One transaction, not one commit per row: even a slow disk finishes
+        // 5000 rows in well under a second. The per-row autocommit this
+        // replaces took minutes at this size on rotational storage.
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "materialization took {elapsed:?}"
+        );
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&template);
+    }
+
+    #[test]
+    fn failed_materialization_rolls_back_to_an_empty_snapshot() {
+        // Two rows share a primary key, so the second insert fails midway
+        // through the bundle. The transaction must leave nothing behind —
+        // a partial snapshot would let a later step read half a bundle.
+        let bundle = big_grades_bundle([1, 2, 3, 3, 4].into_iter());
+        let path = temp_snapshot("rollback");
+        let template = temp_snapshot("rollback-template");
+        Connection::open(&template).unwrap();
+
+        let error = materialize_bundle(&path, &template, &bundle).unwrap_err();
+        assert!(
+            error.to_string().to_lowercase().contains("unique"),
+            "unexpected error: {error:#}"
+        );
+
+        let connection = Connection::open(&path).unwrap();
+        let tables: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(tables, 0, "rollback left tables in the snapshot");
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&template);
+    }
+
+    #[test]
+    fn merge_exports_skip_thumbnails_unless_asked() {
+        let path = temp_snapshot("export-src");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute_batch(
+                "PRAGMA user_version = 23;
+                 CREATE TABLE project (Id INTEGER PRIMARY KEY, guid TEXT);
+                 CREATE TABLE target (Id INTEGER PRIMARY KEY, guid TEXT);
+                 CREATE TABLE exposuretemplate (Id INTEGER PRIMARY KEY, guid TEXT);
+                 CREATE TABLE exposureplan (Id INTEGER PRIMARY KEY, guid TEXT);
+                 CREATE TABLE ruleweight (Id INTEGER PRIMARY KEY, name TEXT);
+                 CREATE TABLE acquiredimage (Id INTEGER PRIMARY KEY, gradingStatus INTEGER, guid TEXT);
+                 CREATE TABLE imagedata (Id INTEGER PRIMARY KEY, imagedata BLOB, acquiredimageid INTEGER);
+                 INSERT INTO project VALUES (1, 'pg');
+                 INSERT INTO target VALUES (1, 'tg');
+                 INSERT INTO acquiredimage VALUES (1, 1, 'ig');
+                 INSERT INTO imagedata VALUES (1, X'0102030405', 1);",
+            )
+            .unwrap();
+        drop(connection);
+
+        // Thumbnails dominate bundle size; a merge export leaves them out
+        // unless the client opts in.
+        let lean = export_bundle(&path, "cat", SyncOperation::Merge, false, false).unwrap();
+        assert!(!lean.tables.contains_key("imagedata"));
+        assert_eq!(lean.tables["acquiredimage"].rows.len(), 1);
+
+        let full = export_bundle(&path, "cat", SyncOperation::Merge, false, true).unwrap();
+        assert_eq!(full.tables["imagedata"].rows.len(), 1);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn preview_jobs_report_phases_until_finished() {
+        let store = PreviewJobStore::new();
+        let (job, started) = store.start("catalog".to_string(), None).unwrap();
+        assert!(started);
+        assert_eq!(job.state, "running");
+        assert_eq!(job.phase, Some("materializing"));
+
+        store.set_phase(&job.job_id, "comparing");
+        let running = store.get(&job.job_id, "catalog").unwrap().unwrap();
+        assert_eq!(running.phase, Some("comparing"));
+
+        store.finish(
+            &job.job_id,
+            Ok(SyncPreview {
+                preview_id: "preview-1".to_string(),
+                state: "ready",
+                expires_at: "2026-08-18T00:30:00Z".to_string(),
+                summary: BTreeMap::new(),
+            }),
+        );
+        let finished = store.get(&job.job_id, "catalog").unwrap().unwrap();
+        assert_eq!(finished.state, "ready");
+        assert_eq!(finished.phase, None);
+
+        // A phase set after completion must not resurrect a running look.
+        store.set_phase(&job.job_id, "comparing");
+        let still = store.get(&job.job_id, "catalog").unwrap().unwrap();
+        assert_eq!(still.phase, None);
+    }
 
     #[tokio::test]
     async fn export_response_header_matches_the_body_bytes() {

--- a/src/server/sync_preview.rs
+++ b/src/server/sync_preview.rs
@@ -166,6 +166,41 @@ impl SyncPreviewManager {
         Ok(Some(record))
     }
 
+    /// Every unexpired preview staged for one catalog, newest first —
+    /// including previews a remote client created, which the UI could not
+    /// otherwise discover. Expired records and records whose snapshot file
+    /// vanished are dropped on the way, like `get` does.
+    pub fn list(&self, local_db_id: &str) -> Result<Vec<SyncPreviewRecord>> {
+        let mut records = self
+            .records
+            .lock()
+            .map_err(|error| anyhow::anyhow!("sync preview lock poisoned: {error}"))?;
+        let now = unix_seconds();
+        let mut dead = Vec::new();
+        let mut alive = Vec::new();
+        for (id, record) in records.iter() {
+            if record.local_db_id != local_db_id {
+                continue;
+            }
+            let snapshot_exists = self
+                .source_snapshot_path(record)
+                .map(|path| path.is_file())
+                .unwrap_or(false);
+            if record.expires_at <= now || !snapshot_exists {
+                dead.push((id.clone(), record.source_snapshot_file.clone()));
+            } else {
+                alive.push(record.clone());
+            }
+        }
+        for (id, snapshot) in dead {
+            records.remove(&id);
+            let _ = fs::remove_file(record_path(&self.directory, &id));
+            self.remove_source_snapshot(&snapshot);
+        }
+        alive.sort_by_key(|record| std::cmp::Reverse(record.created_at));
+        Ok(alive)
+    }
+
     /// Atomically take a preview for one Apply attempt. A stale or failed
     /// Apply must be previewed again; two callers can never apply the same ID.
     pub fn claim(&self, id: &str, local_db_id: &str) -> Result<Option<SyncPreviewRecord>> {

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -263,8 +263,15 @@ pub fn local_bundle(
     catalog_id: &str,
     operation: SyncOperation,
     reviewed_only: bool,
+    include_thumbnails: bool,
 ) -> Result<CatalogBundle> {
-    crate::server::remote_sync::export_bundle(database_path, catalog_id, operation, reviewed_only)
+    crate::server::remote_sync::export_bundle(
+        database_path,
+        catalog_id,
+        operation,
+        reviewed_only,
+        include_thumbnails,
+    )
 }
 
 /// Write a bundle received from a peer into a throwaway SQLite source the

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -22,6 +22,7 @@ import type {
   UpdateAuthUserRequest,
   UpdateNoticeStatus,
   SchedulerSyncRequest,
+  SchedulerSyncPreviewListEntry,
   SchedulerSyncPreviewResponse,
   SchedulerSyncResponse,
   DatabaseSummary,
@@ -435,6 +436,31 @@ export const apiClient = {
       `/databases/${encodeURIComponent(dbId)}/sync/previews/${encodeURIComponent(previewId)}`
     );
     if (!data.data) throw new Error(data.error || 'Database sync preview not found');
+    return data.data;
+  },
+
+  /** Every unexpired staged preview for one catalog, including previews a
+   * remote client (the N.I.N.A. plugin) parked and never applied. */
+  listDatabaseSyncPreviews: async (
+    dbId: string
+  ): Promise<SchedulerSyncPreviewListEntry[]> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<SchedulerSyncPreviewListEntry[]>>(
+      `/databases/${encodeURIComponent(dbId)}/sync/previews`
+    );
+    return data.data ?? [];
+  },
+
+  /** Re-run one preview's dry run against the catalog as it stands now. */
+  refreshDatabaseSyncPreview: async (
+    dbId: string,
+    previewId: string
+  ): Promise<SchedulerSyncPreviewResponse> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<SchedulerSyncPreviewResponse>>(
+      `/databases/${encodeURIComponent(dbId)}/sync/previews/${encodeURIComponent(previewId)}/refresh`
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to refresh database sync preview');
     return data.data;
   },
 

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1148,6 +1148,17 @@ export interface SchedulerSyncPreviewResponse {
   result: SchedulerSyncResponse;
 }
 
+/** One staged transfer for a catalog, wherever it was created — the UI's
+ * own preview flow or a remote client's push. */
+export interface SchedulerSyncPreviewListEntry {
+  preview_id: string;
+  kind: string;
+  source: string;
+  created_at: number;
+  expires_at: number;
+  result: SchedulerSyncResponse;
+}
+
 /** Per-project line of an import outcome report. */
 export interface ImportProjectSummary {
   name: string;

--- a/static/src/components/RemoteSyncPreviews.tsx
+++ b/static/src/components/RemoteSyncPreviews.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import { useQueries, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import type { SchedulerSyncPreviewListEntry } from '../api/types';
+
+const KIND_LABELS: Record<string, string> = {
+  merge: 'Merge',
+  push_planning: 'Planning push',
+  push_grades: 'Grades push',
+};
+
+function expiresIn(expiresAt: number): string {
+  const seconds = expiresAt - Math.floor(Date.now() / 1000);
+  if (seconds <= 0) return 'expired';
+  if (seconds < 90) return `${seconds}s`;
+  return `${Math.round(seconds / 60)} min`;
+}
+
+/**
+ * Every staged transfer parked on the server, per catalog — including
+ * previews a remote client (the N.I.N.A. plugin) created and never
+ * applied. Without this listing those previews sit invisible until they
+ * expire; the operator can now review, apply, refresh, or discard them.
+ */
+export default function RemoteSyncPreviews({
+  databases,
+  disabled = false,
+}: {
+  databases: Array<{ id: string; name: string }>;
+  disabled?: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [message, setMessage] = useState('');
+
+  const previewQueries = useQueries({
+    queries: databases.map((db) => ({
+      queryKey: ['db', db.id, 'sync-preview-list'] as const,
+      queryFn: () => apiClient.listDatabaseSyncPreviews(db.id),
+      refetchInterval: 30_000,
+    })),
+  });
+
+  const rows: Array<{ dbId: string; dbName: string; entry: SchedulerSyncPreviewListEntry }> =
+    databases.flatMap((db, index) =>
+      (previewQueries[index]?.data ?? []).map((entry) => ({
+        dbId: db.id,
+        dbName: db.name,
+        entry,
+      }))
+    );
+
+  const reload = (dbId: string) =>
+    queryClient.invalidateQueries({ queryKey: ['db', dbId, 'sync-preview-list'] });
+
+  const act = async (
+    label: string,
+    key: string,
+    dbId: string,
+    action: () => Promise<unknown>
+  ) => {
+    setBusy(key);
+    setMessage('');
+    try {
+      await action();
+      setMessage(`${label} succeeded`);
+      await reload(dbId);
+      // An apply changes the catalog itself; refresh its views too.
+      queryClient.invalidateQueries({ queryKey: ['db', dbId] });
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  // After applying or discarding the last preview the table goes away,
+  // but the outcome message must survive that render or the user never
+  // sees whether their click worked.
+  if (rows.length === 0 && !message) {
+    return null;
+  }
+
+  return (
+    <div className="remote-sync-previews">
+      <h4>Staged previews</h4>
+      <p className="remote-sync-previews-hint">
+        Transfers waiting for review — including pushes a remote client
+        staged. Nothing changes the catalog until Apply.
+      </p>
+      {rows.length > 0 && (
+      <table>
+        <thead>
+          <tr>
+            <th>Catalog</th>
+            <th>Operation</th>
+            <th>From</th>
+            <th>Changes</th>
+            <th>Expires</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(({ dbId, dbName, entry }) => {
+            const key = `${dbId}:${entry.preview_id}`;
+            return (
+              <tr key={key}>
+                <td>{dbName}</td>
+                <td>{KIND_LABELS[entry.kind] ?? entry.kind}</td>
+                <td>{entry.source}</td>
+                <td>
+                  {entry.result.total_inserted} new · {entry.result.total_updated} updated
+                  {entry.result.grades
+                    ? ` · ${entry.result.grade_filled + entry.result.grade_preserved} grades`
+                    : ''}
+                </td>
+                <td>{expiresIn(entry.expires_at)}</td>
+                <td className="remote-sync-preview-actions">
+                  <button
+                    disabled={disabled || busy !== null}
+                    onClick={() =>
+                      act('Apply', key, dbId, () =>
+                        apiClient.applyDatabaseSyncPreview(dbId, entry.preview_id)
+                      )
+                    }
+                  >
+                    {busy === key ? 'Working…' : 'Apply'}
+                  </button>
+                  <button
+                    disabled={disabled || busy !== null}
+                    onClick={() =>
+                      act('Refresh', key, dbId, () =>
+                        apiClient.refreshDatabaseSyncPreview(dbId, entry.preview_id)
+                      )
+                    }
+                  >
+                    Refresh
+                  </button>
+                  <button
+                    disabled={disabled || busy !== null}
+                    onClick={() =>
+                      act('Discard', key, dbId, () =>
+                        apiClient.deleteDatabaseSyncPreview(dbId, entry.preview_id)
+                      )
+                    }
+                  >
+                    Discard
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      )}
+      {message && <p className="remote-sync-previews-status">{message}</p>}
+    </div>
+  );
+}

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -1576,3 +1576,43 @@
   font-size: 0.85rem;
   margin: 0.4rem 0 0;
 }
+
+.remote-sync-previews {
+  margin-top: 1.2rem;
+  border-top: 1px solid var(--color-border, #444);
+  padding-top: 0.8rem;
+}
+
+.remote-sync-previews h4 {
+  margin: 0 0 0.2rem;
+}
+
+.remote-sync-previews-hint {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  margin: 0 0 0.6rem;
+}
+
+.remote-sync-previews table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.88rem;
+}
+
+.remote-sync-previews th,
+.remote-sync-previews td {
+  text-align: left;
+  padding: 0.3rem 0.8rem 0.3rem 0;
+  border-bottom: 1px solid var(--color-border, #333);
+  white-space: nowrap;
+}
+
+.remote-sync-preview-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.remote-sync-previews-status {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+}

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -18,6 +18,7 @@ import { starMetadataFillEnabled } from '../hooks/useStarMetadataFill';
 import QualityBackfillControls from './QualityBackfillControls';
 import RemotePeerSync from './RemotePeerSync';
 import SchedulerSyncControls from './SchedulerSyncControls';
+import RemoteSyncPreviews from './RemoteSyncPreviews';
 import SeizaCatalogControls from './SeizaCatalogControls';
 import ProcessingSetupsManager from './ProcessingSetupsManager';
 import CalibrationLibrarySummary from './CalibrationLibrarySummary';
@@ -1381,6 +1382,7 @@ export default function TauriSettings({
           {currentTab === 'sync' && (
             <>
               <SchedulerSyncControls databases={databases} disabled={isApplying} />
+              <RemoteSyncPreviews databases={databases} disabled={isApplying} />
               <RemotePeerSync databases={databases} disabled={isApplying} />
             </>
           )}

--- a/static/src/components/__tests__/RemoteSyncPreviews.test.tsx
+++ b/static/src/components/__tests__/RemoteSyncPreviews.test.tsx
@@ -1,0 +1,135 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server } from '../../test/msw-server';
+import RemoteSyncPreviews from '../RemoteSyncPreviews';
+
+const databases = [{ id: 'review', name: 'Review copy' }];
+
+const counts = {
+  inserted: 0,
+  updated: 0,
+  unchanged: 0,
+  skipped: 0,
+};
+
+function previewEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    preview_id: 'preview-1',
+    kind: 'push_grades',
+    source: 'telescope-catalog',
+    created_at: 1_000,
+    expires_at: Math.floor(Date.now() / 1000) + 900,
+    result: {
+      kind: 'push_grades',
+      dry_run: true,
+      source_db_id: 'telescope-catalog',
+      destination_db_id: 'review',
+      exposuretemplate: counts,
+      project: counts,
+      ruleweight: counts,
+      target: counts,
+      exposureplan: counts,
+      acquiredimage: { ...counts, updated: 42 },
+      imagedata: null,
+      grades: { changed: 42, unchanged: 3 },
+      grade_filled: 40,
+      grade_preserved: 2,
+      imagedata_bytes: 0,
+      total_inserted: 0,
+      total_updated: 42,
+    },
+    ...overrides,
+  };
+}
+
+function ok(data: unknown) {
+  return HttpResponse.json({ success: true, data, error: null, status: 'ready' });
+}
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('RemoteSyncPreviews', () => {
+  it('lists staged previews with their source and counts', async () => {
+    server.use(
+      http.get('/api/databases/review/sync/previews', () => ok([previewEntry()]))
+    );
+    render(<RemoteSyncPreviews databases={databases} />, { wrapper: wrapper() });
+
+    expect(await screen.findByText('Grades push')).toBeInTheDocument();
+    expect(screen.getByText('telescope-catalog')).toBeInTheDocument();
+    expect(screen.getByText(/42 updated/)).toBeInTheDocument();
+    expect(screen.getByText(/42 grades/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when no previews are staged', async () => {
+    server.use(http.get('/api/databases/review/sync/previews', () => ok([])));
+    const { container } = render(<RemoteSyncPreviews databases={databases} />, {
+      wrapper: wrapper(),
+    });
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it('applies a preview and reloads the list', async () => {
+    let applied = 0;
+    let listCalls = 0;
+    server.use(
+      http.get('/api/databases/review/sync/previews', () => {
+        listCalls++;
+        return ok(listCalls === 1 ? [previewEntry()] : []);
+      }),
+      http.post('/api/databases/review/sync/previews/preview-1/apply', () => {
+        applied++;
+        return ok(previewEntry().result);
+      })
+    );
+    render(<RemoteSyncPreviews databases={databases} />, { wrapper: wrapper() });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Apply' }));
+
+    await waitFor(() => expect(applied).toBe(1));
+    expect(await screen.findByText('Apply succeeded')).toBeInTheDocument();
+  });
+
+  it('discards a preview', async () => {
+    let discarded = 0;
+    server.use(
+      http.get('/api/databases/review/sync/previews', () => ok([previewEntry()])),
+      http.delete('/api/databases/review/sync/previews/preview-1', () => {
+        discarded++;
+        return ok(true);
+      })
+    );
+    render(<RemoteSyncPreviews databases={databases} />, { wrapper: wrapper() });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Discard' }));
+    await waitFor(() => expect(discarded).toBe(1));
+  });
+
+  it('surfaces an apply failure without dropping the row', async () => {
+    server.use(
+      http.get('/api/databases/review/sync/previews', () => ok([previewEntry()])),
+      http.post('/api/databases/review/sync/previews/preview-1/apply', () =>
+        HttpResponse.json(
+          { success: false, data: null, error: 'destination changed since preview', status: null },
+          { status: 409 }
+        )
+      )
+    );
+    render(<RemoteSyncPreviews databases={databases} />, { wrapper: wrapper() });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Apply' }));
+    expect(await screen.findByText(/destination changed|Request failed/)).toBeInTheDocument();
+    expect(screen.getByText('Grades push')).toBeInTheDocument();
+  });
+});

--- a/tests/integration_remote_sync.rs
+++ b/tests/integration_remote_sync.rs
@@ -216,6 +216,10 @@ impl Harness {
 
     /// Build a bundle on the source catalog, exactly as a remote client would.
     async fn export(&self, operation: &str) -> Value {
+        self.export_with_thumbnails(operation, false).await
+    }
+
+    async fn export_with_thumbnails(&self, operation: &str, include_thumbnails: bool) -> Value {
         let (status, exported) = call(
             self.router.clone(),
             "POST",
@@ -225,7 +229,8 @@ impl Harness {
                 "protocol_version": 1,
                 "catalog_id": "source",
                 "operation": operation,
-                "reviewed_only": false
+                "reviewed_only": false,
+                "include_thumbnails": include_thumbnails
             })),
         )
         .await;
@@ -479,7 +484,16 @@ const OBSERVED: &str = "INSERT INTO project VALUES (1,'p','M42','remote settings
 async fn merge_brings_a_remote_catalogs_projects_targets_and_captures_across() {
     let harness = Harness::new(OBSERVED, "");
 
-    let bundle = harness.export("merge").await;
+    // Thumbnails are opt-in payload: the default merge export leaves the
+    // imagedata table out entirely so a season of blobs never rides along
+    // uninvited.
+    let lean = harness.export("merge").await;
+    assert!(
+        lean["tables"].get("imagedata").is_none(),
+        "default merge export carried thumbnails: {lean:#}"
+    );
+
+    let bundle = harness.export_with_thumbnails("merge", true).await;
     // A merge has to carry the capture tables, not only the planning ones.
     for table in ["project", "target", "acquiredimage", "imagedata"] {
         assert!(
@@ -712,7 +726,7 @@ async fn merge_carries_image_data_blobs_across() {
         "",
     );
 
-    let bundle = harness.export("merge").await;
+    let bundle = harness.export_with_thumbnails("merge", true).await;
     let preview_id = harness.preview("merge", bundle).await;
     let (status, applied) = harness.apply(&preview_id).await;
     assert_eq!(status, StatusCode::OK, "{applied:#}");

--- a/tests/integration_remote_sync_real_schema.rs
+++ b/tests/integration_remote_sync_real_schema.rs
@@ -135,7 +135,10 @@ impl Harness {
                 "protocol_version": 1,
                 "catalog_id": "source",
                 "operation": operation,
-                "reviewed_only": false
+                "reviewed_only": false,
+                // The round trip asserts thumbnail blobs survive the wire,
+                // and thumbnails are opt-in on merge exports.
+                "include_thumbnails": true
             })),
         )
         .await;


### PR DESCRIPTION
Implements the sync-performance and visibility brief.

## One transaction per bundle

`materialize_bundle` committed once per row — `journal_mode=DELETE` plus autocommit meant two fsyncs per insert, which is why staging a C925-sized push felt stuck. Measured on this machine's disk with a 6,000-row grades bundle: **~128 s before, <50 ms after**. The staging connection now wraps table creation, row inserts (still one prepared INSERT per table, no multi-row SQL), and `user_version` in a single transaction, with `synchronous=OFF` — the snapshot is scratch state; a crash discards it and the client re-uploads. A mid-bundle failure (test: duplicate primary key) now rolls back to an empty database instead of leaving a partial snapshot.

## Thumbnails are opt-in on merge exports

A merge export always included `imagedata` — using it against C925 would ship all **143.8 MB** of thumbnails on every round trip. `CreateExportRequest` gains `include_thumbnails` (default false); the receiving materializer already tolerates the omitted table (it creates it empty from the destination's DDL, and the merge is additive). The CLI passes its existing `with_image_data` flag through.

## Phases, timing, and visibility

- `PreviewJob` carries an optional `phase` (`materializing` → `comparing`; cleared on ready/failed), and the server logs catalog id, bundle id, operation, row count, and per-phase + total durations — never tokens or row contents.
- **Settings → Data Transfer** gains a *Staged previews* section listing every unexpired preview parked on the server for each catalog — including pushes a remote N.I.N.A. client created and never applied, which previously sat invisible until expiry (the existing UI only knew previews in its own session). Each row shows source, operation, inserted/updated counts, and expiry, with Apply / Refresh / Discard. Server side: a new list endpoint (`GET /databases/{db}/sync/previews`), a new token-free refresh endpoint, and the existing apply/discard routes unchanged. The HTTP reconcile remains one logical preview — nothing is split into batches, so fingerprint guarding, duplicate detection, and atomicity are untouched.

Tests: 5,000-row single-transaction materialization (asserts speed and `user_version`), mid-bundle failure rolls back to zero tables, job phase lifecycle (including no phase resurrection after finish), merge export with/without thumbnails, and 5 frontend tests for listing/applying/discarding/error-surfacing (one caught a real flaw: applying the last preview unmounted the section and swallowed the outcome message). Existing integration tests that assert blob round-trips now opt into thumbnails, with a new assertion that the default export is lean.

Checks: `cargo fmt -- --check`, `cargo test` (733 passed), `cargo clippy --all-targets --all-features -- -D warnings`, focused + full Vitest (299 passed), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)