### PR TITLE
Speed up bundle comparing, and show what a staged preview would change

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -107,6 +107,14 @@
   immediate), read and written with the same schema tolerance as the
   other project fields.
 
+- The "comparing" phase of a pushed bundle no longer scans the thumbnail
+  table once per image. The Target Scheduler schema has no index on
+  `imagedata.acquiredimageid`, so a merge preview against a season-sized
+  catalog ran thousands of full scans over the blob table — measured at
+  163 seconds for a 6.5k-row push whose bundle carried no thumbnails at
+  all. The comparison now makes one pass over each side and skips the
+  thumbnail step entirely when the bundle has none.
+
 - Staging a pushed bundle no longer commits once per row. A large grades
   push materialized each row in its own SQLite transaction — thousands of
   journal round-trips, minutes of "preview" — and a failure mid-bundle

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -95,7 +95,10 @@
 - Data Transfer in Settings now lists every **staged preview** parked on
   the server — including pushes a remote N.I.N.A. client created and never
   applied — with its source, operation, change counts, and expiry, plus
-  Apply, Refresh, and Discard actions. Previously only the browser session
+  Apply, Refresh, and Discard actions, and a "What would change" list
+  naming each staged change — every grade transition with its reason, and
+  each project, target, plan, or image the transfer would insert or
+  update (capped at 400 lines). Previously only the browser session
   that created a preview could see it, so a plugin's staged push sat
   invisible until it expired. Remote preview jobs also report a phase
   (materializing, then comparing) while they run.

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -610,57 +610,75 @@ fn copy_imagedata(
     bytes: &mut u64,
     dry_run: bool,
 ) -> Result<()> {
-    let mut existing_stmt = tx.prepare("SELECT tag FROM imagedata WHERE acquiredimageid = ?1")?;
-    let mut sel_len_stmt =
-        src.prepare("SELECT tag, LENGTH(imagedata) FROM imagedata WHERE acquiredimageid = ?1")?;
-    let mut sel_full_stmt = src.prepare(
-        "SELECT tag, imagedata, width, height FROM imagedata WHERE acquiredimageid = ?1",
-    )?;
+    // One pass over each side instead of two point queries per image. The
+    // Target Scheduler schema has no index on imagedata.acquiredimageid, so
+    // the per-image lookups were each a full scan of the destination's blob
+    // table — quadratic, measured at 162 s of "comparing" for a 6.5k-row
+    // merge preview whose bundle carried no thumbnails at all.
+    let source_rows: i64 = src.query_row("SELECT COUNT(*) FROM imagedata", [], |r| r.get(0))?;
+    if source_rows == 0 {
+        return Ok(());
+    }
+
+    // Tags already present at the destination, keyed by image, one scan.
+    let mut existing: HashMap<i64, HashSet<Option<String>>> = HashMap::new();
+    {
+        let mut stmt = tx.prepare("SELECT acquiredimageid, tag FROM imagedata")?;
+        let mut rows = stmt.query([])?;
+        while let Some(r) = rows.next()? {
+            if let Some(image_id) = r.get::<_, Option<i64>>(0)? {
+                existing.entry(image_id).or_default().insert(r.get(1)?);
+            }
+        }
+    }
+    let tag_exists = |dest_img: i64, tag: &Option<String>| {
+        existing
+            .get(&dest_img)
+            .is_some_and(|tags| tags.contains(tag))
+    };
+
+    if dry_run {
+        let mut stmt =
+            src.prepare("SELECT acquiredimageid, tag, LENGTH(imagedata) FROM imagedata")?;
+        let mut rows = stmt.query([])?;
+        while let Some(r) = rows.next()? {
+            let source_image: Option<i64> = r.get(0)?;
+            let Some(&dest_img) = source_image.and_then(|id| img_map.get(&id)) else {
+                continue;
+            };
+            let tag: Option<String> = r.get(1)?;
+            if tag_exists(dest_img, &tag) {
+                counts.unchanged += 1;
+            } else {
+                counts.inserted += 1;
+                *bytes += r.get::<_, i64>(2).unwrap_or(0).max(0) as u64;
+            }
+        }
+        return Ok(());
+    }
+
     let mut ins_stmt = tx.prepare(
         "INSERT INTO imagedata (tag, imagedata, acquiredimageid, width, height) VALUES (?1,?2,?3,?4,?5)",
     )?;
-    for (src_img, dest_img) in img_map {
-        // Tags already present at the destination for this image.
-        let mut existing: HashSet<Option<String>> = HashSet::new();
-        {
-            let mut rows = existing_stmt.query(params![dest_img])?;
-            while let Some(r) = rows.next()? {
-                existing.insert(r.get::<_, Option<String>>(0)?);
-            }
-        }
-        if dry_run {
-            let mut rows = sel_len_stmt.query(params![src_img])?;
-            while let Some(r) = rows.next()? {
-                let tag: Option<String> = r.get(0)?;
-                if existing.contains(&tag) {
-                    counts.unchanged += 1;
-                } else {
-                    counts.inserted += 1;
-                    *bytes += r.get::<_, i64>(1).unwrap_or(0).max(0) as u64;
-                }
-            }
+    let mut stmt =
+        src.prepare("SELECT acquiredimageid, tag, imagedata, width, height FROM imagedata")?;
+    let mut rows = stmt.query([])?;
+    while let Some(r) = rows.next()? {
+        let source_image: Option<i64> = r.get(0)?;
+        let Some(&dest_img) = source_image.and_then(|id| img_map.get(&id)) else {
+            continue;
+        };
+        let tag: Option<String> = r.get(1)?;
+        if tag_exists(dest_img, &tag) {
+            counts.unchanged += 1;
             continue;
         }
-        #[allow(clippy::type_complexity)]
-        let blobs: Vec<(Option<String>, Option<Vec<u8>>, i64, i64)> = sel_full_stmt
-            .query_map(params![src_img], |r| {
-                Ok((
-                    r.get(0)?,
-                    r.get(1)?,
-                    r.get::<_, i64>(2).unwrap_or(0),
-                    r.get::<_, i64>(3).unwrap_or(0),
-                ))
-            })?
-            .collect::<rusqlite::Result<_>>()?;
-        for (tag, blob, w, h) in blobs {
-            if existing.contains(&tag) {
-                counts.unchanged += 1;
-                continue;
-            }
-            *bytes += blob.as_ref().map(|b| b.len() as u64).unwrap_or(0);
-            ins_stmt.execute(params![tag, blob, dest_img, w, h])?;
-            counts.inserted += 1;
-        }
+        let blob: Option<Vec<u8>> = r.get(2)?;
+        let width = r.get::<_, i64>(3).unwrap_or(0);
+        let height = r.get::<_, i64>(4).unwrap_or(0);
+        *bytes += blob.as_ref().map(|b| b.len() as u64).unwrap_or(0);
+        ins_stmt.execute(params![tag, blob, dest_img, width, height])?;
+        counts.inserted += 1;
     }
     Ok(())
 }

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -466,6 +466,11 @@ pub struct SchedulerSyncResponse {
     pub imagedata_bytes: u64,
     pub total_inserted: usize,
     pub total_updated: usize,
+    /// Human-readable per-entity change lines ("update target <guid>",
+    /// "grade <guid>: Pending → Rejected"), capped — the tail line says how
+    /// many more there are. Empty on responses stored before this field.
+    #[serde(default)]
+    pub changes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -583,6 +583,25 @@ async fn execute_scheduler_sync_guarded(
     .await
 }
 
+/// Cap a change-line list for transport; the tail line names the overflow.
+fn capped_change_lines(mut lines: Vec<String>) -> Vec<String> {
+    const MAX_CHANGE_LINES: usize = 400;
+    if lines.len() > MAX_CHANGE_LINES {
+        let more = lines.len() - MAX_CHANGE_LINES;
+        lines.truncate(MAX_CHANGE_LINES);
+        lines.push(format!("… and {more} more"));
+    }
+    lines
+}
+
+fn grade_label(status: i32) -> &'static str {
+    match status {
+        1 => "Accepted",
+        2 => "Rejected",
+        _ => "Pending",
+    }
+}
+
 pub(crate) async fn execute_scheduler_sync_paths(
     state: &Arc<AppState>,
     source_path: PathBuf,
@@ -668,6 +687,7 @@ pub(crate) async fn execute_scheduler_sync_paths(
                                 imagedata_bytes: summary.imagedata_bytes,
                                 total_inserted: summary.total_inserted(),
                                 total_updated: summary.total_updated(),
+                                changes: capped_change_lines(summary.changes),
                             }
                         }
                         SchedulerSyncKind::PushPlanning => {
@@ -699,6 +719,7 @@ pub(crate) async fn execute_scheduler_sync_paths(
                                 imagedata_bytes: 0,
                                 total_inserted: summary.total_inserted(),
                                 total_updated: summary.total_updated(),
+                                changes: capped_change_lines(summary.changes),
                             }
                         }
                         SchedulerSyncKind::PushGrades => {
@@ -743,6 +764,26 @@ pub(crate) async fn execute_scheduler_sync_paths(
                                 imagedata_bytes: 0,
                                 total_inserted: 0,
                                 total_updated: summary.changed,
+                                changes: capped_change_lines(
+                                    summary
+                                        .changes
+                                        .iter()
+                                        .map(|change| {
+                                            let reason = change
+                                                .reason
+                                                .as_deref()
+                                                .map(|reason| format!(" ({reason})"))
+                                                .unwrap_or_default();
+                                            format!(
+                                                "grade {}: {} → {}{}",
+                                                change.guid,
+                                                grade_label(change.from),
+                                                grade_label(change.to),
+                                                reason,
+                                            )
+                                        })
+                                        .collect(),
+                                ),
                             }
                         }
                     };

--- a/src/server/sync_preview.rs
+++ b/src/server/sync_preview.rs
@@ -504,6 +504,7 @@ mod tests {
             imagedata_bytes: 0,
             total_inserted: 0,
             total_updated: 0,
+            changes: Vec::new(),
         }
     }
 

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1139,6 +1139,8 @@ export interface SchedulerSyncResponse {
   imagedata_bytes: number;
   total_inserted: number;
   total_updated: number;
+  /** Per-entity change lines, capped server-side; absent on old previews. */
+  changes?: string[];
 }
 
 export interface SchedulerSyncPreviewResponse {

--- a/static/src/components/RemoteSyncPreviews.tsx
+++ b/static/src/components/RemoteSyncPreviews.tsx
@@ -113,6 +113,16 @@ export default function RemoteSyncPreviews({
                   {entry.result.grades
                     ? ` · ${entry.result.grade_filled + entry.result.grade_preserved} grades`
                     : ''}
+                  {(entry.result.changes?.length ?? 0) > 0 && (
+                    <details className="remote-sync-preview-changes">
+                      <summary>What would change</summary>
+                      <ul>
+                        {entry.result.changes!.map((line, index) => (
+                          <li key={index}>{line}</li>
+                        ))}
+                      </ul>
+                    </details>
+                  )}
                 </td>
                 <td>{expiresIn(entry.expires_at)}</td>
                 <td className="remote-sync-preview-actions">

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -1616,3 +1616,22 @@
   margin: 0.5rem 0 0;
   font-size: 0.85rem;
 }
+
+.remote-sync-preview-changes {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+}
+
+.remote-sync-preview-changes summary {
+  cursor: pointer;
+  color: var(--color-primary, #4da3ff);
+}
+
+.remote-sync-preview-changes ul {
+  margin: 0.3rem 0 0;
+  padding-left: 1.1rem;
+  max-height: 14rem;
+  overflow-y: auto;
+  font-family: monospace;
+  white-space: normal;
+}

--- a/static/src/components/__tests__/RemoteSyncPreviews.test.tsx
+++ b/static/src/components/__tests__/RemoteSyncPreviews.test.tsx
@@ -41,6 +41,10 @@ function previewEntry(overrides: Record<string, unknown> = {}) {
       imagedata_bytes: 0,
       total_inserted: 0,
       total_updated: 42,
+      changes: [
+        'grade image-guid-1: Pending → Rejected (clouds)',
+        'grade image-guid-2: Accepted → Rejected (satellite trail)',
+      ],
     },
     ...overrides,
   };
@@ -70,6 +74,13 @@ describe('RemoteSyncPreviews', () => {
     expect(screen.getByText('telescope-catalog')).toBeInTheDocument();
     expect(screen.getByText(/42 updated/)).toBeInTheDocument();
     expect(screen.getByText(/42 grades/)).toBeInTheDocument();
+
+    // The counts alone say nothing about WHICH rows move; the expandable
+    // details list the actual changes the apply would make.
+    await userEvent.click(screen.getByText('What would change'));
+    expect(
+      screen.getByText('grade image-guid-1: Pending → Rejected (clouds)')
+    ).toBeInTheDocument();
   });
 
   it('renders nothing when no previews are staged', async () => {

--- a/tests/integration_sync_api.rs
+++ b/tests/integration_sync_api.rs
@@ -212,6 +212,12 @@ async fn planning_and_grade_pushes_preview_before_writing() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(preview["data"]["result"]["dry_run"], true);
     assert_eq!(preview["data"]["result"]["grades"]["changed"], 1);
+    // The preview says WHAT would change, not only how much: one line per
+    // grade move, with the guid, transition, and reason.
+    let changes = preview["data"]["result"]["changes"].as_array().unwrap();
+    assert_eq!(changes.len(), 1, "{changes:#?}");
+    let line = changes[0].as_str().unwrap();
+    assert_eq!(line, "grade image-guid: Rejected → Accepted");
     let preview_id = preview["data"]["preview_id"].as_str().unwrap();
     let (status, restored) = get_request(
         app.clone(),


### PR DESCRIPTION
Follow-up to #353, from the live phase logs it added. Materialization dropped to 11 ms, which exposed the next bottleneck: `compare=162.57s` for a 6,506-row merge preview (and a ~10k-row one running even longer).

**Root cause.** `copy_imagedata` ran `SELECT tag FROM imagedata WHERE acquiredimageid = ?` on the destination (plus a matching source query) for every pulled image. The Target Scheduler schema has no index on `imagedata.acquiredimageid`, so each lookup was a full scan of the blob table — ~6k scans over 143 MB of thumbnails per preview. And with #353 making lean bundles the default, all that work happened for bundles carrying **zero** thumbnails.

**Fix.** Short-circuit when the source has no imagedata rows; otherwise build the destination's per-image tag map in one scan and walk the source in one pass through the existing id map. Insert-only semantics, counters, and dry-run byte accounting unchanged — the existing `imagedata_copies_missing_tags`, idempotence, and blob round-trip tests all pass unmodified. No index is added to the user's catalog: previews should not write DDL into a live Target Scheduler database.

Expected effect on the observed case: the lean-bundle merge preview's compare drops from minutes to roughly the cost of the row upserts (seconds at worst).

Checks: `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (733 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)