### PR TITLE
Pair remote clients with a one-time code, one credential per client

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -104,6 +104,14 @@
   invisible until it expired. Remote preview jobs also report a phase
   (materializing, then comparing) while they run.
 
+- Remote clients now pair with a **one-time code** instead of a
+  hand-copied API key. Settings gains "Pair a client" per database: a
+  single-use code, good for an hour, that the N.I.N.A. plugin exchanges
+  for its own credential and the catalog id in one step. Every pairing
+  mints a separate credential, and the new **Paired clients** list revokes
+  any one install without signing out the rest. Manually configured keys
+  keep working.
+
 ## Fixed
 
 - Flat matching now respects the rotator. A flat only corrects lights

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -54,6 +54,19 @@ pub struct DbEntry {
     pub export_dir: Option<String>,
 }
 
+/// One paired client credential. Each pairing mints its own, so revoking a
+/// laptop does not sign out the observatory machine. Only the salted hash
+/// is stored; the plaintext existed once, in the pairing response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RemoteClient {
+    pub client_uuid: String,
+    /// Operator-facing label, from the client's pairing request.
+    pub name: String,
+    pub token_salt: String,
+    pub token_sha256: String,
+    pub paired_at: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct RemoteImageUploadConfig {
     #[serde(default)]
@@ -64,6 +77,10 @@ pub struct RemoteImageUploadConfig {
     pub token_salt: String,
     #[serde(default)]
     pub token_sha256: String,
+    /// Per-client credentials from pairing. The legacy single token above
+    /// keeps working for installs configured before pairing existed.
+    #[serde(default)]
+    pub clients: Vec<RemoteClient>,
     /// Opt this database into the remote scheduler sync protocol
     /// (`/api/sync/v1`). Independent of `enabled`, which covers image upload
     /// only. Defaults to false, so a token configured for uploads before the
@@ -93,18 +110,67 @@ impl RemoteImageUploadConfig {
     }
 
     pub fn token_is_configured(&self) -> bool {
-        self.token_salt.len() == 32
+        let legacy = self.token_salt.len() == 32
             && self.token_salt.bytes().all(|byte| byte.is_ascii_hexdigit())
             && self.token_sha256.len() == 64
             && self
                 .token_sha256
                 .bytes()
-                .all(|byte| byte.is_ascii_hexdigit())
+                .all(|byte| byte.is_ascii_hexdigit());
+        legacy || !self.clients.is_empty()
     }
 
     pub fn token_matches(&self, token: &str) -> bool {
-        let candidate = salted_token_sha256(&self.token_salt, token);
-        constant_time_eq(self.token_sha256.as_bytes(), candidate.as_bytes())
+        // Legacy single token, then every paired client. All comparisons run
+        // (no early exit on the legacy match shape) with constant-time
+        // equality per candidate.
+        let legacy = {
+            let candidate = salted_token_sha256(&self.token_salt, token);
+            constant_time_eq(self.token_sha256.as_bytes(), candidate.as_bytes())
+        };
+        let client = self
+            .clients
+            .iter()
+            .filter(|client| client.token_salt.len() == 32 && client.token_sha256.len() == 64)
+            .fold(false, |matched, client| {
+                let candidate = salted_token_sha256(&client.token_salt, token);
+                matched | constant_time_eq(client.token_sha256.as_bytes(), candidate.as_bytes())
+            });
+        legacy | client
+    }
+
+    /// Add a paired client credential, returning its id. Validates the token
+    /// the same way `set_token` does; the legacy single token is untouched.
+    pub fn add_client(&mut self, name: &str, token: &str) -> Result<String> {
+        if token.len() < Self::MIN_TOKEN_LENGTH || token.len() > Self::MAX_TOKEN_LENGTH {
+            anyhow::bail!(
+                "client token must be {}-{} characters",
+                Self::MIN_TOKEN_LENGTH,
+                Self::MAX_TOKEN_LENGTH
+            );
+        }
+        let client_uuid = uuid::Uuid::new_v4().to_string();
+        let token_salt = uuid::Uuid::new_v4().simple().to_string();
+        let token_sha256 = salted_token_sha256(&token_salt, token);
+        self.clients.push(RemoteClient {
+            client_uuid: client_uuid.clone(),
+            name: name.trim().to_string(),
+            token_salt,
+            token_sha256,
+            paired_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|duration| duration.as_secs() as i64)
+                .unwrap_or(0),
+        });
+        Ok(client_uuid)
+    }
+
+    /// Revoke one paired client. Returns whether anything was removed.
+    pub fn revoke_client(&mut self, client_uuid: &str) -> bool {
+        let before = self.clients.len();
+        self.clients
+            .retain(|client| client.client_uuid != client_uuid);
+        self.clients.len() != before
     }
 
     /// Resolve the selected receive directory and prove that it is exactly

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -575,6 +575,44 @@ mod tests {
     }
 
     #[test]
+    fn paired_clients_and_the_legacy_key_authenticate_independently() {
+        let mut config = RemoteImageUploadConfig::default();
+        config.set_token("legacy-manual-key-0123456789").unwrap();
+        let laptop = config
+            .add_client("Laptop", "psfrc_laptop_credential_0123456789")
+            .unwrap();
+        let observatory = config
+            .add_client("Observatory", "psfrc_observatory_credential_0123456789")
+            .unwrap();
+
+        assert!(config.token_is_configured());
+        assert!(config.token_matches("legacy-manual-key-0123456789"));
+        assert!(config.token_matches("psfrc_laptop_credential_0123456789"));
+        assert!(config.token_matches("psfrc_observatory_credential_0123456789"));
+        assert!(!config.token_matches("psfrc_never_issued_0123456789"));
+
+        // Revoking one client leaves the other and the legacy key alone.
+        assert!(config.revoke_client(&laptop));
+        assert!(!config.revoke_client(&laptop));
+        assert!(!config.token_matches("psfrc_laptop_credential_0123456789"));
+        assert!(config.token_matches("psfrc_observatory_credential_0123456789"));
+        assert!(config.token_matches("legacy-manual-key-0123456789"));
+        let _ = observatory;
+    }
+
+    #[test]
+    fn clients_alone_configure_the_token_check() {
+        // A catalog that was only ever paired (no manual key) still counts
+        // as configured, or capabilities would hide it from its own client.
+        let mut config = RemoteImageUploadConfig::default();
+        config
+            .add_client("Only client", "psfrc_only_credential_0123456789")
+            .unwrap();
+        assert!(config.token_is_configured());
+        assert!(config.token_matches("psfrc_only_credential_0123456789"));
+    }
+
+    #[test]
     fn loads_empty_when_file_missing() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("config.json");

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -315,6 +315,16 @@ pub struct RemoteImageUploadSummary {
     pub image_directory: Option<String>,
     pub token_configured: bool,
     pub sync_enabled: bool,
+    /// Paired clients, for the Settings list and per-client revocation.
+    #[serde(default)]
+    pub clients: Vec<RemoteClientSummary>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RemoteClientSummary {
+    pub client_uuid: String,
+    pub name: String,
+    pub paired_at: i64,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1095,6 +1095,7 @@ pub async fn add_database_route(
 
     require_database_management_allowed(&state)?;
     let registry_path = require_registry_path(&state)?;
+    let _registry_guard = state.registry_write.lock().await;
     let mut reg = DbRegistry::load_or_init(&registry_path)
         .map_err(|e| AppError::InternalError(format!("loading registry: {}", e)))?;
 
@@ -1146,6 +1147,7 @@ pub async fn update_database_route(
 
     require_database_management_allowed(&state)?;
     let registry_path = require_registry_path(&state)?;
+    let _registry_guard = state.registry_write.lock().await;
     let mut reg = DbRegistry::load_or_init(&registry_path)
         .map_err(|e| AppError::InternalError(format!("loading registry: {}", e)))?;
 
@@ -1296,6 +1298,7 @@ pub async fn remove_database_route(
 
     require_database_management_allowed(&state)?;
     let registry_path = require_registry_path(&state)?;
+    let _registry_guard = state.registry_write.lock().await;
     let mut reg = DbRegistry::load_or_init(&registry_path)
         .map_err(|e| AppError::InternalError(format!("loading registry: {}", e)))?;
     let removed_from_registry = reg
@@ -1776,6 +1779,7 @@ pub async fn create_database_route(
         }
     }
 
+    let _registry_guard = state.registry_write.lock().await;
     let mut reg = DbRegistry::load_or_init(&registry_path)
         .map_err(|e| AppError::InternalError(format!("loading registry: {}", e)))?;
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -498,6 +498,19 @@ fn remote_image_upload_summary(
             .filter(|directory| !directory.is_empty()),
         token_configured: config.is_some_and(|config| config.token_is_configured()),
         sync_enabled: config.is_some_and(|config| config.sync_enabled),
+        clients: config
+            .map(|config| {
+                config
+                    .clients
+                    .iter()
+                    .map(|client| RemoteClientSummary {
+                        client_uuid: client.client_uuid.clone(),
+                        name: client.name.clone(),
+                        paired_at: client.paired_at,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,6 +8,7 @@ pub mod export_job;
 pub mod extract;
 pub mod handlers;
 pub mod import_job;
+pub mod pairing;
 pub mod peers;
 pub mod preview_queue;
 pub mod processing_setups;
@@ -578,6 +579,14 @@ async fn run_server_internal(
             get(handlers::list_sync_database_previews_route),
         )
         .route(
+            "/databases/{db_id}/pairing-token",
+            post(pairing::issue_pairing_token_route),
+        )
+        .route(
+            "/databases/{db_id}/clients/{client_uuid}",
+            delete(pairing::revoke_client_route),
+        )
+        .route(
             "/databases/{db_id}/sync/previews/{preview_id}/apply",
             post(handlers::apply_sync_database_preview_route),
         )
@@ -605,6 +614,7 @@ async fn run_server_internal(
             post(peers::sync_with_peer),
         )
         .route("/sync/v1/capabilities", get(remote_sync::capabilities))
+        .route("/sync/v1/pair", post(pairing::pair_route))
         .route(
             "/sync/v1/previews",
             post(remote_sync::create_preview)

--- a/src/server/pairing.rs
+++ b/src/server/pairing.rs
@@ -1,0 +1,347 @@
+//! One-token pairing for remote clients, modeled on chatstronomy's hub
+//! pairing: the operator mints a short-lived, single-use pairing code in
+//! Settings; the client presents it once and receives the durable bearer
+//! token in exchange. Nobody transcribes a long-lived secret by hand, and
+//! the code is worthless after one use or an hour. Every pairing mints its
+//! own credential, so the operator revokes one client without signing out
+//! the rest.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use crate::server::{
+    api::ApiResponse,
+    handlers::{require_database_management_allowed, require_registry_path, AppError},
+    remote_audit::{AuditAction, AuditOutcome, AuditRecord},
+    state::AppState,
+};
+
+/// Pairing codes die after an hour, matching chatstronomy's TTL: long
+/// enough to walk to the telescope machine, short enough that a leaked
+/// code from a screenshot goes stale the same evening.
+const PAIRING_TTL_SECONDS: i64 = 3600;
+const PAIRING_TOKEN_PREFIX: &str = "psfpt_";
+const CLIENT_TOKEN_PREFIX: &str = "psfrc_";
+
+/// A fresh high-entropy secret: 64 hex chars from two UUIDv4s.
+fn random_secret() -> String {
+    format!(
+        "{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    )
+}
+
+fn hash_token(token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push_str(&format!("{byte:02x}"));
+    }
+    encoded
+}
+
+fn unix_seconds() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+struct PendingPairing {
+    db_id: String,
+    expires_at: i64,
+}
+
+/// In-memory store of outstanding pairing codes, keyed by token hash.
+///
+/// Deliberately not persisted: a pairing code is an ephemeral handshake, and
+/// a server restart mid-pairing simply means reissuing the code. Only the
+/// hash lives here — the plaintext exists once, in the issue response.
+#[derive(Default)]
+pub struct PairingStore {
+    pending: Mutex<HashMap<String, PendingPairing>>,
+}
+
+impl PairingStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mint a code for one catalog. Any earlier unconsumed code for the same
+    /// catalog is revoked — one outstanding code per catalog, so a stale
+    /// sticky note cannot pair after the operator issued a fresh one.
+    pub fn issue(&self, db_id: &str) -> Result<(String, i64), AppError> {
+        let token = format!("{PAIRING_TOKEN_PREFIX}{}", random_secret());
+        let expires_at = unix_seconds() + PAIRING_TTL_SECONDS;
+        let mut pending = self.lock()?;
+        let now = unix_seconds();
+        pending.retain(|_, entry| entry.db_id != db_id && entry.expires_at > now);
+        pending.insert(
+            hash_token(&token),
+            PendingPairing {
+                db_id: db_id.to_string(),
+                expires_at,
+            },
+        );
+        Ok((token, expires_at))
+    }
+
+    /// Consume a code, returning the catalog it pairs. Single-use: a second
+    /// presentation of the same code finds nothing.
+    pub fn consume(&self, token: &str) -> Result<Option<String>, AppError> {
+        let mut pending = self.lock()?;
+        let Some(entry) = pending.remove(&hash_token(token)) else {
+            return Ok(None);
+        };
+        if entry.expires_at <= unix_seconds() {
+            return Ok(None);
+        }
+        Ok(Some(entry.db_id))
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, HashMap<String, PendingPairing>>, AppError> {
+        self.pending
+            .lock()
+            .map_err(|error| AppError::InternalError(format!("pairing lock poisoned: {error}")))
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct PairingCode {
+    pub pairing_token: String,
+    pub expires_at: i64,
+}
+
+/// `POST /api/databases/{db_id}/pairing-token` — operator-side, management
+/// gated exactly like editing the database the code will grant.
+pub async fn issue_pairing_token_route(
+    State(state): State<Arc<AppState>>,
+    Path(db_id): Path<String>,
+) -> Result<Json<ApiResponse<PairingCode>>, AppError> {
+    require_database_management_allowed(&state)?;
+    require_registry_path(&state)?;
+    if !state.databases.read().unwrap().contains_key(&db_id) {
+        return Err(AppError::NotFound);
+    }
+    let (pairing_token, expires_at) = state.pairing.issue(&db_id)?;
+    Ok(Json(ApiResponse::success(PairingCode {
+        pairing_token,
+        expires_at,
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PairRequest {
+    pub protocol_version: u32,
+    pub pairing_token: String,
+    /// Operator-facing label for this install ("OBSERVATORY-PC · Profile
+    /// Astro"), shown in the paired-clients list.
+    #[serde(default)]
+    pub client_name: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PairResult {
+    pub catalog_id: String,
+    pub catalog_name: String,
+    /// This client's credential id — the handle the operator revokes.
+    pub client_uuid: String,
+    /// The durable bearer token. This response is the only place the
+    /// plaintext ever exists — the registry stores a salted hash.
+    pub token: String,
+    pub product: &'static str,
+    pub product_version: &'static str,
+}
+
+/// `POST /api/sync/v1/pair` — client-side exchange. The pairing code is the
+/// entire authorization: it was minted behind the management gate and dies
+/// on first use. Each pairing mints its own credential — other paired
+/// clients keep working, and the operator revokes them one by one.
+pub async fn pair_route(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<PairRequest>,
+) -> Result<Json<ApiResponse<PairResult>>, AppError> {
+    use crate::db_registry::{DbRegistry, RemoteImageUploadConfig};
+    use crate::server::database_context::DatabaseContext;
+
+    let audit = |db_id: &str, outcome, detail: Option<&str>| {
+        state.remote_audit.record(
+            db_id,
+            AuditAction::Pair,
+            outcome,
+            AuditRecord {
+                detail,
+                ..Default::default()
+            },
+        );
+    };
+    if request.protocol_version != 1 {
+        return Err(AppError::BadRequest(format!(
+            "unsupported pairing protocol {}",
+            request.protocol_version
+        )));
+    }
+    let Some(db_id) = state.pairing.consume(&request.pairing_token)? else {
+        audit("-", AuditOutcome::Refused, Some("unknown or expired code"));
+        return Err(AppError::Forbidden(
+            "pairing code is unknown, expired, or already used".into(),
+        ));
+    };
+
+    let registry_path = require_registry_path(&state)?;
+    let mut registry = DbRegistry::load_or_init(&registry_path)
+        .map_err(|error| AppError::InternalError(format!("loading registry: {error}")))?;
+    let Some(entry) = registry
+        .databases
+        .iter_mut()
+        .find(|entry| entry.id == db_id)
+    else {
+        audit(&db_id, AuditOutcome::Failed, Some("catalog vanished"));
+        return Err(AppError::NotFound);
+    };
+
+    let token = format!("{CLIENT_TOKEN_PREFIX}{}", random_secret());
+    let client_name = request
+        .client_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .unwrap_or("Paired client");
+    let config = entry
+        .remote_image_upload
+        .get_or_insert_with(RemoteImageUploadConfig::default);
+    let client_uuid = config
+        .add_client(client_name, &token)
+        .map_err(|error| AppError::InternalError(format!("storing client token: {error}")))?;
+    // Pairing exists to connect a scheduler-sync client; upload stays
+    // whatever the operator configured (it needs a receive directory too).
+    config.sync_enabled = true;
+    let entry = entry.clone();
+
+    let context = Arc::new(
+        DatabaseContext::new(
+            entry.id.clone(),
+            entry.name.clone(),
+            entry.db_path.clone(),
+            entry.image_dirs.clone(),
+            entry.remote_image_upload.clone(),
+            entry.export_dir.clone(),
+            state.cache_dir_root.clone(),
+        )
+        .map_err(|error| AppError::InternalError(format!("reopening database: {error}")))?,
+    );
+    registry
+        .save(&registry_path)
+        .map_err(|error| AppError::InternalError(format!("persisting registry: {error}")))?;
+    state
+        .databases
+        .write()
+        .unwrap()
+        .insert(entry.id.clone(), context);
+
+    audit(&db_id, AuditOutcome::Ok, Some(client_name));
+    tracing::info!("remote client \"{client_name}\" paired with catalog {db_id}");
+    Ok(Json(ApiResponse::success(PairResult {
+        catalog_id: entry.id,
+        catalog_name: entry.name,
+        client_uuid,
+        token,
+        product: "PSF Guard",
+        product_version: env!("CARGO_PKG_VERSION"),
+    })))
+}
+
+/// `DELETE /api/databases/{db_id}/clients/{client_uuid}` — revoke one
+/// paired client. Management gated: same trust as issuing a code. Other
+/// clients and the legacy manual key keep working.
+pub async fn revoke_client_route(
+    State(state): State<Arc<AppState>>,
+    Path((db_id, client_uuid)): Path<(String, String)>,
+) -> Result<Json<ApiResponse<bool>>, AppError> {
+    use crate::db_registry::DbRegistry;
+    use crate::server::database_context::DatabaseContext;
+
+    require_database_management_allowed(&state)?;
+    let registry_path = require_registry_path(&state)?;
+    let mut registry = DbRegistry::load_or_init(&registry_path)
+        .map_err(|error| AppError::InternalError(format!("loading registry: {error}")))?;
+    let Some(entry) = registry
+        .databases
+        .iter_mut()
+        .find(|entry| entry.id == db_id)
+    else {
+        return Err(AppError::NotFound);
+    };
+    let removed = entry
+        .remote_image_upload
+        .as_mut()
+        .is_some_and(|config| config.revoke_client(&client_uuid));
+    if !removed {
+        return Err(AppError::NotFound);
+    }
+    let entry = entry.clone();
+    let context = Arc::new(
+        DatabaseContext::new(
+            entry.id.clone(),
+            entry.name.clone(),
+            entry.db_path.clone(),
+            entry.image_dirs.clone(),
+            entry.remote_image_upload.clone(),
+            entry.export_dir.clone(),
+            state.cache_dir_root.clone(),
+        )
+        .map_err(|error| AppError::InternalError(format!("reopening database: {error}")))?,
+    );
+    registry
+        .save(&registry_path)
+        .map_err(|error| AppError::InternalError(format!("persisting registry: {error}")))?;
+    state.databases.write().unwrap().insert(entry.id, context);
+    tracing::info!("revoked paired client {client_uuid} on catalog {db_id}");
+    Ok(Json(ApiResponse::success(true)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pairing_codes_are_single_use() {
+        let store = PairingStore::new();
+        let (token, _) = store.issue("catalog").unwrap();
+        assert!(token.starts_with(PAIRING_TOKEN_PREFIX));
+        assert_eq!(store.consume(&token).unwrap().as_deref(), Some("catalog"));
+        assert_eq!(store.consume(&token).unwrap(), None);
+    }
+
+    #[test]
+    fn reissuing_revokes_the_previous_code_for_that_catalog() {
+        let store = PairingStore::new();
+        let (first, _) = store.issue("catalog").unwrap();
+        let (second, _) = store.issue("catalog").unwrap();
+        assert_eq!(store.consume(&first).unwrap(), None);
+        assert_eq!(store.consume(&second).unwrap().as_deref(), Some("catalog"));
+    }
+
+    #[test]
+    fn codes_for_other_catalogs_survive_a_reissue() {
+        let store = PairingStore::new();
+        let (other, _) = store.issue("other").unwrap();
+        let (_, _) = store.issue("catalog").unwrap();
+        assert_eq!(store.consume(&other).unwrap().as_deref(), Some("other"));
+    }
+
+    #[test]
+    fn unknown_codes_consume_to_nothing() {
+        let store = PairingStore::new();
+        assert_eq!(store.consume("psfpt_nope").unwrap(), None);
+    }
+}

--- a/src/server/pairing.rs
+++ b/src/server/pairing.rs
@@ -198,6 +198,7 @@ pub async fn pair_route(
     };
 
     let registry_path = require_registry_path(&state)?;
+    let _registry_guard = state.registry_write.lock().await;
     let mut registry = DbRegistry::load_or_init(&registry_path)
         .map_err(|error| AppError::InternalError(format!("loading registry: {error}")))?;
     let Some(entry) = registry
@@ -272,6 +273,7 @@ pub async fn revoke_client_route(
 
     require_database_management_allowed(&state)?;
     let registry_path = require_registry_path(&state)?;
+    let _registry_guard = state.registry_write.lock().await;
     let mut registry = DbRegistry::load_or_init(&registry_path)
         .map_err(|error| AppError::InternalError(format!("loading registry: {error}")))?;
     let Some(entry) = registry

--- a/src/server/remote_audit.rs
+++ b/src/server/remote_audit.rs
@@ -33,6 +33,7 @@ pub enum AuditAction {
     Preview,
     PreviewRefresh,
     Apply,
+    Pair,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -99,6 +99,11 @@ pub struct AppState {
     pub remote_audit: crate::server::remote_audit::RemoteAuditLog,
     /// Outstanding one-time pairing codes (see `server::pairing`).
     pub pairing: crate::server::pairing::PairingStore,
+    /// Serializes registry load-modify-save cycles. Every writer must hold
+    /// it: the management CRUD routes and the pairing/revoke exchange all
+    /// read the file, mutate, and save — two interleaved writers silently
+    /// drop one write.
+    pub registry_write: tokio::sync::Mutex<()>,
     /// Process-global Seiza catalogs and capability diagnostics. Catalogs are
     /// shared across databases and opened lazily on first use.
     pub astrometry: Arc<crate::astrometry::AstrometryContext>,
@@ -414,6 +419,7 @@ impl AppState {
             remote_preview_jobs: crate::server::remote_sync::PreviewJobStore::new(),
             remote_audit: crate::server::remote_audit::RemoteAuditLog::new(&cache_dir),
             pairing: crate::server::pairing::PairingStore::new(),
+            registry_write: tokio::sync::Mutex::new(()),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::new(astrometry_config)),
             satellites: Arc::new(satellites),
         })
@@ -585,6 +591,7 @@ impl AppState {
             remote_preview_jobs: crate::server::remote_sync::PreviewJobStore::new(),
             remote_audit: crate::server::remote_audit::RemoteAuditLog::new("/tmp/psf-guard-test"),
             pairing: crate::server::pairing::PairingStore::new(),
+            registry_write: tokio::sync::Mutex::new(()),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::default()),
             satellites: Arc::new(
                 crate::satellites::SatelliteContext::new(

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -97,6 +97,8 @@ pub struct AppState {
     /// Append-only record of remote sync actions, so an operator can tell
     /// afterwards which token-holder changed the scheduler database and when.
     pub remote_audit: crate::server::remote_audit::RemoteAuditLog,
+    /// Outstanding one-time pairing codes (see `server::pairing`).
+    pub pairing: crate::server::pairing::PairingStore,
     /// Process-global Seiza catalogs and capability diagnostics. Catalogs are
     /// shared across databases and opened lazily on first use.
     pub astrometry: Arc<crate::astrometry::AstrometryContext>,
@@ -411,6 +413,7 @@ impl AppState {
             remote_exports: crate::server::remote_sync::ExportStore::new(),
             remote_preview_jobs: crate::server::remote_sync::PreviewJobStore::new(),
             remote_audit: crate::server::remote_audit::RemoteAuditLog::new(&cache_dir),
+            pairing: crate::server::pairing::PairingStore::new(),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::new(astrometry_config)),
             satellites: Arc::new(satellites),
         })
@@ -581,6 +584,7 @@ impl AppState {
             remote_exports: crate::server::remote_sync::ExportStore::new(),
             remote_preview_jobs: crate::server::remote_sync::PreviewJobStore::new(),
             remote_audit: crate::server::remote_audit::RemoteAuditLog::new("/tmp/psf-guard-test"),
+            pairing: crate::server::pairing::PairingStore::new(),
             astrometry: Arc::new(crate::astrometry::AstrometryContext::default()),
             satellites: Arc::new(
                 crate::satellites::SatelliteContext::new(

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -439,6 +439,27 @@ export const apiClient = {
     return data.data;
   },
 
+  /** Mint a one-time pairing code for a catalog. The client exchanges it
+   * once at /api/sync/v1/pair for the durable bearer token. */
+  issuePairingCode: async (
+    dbId: string
+  ): Promise<{ pairing_token: string; expires_at: number }> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<
+      ApiResponse<{ pairing_token: string; expires_at: number }>
+    >(`/databases/${encodeURIComponent(dbId)}/pairing-token`);
+    if (!data.data) throw new Error(data.error || 'Failed to issue pairing code');
+    return data.data;
+  },
+
+  /** Revoke one paired client's credential. Other clients keep working. */
+  revokePairedClient: async (dbId: string, clientUuid: string): Promise<void> => {
+    const apiInstance = await getApi();
+    await apiInstance.delete(
+      `/databases/${encodeURIComponent(dbId)}/clients/${encodeURIComponent(clientUuid)}`
+    );
+  },
+
   /** Every unexpired staged preview for one catalog, including previews a
    * remote client (the N.I.N.A. plugin) parked and never applied. */
   listDatabaseSyncPreviews: async (

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1081,12 +1081,20 @@ export interface ExportStatus {
   progress: ExportJobProgress;
 }
 
+export interface RemoteClientSummary {
+  client_uuid: string;
+  name: string;
+  paired_at: number;
+}
+
 export interface RemoteImageUploadSummary {
   enabled: boolean;
   image_directory?: string;
   token_configured: boolean;
   /** Remote scheduler sync is a separate grant from image upload. */
   sync_enabled: boolean;
+  /** Paired clients; each holds its own revocable credential. */
+  clients?: RemoteClientSummary[];
 }
 
 export type SchedulerSyncKind = 'pull' | 'push_planning' | 'push_grades';

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -1635,3 +1635,20 @@
   font-family: monospace;
   white-space: normal;
 }
+
+.paired-clients ul {
+  list-style: none;
+  margin: 0.3rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.paired-clients li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  font-size: 0.88rem;
+}

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -234,6 +234,10 @@ export default function TauriSettings({
 
   const startEdit = (entry: DbEntry) => {
     setEditingId(entry.id);
+    // A pairing code is scoped to one database; never show it under another.
+    setPairingCode(null);
+    setPairingExpiresAt(null);
+    setPairingCopyState('idle');
     setFormName(entry.name);
     setFormDbPath(entry.db_path);
     setFormImageDirs(entry.image_dirs);
@@ -375,6 +379,10 @@ export default function TauriSettings({
     if (!editingId) return;
     try {
       await apiClient.revokePairedClient(editingId, clientUuid);
+      // The databases list is component state fed by reload(), not a
+      // react-query cache — invalidation alone would leave the revoked
+      // client on screen.
+      await reload();
       queryClient.invalidateQueries({ queryKey: ['databases'] });
       setStatusMessage('Client revoked');
     } catch (error) {

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -148,6 +148,7 @@ export default function TauriSettings({
                     summary.remote_image_upload?.token_configured ?? false,
                   sync_enabled:
                     summary.remote_image_upload?.sync_enabled ?? false,
+                  clients: summary.remote_image_upload?.clients ?? [],
                 },
               };
             }),
@@ -168,6 +169,7 @@ export default function TauriSettings({
               image_dir: s.remote_image_upload?.image_directory,
               token_configured: s.remote_image_upload?.token_configured ?? false,
               sync_enabled: s.remote_image_upload?.sync_enabled ?? false,
+              clients: s.remote_image_upload?.clients ?? [],
             },
           })),
         };
@@ -350,6 +352,43 @@ export default function TauriSettings({
     setFormImageDirs(remaining);
     if (formRemoteUploadDir === removed) {
       setFormRemoteUploadDir(remaining[0] ?? '');
+    }
+  };
+
+  const [pairingCode, setPairingCode] = useState<string | null>(null);
+  const [pairingExpiresAt, setPairingExpiresAt] = useState<number | null>(null);
+  const [pairingCopyState, setPairingCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+
+  const handleIssuePairingCode = async () => {
+    if (!editingId) return;
+    try {
+      const issued = await apiClient.issuePairingCode(editingId);
+      setPairingCode(issued.pairing_token);
+      setPairingExpiresAt(issued.expires_at);
+      setPairingCopyState('idle');
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleRevokeClient = async (clientUuid: string) => {
+    if (!editingId) return;
+    try {
+      await apiClient.revokePairedClient(editingId, clientUuid);
+      queryClient.invalidateQueries({ queryKey: ['databases'] });
+      setStatusMessage('Client revoked');
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleCopyPairingCode = async () => {
+    if (!pairingCode) return;
+    try {
+      await navigator.clipboard.writeText(pairingCode);
+      setPairingCopyState('copied');
+    } catch {
+      setPairingCopyState('failed');
     }
   };
 
@@ -799,6 +838,70 @@ export default function TauriSettings({
 
         {editingId && (
           <div className="database-config">
+            <label>Pair a client:</label>
+            <div className="remote-upload-token-row">
+              <button
+                type="button"
+                onClick={handleIssuePairingCode}
+                className="browse-button"
+              >
+                Generate pairing code
+              </button>
+              {pairingCode && (
+                <>
+                  <input
+                    type="text"
+                    readOnly
+                    value={pairingCode}
+                    className="file-path-input"
+                    onFocus={(event) => event.target.select()}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleCopyPairingCode}
+                    className="browse-button"
+                  >
+                    {pairingCopyState === 'copied' ? 'Copied' : 'Copy'}
+                  </button>
+                </>
+              )}
+            </div>
+            {pairingCode && (
+              <small className="remote-upload-token-notice" role="status">
+                {pairingCopyState === 'failed'
+                  ? 'Copy failed. Select and copy the code manually.'
+                  : `Paste this code into the client. One use, expires ${
+                      pairingExpiresAt
+                        ? new Date(pairingExpiresAt * 1000).toLocaleTimeString()
+                        : 'in an hour'
+                    }. Each pairing adds its own revocable credential.`}
+              </small>
+            )}
+            {(databases.find((db) => db.id === editingId)?.remote_image_upload
+              ?.clients?.length ?? 0) > 0 && (
+              <div className="paired-clients">
+                <label>Paired clients:</label>
+                <ul>
+                  {databases
+                    .find((db) => db.id === editingId)!
+                    .remote_image_upload!.clients!.map((client) => (
+                      <li key={client.client_uuid}>
+                        <span>
+                          {client.name} ·{' '}
+                          {new Date(client.paired_at * 1000).toLocaleDateString()}
+                        </span>
+                        <button
+                          type="button"
+                          className="browse-button"
+                          onClick={() => handleRevokeClient(client.client_uuid)}
+                        >
+                          Revoke
+                        </button>
+                      </li>
+                    ))}
+                </ul>
+              </div>
+            )}
             <label htmlFor="remote-upload-token">Remote API key:</label>
             <div className="remote-upload-token-row">
               <input

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -65,6 +65,8 @@ export interface DbEntry {
     token_sha256?: string;
     token_configured?: boolean;
     sync_enabled?: boolean;
+    /** Paired clients; each holds its own revocable credential. */
+    clients?: { client_uuid: string; name: string; paired_at: number }[];
   };
   /** Server-side destination for UI-triggered exports. */
   export_dir?: string;

--- a/tests/integration_pairing.rs
+++ b/tests/integration_pairing.rs
@@ -1,0 +1,291 @@
+//! One-token pairing: the operator mints a single-use code, the client
+//! exchanges it for its own durable credential, and the operator revokes
+//! clients one by one.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use http_body_util::BodyExt;
+use psf_guard::cli::PregenerationConfig;
+use psf_guard::db_registry::{DbEntry, DbRegistry};
+use psf_guard::server::{pairing, remote_sync, state::AppState};
+use rusqlite::Connection;
+use serde_json::{json, Value};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tempfile::tempdir;
+use tower::ServiceExt;
+
+fn schema(connection: &Connection) {
+    connection
+        .execute_batch(
+            "PRAGMA user_version = 23;
+             CREATE TABLE project (Id INTEGER PRIMARY KEY, guid TEXT);
+             CREATE TABLE target (Id INTEGER PRIMARY KEY, guid TEXT);
+             CREATE TABLE exposuretemplate (Id INTEGER PRIMARY KEY, guid TEXT);
+             CREATE TABLE exposureplan (Id INTEGER PRIMARY KEY, guid TEXT);
+             CREATE TABLE ruleweight (Id INTEGER PRIMARY KEY, name TEXT);
+             CREATE TABLE acquiredimage (Id INTEGER PRIMARY KEY, gradingStatus INTEGER, guid TEXT);
+             CREATE TABLE imagedata (Id INTEGER PRIMARY KEY, imagedata BLOB, acquiredimageid INTEGER);",
+        )
+        .unwrap();
+}
+
+async fn call(
+    router: Router,
+    method: &str,
+    uri: &str,
+    bearer: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut request = Request::builder().method(method).uri(uri);
+    if let Some(token) = bearer {
+        request = request.header("authorization", format!("Bearer {token}"));
+    }
+    let request = match body {
+        Some(body) => request
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap(),
+        None => request.body(Body::empty()).unwrap(),
+    };
+    let response = router.oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, value)
+}
+
+fn harness() -> (Arc<AppState>, Router, PathBuf, tempfile::TempDir) {
+    let directory = tempdir().unwrap();
+    let db_path = directory.path().join("catalog.sqlite");
+    schema(&Connection::open(&db_path).unwrap());
+    let image_dir = directory.path().join("images");
+    std::fs::create_dir(&image_dir).unwrap();
+    let entry = DbEntry {
+        id: "review".into(),
+        name: "Review copy".into(),
+        db_path: db_path.to_string_lossy().into_owned(),
+        image_dirs: vec![image_dir.to_string_lossy().into_owned()],
+        reject_archive: None,
+        remote_image_upload: None,
+        export_dir: None,
+    };
+    let registry_path = directory.path().join("registry.json");
+    let mut registry = DbRegistry::default();
+    registry.databases.push(entry.clone());
+    registry.save(&registry_path).unwrap();
+
+    let state = Arc::new(
+        AppState::from_databases(
+            vec![entry],
+            directory
+                .path()
+                .join("cache")
+                .to_string_lossy()
+                .into_owned(),
+            PregenerationConfig::default(),
+        )
+        .unwrap(),
+    );
+    state.set_registry_path(Some(registry_path.clone()));
+    state.set_allow_database_management(true);
+
+    let router = Router::new()
+        .route(
+            "/api/databases/{db_id}/pairing-token",
+            post(pairing::issue_pairing_token_route),
+        )
+        .route("/api/sync/v1/pair", post(pairing::pair_route))
+        .route(
+            "/api/databases/{db_id}/clients/{client_uuid}",
+            axum::routing::delete(pairing::revoke_client_route),
+        )
+        .route("/api/sync/v1/capabilities", get(remote_sync::capabilities))
+        .with_state(Arc::clone(&state));
+    (state, router, registry_path, directory)
+}
+
+#[tokio::test]
+async fn pairing_exchanges_one_code_for_a_working_token() {
+    let (_state, router, registry_path, _directory) = harness();
+
+    let (status, issued) = call(
+        router.clone(),
+        "POST",
+        "/api/databases/review/pairing-token",
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{issued:#}");
+    let code = issued["data"]["pairing_token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(code.starts_with("psfpt_"), "{code}");
+
+    let (status, paired) = call(
+        router.clone(),
+        "POST",
+        "/api/sync/v1/pair",
+        None,
+        Some(json!({
+            "protocol_version": 1,
+            "pairing_token": code,
+            "client_name": "OBSERVATORY-PC"
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{paired:#}");
+    assert_eq!(paired["data"]["catalog_id"], "review");
+    assert_eq!(paired["data"]["catalog_name"], "Review copy");
+    assert!(paired["data"]["client_uuid"].as_str().is_some());
+    let token = paired["data"]["token"].as_str().unwrap().to_string();
+    assert!(token.starts_with("psfrc_"), "{token}");
+
+    // The exchanged token authenticates, and pairing opted the catalog into
+    // scheduler sync.
+    let (status, capabilities) = call(
+        router.clone(),
+        "GET",
+        "/api/sync/v1/capabilities",
+        Some(&token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{capabilities:#}");
+    let catalogs = capabilities["data"]["catalogs"].as_array().unwrap();
+    assert!(
+        catalogs
+            .iter()
+            .any(|catalog| catalog["id"] == "review" && catalog["writable"] == true),
+        "{capabilities:#}"
+    );
+
+    // The rotated token hash persisted to the registry, so a restart keeps
+    // the pairing.
+    let registry = DbRegistry::load_or_init(&registry_path).unwrap();
+    let stored = registry.find("review").unwrap();
+    let config = stored.remote_image_upload.as_ref().unwrap();
+    assert!(config.token_is_configured());
+    assert!(config.token_matches(&token));
+    assert!(config.sync_enabled);
+    assert_eq!(config.clients.len(), 1);
+    assert_eq!(config.clients[0].name, "OBSERVATORY-PC");
+
+    // Single use: presenting the same code again is refused.
+    let (status, refused) = call(
+        router.clone(),
+        "POST",
+        "/api/sync/v1/pair",
+        None,
+        Some(json!({ "protocol_version": 1, "pairing_token": code })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{refused:#}");
+}
+
+#[tokio::test]
+async fn each_pairing_mints_its_own_credential_and_revokes_alone() {
+    let (_state, router, _registry_path, _directory) = harness();
+
+    let pair = |router: Router, name: &'static str| async move {
+        let (_, issued) = call(
+            router.clone(),
+            "POST",
+            "/api/databases/review/pairing-token",
+            None,
+            None,
+        )
+        .await;
+        let code = issued["data"]["pairing_token"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let (_, paired) = call(
+            router,
+            "POST",
+            "/api/sync/v1/pair",
+            None,
+            Some(json!({
+                "protocol_version": 1,
+                "pairing_token": code,
+                "client_name": name
+            })),
+        )
+        .await;
+        (
+            paired["data"]["token"].as_str().unwrap().to_string(),
+            paired["data"]["client_uuid"].as_str().unwrap().to_string(),
+        )
+    };
+
+    let (first_token, first_uuid) = pair(router.clone(), "Laptop").await;
+    let (second_token, _second_uuid) = pair(router.clone(), "Observatory").await;
+    assert_ne!(first_token, second_token);
+
+    // Both clients hold live credentials at once.
+    for token in [&first_token, &second_token] {
+        let (status, _) = call(
+            router.clone(),
+            "GET",
+            "/api/sync/v1/capabilities",
+            Some(token),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    // Revoking the laptop signs out only the laptop.
+    let (status, _) = call(
+        router.clone(),
+        "DELETE",
+        &format!("/api/databases/review/clients/{first_uuid}"),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _) = call(
+        router.clone(),
+        "GET",
+        "/api/sync/v1/capabilities",
+        Some(&first_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    let (status, _) = call(
+        router,
+        "GET",
+        "/api/sync/v1/capabilities",
+        Some(&second_token),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn issuing_requires_database_management() {
+    let (state, router, _registry_path, _directory) = harness();
+    state.set_allow_database_management(false);
+    let (status, _) = call(
+        router,
+        "POST",
+        "/api/databases/review/pairing-token",
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
Adopts chatstronomy's hub pairing model for connecting the N.I.N.A. plugin (companion plugin PR: theatrus/psf-guard-nina-plugin#14). Today's flow — generate a long-lived key in Settings, hand-copy it and the catalog id into the plugin — becomes: click **Generate pairing code**, paste one code into the plugin, done.

**Server.**
- `POST /api/databases/{db}/pairing-token` (management-gated) mints a single-use `psfpt_…` code: one outstanding code per catalog, one-hour TTL, held in memory as a hash only (a restart mid-pairing just means reissuing).
- `POST /api/sync/v1/pair` exchanges it — the code is the entire authorization — for the catalog id and a fresh `psfrc_…` bearer token, stored in the registry as a salted hash with an operator-facing client name (`MACHINE · Profile`). Pairing sets the catalog's sync opt-in; image upload stays behind its own directory configuration.
- **One credential per client**: token verification accepts the legacy manual key or any paired client (constant-time, no early exit), the database summary lists paired clients, and `DELETE /api/databases/{db}/clients/{uuid}` revokes exactly one install without touching the rest. Pairing and revocation are audited.

**UI.** The database editor gains "Pair a client" (code + expiry + copy) and a **Paired clients** list with per-client Revoke. Manual key entry is unchanged.

Tests: pairing-store unit tests (single-use, per-catalog reissue revocation, cross-catalog isolation) and integration coverage: issue → pair → the token authenticates capabilities and persists in the registry; a second use of the code is refused; two pairings coexist and revoking one signs out only that one; issuing requires the management gate. Checks: `cargo fmt -- --check`, `clippy -D warnings`, `cargo test` (743 passed), `npx tsc`, `npm run lint`, `npx vitest run` (299), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)