### PR TITLE
Rotator-aware flat matching, and exact sync change lines

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -96,7 +96,8 @@
   the server — including pushes a remote N.I.N.A. client created and never
   applied — with its source, operation, change counts, and expiry, plus
   Apply, Refresh, and Discard actions, and a "What would change" list
-  naming each staged change — every grade transition with its reason, and
+  naming each staged change by its own name with exact field-level moves
+  ("update project \"Caldwell 49\": state: 1 → 3") — every grade transition with its reason, and
   each project, target, plan, or image the transfer would insert or
   update (capped at 400 lines). Previously only the browser session
   that created a preview could see it, so a plugin's staged push sat
@@ -104,6 +105,14 @@
   (materializing, then comparing) while they run.
 
 ## Fixed
+
+- Flat matching now respects the rotator. A flat only corrects lights
+  shot at (nearly) the same rotator angle — vignetting from the optics
+  ahead of the rotator turns relative to the sensor — so flats now match
+  lights within 1° (wrap-aware), and a flat master never integrates
+  frames from different angles. Frames without a recorded angle keep
+  matching everything: rigs without rotators and flats catalogued before
+  this change lose nothing. Re-import flats to record their angles.
 
 - The project scheduler editor now exposes Target Scheduler's **flats
   handling** setting (off, every 1-7 sessions, target completion, or

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -87,6 +87,8 @@ pub struct CalibrationFrame {
     pub camera_temp: Option<f64>,
     pub filter: Option<String>,
     pub focal_length_mm: Option<f64>,
+    /// Rotator angle in degrees at capture, when the rig recorded one.
+    pub rotation: Option<f64>,
     /// Set after the current file (or a basename-remapped file) has been
     /// checked against this catalog row's hard settings.
     pub source_verified: bool,
@@ -366,6 +368,7 @@ pub fn ensure_schema(conn: &Connection) -> Result<()> {
             camera_temp        REAL,
             filter_name        TEXT,
             focal_length_mm    REAL,
+            rotation           REAL,
             file_size          INTEGER,
             file_mtime_ns      TEXT,
             added_at           INTEGER NOT NULL,
@@ -418,6 +421,16 @@ pub fn ensure_schema(conn: &Connection) -> Result<()> {
             "PSF Guard calibration schema version {version} is not supported by this build \
              (expected {CALIBRATION_SCHEMA_VERSION})"
         );
+    }
+    // Catalogs created before the rotation column: add it in place. NULL
+    // means "not recorded", which the matcher treats as compatible.
+    let has_rotation = conn
+        .prepare("PRAGMA table_info('psf_guard_calibration_frame')")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .filter_map(|name| name.ok())
+        .any(|name| name.eq_ignore_ascii_case("rotation"));
+    if !has_rotation {
+        conn.execute_batch("ALTER TABLE psf_guard_calibration_frame ADD COLUMN rotation REAL;")?;
     }
     Ok(())
 }
@@ -482,11 +495,11 @@ pub fn import_calibration_frames(
                 channels, binning_x, binning_y, gain, offset, readout_mode,
                 bayer_pattern, bayer_x_offset, bayer_y_offset, exposure_s,
                 camera_temp, filter_name, focal_length_mm, file_size,
-                file_mtime_ns, added_at, updated_at
+                file_mtime_ns, added_at, updated_at, rotation
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
                 ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24,
-                ?25, ?26, ?27, ?27
+                ?25, ?26, ?27, ?27, ?28
             )
             ON CONFLICT(source_path) DO UPDATE SET
                 rig_uuid=excluded.rig_uuid, kind=excluded.kind,
@@ -502,7 +515,7 @@ pub fn import_calibration_frames(
                 exposure_s=excluded.exposure_s, camera_temp=excluded.camera_temp,
                 filter_name=excluded.filter_name, focal_length_mm=excluded.focal_length_mm,
                 file_size=excluded.file_size, file_mtime_ns=excluded.file_mtime_ns,
-                updated_at=excluded.updated_at
+                updated_at=excluded.updated_at, rotation=excluded.rotation
             "#,
             params![
                 frame_uuid,
@@ -532,6 +545,7 @@ pub fn import_calibration_frames(
                 file_size,
                 file_mtime_ns,
                 now,
+                frame.rotator_position,
             ],
         )?;
         if existing.is_some() {
@@ -909,7 +923,7 @@ pub fn select_for_light(conn: &Connection, light: &FrameMeta) -> Result<Calibrat
         SELECT id, frame_uuid, rig_uuid, kind, source_path, source_fingerprint,
                captured_at, telescope, camera, width, height, channels,
                binning_x, binning_y, gain, offset, readout_mode, bayer_pattern,
-               exposure_s, camera_temp, filter_name, focal_length_mm
+               exposure_s, camera_temp, filter_name, focal_length_mm, rotation
         FROM psf_guard_calibration_frame
         ORDER BY captured_at DESC, id DESC
         "#,
@@ -2514,6 +2528,26 @@ fn flat_matches(light: &FrameMeta, candidate: &CalibrationFrame) -> bool {
             candidate.focal_length_mm,
             |left, right| (left - right).abs() <= 1.0,
         )
+        && rotation_matches(light.rotator_position, candidate.rotation)
+}
+
+/// Rotator tolerance when pairing a flat with a light or another flat.
+const ROTATION_TOLERANCE_DEG: f64 = 1.0;
+
+/// The rotator sits between the telescope and the camera, so vignetting
+/// from the optics ahead of it rotates relative to the sensor as the
+/// rotator moves — a flat only corrects lights shot at (nearly) the same
+/// angle. Unknown on either side matches: NULL means the rig recorded no
+/// rotator, or the frame predates the column, and punishing either would
+/// strip flats from every catalog imported before rotation was stored.
+fn rotation_matches(left: Option<f64>, right: Option<f64>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => {
+            let diff = (left - right).rem_euclid(360.0);
+            diff.min(360.0 - diff) <= ROTATION_TOLERANCE_DEG
+        }
+        _ => true,
+    }
 }
 
 fn frame_pair_matches(left: &CalibrationFrame, right: &CalibrationFrame) -> bool {
@@ -2625,7 +2659,12 @@ fn coherent_master_subset(
         } else {
             true
         };
-        temperature_ok && session_ok
+        let rotation_ok = if kind == CalibrationKind::Flat {
+            rotation_matches(anchor.rotation, frame.rotation)
+        } else {
+            true
+        };
+        temperature_ok && session_ok && rotation_ok
     };
 
     let mut first_cluster: Option<Vec<CalibrationFrame>> = None;
@@ -2659,7 +2698,7 @@ fn query_kind(conn: &Connection, kind: CalibrationKind) -> Result<Vec<Calibratio
         SELECT id, frame_uuid, rig_uuid, kind, source_path, source_fingerprint,
                captured_at, telescope, camera, width, height, channels,
                binning_x, binning_y, gain, offset, readout_mode, bayer_pattern,
-               exposure_s, camera_temp, filter_name, focal_length_mm
+               exposure_s, camera_temp, filter_name, focal_length_mm, rotation
         FROM psf_guard_calibration_frame WHERE kind = ?1
         ORDER BY captured_at DESC, id DESC
         "#,
@@ -2701,6 +2740,7 @@ fn row_to_frame(row: &rusqlite::Row<'_>) -> rusqlite::Result<CalibrationFrame> {
         camera_temp: row.get(19)?,
         filter: row.get(20)?,
         focal_length_mm: row.get(21)?,
+        rotation: row.get(22)?,
         source_verified: false,
     })
 }
@@ -3021,6 +3061,61 @@ mod tests {
     }
 
     #[test]
+    fn flats_match_rotation_within_tolerance_and_across_the_wrap() {
+        // Same axis expressed on either side of 0°/360° still matches;
+        // a quarter turn does not.
+        assert!(rotation_matches(Some(120.0), Some(120.6)));
+        assert!(rotation_matches(Some(359.8), Some(0.4)));
+        assert!(!rotation_matches(Some(120.0), Some(122.0)));
+        assert!(!rotation_matches(Some(0.0), Some(90.0)));
+        // Unknown on either side is compatible: rigs without rotators, and
+        // flats catalogued before the column existed, keep matching.
+        assert!(rotation_matches(None, Some(45.0)));
+        assert!(rotation_matches(Some(45.0), None));
+        assert!(rotation_matches(None, None));
+    }
+
+    #[test]
+    fn flat_master_never_mixes_rotator_angles() {
+        let flat = |id: i64, rotation: Option<f64>| CalibrationFrame {
+            id,
+            frame_uuid: format!("f{id}"),
+            rig_uuid: "r".into(),
+            kind: CalibrationKind::Flat,
+            source_path: format!("/flat-{id}.fits").into(),
+            source_fingerprint: "x".into(),
+            captured_at: Some(1_000_000_000),
+            telescope: None,
+            camera: None,
+            width: Some(3000),
+            height: Some(2000),
+            channels: Some(1),
+            binning_x: Some(1),
+            binning_y: Some(1),
+            gain: Some(100),
+            offset: Some(20),
+            readout_mode: None,
+            bayer_pattern: None,
+            exposure_s: Some(3.0),
+            camera_temp: Some(-10.0),
+            filter: Some("Ha".into()),
+            focal_length_mm: None,
+            rotation,
+            source_verified: false,
+        };
+        // Five flats at 30° and two strays at 120°: the master takes only
+        // the coherent angle, because integrating both would average two
+        // different vignette orientations into one wrong correction.
+        let frames: Vec<CalibrationFrame> = (0..5)
+            .map(|id| flat(id, Some(30.0 + 0.1 * id as f64)))
+            .chain((5..7).map(|id| flat(id, Some(120.0))))
+            .collect();
+        let subset = coherent_master_subset(CalibrationKind::Flat, &frames);
+        assert_eq!(subset.len(), 5);
+        assert!(subset.iter().all(|frame| frame.rotation.unwrap() < 40.0));
+    }
+
+    #[test]
     fn rejects_wrong_sensor_or_dark_temperature() {
         let light = frame("/light.fits", "LIGHT");
         let candidate = CalibrationFrame {
@@ -3046,6 +3141,7 @@ mod tests {
             camera_temp: Some(0.0),
             filter: None,
             focal_length_mm: None,
+            rotation: None,
             source_verified: false,
         };
         assert!(!sensor_matches(&light, &candidate));
@@ -3164,6 +3260,7 @@ mod tests {
             camera_temp: temp,
             filter: Some("Ha".into()),
             focal_length_mm: None,
+            rotation: None,
             source_verified: false,
         };
         let day = 24 * 60 * 60;

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -362,13 +362,19 @@ fn upsert_guid_table(
                 if values_equal(&write_values, cur_vals) {
                     counts.unchanged += 1;
                 } else {
+                    let diffs = column_diffs(&write_cols, &write_values, cur_vals);
                     let mut p: Vec<&dyn ToSql> =
                         write_values.iter().map(|v| v as &dyn ToSql).collect();
                     let did = *dest_id;
                     p.push(&did);
                     upd_stmt.execute(p.as_slice())?;
                     counts.updated += 1;
-                    changes.push(format!("update {} {}", table, guid));
+                    changes.push(format!(
+                        "update {} {}: {}",
+                        table,
+                        row_label(&write_cols, &write_values, &guid),
+                        diffs.join(", "),
+                    ));
                 }
             }
             None => {
@@ -384,12 +390,67 @@ fn upsert_guid_table(
                 let dest_id = tx.last_insert_rowid();
                 id_map.insert(src_id, dest_id);
                 counts.inserted += 1;
-                changes.push(format!("insert {} {}", table, guid));
+                changes.push(format!(
+                    "insert {} {}",
+                    table,
+                    row_label(&write_cols, &write_values, &guid),
+                ));
             }
         }
     }
 
     Ok(GuidUpsert { id_map, counts })
+}
+
+/// Compact, human-readable form of one SQLite value for a change line.
+/// Long text (metadata JSON above all) truncates so one row cannot flood
+/// the preview; blobs show their size only.
+fn display_value(value: &Value) -> String {
+    const MAX_TEXT: usize = 48;
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Integer(n) => n.to_string(),
+        Value::Real(r) => format!("{r}"),
+        Value::Text(t) => {
+            if t.chars().count() > MAX_TEXT {
+                let head: String = t.chars().take(MAX_TEXT).collect();
+                format!("\"{head}…\"")
+            } else {
+                format!("\"{t}\"")
+            }
+        }
+        Value::Blob(b) => format!("<blob {} bytes>", b.len()),
+    }
+}
+
+/// The row's own name for a change line — its `name` column when the table
+/// has one, else the guid. "update project <guid>" tells an operator
+/// nothing; "update project \"Caldwell 49\"" does.
+fn row_label(write_cols: &[&str], values: &[Value], guid: &str) -> String {
+    let name = write_cols
+        .iter()
+        .position(|column| column.eq_ignore_ascii_case("name"))
+        .and_then(|position| match &values[position] {
+            Value::Text(name) if !name.is_empty() => Some(name.clone()),
+            _ => None,
+        });
+    match name {
+        Some(name) => format!("\"{name}\""),
+        None => guid.to_string(),
+    }
+}
+
+/// Exact per-column differences between the incoming row and the current
+/// destination row, as "column: old → new" fragments.
+fn column_diffs(write_cols: &[&str], new_values: &[Value], old_values: &[Value]) -> Vec<String> {
+    write_cols
+        .iter()
+        .zip(new_values.iter().zip(old_values.iter()))
+        .filter(|(_, (new, old))| !value_eq(new, old))
+        .map(|(column, (new, old))| {
+            format!("{column}: {} → {}", display_value(old), display_value(new))
+        })
+        .collect()
 }
 
 fn cols_str(cols: &[String]) -> Vec<&str> {
@@ -1111,6 +1172,17 @@ mod tests {
         let s = sync_pull(&src, &dest, &opts()).unwrap();
         assert_eq!(s.project.updated, 1);
         assert_eq!(s.exposureplan.updated, 1);
+        // The change line names the project and states the exact field
+        // moves — an operator cannot review "update project <guid>".
+        let line = s
+            .changes
+            .iter()
+            .find(|line| line.starts_with("update project"))
+            .expect("project change line");
+        assert!(line.contains("\"Caldwell\""), "{line}");
+        assert!(line.contains("state: 1 → 3"), "{line}");
+        assert!(line.contains("priority: 5 → 9"), "{line}");
+        assert!(!line.contains("project-guid"), "{line}");
         assert_eq!(
             one::<i64>(&dest, "SELECT state FROM project WHERE guid='pg'"),
             3


### PR DESCRIPTION
Two changes from review feedback.

## Flats match the rotator angle

The rotator sits between the telescope and the camera: dust on the sensor rotates with the camera (pixel-fixed at any angle), but vignetting from the optics ahead of the rotator turns relative to the sensor as the rotator moves — a flat shot at 0° applied to lights at 90° corrects the dust and smears the vignette sideways. Target Scheduler's own `flathistory` keys flats on rotation; we ignored it, and the importer parsed `ROTATANG`/`ROTATOR` without storing it for calibration frames.

- The calibration frame catalog gains a `rotation` column, added in place on existing catalogs (probe + `ALTER TABLE`), recorded on import.
- Flat-to-light matching requires agreement within **1°**, wrap-aware (359.8° matches 0.4°).
- A flat master never integrates frames from different angles — averaging two vignette orientations corrects neither.
- A frame without a recorded angle matches everything: rigs without rotators and flats catalogued before the column keep working (re-import flats to fill angles in; the upsert updates in place). Darks and biases stay rotation-blind, which is physically correct.

## "What would change" is now exact

`update project <guid>` is not reviewable. Pull and planning change lines now carry the row's own name and per-column moves — `update project "Caldwell 49": state: 1 → 3, priority: 5 → 9` — with long text truncated and blobs shown by size so a metadata column cannot flood the preview. Inserts name the new row; skip lines keep the guid, since ambiguity is a guid property. Grade lines already named the transition and reason.

Tests: rotation tolerance/wrap/unknown-compatibility, a flat-master grouping split (five flats at 30° + two strays at 120° → only the coherent five integrate), and an exactness assertion on the project change line (name present, `state: 1 → 3`, no guid). `cargo fmt -- --check`, `clippy -D warnings`, `cargo test` (736 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)