### PR TITLE
Harden progressive stack SNR analysis

### DIFF
--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -110,21 +110,23 @@ result.
 ## How deep is deep enough
 
 Every stack build measures how its signal-to-noise ratio grows with depth, and
-the card draws the result. The question it answers is the one you ask at the
-end of a night: is another night worth shooting, or has this target stopped
-paying?
+the card draws the result. When every accepted frame has the same known
+exposure, the card also compares that curve with ideal averaging and estimates
+what more frames would buy. Mixed or missing exposure lengths keep the measured
+curve, but PSF Guard withholds that model-dependent verdict instead of treating
+unequal frames as interchangeable.
 
-Perfect averaging halves the noise for every four frames, so noise should fall
-as the square root of the frame count. On the card's log-log chart that ideal
-is a straight dashed line, and the solid line is what your frames actually did.
-The gap between them is the reading.
+For equal exposures, perfect averaging halves the noise for every four frames,
+so noise should fall as the square root of the frame count. On the card's
+log-log chart that ideal is a straight dashed line, and the solid line is what
+your frames actually did. The gap between them is the reading.
 
 ![A 90-frame Ha stack whose curve sits above the square-root ideal](stack-snr-curve.png)
 
-The stack above ran in quality order, which is why its curve starts above the
-ideal: the best frames went in first, so the early depths beat what averaging
-alone would give, and the line settles back towards the ideal as the weaker
-frames arrive.
+The stack above ran in quality order, which is why its curve rises above the
+ideal after their shared first point: the best frames went in first, so the
+early depths beat what averaging alone would give, and the line settles back
+towards the ideal as the weaker frames arrive.
 
 ### What is measured, and what is predicted
 
@@ -137,12 +139,12 @@ the pixels.
 
 At each depth the build records:
 
-- **Noise**, the median absolute difference between neighbouring samples,
-  scaled to a standard deviation. Working on differences cancels any sky
-  gradient and any nebulosity broader than a pixel, and taking a median throws
-  the stars away, so what is left is the pixel-to-pixel noise of the
-  integration — the quantity that is supposed to fall as the square root of the
-  frame count.
+- **Noise**, a robust two-dimensional difference measurement scaled to a
+  standard deviation. It removes a local linear sky gradient, reads both axes
+  so row or column banding cannot disappear, and uses medians so stars do not
+  set the result. What remains is the pixel-scale noise of the integration —
+  the quantity that should fall as the square root of the frame count for
+  comparable exposures.
 - **Background**, the median sample.
 - **Signal**, how far the brightest one percent of the frame sits above that
   background.
@@ -156,17 +158,20 @@ the ratio and flatter the early frames. Each depth keeps the signal it
 measured, which is worth seeing when it drifts: that is normalization moving,
 not the sky.
 
-Everything past the curve is prediction, and is labelled as such. The fitted
-exponent, how far short of the ideal the run falls, where the returns
-flattened, and how many more frames a further five or ten percent would take
-all come from a least-squares fit through the deeper half of the curve — the
-part that describes where the stack is now, since the first frames of any stack
-improve it steeply and would flatter the estimate.
+Everything past the curve is prediction, and is labelled as such. For equal,
+known exposures, the fitted exponent, how far short of the ideal the run falls,
+where the returns flattened, and how many more frames a further five or ten
+percent would take all come from a least-squares fit through the deeper part of
+the curve. If those deeper measurements do not establish a consistent trend,
+PSF Guard labels the result inconclusive and withholds the projection.
+It also applies a scatter threshold before calling a run worse; a tiny upward
+wobble is a plateau, not evidence that later frames hurt.
 
 The verdict is one word:
 
 | Verdict | What it means |
 |---|---|
+| Inconclusive | The deeper measurements do not fit one stable direction, so PSF Guard makes no projection. |
 | Still improving | Noise is falling at three quarters of the ideal rate or better. More frames pay. |
 | Diminishing returns | Noise is still falling, but each frame buys well under what it should. |
 | Plateau | Noise has all but stopped falling. More frames like these will not help. |
@@ -181,9 +186,12 @@ shoot more of the same.
 
 The **Order** control decides which question the curve answers.
 
-**Capture** is the default and is chronological. Its curve reads as one night
-after another, so it answers "did the last night help, and would another one?".
-It costs nothing: it is the order the stacker already integrates in.
+**Capture sequence** is the default. The server seeds the stack with its
+best-graded registration reference, then integrates every other eligible frame
+chronologically. The curve therefore shows how the captured sequence grows
+after that fixed reference; it is a broad time trend, not a claim that the
+reference itself was the first exposure. It costs nothing because this is the
+order the stacker already integrates in.
 
 **Quality** puts the best-graded frames first. Its curve reads as the frames
 you would keep before the ones you would throw away, so the depth where it
@@ -198,8 +206,10 @@ and never writes one. Your capture-order checkpoint is left untouched, and a
 quality build is a full restack every time. It is a question you ask
 deliberately, not a default.
 
-The best-graded frame is the registration reference under either order. Only
-what follows it changes.
+The best-graded frame is the registration reference under either server order.
+Only what follows it changes. A resumed capture sequence is used only when its
+saved ledger is an exact prefix of the new sequence; a backfilled exposure or a
+changed reference forces a full restack.
 
 ### Turning the chart off
 
@@ -215,8 +225,9 @@ The card draws it live as the build passes each depth, and keeps it with the
 finished result. It is also published three ways:
 
 - as JSON beside the stack's FITS, at
-  `/api/db/{db}/stack-previews/{job}/{group}/snr`, which is the same file the
-  card reads and survives a server restart;
+  `/api/db/{db}/stack-previews/{job}/{group}/snr`; the card receives the same
+  data in job status, and the endpoint serves an atomic sidecar that survives
+  a server restart;
 - as `SNRORDER`, `SNRNOISE`, `SNRVALUE`, `SNRSLOPE`, and `SNRVERDT` cards in
   the downloaded stack FITS;
 - inside the resume checkpoint, so a target stacked one night at a time still
@@ -234,7 +245,9 @@ psf-guard stack-snr /path/to/lights --order quality --csv curve.csv --json curve
 It stacks the frames raw — calibration lives in the catalog, and a folder has
 none to match against — and prints the curve and its reading. Its quality order
 ranks frames by detected stars against their sharpness rather than by a catalog
-grade, so it need not agree with the server's order frame for frame.
+grade, so it need not agree with the server's order frame for frame. Unlike the
+server, a capture-order folder run has no separately chosen registration
+reference, so its first frame and every point after it are chronological.
 
 ## Stack orientation
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -7,16 +7,17 @@
 ## Added
 
 - Every stack build now measures how its signal-to-noise ratio grows with
-  depth and draws the curve on the channel card, beside a straight line for
-  the square-root improvement perfect averaging would give. It says in one
-  word whether the noise is still falling, how far short of ideal the run is,
-  where the returns flattened, and about how many more frames another five or
-  ten percent would take. The measurement is free: the build reads its own
+  depth and draws the curve on the channel card. For equal, known exposures it
+  adds the square-root line perfect averaging would give and says whether the
+  noise is still falling, how far short of ideal the run is, where the returns
+  flattened, and about how many more frames another five or ten percent would
+  take. The measurement is free: the build reads its own
   accumulator on the way past instead of stacking anything twice, and the
   curve is kept in the resume checkpoint, so a target stacked one night at a
   time ends with one curve over the whole season. A new **Order** control
-  switches the reading: capture order asks whether another night would help,
-  quality order asks which frames are worth keeping. An **SNR curve** switch
+  switches the reading: capture sequence follows the frames after a fixed
+  high-quality reference, while quality order asks which frames are worth
+  keeping. An **SNR curve** switch
   hides the chart on every card and is remembered; builds measure and publish
   the curve either way. `psf-guard stack-snr`
   runs the same analysis over a folder of frames without a catalog. See
@@ -129,6 +130,13 @@
 
 ## Fixed
 
+- Progressive stack SNR now invalidates pre-curve checkpoints, resumes only an
+  exact sequence prefix, verifies the checkpoint files agree, and retries
+  transient frame-read failures from a clean stack. It measures row and column
+  structure without turning a linear gradient into a noise floor and treats
+  small uncertain rises as measurement scatter. Mixed or missing exposure
+  lengths and inconsistent fitted trends keep their measured curve but no
+  longer receive an invalid directional verdict or projection.
 - Flat matching now respects the rotator. A flat only corrects lights
   shot at (nearly) the same rotator angle — vignetting from the optics
   ahead of the rotator turns relative to the sensor — so flats now match

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -489,7 +489,6 @@ pub enum Commands {
         verbose: bool,
     },
 
-    /// Screen FITS frames for occlusion, clouds, pointing and cached satellite risk
     /// Measure how the signal-to-noise ratio of a stack grows with depth.
     ///
     /// Integrates the frames one depth at a time and reads the accumulator on
@@ -521,6 +520,7 @@ pub enum Commands {
         threads: Option<usize>,
     },
 
+    /// Screen FITS frames for occlusion, clouds, pointing and cached satellite risk
     ScreenFits {
         /// Path to a FITS file or directory (searched recursively)
         path: String,

--- a/src/commands/stack_snr.rs
+++ b/src/commands/stack_snr.rs
@@ -73,8 +73,8 @@ pub fn stack_snr(paths: &[String], options: &StackSnrOptions) -> Result<()> {
         }
     }
 
-    let points = accumulate(&candidates)?;
-    let progressive = snr::ProgressiveSnr::new(options.order, points);
+    let (points, accepted_exposures) = accumulate(&candidates)?;
+    let progressive = snr::ProgressiveSnr::new(options.order, points, &accepted_exposures);
     report(&progressive);
 
     if let Some(path) = &options.json {
@@ -92,7 +92,7 @@ pub fn stack_snr(paths: &[String], options: &StackSnrOptions) -> Result<()> {
 
 /// Stack the frames in order, reading the accumulator at every depth on the
 /// ladder. This is the group build's loop with the catalog taken out.
-fn accumulate(candidates: &[Candidate]) -> Result<Vec<snr::SnrPoint>> {
+fn accumulate(candidates: &[Candidate]) -> Result<(Vec<snr::SnrPoint>, Vec<f64>)> {
     use seiza_stacking::{FrameDisposition, LiveStacker, NormalizationMode, StackOptions};
 
     let reference = crate::image_io::open_linear_frame(&candidates[0].path)
@@ -113,6 +113,7 @@ fn accumulate(candidates: &[Candidate]) -> Result<Vec<snr::SnrPoint>> {
     };
     let mut points = Vec::new();
     let mut integrated_exposure = candidates[0].exposure_seconds;
+    let mut accepted_exposures = vec![candidates[0].exposure_seconds];
     let mut pushed = 1usize;
     if let Some(sample) = snr::measure(stacker.view()) {
         points.push(snr::point(sample, integrated_exposure));
@@ -134,6 +135,7 @@ fn accumulate(candidates: &[Candidate]) -> Result<Vec<snr::SnrPoint>> {
                 match outcome {
                     Ok(FrameDisposition::Accepted(_)) => {
                         integrated_exposure += frame.exposure_seconds;
+                        accepted_exposures.push(frame.exposure_seconds);
                     }
                     Ok(FrameDisposition::Rejected(reason)) => {
                         eprintln!("  turned away {}: {reason}", frame.path.display());
@@ -160,7 +162,7 @@ fn accumulate(candidates: &[Candidate]) -> Result<Vec<snr::SnrPoint>> {
             points.push(measured);
         }
     }
-    Ok(points)
+    Ok((points, accepted_exposures))
 }
 
 /// Rank frames by detected stars against their sharpness: more stars and
@@ -170,9 +172,18 @@ fn accumulate(candidates: &[Candidate]) -> Result<Vec<snr::SnrPoint>> {
 fn score_frames(candidates: &mut [Candidate], threads: Option<usize>) -> Result<()> {
     use rayon::prelude::*;
 
-    println!("Detecting stars in {} frames…", candidates.len());
+    let frame_pixels = candidates
+        .first()
+        .and_then(|candidate| crate::concurrency::probe_frame_pixels(&candidate.path));
+    let budget = quality_worker_budget(threads, frame_pixels);
+    println!(
+        "Detecting stars in {} frames with {} worker(s) — {}",
+        candidates.len(),
+        budget.workers,
+        budget.rationale
+    );
     let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(threads.unwrap_or_else(rayon::current_num_threads))
+        .num_threads(budget.workers)
         .build()
         .context("Building the detection pool")?;
     pool.install(|| {
@@ -202,6 +213,18 @@ fn score_frames(candidates: &mut [Candidate], threads: Option<usize>) -> Result<
     Ok(())
 }
 
+fn quality_worker_budget(
+    requested: Option<usize>,
+    frame_pixels: Option<usize>,
+) -> crate::concurrency::WorkerBudget {
+    crate::concurrency::plan_workers(
+        requested,
+        &crate::concurrency::WorkerPolicy::all_cores(),
+        crate::concurrency::Priority::Interactive,
+        frame_pixels,
+    )
+}
+
 fn report(progressive: &snr::ProgressiveSnr) {
     println!(
         "\nProgressive signal-to-noise, {} order",
@@ -222,6 +245,10 @@ fn report(progressive: &snr::ProgressiveSnr) {
         );
     }
     let Some(analysis) = &progressive.analysis else {
+        if let Some(reason) = &progressive.analysis_reason {
+            println!("\n{reason}");
+            return;
+        }
         println!("\nToo few depths to read a trend.");
         return;
     };
@@ -327,4 +354,14 @@ fn string_card(headers: &[(String, HeaderValue)], name: &str) -> Option<String> 
             HeaderValue::String(text) | HeaderValue::Raw(text) => Some(text.trim().to_string()),
             _ => None,
         })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn an_explicit_quality_worker_count_is_preserved() {
+        let budget = super::quality_worker_budget(Some(3), Some(60_000_000));
+        assert_eq!(budget.workers, 3);
+        assert!(budget.rationale.contains("explicit override"));
+    }
 }

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -49,7 +49,7 @@ use crate::server::state::AppState;
 pub const SEIZA_STACKING_VERSION: &str = "0.2.2";
 /// Bump whenever stack admission, rendering, or persisted artifact semantics
 /// change. This deliberately versions PSF Guard policy separately from Seiza.
-pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 12;
+pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 13;
 const MAX_REQUEST_IMAGES: usize = 10_000;
 const MAX_REMEMBERED_JOBS: usize = 64;
 const PREVIEW_MAX_DIMENSION: u32 = 2400;
@@ -300,6 +300,10 @@ pub struct LatestStackPreviewGroup {
     pub created_unix_seconds: i64,
     #[serde(default)]
     pub cache_version: u32,
+    /// The order used to build this persisted artifact. Old indices default
+    /// to capture order, which was the only order available before this field.
+    #[serde(default)]
+    pub order: snr::StackFrameOrder,
     pub group: StackGroupStatus,
 }
 
@@ -1375,6 +1379,8 @@ fn prepare_job(
             };
             let source_fingerprint = source_fingerprint(&path);
             hasher.update(source_fingerprint.as_bytes());
+            let exposure_seconds = exposure_seconds_from_metadata(&image.metadata);
+            hasher.update(exposure_seconds.to_le_bytes());
             frames.push(PreparedFrame {
                 image_id: image.id,
                 acquired_date: image.acquired_date,
@@ -1382,7 +1388,7 @@ fn prepare_job(
                 path,
                 source_fingerprint,
                 expected_target: expected_by_image.get(&image.id).copied().flatten(),
-                exposure_seconds: exposure_seconds_from_metadata(&image.metadata),
+                exposure_seconds,
             });
         }
 
@@ -1396,8 +1402,8 @@ fn prepare_job(
         });
         let reference_image_id = frames.first().map(|frame| frame.image_id);
         // The best-graded frame is the registration reference either way. What
-        // the order decides is the rest: chronological, so the curve reads as
-        // one night after another, or best-first, so the curve reads as the
+        // the order decides is the rest: chronological for a broad capture
+        // trend after that reference, or best-first so the curve reads as the
         // frames you would keep before the ones you would throw away.
         if frames.len() > 1 && request.order == snr::StackFrameOrder::Capture {
             frames[1..].sort_by_key(|frame| (frame.acquired_date.unwrap_or(0), frame.image_id));
@@ -1474,10 +1480,6 @@ fn prepare_job(
             ));
             group.fits_url = Some(format!(
                 "/api/db/{}/stack-previews/{}/{}/fits?v={}",
-                ctx.id, job_id, group.index, artifact_revision
-            ));
-            group.snr_url = Some(format!(
-                "/api/db/{}/stack-previews/{}/{}/snr?v={}",
                 ctx.id, job_id, group.index, artifact_revision
             ));
         }
@@ -1984,7 +1986,13 @@ fn run_group(
     let requested = group
         .frames
         .iter()
-        .map(|frame| (frame.image_id, frame.source_fingerprint.as_str()))
+        .map(|frame| {
+            (
+                frame.image_id,
+                frame.source_fingerprint.as_str(),
+                frame.exposure_seconds,
+            )
+        })
         .collect::<Vec<_>>();
     let decision = resume::load(
         cache_root,
@@ -2051,7 +2059,26 @@ fn run_group(
         // truncated file — is discarded and the group builds from scratch.
         let restored = checkpoint.and_then(|checkpoint| {
             match LiveStacker::open_context(&checkpoint.context_path) {
-                Ok(stacker) => Some((stacker, checkpoint.manifest)),
+                Ok(stacker)
+                    if resume::context_matches_manifest(
+                        stacker.view().accepted_frames,
+                        stacker.view().rejected_frames,
+                        &checkpoint.manifest,
+                    ) =>
+                {
+                    Some((stacker, checkpoint.manifest))
+                }
+                Ok(_) => {
+                    tracing::warn!(
+                        "Stack checkpoint context and manifest did not match; rebuilding from scratch"
+                    );
+                    resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
+                    state.stack_previews.update(job_id, |job| {
+                        job.groups[group.index].resume_note =
+                            Some("Full restack: the checkpoint files did not match".into());
+                    });
+                    None
+                }
                 Err(error) => {
                     tracing::warn!(
                         "Stack checkpoint could not be reopened ({error}); rebuilding from scratch"
@@ -2105,8 +2132,10 @@ fn run_group(
                         .map(|frame| frame.exposure_seconds)
                         .sum();
                     status.frames = ledger.iter().map(|frame| frame.decision.clone()).collect();
-                    status.snr = (!points.is_empty())
-                        .then(|| snr::ProgressiveSnr::new(order, points.clone()));
+                    let exposures = accepted_exposures(&ledger);
+                    status.snr = (!points.is_empty()).then(|| {
+                        snr::ProgressiveSnr::new(order, points.clone(), &exposures)
+                    });
                 });
                 (stacker, ledger, points)
             }
@@ -2163,6 +2192,7 @@ fn run_group(
                 let ledger = vec![resume::ResumeFrame {
                     decision: reference_decision,
                     exposure_seconds: reference_exposure,
+                    retryable_failure: false,
                     rotation_radians: Some(0.0),
                 }];
                 (stacker, ledger, Vec::new())
@@ -2175,8 +2205,6 @@ fn run_group(
         {
             points.push(snr::point(sample, integrated_exposure(&ledger)));
         }
-        let already_integrated: std::collections::HashSet<i32> =
-            ledger.iter().map(|frame| frame.decision.image_id).collect();
         let save_checkpoint = |stacker: &LiveStacker,
                                ledger: &[resume::ResumeFrame],
                                points: &[snr::SnrPoint]| {
@@ -2184,6 +2212,10 @@ fn run_group(
             // accumulator here would leave a checkpoint no later build can
             // extend, in place of the capture-order one that can be.
             if !order.resumable() {
+                return;
+            }
+            if ledger.iter().any(|frame| frame.retryable_failure) {
+                resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
                 return;
             }
             let context_path =
@@ -2231,12 +2263,8 @@ fn run_group(
 
         // Pending frames keep their index into `group.frames`, which is what
         // the calibration plan's session assignments are aligned with.
-        let pending: Vec<(usize, &PreparedFrame)> = group
-            .frames
-            .iter()
-            .enumerate()
-            .filter(|(_, frame)| !already_integrated.contains(&frame.image_id))
-            .collect();
+        let pending: Vec<(usize, &PreparedFrame)> =
+            group.frames.iter().enumerate().skip(ledger.len()).collect();
         // Reads, calibration, registration and normalization overlap across
         // frames while integration stays in this order, so the accumulator
         // sees exactly the sequence a frame-at-a-time loop would. A frame
@@ -2292,11 +2320,11 @@ fn run_group(
                     let (_, frame) = batch[consumed];
                     consumed += 1;
                     let exposure = frame.exposure_seconds;
-                    let decision = match outcome {
+                    let (decision, retryable_failure) = match outcome {
                         Ok(FrameDisposition::Accepted(diagnostics)) => {
                             orientation_vote
                                 .add(diagnostics.mapping.transform().rotation_radians, exposure);
-                            StackFrameDecision {
+                            (StackFrameDecision {
                                 image_id: frame.image_id,
                                 disposition: "accepted".into(),
                                 reason: None,
@@ -2314,19 +2342,20 @@ fn run_group(
                                 source_fingerprint: Some(frame.source_fingerprint.clone()),
                                 overlap_fraction: Some(diagnostics.overlap_fraction),
                                 integrated_fraction: Some(diagnostics.integrated_fraction),
-                            }
+                            }, false)
                         }
                         // A frame the stack turned away and one that could not be
                         // read are both "not integrated" to a caller reading the
                         // group's decisions; only the reason differs.
                         Ok(FrameDisposition::Rejected(reason)) => {
-                            rejected_decision(frame, reason.to_string())
+                            (rejected_decision(frame, reason.to_string()), false)
                         }
-                        Err(error) => rejected_decision(frame, error.to_string()),
+                        Err(error) => (rejected_decision(frame, error.to_string()), true),
                     };
                     ledger.push(resume::ResumeFrame {
                         decision: decision.clone(),
                         exposure_seconds: exposure,
+                        retryable_failure,
                         rotation_radians: if decision.disposition == "accepted" {
                             decision
                                 .registered_mapping
@@ -2379,7 +2408,9 @@ fn run_group(
                 && let Some(sample) = snr::measure(stacker.view())
             {
                 points.push(snr::point(sample, integrated_exposure(&ledger)));
-                let progressive = snr::ProgressiveSnr::new(order, points.clone());
+                let exposures = accepted_exposures(&ledger);
+                let progressive =
+                    snr::ProgressiveSnr::new(order, points.clone(), &exposures);
                 state.stack_previews.update(job_id, |job| {
                     job.groups[group.index].snr = Some(progressive);
                 });
@@ -2491,7 +2522,8 @@ fn run_group(
             )
             .with_comment("rejected input frames"),
         );
-        let progressive = snr::ProgressiveSnr::new(order, points);
+        let exposures = accepted_exposures(&ledger);
+        let progressive = snr::ProgressiveSnr::new(order, points, &exposures);
         output_cards.push(
             seiza_fits::WriteHeaderCard::new(
                 "SNRORDER",
@@ -2539,10 +2571,6 @@ fn run_group(
         )
         .map_err(|error| error.to_string())?;
         std::fs::rename(&fits_temporary, &fits_destination).map_err(|error| error.to_string())?;
-        write_snr_artifact(&snr_path(cache_root, job_id, group.index), &progressive);
-        state.stack_previews.update(job_id, |job| {
-            job.groups[group.index].snr = Some(progressive);
-        });
         stretch::render_image_previews_atomic(
             &image,
             &stretch::default_linear_config(),
@@ -2550,7 +2578,23 @@ fn run_group(
             &preview_path(cache_root, job_id, group.index),
             &original_preview_path(cache_root, job_id, group.index),
         )
-        .map(|_| GroupOutcome::Built)
+        .map_err(|error| error.to_string())?;
+        let snr_url = state.stack_previews.get(job_id).and_then(|current| {
+            publish_snr_artifact(
+                &snr_path(cache_root, job_id, group.index),
+                &progressive,
+                format!(
+                    "/api/db/{}/stack-previews/{}/{}/snr?v={}",
+                    database_id, job_id, group.index, current.artifact_revision
+                ),
+            )
+        });
+        state.stack_previews.update(job_id, |job| {
+            let status = &mut job.groups[group.index];
+            status.snr = Some(progressive);
+            status.snr_url = snr_url;
+        });
+        Ok(GroupOutcome::Built)
     })
 }
 
@@ -2672,6 +2716,7 @@ fn persist_latest_groups(cache_root: &FsPath, job: &StackPreviewJob) -> Result<(
             accepted_only: job.accepted_only,
             created_unix_seconds: job.created_unix_seconds,
             cache_version: job.cache_version,
+            order: job.order,
             group,
         };
         if let Some(existing) = latest.groups.iter_mut().find(|existing| {
@@ -2775,20 +2820,42 @@ fn integrated_exposure(ledger: &[resume::ResumeFrame]) -> f64 {
         .sum()
 }
 
+fn accepted_exposures(ledger: &[resume::ResumeFrame]) -> Vec<f64> {
+    ledger
+        .iter()
+        .filter(|frame| frame.rotation_radians.is_some())
+        .map(|frame| frame.exposure_seconds)
+        .collect()
+}
+
 /// Publish the curve beside the stack, through a temporary name like every
-/// other artifact. A curve that fails to write is a missing sidecar, never a
-/// failed build.
-fn write_snr_artifact(path: &FsPath, progressive: &snr::ProgressiveSnr) {
-    let written = serde_json::to_vec_pretty(progressive)
-        .map_err(|error| error.to_string())
-        .and_then(|bytes| {
-            let temporary = path.with_extension(format!("{}.tmp.json", std::process::id()));
-            std::fs::write(&temporary, bytes)
-                .map_err(|error| error.to_string())
-                .and_then(|()| std::fs::rename(&temporary, path).map_err(|error| error.to_string()))
-        });
-    if let Err(error) = written {
-        tracing::warn!("Failed to write the stack SNR curve: {error}");
+/// other artifact. The caller exposes its URL only after this succeeds.
+fn write_snr_artifact(path: &FsPath, progressive: &snr::ProgressiveSnr) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "stack SNR path has no parent".to_string())?;
+    std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let bytes = serde_json::to_vec_pretty(progressive).map_err(|error| error.to_string())?;
+    let temporary = path.with_extension(format!("{}.tmp.json", std::process::id()));
+    std::fs::write(&temporary, bytes).map_err(|error| error.to_string())?;
+    if let Err(error) = std::fs::rename(&temporary, path) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(error.to_string());
+    }
+    Ok(())
+}
+
+fn publish_snr_artifact(
+    path: &FsPath,
+    progressive: &snr::ProgressiveSnr,
+    url: String,
+) -> Option<String> {
+    match write_snr_artifact(path, progressive) {
+        Ok(()) => Some(url),
+        Err(error) => {
+            tracing::warn!("Failed to write the stack SNR curve: {error}");
+            None
+        }
     }
 }
 
@@ -3125,6 +3192,22 @@ mod tests {
     }
 
     #[test]
+    fn a_failed_snr_sidecar_is_not_advertised() {
+        let cache = tempfile::tempdir().unwrap();
+        let blocked_parent = cache.path().join("not-a-directory");
+        std::fs::write(&blocked_parent, b"file").unwrap();
+        let progressive = snr::ProgressiveSnr::new(snr::StackFrameOrder::Capture, Vec::new(), &[]);
+
+        let url = publish_snr_artifact(
+            &blocked_parent.join("curve.json"),
+            &progressive,
+            "/curve.json".into(),
+        );
+
+        assert!(url.is_none());
+    }
+
+    #[test]
     fn latest_index_replaces_only_the_rebuilt_channel() {
         let cache = tempfile::tempdir().unwrap();
         let first = completed_job(
@@ -3135,7 +3218,8 @@ mod tests {
 
         let mut rebuilt_blue = ready_group(10, "B", 3);
         rebuilt_blue.index = 4;
-        let second = completed_job("second", vec![rebuilt_blue]);
+        let mut second = completed_job("second", vec![rebuilt_blue]);
+        second.order = snr::StackFrameOrder::Quality;
         persist_latest_groups(cache.path(), &second).unwrap();
 
         let bytes = std::fs::read(latest_path(cache.path(), 7)).unwrap();
@@ -3153,18 +3237,21 @@ mod tests {
             .unwrap();
         assert_eq!(blue.job_id, "second");
         assert_eq!(blue.group.reference_image_id, Some(3));
+        assert_eq!(blue.order, snr::StackFrameOrder::Quality);
         assert_eq!(red.job_id, "first");
         assert_eq!(red.group.reference_image_id, Some(2));
+        assert_eq!(red.order, snr::StackFrameOrder::Capture);
     }
 
     #[test]
-    fn latest_index_hides_pre_orientation_artifacts() {
+    fn latest_index_hides_artifacts_from_older_cache_versions() {
         let current = LatestStackPreviewGroup {
             job_id: "current".into(),
             artifact_revision: "current-revision".into(),
             accepted_only: false,
             created_unix_seconds: 100,
             cache_version: STACK_PREVIEW_CACHE_VERSION,
+            order: snr::StackFrameOrder::Capture,
             group: ready_group(10, "B", 1),
         };
         let mut legacy = current.clone();
@@ -3184,6 +3271,25 @@ mod tests {
     }
 
     #[test]
+    fn an_old_latest_entry_defaults_to_capture_order() {
+        let current = LatestStackPreviewGroup {
+            job_id: "legacy".into(),
+            artifact_revision: "legacy-revision".into(),
+            accepted_only: false,
+            created_unix_seconds: 100,
+            cache_version: STACK_PREVIEW_CACHE_VERSION,
+            order: snr::StackFrameOrder::Capture,
+            group: ready_group(10, "B", 1),
+        };
+        let mut serialized = serde_json::to_value(current).unwrap();
+        serialized.as_object_mut().unwrap().remove("order");
+
+        let restored: LatestStackPreviewGroup = serde_json::from_value(serialized).unwrap();
+
+        assert_eq!(restored.order, snr::StackFrameOrder::Capture);
+    }
+
+    #[test]
     fn latest_index_keeps_both_orientation_conventions() {
         let source_frame = LatestStackPreviewGroup {
             job_id: "source-frame".into(),
@@ -3191,6 +3297,7 @@ mod tests {
             accepted_only: false,
             created_unix_seconds: 100,
             cache_version: STACK_PREVIEW_CACHE_VERSION,
+            order: snr::StackFrameOrder::Capture,
             group: ready_group(10, "B", 1),
         };
         let mut north_up = source_frame.clone();

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -2865,6 +2865,7 @@ mod tests {
             job_id: format!("{index:064x}"),
             artifact_revision: format!("rev-{index}"),
             accepted_only: false,
+            order: crate::server::stack_preview::snr::StackFrameOrder::Capture,
             created_unix_seconds: 10,
             cache_version: super::super::STACK_PREVIEW_CACHE_VERSION,
             group: StackGroupStatus {

--- a/src/server/stack_preview/resume.rs
+++ b/src/server/stack_preview/resume.rs
@@ -2,14 +2,16 @@
 //!
 //! A finished or stopped group build checkpoints its Seiza live-stack context
 //! beside a manifest of every frame it pushed. A later build of the same
-//! target/filter whose frame set only grew reopens that context and pushes the
-//! new frames, instead of registering and integrating the whole set again.
+//! target/filter whose ordered frame sequence only grew at the end reopens
+//! that context and pushes the new frames, instead of registering and
+//! integrating the whole set again.
 //!
-//! The manifest is the proof of "only grew": every recorded frame must still
-//! be requested with an identical source fingerprint, and the calibration
-//! fingerprint must match, or the build starts fresh. Removing a frame,
-//! regrading one in place, or changing calibration therefore never reuses a
-//! stale accumulator. Seiza validates the context itself — format version,
+//! The manifest is the proof of "only grew": its frame ledger must be an exact
+//! ordered prefix of the new request, every source fingerprint and exposure
+//! must match, and the calibration fingerprint must match, or the build starts
+//! fresh. Inserting, removing, reordering, regrading, or correcting exposure
+//! metadata never reuses a stale accumulator. A transient read failure is not
+//! checkpointed. Seiza validates the context itself — format version,
 //! dimensions, configuration, checksum — when it reopens it.
 
 use super::snr;
@@ -21,7 +23,7 @@ use std::path::{Path, PathBuf};
 
 /// Bumped whenever the recorded shape or the stacking pipeline changes in a
 /// way that makes an old accumulator wrong to extend.
-pub(super) const RESUME_SCHEMA_VERSION: u32 = 1;
+pub(super) const RESUME_SCHEMA_VERSION: u32 = 2;
 
 /// One frame the checkpointed stack already integrated or turned away, with
 /// everything needed to replay its ledger entry and its orientation vote.
@@ -29,6 +31,10 @@ pub(super) const RESUME_SCHEMA_VERSION: u32 = 1;
 pub(super) struct ResumeFrame {
     pub decision: StackFrameDecision,
     pub exposure_seconds: f64,
+    /// A read or pipeline error may clear on retry, so no checkpoint that
+    /// contains one is safe to extend.
+    #[serde(default)]
+    pub retryable_failure: bool,
     /// Registration rotation for an accepted frame; `None` for a rejection.
     pub rotation_radians: Option<f64>,
 }
@@ -61,6 +67,22 @@ pub(super) struct ResumeManifest {
 pub(super) struct ResumeState {
     pub context_path: PathBuf,
     pub manifest: ResumeManifest,
+}
+
+/// The Seiza context and our ledger are published separately. Refuse a pair
+/// interrupted between those writes rather than integrating frames twice.
+pub(super) fn context_matches_manifest(
+    context_accepted_frames: u32,
+    context_rejected_frames: u32,
+    manifest: &ResumeManifest,
+) -> bool {
+    let accepted = manifest
+        .frames
+        .iter()
+        .filter(|frame| frame.rotation_radians.is_some())
+        .count();
+    let rejected = manifest.frames.len() - accepted;
+    accepted == context_accepted_frames as usize && rejected == context_rejected_frames as usize
 }
 
 /// Whether a build may extend the checkpoint or must start over, and — when a
@@ -142,7 +164,7 @@ pub(super) fn load(
     stacking_version: &str,
     calibration_fingerprint: &str,
     order: snr::StackFrameOrder,
-    requested: &[(i32, &str)],
+    requested: &[(i32, &str, f64)],
 ) -> ResumeDecision {
     let manifest_path = manifest_path(cache_root, database_id, target_id, filter_name);
     let context_path = context_path(cache_root, database_id, target_id, filter_name);
@@ -177,19 +199,24 @@ pub(super) fn load(
     if manifest.order != order {
         return ResumeDecision::Fresh(Some("the frame order changed"));
     }
-    // Every checkpointed frame must still be requested, byte-identical. A
-    // fingerprint mismatch means the file changed under the same image id.
-    let requested_fingerprints: std::collections::HashMap<i32, &str> =
-        requested.iter().copied().collect();
-    let all_present = manifest.frames.iter().all(|frame| {
-        let recorded = frame.decision.source_fingerprint.as_deref();
-        matches!(
-            (requested_fingerprints.get(&frame.decision.image_id), recorded),
-            (Some(requested), Some(recorded)) if *requested == recorded
-        )
-    });
-    if !all_present {
-        return ResumeDecision::Fresh(Some("frames were removed or changed since the last build"));
+    if manifest.frames.iter().any(|frame| frame.retryable_failure) {
+        return ResumeDecision::Fresh(Some("a frame could not be read"));
+    }
+    // The accumulator is order-sensitive, so membership is not enough. Its
+    // complete ledger must be the exact prefix the new build would push,
+    // including the first frame that defines registration and WCS provenance.
+    let exact_prefix = manifest.frames.len() <= requested.len()
+        && manifest
+            .frames
+            .iter()
+            .zip(requested)
+            .all(|(frame, requested)| {
+                frame.decision.image_id == requested.0
+                    && frame.decision.source_fingerprint.as_deref() == Some(requested.1)
+                    && frame.exposure_seconds.to_bits() == requested.2.to_bits()
+            });
+    if !exact_prefix {
+        return ResumeDecision::Fresh(Some("the frame sequence changed since the last build"));
     }
     ResumeDecision::Resume(Box::new(ResumeState {
         context_path,
@@ -266,6 +293,7 @@ mod tests {
         ResumeFrame {
             decision: decision(image_id, fingerprint),
             exposure_seconds: 300.0,
+            retryable_failure: false,
             rotation_radians: Some(0.0),
         }
     }
@@ -285,6 +313,17 @@ mod tests {
     }
 
     fn try_load(cache_root: &Path, requested: &[(i32, &str)]) -> Option<ResumeState> {
+        let requested = requested
+            .iter()
+            .map(|&(image_id, fingerprint)| (image_id, fingerprint, 300.0))
+            .collect::<Vec<_>>();
+        try_load_with_exposures(cache_root, &requested)
+    }
+
+    fn try_load_with_exposures(
+        cache_root: &Path,
+        requested: &[(i32, &str, f64)],
+    ) -> Option<ResumeState> {
         load(
             cache_root,
             "db",
@@ -308,6 +347,74 @@ mod tests {
         );
         let resumed = try_load(cache.path(), &[(1, "f1"), (2, "f2"), (3, "f3")]).unwrap();
         assert_eq!(resumed.manifest.frames.len(), 2);
+    }
+
+    #[test]
+    fn a_context_newer_than_its_manifest_is_rejected() {
+        let recorded = manifest(vec![frame(1, "f1"), frame(2, "f2")]);
+        assert!(context_matches_manifest(2, 0, &recorded));
+        assert!(!context_matches_manifest(3, 0, &recorded));
+        assert!(!context_matches_manifest(2, 1, &recorded));
+
+        let mut rejected = frame(2, "f2");
+        rejected.decision.disposition = "rejected".into();
+        rejected.rotation_radians = None;
+        let recorded = manifest(vec![frame(1, "f1"), rejected]);
+        assert!(context_matches_manifest(1, 1, &recorded));
+    }
+
+    #[test]
+    fn a_frame_inserted_inside_the_checkpoint_prefix_rebuilds_from_scratch() {
+        let cache = tempfile::tempdir().unwrap();
+        store(
+            cache.path(),
+            &manifest(vec![frame(1, "f1"), frame(2, "f2")]),
+        );
+        assert!(try_load(cache.path(), &[(1, "f1"), (3, "f3"), (2, "f2")]).is_none());
+    }
+
+    #[test]
+    fn a_changed_reference_rebuilds_from_scratch() {
+        let cache = tempfile::tempdir().unwrap();
+        store(
+            cache.path(),
+            &manifest(vec![frame(1, "f1"), frame(2, "f2")]),
+        );
+        assert!(try_load(cache.path(), &[(3, "f3"), (1, "f1"), (2, "f2")]).is_none());
+    }
+
+    #[test]
+    fn a_changed_exposure_rebuilds_from_scratch() {
+        let cache = tempfile::tempdir().unwrap();
+        store(
+            cache.path(),
+            &manifest(vec![frame(1, "f1"), frame(2, "f2")]),
+        );
+        assert!(
+            try_load_with_exposures(cache.path(), &[(1, "f1", 300.0), (2, "f2", 600.0)]).is_none()
+        );
+    }
+
+    #[test]
+    fn a_retryable_frame_failure_never_resumes() {
+        let cache = tempfile::tempdir().unwrap();
+        let mut failed = frame(2, "f2");
+        failed.retryable_failure = true;
+        store(cache.path(), &manifest(vec![frame(1, "f1"), failed]));
+
+        let decision = load(
+            cache.path(),
+            "db",
+            7,
+            "Ha",
+            false,
+            "test",
+            "cal-1",
+            snr::StackFrameOrder::Capture,
+            &[(1, "f1", 300.0), (2, "f2", 300.0)],
+        );
+
+        assert_eq!(decision.fresh_reason(), Some("a frame could not be read"));
     }
 
     #[test]
@@ -371,7 +478,7 @@ mod tests {
             "test",
             "cal-1",
             snr::StackFrameOrder::Quality,
-            &[(1, "f1"), (2, "f2"), (3, "f3")],
+            &[(1, "f1", 300.0), (2, "f2", 300.0), (3, "f3", 300.0)],
         );
         assert_eq!(
             decision.fresh_reason(),
@@ -394,7 +501,7 @@ mod tests {
             "test",
             "cal-1",
             snr::StackFrameOrder::Capture,
-            &[(1, "f1"), (2, "f2")],
+            &[(1, "f1", 300.0), (2, "f2", 300.0)],
         );
         assert_eq!(decision.fresh_reason(), Some("the frame order changed"));
     }
@@ -432,7 +539,7 @@ mod tests {
             "test",
             "cal-2",
             snr::StackFrameOrder::Capture,
-            &[(1, "f1"), (2, "f2")],
+            &[(1, "f1", 300.0), (2, "f2", 300.0)],
         );
         assert_eq!(decision.fresh_reason(), Some("calibration changed"));
     }
@@ -450,7 +557,50 @@ mod tests {
             "newer",
             "cal-1",
             snr::StackFrameOrder::Capture,
-            &[(1, "f1"), (2, "f2")],
+            &[(1, "f1", 300.0), (2, "f2", 300.0)],
+        );
+        assert_eq!(
+            decision.fresh_reason(),
+            Some("the stacking pipeline changed")
+        );
+    }
+
+    #[test]
+    fn a_pre_snr_v1_checkpoint_rebuilds_the_complete_curve() {
+        let cache = tempfile::tempdir().unwrap();
+        let recorded = manifest(vec![frame(1, "f1"), frame(2, "f2")]);
+        let path = manifest_path(
+            cache.path(),
+            "db",
+            recorded.target_id,
+            &recorded.filter_name,
+        );
+        let mut legacy = serde_json::to_value(&recorded).unwrap();
+        legacy["schema_version"] = serde_json::Value::from(1);
+        legacy.as_object_mut().unwrap().remove("snr_points");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+        std::fs::write(
+            context_path(
+                cache.path(),
+                "db",
+                recorded.target_id,
+                &recorded.filter_name,
+            ),
+            b"legacy context",
+        )
+        .unwrap();
+
+        let decision = load(
+            cache.path(),
+            "db",
+            7,
+            "Ha",
+            false,
+            "test",
+            "cal-1",
+            snr::StackFrameOrder::Capture,
+            &[(1, "f1", 300.0), (2, "f2", 300.0), (3, "f3", 300.0)],
         );
         assert_eq!(
             decision.fresh_reason(),
@@ -471,7 +621,7 @@ mod tests {
             "test",
             "cal-1",
             snr::StackFrameOrder::Capture,
-            &[(1, "f1"), (2, "f2")],
+            &[(1, "f1", 300.0), (2, "f2", 300.0)],
         );
         assert_eq!(
             decision.fresh_reason(),

--- a/src/server/stack_preview/snr.rs
+++ b/src/server/stack_preview/snr.rs
@@ -9,12 +9,12 @@
 //!
 //! What each depth records:
 //!
-//! - **Noise** is the median absolute difference between horizontally adjacent
-//!   samples, scaled to a standard deviation. First differences cancel any sky
-//!   gradient and any nebulosity broader than a pixel, and the median throws
-//!   the stars away, so what is left is the pixel-to-pixel noise of the
-//!   integration — the quantity that should fall as the square root of the
-//!   frame count.
+//! - **Noise** is the robust spread of second differences measured in both
+//!   image axes, scaled to a standard deviation. Second differences cancel a
+//!   planar sky gradient, the median throws the stars away, and taking the
+//!   noisier axis keeps row or column banding visible. What is left is the
+//!   pixel-scale noise of the integration — the quantity that should fall as
+//!   the square root of the frame count.
 //! - **Background** is the median sample.
 //! - **Signal** is how far the brightest one percent of samples sits above that
 //!   background. The fraction is fixed rather than a multiple of the noise, so
@@ -57,13 +57,32 @@ const PROJECTED_GAINS: [f64; 2] = [1.05, 1.10];
 /// a frame that hurt.
 const REGRESSION_THRESHOLD: f64 = 0.02;
 
+/// A fitted rise must exceed the same two-percent scatter allowance over one
+/// doubling before it is called a degrading trend: `ln(1.02) / ln(2)`.
+const DEGRADING_EXPONENT_THRESHOLD: f64 = 0.028_569_152_196_770_92;
+
+/// A slope needs to explain at least half the measured variation before it
+/// becomes a directional verdict rather than an inconclusive fit.
+const MIN_DIRECTIONAL_FIT_R_SQUARED: f64 = 0.5;
+
+/// Exposure durations within one percent are equivalent for the frame-count
+/// model. Larger differences need a weighted model that this curve does not
+/// currently claim to provide.
+const EXPOSURE_VARIATION_TOLERANCE: f64 = 0.01;
+
+const MISSING_EXPOSURE_REASON: &str =
+    "Analysis unavailable because exposure duration is missing for one or more accepted frames.";
+const MIXED_EXPOSURE_REASON: &str =
+    "Analysis unavailable because exposure duration varies between accepted frames.";
+
 /// The order a build pushes its frames in, which decides what its curve
 /// answers.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StackFrameOrder {
-    /// Chronological. The curve answers "did the last night help, and would
-    /// another one help?".
+    /// Registration reference first, then the remaining frames in capture
+    /// order. The curve shows the broad trend through the later data while
+    /// keeping registration anchored to the chosen frame.
     #[default]
     Capture,
     /// Best-graded frame first. The curve answers "which of these frames are
@@ -122,6 +141,8 @@ pub struct SnrSample {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SnrVerdict {
+    /// The deeper measurements do not support a stable directional fit.
+    Uncertain,
     /// Noise is still falling at close to the ideal rate. More frames pay.
     Improving,
     /// Noise is still falling, but well short of the ideal rate.
@@ -135,6 +156,7 @@ pub enum SnrVerdict {
 impl SnrVerdict {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::Uncertain => "uncertain",
             Self::Improving => "improving",
             Self::Diminishing => "diminishing",
             Self::Plateau => "plateau",
@@ -202,8 +224,13 @@ pub struct SnrAnalysis {
 pub struct ProgressiveSnr {
     pub order: StackFrameOrder,
     pub points: Vec<SnrPoint>,
-    /// Absent until three depths have been measured.
+    /// Absent until three depths have been measured, or when their exposure
+    /// durations cannot support the frame-count model.
     pub analysis: Option<SnrAnalysis>,
+    /// Why a complete measured curve cannot be modeled. An ordinary partial
+    /// curve has neither an analysis nor a reason.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub analysis_reason: Option<String>,
 }
 
 impl ProgressiveSnr {
@@ -220,7 +247,11 @@ impl ProgressiveSnr {
     /// from the noise alone. Each depth keeps the signal it measured, which
     /// is worth seeing when it drifts: that is normalization moving, not the
     /// sky.
-    pub fn new(order: StackFrameOrder, mut points: Vec<SnrPoint>) -> Self {
+    ///
+    /// `frame_exposures` contains every accepted frame through the deepest
+    /// point. The fitted frame-count model is withheld unless each duration
+    /// is known and equivalent.
+    pub fn new(order: StackFrameOrder, mut points: Vec<SnrPoint>, frame_exposures: &[f64]) -> Self {
         if let Some(signal) = points.last().map(|deepest| deepest.signal) {
             for point in &mut points {
                 point.snr = if point.noise > 0.0 {
@@ -230,10 +261,17 @@ impl ProgressiveSnr {
                 };
             }
         }
+        let analysis_reason = exposure_analysis_reason(&points, frame_exposures).map(str::to_owned);
+        let analysis = if analysis_reason.is_none() {
+            analyze_curve(&points)
+        } else {
+            None
+        };
         Self {
             order,
-            analysis: analyze(&points),
             points,
+            analysis,
+            analysis_reason,
         }
     }
 }
@@ -261,50 +299,71 @@ pub fn checkpoint_depths(total: usize) -> Vec<usize> {
 /// Read the live accumulator. `None` when too little of the frame is covered
 /// to measure, or when the samples carry no noise at all.
 pub fn measure(view: seiza_stacking::StackView<'_>) -> Option<SnrSample> {
+    if view.width < 3 || view.height < 3 {
+        return None;
+    }
     let channels = view.channels.max(1);
-    let stride = view.height.div_ceil(MAX_SAMPLED_ROWS).max(1);
+    let interior_rows = view.height - 2;
+    let stride = interior_rows.div_ceil(MAX_SAMPLED_ROWS).max(1);
     let mut channel_noise = Vec::with_capacity(channels);
     let mut channel_background = Vec::with_capacity(channels);
     let mut channel_signal = Vec::with_capacity(channels);
 
     for channel in 0..channels {
         let mut levels: Vec<f32> = Vec::new();
-        let mut differences: Vec<f32> = Vec::new();
-        let mut y = 0usize;
-        while y < view.height {
+        let mut horizontal_differences: Vec<f32> = Vec::new();
+        let mut vertical_differences: Vec<f32> = Vec::new();
+        let mut y = 1usize;
+        while y + 1 < view.height {
             let row = y * view.width;
-            // Reset at the start of every row: the last sample of one row is
-            // not adjacent to the first of the next.
-            let mut previous: Option<(f32, u32)> = None;
-            for x in 0..view.width {
+            for x in 1..view.width - 1 {
                 let index = (row + x) * channels + channel;
                 let coverage = view.coverage[index];
                 let value = view.mean[index];
                 if coverage == 0 || !value.is_finite() {
-                    previous = None;
                     continue;
                 }
-                // Two samples only compare when the same number of frames
-                // reached both. At a dithered edge one neighbour can be
-                // thinner than the other, and its extra noise is not a
-                // difference between neighbouring pixels.
-                if let Some((earlier, earlier_coverage)) = previous
-                    && earlier_coverage == coverage
-                {
-                    differences.push((value - earlier).abs());
-                }
                 levels.push(value);
-                previous = Some((value, coverage));
+
+                // A second difference removes any linear gradient. All three
+                // samples need equal coverage so dithered edges cannot
+                // masquerade as pixel structure.
+                let left = index - channels;
+                let right = index + channels;
+                if view.coverage[left] == coverage
+                    && view.coverage[right] == coverage
+                    && view.mean[left].is_finite()
+                    && view.mean[right].is_finite()
+                {
+                    horizontal_differences.push(view.mean[left] - 2.0 * value + view.mean[right]);
+                }
+
+                let above = index - view.width * channels;
+                let below = index + view.width * channels;
+                if view.coverage[above] == coverage
+                    && view.coverage[below] == coverage
+                    && view.mean[above].is_finite()
+                    && view.mean[below].is_finite()
+                {
+                    vertical_differences.push(view.mean[above] - 2.0 * value + view.mean[below]);
+                }
             }
             y += stride;
         }
 
-        if differences.len() < MIN_SAMPLES || levels.len() < MIN_SAMPLES {
+        if horizontal_differences.len() < MIN_SAMPLES
+            || vertical_differences.len() < MIN_SAMPLES
+            || levels.len() < MIN_SAMPLES
+        {
             return None;
         }
-        // Differences of two samples of equal noise carry root-two times the
-        // noise of one sample.
-        let noise = median(&mut differences) * MAD_TO_SIGMA / std::f64::consts::SQRT_2;
+        // A second difference has coefficients 1, -2, 1, so independent
+        // samples with sigma noise produce a difference with sqrt(6) sigma.
+        // Keep the noisier axis: that makes horizontal and vertical banding
+        // equally visible instead of averaging either one away.
+        let horizontal_noise = second_difference_noise(&mut horizontal_differences)?;
+        let vertical_noise = second_difference_noise(&mut vertical_differences)?;
+        let noise = horizontal_noise.max(vertical_noise);
         if noise <= 0.0 || !noise.is_finite() {
             return None;
         }
@@ -342,7 +401,12 @@ pub fn point(sample: SnrSample, exposure_seconds: f64) -> SnrPoint {
 
 /// Read a finished curve. `None` until three usable depths exist, because two
 /// points fit any power law exactly and say nothing about the fit.
-pub fn analyze(points: &[SnrPoint]) -> Option<SnrAnalysis> {
+#[cfg(test)]
+fn analyze(points: &[SnrPoint]) -> Option<SnrAnalysis> {
+    analyze_curve(points)
+}
+
+fn analyze_curve(points: &[SnrPoint]) -> Option<SnrAnalysis> {
     let usable: Vec<&SnrPoint> = points
         .iter()
         .filter(|point| point.frames >= 1 && point.noise > 0.0 && point.snr.is_finite())
@@ -383,7 +447,9 @@ pub fn analyze(points: &[SnrPoint]) -> Option<SnrAnalysis> {
     let (frames_for_95_percent, seconds_for_95_percent) = reached(0.95);
 
     let efficiency = (recent_fit.exponent / IDEAL_EXPONENT).max(0.0);
-    let verdict = if recent_fit.exponent >= 0.0 {
+    let verdict = if recent_fit.r_squared < MIN_DIRECTIONAL_FIT_R_SQUARED {
+        SnrVerdict::Uncertain
+    } else if recent_fit.exponent > DEGRADING_EXPONENT_THRESHOLD {
         SnrVerdict::Degrading
     } else if efficiency >= 0.75 {
         SnrVerdict::Improving
@@ -398,7 +464,11 @@ pub fn analyze(points: &[SnrPoint]) -> Option<SnrAnalysis> {
     } else {
         0.0
     };
-    let projections = project(deepest.frames, recent_fit.exponent, average_exposure);
+    let projections = if verdict == SnrVerdict::Uncertain {
+        Vec::new()
+    } else {
+        project(deepest.frames, recent_fit.exponent, average_exposure)
+    };
     let regressions = regressions(&usable);
     let summary = summarize(
         verdict,
@@ -427,6 +497,38 @@ pub fn analyze(points: &[SnrPoint]) -> Option<SnrAnalysis> {
         verdict,
         summary,
     })
+}
+
+/// Confirm that frame count is a meaningful independent variable from every
+/// accepted frame, rather than from checkpoint averages that could hide a
+/// mixture of short and long exposures.
+fn exposure_analysis_reason(points: &[SnrPoint], frame_exposures: &[f64]) -> Option<&'static str> {
+    let expected_frames = points.last().map_or(0, |point| point.frames as usize);
+    if expected_frames == 0 {
+        return None;
+    }
+    if frame_exposures.len() < expected_frames {
+        return Some(MISSING_EXPOSURE_REASON);
+    }
+    let mut minimum_per_frame = f64::INFINITY;
+    let mut maximum_per_frame = f64::NEG_INFINITY;
+
+    for &exposure in &frame_exposures[..expected_frames] {
+        if !exposure.is_finite() || exposure <= 0.0 {
+            return Some(MISSING_EXPOSURE_REASON);
+        }
+        minimum_per_frame = minimum_per_frame.min(exposure);
+        maximum_per_frame = maximum_per_frame.max(exposure);
+    }
+
+    if minimum_per_frame.is_finite()
+        && (maximum_per_frame - minimum_per_frame) / maximum_per_frame
+            > EXPOSURE_VARIATION_TOLERANCE
+    {
+        Some(MIXED_EXPOSURE_REASON)
+    } else {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -504,9 +606,9 @@ fn project(frames: u32, exponent: f64, average_exposure: f64) -> Vec<SnrProjecti
         .collect()
 }
 
-/// Steps where the noise rose. In capture order these are the nights that
-/// hurt; in quality order they are where the weaker frames start costing more
-/// than they add.
+/// Steps where the noise rose. In reference-first capture order these are
+/// later parts of the capture sequence that hurt; in quality order they are
+/// where the weaker frames start costing more than they add.
 fn regressions(points: &[&SnrPoint]) -> Vec<SnrRegression> {
     points
         .windows(2)
@@ -534,6 +636,9 @@ fn summarize(
 ) -> String {
     let share = (efficiency * 100.0).round();
     let mut summary = match verdict {
+        SnrVerdict::Uncertain =>
+            "The deeper measurements are too inconsistent to establish a trend. No projection is made from this curve."
+                .to_string(),
         SnrVerdict::Improving => format!(
             "Noise is still falling at {share:.0}% of the ideal rate (exponent {exponent:.2} against -0.50). More frames pay off."
         ),
@@ -570,6 +675,18 @@ fn median(values: &mut [f32]) -> f64 {
     let middle = values.len() / 2;
     let (_, value, _) = values.select_nth_unstable_by(middle, f32::total_cmp);
     f64::from(*value)
+}
+
+fn second_difference_noise(differences: &mut [f32]) -> Option<f64> {
+    if differences.len() < MIN_SAMPLES {
+        return None;
+    }
+    let center = median(differences);
+    for difference in differences.iter_mut() {
+        *difference = (f64::from(*difference) - center).abs() as f32;
+    }
+    let noise = median(differences) * MAD_TO_SIGMA / 6.0f64.sqrt();
+    (noise >= 0.0 && noise.is_finite()).then_some(noise)
 }
 
 /// How far the brightest [`SIGNAL_FRACTION`] of the samples sits above the
@@ -635,6 +752,39 @@ mod tests {
         data
     }
 
+    fn planar_gradient_frame(width: usize, height: usize, sigma: f64, seed: u64) -> Vec<f32> {
+        let mut noise = Noise(seed);
+        let mut data = vec![0.0f32; width * height];
+        for (index, sample) in data.iter_mut().enumerate() {
+            let (x, y) = (index % width, index / width);
+            *sample =
+                1000.0 + x as f32 * 5.0 + y as f32 * 3.0 + (noise.next_normal() * sigma) as f32;
+        }
+        data
+    }
+
+    fn banded_frame(
+        width: usize,
+        height: usize,
+        rows: bool,
+        band_sigma: f64,
+        pixel_sigma: f64,
+        seed: u64,
+    ) -> Vec<f32> {
+        let mut noise = Noise(seed);
+        let band_count = if rows { height } else { width };
+        let bands: Vec<f32> = (0..band_count)
+            .map(|_| (noise.next_normal() * band_sigma) as f32)
+            .collect();
+        let mut data = vec![0.0f32; width * height];
+        for (index, sample) in data.iter_mut().enumerate() {
+            let (x, y) = (index % width, index / width);
+            let band = if rows { bands[y] } else { bands[x] };
+            *sample = 1000.0 + band + (noise.next_normal() * pixel_sigma) as f32;
+        }
+        data
+    }
+
     fn view<'a>(
         data: &'a [f32],
         coverage: &'a [u32],
@@ -689,6 +839,42 @@ mod tests {
             sample.background
         );
         assert!(sample.signal > 400.0, "{}", sample.signal);
+    }
+
+    #[test]
+    fn a_strong_planar_gradient_does_not_become_a_noise_floor() {
+        let (width, height) = (400, 400);
+        let data = planar_gradient_frame(width, height, 12.0, 29);
+        let coverage = vec![4u32; data.len()];
+        let sample = measure(view(&data, &coverage, width, height, 4)).expect("measurable");
+        assert!(
+            (sample.noise - 12.0).abs() < 0.8,
+            "measured {} for a sigma of 12 through a strong plane",
+            sample.noise
+        );
+    }
+
+    #[test]
+    fn row_and_column_banding_are_measured_symmetrically() {
+        let (width, height) = (400, 400);
+        let coverage = vec![4u32; width * height];
+        let rows = banded_frame(width, height, true, 16.0, 0.0, 31);
+        let columns = banded_frame(width, height, false, 16.0, 0.0, 31);
+        let row_noise = measure(view(&rows, &coverage, width, height, 4))
+            .expect("row banding is measurable")
+            .noise;
+        let column_noise = measure(view(&columns, &coverage, width, height, 4))
+            .expect("column banding is measurable")
+            .noise;
+        assert!(row_noise > 12.0, "row banding measured as {row_noise}");
+        assert!(
+            column_noise > 12.0,
+            "column banding measured as {column_noise}"
+        );
+        assert!(
+            (row_noise - column_noise).abs() < 1.5,
+            "row {row_noise}, column {column_noise}"
+        );
     }
 
     #[test]
@@ -804,9 +990,124 @@ mod tests {
     }
 
     #[test]
+    fn a_tiny_well_fitted_rise_is_measurement_scatter() {
+        let points = curve(
+            |n| 10.0 * f64::from(n).powf(0.015),
+            &[1, 2, 4, 8, 16, 32, 64],
+        );
+        let analysis = analyze(&points).expect("analyzable");
+        assert!(analysis.noise_exponent > 0.0);
+        assert!(analysis.fit_r_squared > 0.99);
+        assert_eq!(analysis.verdict, SnrVerdict::Plateau);
+    }
+
+    #[test]
+    fn a_poorly_fitted_positive_slope_is_not_called_degrading() {
+        let mut points = curve(|n| 20.0 / f64::from(n).sqrt(), &[1, 2, 4, 8, 16, 32, 64]);
+        points[4].noise = 10.0;
+        points[5].noise = 14.0;
+        points[6].noise = 10.8;
+        for point in &mut points[4..] {
+            point.snr = point.signal / point.noise;
+        }
+        let analysis = analyze_curve(&points).expect("the raw fit is available");
+        assert!(
+            analysis.noise_exponent > DEGRADING_EXPONENT_THRESHOLD,
+            "{}",
+            analysis.noise_exponent
+        );
+        assert!(
+            analysis.fit_r_squared < MIN_DIRECTIONAL_FIT_R_SQUARED,
+            "{}",
+            analysis.fit_r_squared
+        );
+        let progressive = ProgressiveSnr::new(StackFrameOrder::Capture, points, &[300.0; 64]);
+        let analysis = progressive.analysis.expect("an inconclusive analysis");
+        assert_eq!(analysis.verdict, SnrVerdict::Uncertain);
+        assert!(analysis.projections.is_empty());
+        assert!(progressive.analysis_reason.is_none());
+    }
+
+    #[test]
+    fn a_poorly_fitted_negative_slope_does_not_make_promises() {
+        let mut points = curve(|n| 20.0 / f64::from(n).sqrt(), &[1, 2, 4, 8, 16, 32, 64]);
+        points[4].noise = 10.0;
+        points[5].noise = 30.0;
+        points[6].noise = 3.0;
+        for point in &mut points[4..] {
+            point.snr = point.signal / point.noise;
+        }
+        let raw = analyze_curve(&points).expect("the raw fit is available");
+        assert!(raw.noise_exponent < 0.0);
+        assert!(raw.fit_r_squared < MIN_DIRECTIONAL_FIT_R_SQUARED);
+
+        let progressive = ProgressiveSnr::new(StackFrameOrder::Capture, points, &[300.0; 64]);
+        let analysis = progressive.analysis.expect("an inconclusive analysis");
+        assert_eq!(analysis.verdict, SnrVerdict::Uncertain);
+        assert!(analysis.projections.is_empty());
+        assert!(progressive.analysis_reason.is_none());
+    }
+
+    #[test]
     fn two_points_are_not_a_curve() {
         let points = curve(|n| 20.0 / f64::from(n).sqrt(), &[1, 2]);
         assert!(analyze(&points).is_none());
+    }
+
+    #[test]
+    fn mixed_exposures_keep_measurements_but_suppress_the_model() {
+        let points = curve(|n| 20.0 / f64::from(n).sqrt(), &[1, 2, 4, 8]);
+        // The 200 and 400 second frames average to 300 at the four-frame
+        // checkpoint. Per-frame validation must still catch the mixture.
+        let exposures = [300.0, 300.0, 200.0, 400.0, 300.0, 300.0, 300.0, 300.0];
+
+        let progressive = ProgressiveSnr::new(StackFrameOrder::Capture, points.clone(), &exposures);
+        assert_eq!(progressive.points.len(), points.len());
+        assert!(progressive.analysis.is_none());
+        assert_eq!(
+            progressive.analysis_reason.as_deref(),
+            Some(MIXED_EXPOSURE_REASON)
+        );
+    }
+
+    #[test]
+    fn missing_exposure_suppresses_the_model_with_a_reason() {
+        let points = curve(|n| 20.0 / f64::from(n).sqrt(), &[1, 2, 4, 8]);
+        let progressive = ProgressiveSnr::new(
+            StackFrameOrder::Capture,
+            points,
+            &[300.0, 300.0, 0.0, 300.0, 300.0, 300.0, 300.0, 300.0],
+        );
+        assert!(progressive.analysis.is_none());
+        assert_eq!(
+            progressive.analysis_reason.as_deref(),
+            Some(MISSING_EXPOSURE_REASON)
+        );
+    }
+
+    #[test]
+    fn insignificant_exposure_rounding_keeps_the_model_available() {
+        let points = curve(|n| 20.0 / f64::from(n).sqrt(), &[1, 2, 4, 8]);
+        let progressive = ProgressiveSnr::new(
+            StackFrameOrder::Capture,
+            points,
+            &[300.0, 302.0, 301.0, 302.0, 300.0, 302.0, 301.0, 302.0],
+        );
+        assert!(progressive.analysis.is_some());
+        assert!(progressive.analysis_reason.is_none());
+    }
+
+    #[test]
+    fn accepted_frames_after_the_last_measurement_do_not_invalidate_it() {
+        let points = curve(|n| 20.0 / f64::from(n).sqrt(), &[1, 2, 4]);
+        let progressive = ProgressiveSnr::new(
+            StackFrameOrder::Capture,
+            points,
+            &[300.0, 300.0, 300.0, 300.0, 600.0],
+        );
+
+        assert!(progressive.analysis.is_some());
+        assert!(progressive.analysis_reason.is_none());
     }
 
     #[test]
@@ -827,7 +1128,7 @@ mod tests {
         let mut points = curve(|n| 20.0 / f64::from(n).sqrt(), &[1, 2, 4, 8]);
         points[0].signal = 300.0;
         points[0].snr = 300.0 / points[0].noise;
-        let progressive = ProgressiveSnr::new(StackFrameOrder::Capture, points);
+        let progressive = ProgressiveSnr::new(StackFrameOrder::Capture, points, &[300.0; 8]);
         // Every ratio now comes off the deepest signal, 500.
         for point in &progressive.points {
             assert!((point.snr - 500.0 / point.noise).abs() < 1e-9);

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3958,6 +3958,24 @@
   font-size: 0.82rem;
 }
 
+.stack-snr-live {
+  padding: 0.55rem 0.9rem 0;
+  border-bottom: 1px solid var(--color-bg-tertiary);
+  background: color-mix(in srgb, var(--color-accent) 4%, transparent);
+}
+
+.stack-snr-live > strong {
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.stack-snr-live > .stack-snr {
+  padding-right: 0;
+  padding-left: 0;
+  border-bottom: 0;
+}
+
 .stack-snr {
   padding: 0.6rem 0.9rem 0.7rem;
   border-bottom: 1px solid var(--color-bg-tertiary);
@@ -4005,8 +4023,10 @@
 
 .stack-snr-chart {
   display: block;
-  width: 100%;
+  width: min(100%, 36rem);
   height: auto;
+  max-height: 13.5rem;
+  aspect-ratio: 8 / 3;
   margin: 0.45rem 0 0.2rem;
 }
 
@@ -4033,6 +4053,32 @@
 .stack-snr-chart .stack-snr-axis {
   fill: var(--color-text-muted);
   font-size: 8px;
+}
+
+.stack-snr-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.8rem;
+  color: var(--color-text-muted);
+  font-size: 0.66rem;
+}
+
+.stack-snr-legend > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+}
+
+.stack-snr-key {
+  display: inline-block;
+  width: 1.1rem;
+  border-top: 2px solid var(--color-accent, #6ea8fe);
+}
+
+.stack-snr-key.ideal {
+  border-color: var(--color-text-muted);
+  border-top-style: dashed;
+  border-top-width: 1px;
 }
 
 .stack-snr-summary {
@@ -4066,6 +4112,53 @@
   color: var(--color-text-muted);
   font-size: 0.62rem;
   text-transform: uppercase;
+}
+
+.stack-snr-data {
+  margin-top: 0.45rem;
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
+}
+
+.stack-snr-data summary {
+  width: max-content;
+  cursor: pointer;
+}
+
+.stack-snr-data-table {
+  max-width: 100%;
+  margin-top: 0.35rem;
+  overflow-x: auto;
+}
+
+.stack-snr-data table {
+  width: 100%;
+  min-width: 29rem;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.stack-snr-data caption {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.stack-snr-data th,
+.stack-snr-data td {
+  padding: 0.25rem 0.4rem;
+  border-bottom: 1px solid var(--color-bg-tertiary);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.stack-snr-data th {
+  color: var(--color-text-secondary);
 }
 
 .stack-preview-calibration {

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -438,9 +438,9 @@ export interface StackSkyOrientation {
 
 /**
  * The order a build integrated its frames in, which decides what its
- * progressive signal-to-noise curve answers. `capture` is chronological and
- * asks whether another night would help; `quality` puts the best-graded
- * frames first and asks which frames are worth keeping.
+ * progressive signal-to-noise curve answers. `capture` starts with the best
+ * registration reference, then follows the remaining frames chronologically;
+ * `quality` puts the best-graded frames first and asks which are worth keeping.
  */
 export type StackFrameOrder = 'capture' | 'quality';
 
@@ -457,7 +457,7 @@ export interface SnrPoint {
 }
 
 /** Where the curve stands, in one word. */
-export type SnrVerdict = 'improving' | 'diminishing' | 'plateau' | 'degrading';
+export type SnrVerdict = 'uncertain' | 'improving' | 'diminishing' | 'plateau' | 'degrading';
 
 /** What the fitted trend says more frames would buy. A prediction. */
 export interface SnrProjection {
@@ -502,6 +502,8 @@ export interface ProgressiveSnr {
   points: SnrPoint[];
   /** Absent until three depths have been measured. */
   analysis: SnrAnalysis | null;
+  /** Why the measured curve cannot support a fitted trend, when applicable. */
+  analysis_reason?: string | null;
 }
 
 export interface StackGroupStatus {
@@ -597,6 +599,8 @@ export interface LatestStackPreviewGroup {
   accepted_only: boolean;
   created_unix_seconds: number;
   cache_version: number;
+  /** The order this artifact integrated its frames in; old artifacts used capture order. */
+  order?: StackFrameOrder;
   group: StackGroupStatus;
 }
 

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -56,6 +56,7 @@ interface StackArtifact {
   jobId: string;
   artifactRevision: string;
   acceptedOnly: boolean;
+  order: StackFrameOrder;
   group: StackGroupStatus;
 }
 
@@ -165,7 +166,9 @@ function staleReason(
   builtAcceptedOnly: boolean,
   acceptedOnly: boolean,
   builtCalibration: CalibrationMode,
-  calibrationMode: CalibrationMode
+  calibrationMode: CalibrationMode,
+  builtOrder: StackFrameOrder,
+  frameOrder: StackFrameOrder
 ): string | null {
   if (!current) return 'Out of date — this channel is not in the current input';
   if (inputImages.length === 0) return 'Out of date — rebuild required';
@@ -187,6 +190,9 @@ function staleReason(
   if (builtCalibration !== calibrationMode) {
     return 'Out of date — calibration mode changed';
   }
+  if (builtOrder !== frameOrder) {
+    return 'Out of date — frame order changed';
+  }
   return null;
 }
 // `calibrationMode` above is the channel's EFFECTIVE mode — its override
@@ -198,6 +204,7 @@ function artifactFromLatest(latest: LatestStackPreviewGroup | undefined): StackA
     jobId: latest.job_id,
     artifactRevision: latest.artifact_revision,
     acceptedOnly: latest.accepted_only,
+    order: latest.order ?? 'capture',
     group: latest.group,
   };
 }
@@ -409,6 +416,7 @@ export default function StackPreviewPanel({
     setWatchedJobIds([]);
     setInspector(null);
     setStretches({});
+    setFrameOrder('capture');
     resetStart();
     resetStop();
   }, [dbId, projectId, resetStart, resetStop]);
@@ -509,10 +517,15 @@ export default function StackPreviewPanel({
       activeEntry && activeEntry.group.state === 'ready'
         ? {
             acceptedOnly: activeEntry.job.accepted_only,
+            order: activeEntry.job.order ?? 'capture',
             group: activeEntry.group,
           }
         : latestEntry
-          ? { acceptedOnly: latestEntry.accepted_only, group: latestEntry.group }
+          ? {
+              acceptedOnly: latestEntry.accepted_only,
+              order: latestEntry.order ?? 'capture',
+              group: latestEntry.group,
+            }
           : undefined;
     return artifact
       ? staleReason(
@@ -521,7 +534,9 @@ export default function StackPreviewPanel({
           artifact.acceptedOnly,
           acceptedOnly,
           builtCalibrationMode(artifact.group),
-          effectiveCalibration(key)
+          effectiveCalibration(key),
+          artifact.order,
+          frameOrder
         ) !== null
       : false;
   }).length;
@@ -536,7 +551,9 @@ export default function StackPreviewPanel({
           entry.accepted_only,
           acceptedOnly,
           builtCalibrationMode(entry.group),
-          effectiveCalibration(key)
+          effectiveCalibration(key),
+          entry.order ?? 'capture',
+          frameOrder
         )
       ) {
         targetIds.add(entry.group.target_id);
@@ -544,7 +561,7 @@ export default function StackPreviewPanel({
     }
     return targetIds;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- effectiveCalibration reads calibrationMode and overrides, listed below.
-  }, [acceptedOnly, calibrationMode, overrides, currentChannels, latest.data]);
+  }, [acceptedOnly, calibrationMode, overrides, currentChannels, frameOrder, latest.data]);
   const colorSourceRevision = useMemo(
     () => (latest.data?.groups ?? [])
       .map((entry) => `${entry.job_id}:${entry.group.index}:${entry.artifact_revision}`)
@@ -646,10 +663,11 @@ export default function StackPreviewPanel({
               className="stack-preview-frame-order"
               title={
                 'The order the next build integrates its frames in, which decides what its ' +
-                'signal-to-noise curve answers. Capture order is chronological and asks ' +
-                'whether another night would help. Quality order puts the best-graded frames ' +
-                'first and asks which frames are worth keeping: the depth where the curve ' +
-                'leaves the ideal is where the weaker frames stop paying for themselves. ' +
+                'signal-to-noise curve answers. Capture sequence starts with the best ' +
+                'registration reference, then follows the remaining eligible frames ' +
+                'chronologically. Quality order puts the best-graded frames first and asks ' +
+                'which frames are worth keeping: the depth where the curve leaves the ideal ' +
+                'is where the weaker frames stop paying for themselves. ' +
                 'Quality order integrates every frame again, so it cannot resume.'
               }
             >
@@ -659,7 +677,7 @@ export default function StackPreviewPanel({
                 disabled={running}
                 onChange={(event) => setFrameOrder(event.target.value as StackFrameOrder)}
               >
-                <option value="capture">Capture</option>
+                <option value="capture">Capture sequence</option>
                 <option value="quality">Quality</option>
               </select>
             </label>
@@ -755,6 +773,7 @@ export default function StackPreviewPanel({
                         jobId: activeEntry.job.job_id,
                         artifactRevision: activeEntry.job.artifact_revision,
                         acceptedOnly: activeEntry.job.accepted_only,
+                        order: activeEntry.job.order ?? 'capture',
                         group: activeEntry.group,
                       }
                     : undefined;
@@ -771,13 +790,17 @@ export default function StackPreviewPanel({
                       artifact.acceptedOnly,
                       acceptedOnly,
                       builtCalibrationMode(artifact.group),
-                      effectiveCalibration(key)
+                      effectiveCalibration(key),
+                      artifact.order,
+                      frameOrder
                     )
                   : null;
                 const groupBusy =
                   activeGroup?.state === 'queued' || activeGroup?.state === 'running';
                 const canBuildChannel = (current?.images.length ?? 0) >= 2;
                 const progressGroup = activeGroup ?? artifact?.group;
+                const liveCurve = groupBusy ? activeGroup?.snr : null;
+                const artifactCurve = artifact?.group.snr;
                 const calibration = progressGroup?.calibration;
                 const progressState = progressGroup?.state ?? 'not-built';
                 const processedFrames = progressGroup?.processed_frames ?? 0;
@@ -1000,11 +1023,20 @@ export default function StackPreviewPanel({
                       </div>
                     )}
 
-                    {showSnrCurve && progressGroup?.snr && (
+                    {showSnrCurve && artifactCurve && (
                       <StackSnrCurve
-                        curve={progressGroup.snr}
-                        label={`${targetName} ${filterName || 'no filter'}`}
+                        curve={artifactCurve}
+                        label={`${targetName} ${filterName || 'no filter'} completed stack`}
                       />
+                    )}
+                    {showSnrCurve && liveCurve && (
+                      <section className="stack-snr-live" aria-label="Live build SNR progress">
+                        <strong>{artifact ? 'Live rebuild progress' : 'Live build progress'}</strong>
+                        <StackSnrCurve
+                          curve={liveCurve}
+                          label={`${targetName} ${filterName || 'no filter'} live build`}
+                        />
+                      </section>
                     )}
 
                     {calibration && calibration.state !== 'none' && (

--- a/static/src/components/StackSnrCurve.tsx
+++ b/static/src/components/StackSnrCurve.tsx
@@ -8,6 +8,7 @@ interface StackSnrCurveProps {
 }
 
 const VERDICT_COPY: Record<SnrVerdict, string> = {
+  uncertain: 'Inconclusive',
   improving: 'Still improving',
   diminishing: 'Diminishing returns',
   plateau: 'Plateau',
@@ -23,6 +24,10 @@ function formatHours(seconds: number) {
   return hours >= 10 ? `${Math.round(hours)} h` : `${hours.toFixed(1)} h`;
 }
 
+function formatMeasurement(value: number) {
+  return Number.isInteger(value) ? String(value) : value.toPrecision(6);
+}
+
 /**
  * The progressive signal-to-noise curve of one stack.
  *
@@ -33,14 +38,22 @@ function formatHours(seconds: number) {
  * between them is the whole reading.
  */
 export default function StackSnrCurve({ curve, label }: StackSnrCurveProps) {
-  const points = curve.points.filter((point) => point.frames >= 1 && point.snr > 0);
+  const points = useMemo(
+    () => curve.points.filter((point) => point.frames >= 1 && point.snr > 0),
+    [curve.points]
+  );
+  const analysisReason = curve.analysis_reason?.trim() || null;
+  const showIdeal = analysisReason === null;
   const geometry = useMemo(() => {
     if (points.length < 2) return null;
     const xs = points.map((point) => Math.log(point.frames));
     const first = points[0];
     // The ideal runs from the first measured depth at the square-root rate.
     const ideal = points.map((point) => first.snr * Math.sqrt(point.frames / first.frames));
-    const ys = [...points.map((point) => point.snr), ...ideal].map(Math.log);
+    const ys = [
+      ...points.map((point) => point.snr),
+      ...(showIdeal ? ideal : []),
+    ].map(Math.log);
     const [minX, maxX] = [Math.min(...xs), Math.max(...xs)];
     const [minY, maxY] = [Math.min(...ys), Math.max(...ys)];
     const spanX = maxX - minX || 1;
@@ -57,7 +70,7 @@ export default function StackSnrCurve({ curve, label }: StackSnrCurveProps) {
       .join(' ');
     return {
       path,
-      idealPath,
+      idealPath: showIdeal ? idealPath : null,
       marks: points.map((point) => ({
         x: toX(point.frames),
         y: toY(point.snr),
@@ -66,17 +79,19 @@ export default function StackSnrCurve({ curve, label }: StackSnrCurveProps) {
         seconds: point.exposure_seconds,
       })),
     };
-  }, [points]);
+  }, [points, showIdeal]);
 
   if (points.length < 2) return null;
-  const analysis = curve.analysis;
+  const analysis = analysisReason ? null : curve.analysis;
   const verdict = analysis?.verdict;
 
   return (
-    <section className="stack-snr">
+    <section className="stack-snr" aria-label={`${label} signal-to-noise analysis`}>
       <div className="stack-snr-head">
         <strong>Signal-to-noise vs depth</strong>
-        <span className="stack-snr-order">{curve.order} order</span>
+        <span className="stack-snr-order">
+          {curve.order === 'capture' ? 'Reference-first capture' : 'Quality order'}
+        </span>
         {verdict && <span className={`stack-snr-verdict ${verdict}`}>{VERDICT_COPY[verdict]}</span>}
       </div>
 
@@ -85,9 +100,14 @@ export default function StackSnrCurve({ curve, label }: StackSnrCurveProps) {
           className="stack-snr-chart"
           viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
           role="img"
-          aria-label={`${label}: signal-to-noise ratio against frame count, on log axes`}
+          aria-label={
+            `${label}: measured signal-to-noise ratio against frame count` +
+            `${showIdeal ? ' with the ideal square-root trend' : ''}, on log axes`
+          }
         >
-          <polyline className="stack-snr-ideal" points={geometry.idealPath} />
+          {geometry.idealPath && (
+            <polyline className="stack-snr-ideal" points={geometry.idealPath} />
+          )}
           <polyline className="stack-snr-measured" points={geometry.path} />
           {geometry.marks.map((mark) => (
             <circle key={mark.frames} cx={mark.x} cy={mark.y} r={2.5}>
@@ -113,35 +133,53 @@ export default function StackSnrCurve({ curve, label }: StackSnrCurveProps) {
         </svg>
       )}
 
-      {analysis ? (
+      <div className="stack-snr-legend" aria-label="Chart lines">
+        <span><i className="stack-snr-key measured" aria-hidden="true" />Measured</span>
+        {showIdeal && (
+          <span><i className="stack-snr-key ideal" aria-hidden="true" />Ideal square-root trend</span>
+        )}
+      </div>
+
+      {analysisReason ? (
+        <p className="stack-snr-summary">{analysisReason}</p>
+      ) : analysis ? (
         <>
           <p className="stack-snr-summary">{analysis.summary}</p>
-          <div className="stack-snr-metrics">
-            <div>
-              <strong>{analysis.noise_exponent.toFixed(2)}</strong>
-              <span>noise exponent (ideal -0.50)</span>
-            </div>
-            <div>
-              <strong>{Math.round(analysis.efficiency * 100)}%</strong>
-              <span>of ideal averaging</span>
-            </div>
-            {analysis.frames_for_90_percent !== null && (
+          {verdict === 'uncertain' ? (
+            <div className="stack-snr-metrics">
               <div>
-                <strong>{analysis.frames_for_90_percent}</strong>
-                <span>frames for 90% of the ratio</span>
+                <strong>{Math.round(analysis.fit_r_squared * 100)}%</strong>
+                <span>fit consistency; no projection</span>
               </div>
-            )}
-            {analysis.projections.map((projection) => (
-              <div key={projection.gain}>
-                <strong>+{projection.extra_frames}</strong>
-                <span>
-                  {`frames (${formatHours(projection.extra_seconds)}) for ${Math.round(
-                    (projection.gain - 1) * 100
-                  )}% more`}
-                </span>
+            </div>
+          ) : (
+            <div className="stack-snr-metrics">
+              <div>
+                <strong>{analysis.noise_exponent.toFixed(2)}</strong>
+                <span>noise exponent (ideal -0.50)</span>
               </div>
-            ))}
-          </div>
+              <div>
+                <strong>{Math.round(analysis.efficiency * 100)}%</strong>
+                <span>of ideal averaging</span>
+              </div>
+              {analysis.frames_for_90_percent !== null && (
+                <div>
+                  <strong>{analysis.frames_for_90_percent}</strong>
+                  <span>frames for 90% of the ratio</span>
+                </div>
+              )}
+              {analysis.projections.map((projection) => (
+                <div key={projection.gain}>
+                  <strong>+{projection.extra_frames}</strong>
+                  <span>
+                    {`frames (${formatHours(projection.extra_seconds)}) for ${Math.round(
+                      (projection.gain - 1) * 100
+                    )}% more`}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
           {analysis.regressions.length > 0 && (
             <p className="stack-snr-regression">
               {`Noise rose across ${analysis.regressions.length} span${
@@ -167,6 +205,37 @@ export default function StackSnrCurve({ curve, label }: StackSnrCurveProps) {
           before a trend can be read.
         </p>
       )}
+
+      <details className="stack-snr-data">
+        <summary>Exact measurements ({points.length})</summary>
+        <div className="stack-snr-data-table">
+          <table>
+            <caption>{label} signal-to-noise measurements</caption>
+            <thead>
+              <tr>
+                <th scope="col">Frames</th>
+                <th scope="col">Exposure (s)</th>
+                <th scope="col">Noise</th>
+                <th scope="col">Background</th>
+                <th scope="col">Signal</th>
+                <th scope="col">SNR</th>
+              </tr>
+            </thead>
+            <tbody>
+              {points.map((point) => (
+                <tr key={point.frames}>
+                  <td>{point.frames}</td>
+                  <td>{formatMeasurement(point.exposure_seconds)}</td>
+                  <td>{formatMeasurement(point.noise)}</td>
+                  <td>{formatMeasurement(point.background)}</td>
+                  <td>{formatMeasurement(point.signal)}</td>
+                  <td>{formatMeasurement(point.snr)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
     </section>
   );
 }

--- a/static/src/components/__tests__/StackPreviewPanel.stop.test.tsx
+++ b/static/src/components/__tests__/StackPreviewPanel.stop.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -78,6 +78,175 @@ function job(state: string, groupState: string) {
 }
 
 describe('StackPreviewPanel stop', () => {
+  it('keeps a completed curve bound to its image during and after a stopped rebuild', async () => {
+    const completedSnr = {
+      order: 'capture',
+      points: [
+        { frames: 1, exposure_seconds: 120, noise: 20, background: 1000, signal: 400, snr: 20 },
+        { frames: 2, exposure_seconds: 240, noise: 14, background: 1000, signal: 400, snr: 28.6 },
+        { frames: 4, exposure_seconds: 480, noise: 10, background: 1000, signal: 400, snr: 40 },
+      ],
+      analysis: null,
+    };
+    const liveSnr = {
+      order: 'capture',
+      points: [
+        { frames: 1, exposure_seconds: 120, noise: 30, background: 900, signal: 300, snr: 10 },
+        { frames: 2, exposure_seconds: 240, noise: 25, background: 900, signal: 300, snr: 12 },
+      ],
+      analysis: null,
+    };
+    const completedGroup = {
+      ...group,
+      state: 'ready',
+      phase: 'ready',
+      processed_frames: 2,
+      accepted_frames: 2,
+      snr: completedSnr,
+    };
+    const rebuildingGroup = { ...group, snr: liveSnr };
+    let currentJob = {
+      ...job('running', 'running'),
+      order: 'capture',
+      groups: [rebuildingGroup],
+    };
+
+    server.use(
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/latest', () => ok({
+        schema_version: 2,
+        database_id: 'test',
+        project_id: 1,
+        updated_unix_seconds: 100,
+        groups: [{
+          job_id: 'completed-job',
+          artifact_revision: 'completed-revision',
+          accepted_only: false,
+          created_unix_seconds: 90,
+          cache_version: 7,
+          order: 'capture',
+          group: completedGroup,
+        }],
+      })),
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/color', () => ok({
+        schema_version: 1,
+        database_id: 'test',
+        project_id: 1,
+        targets: [],
+        jobs: [],
+      })),
+      http.post('/api/db/:dbId/projects/:projectId/stack-previews', () => ok(currentJob)),
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/job-a', () => ok(currentJob)),
+      http.post('/api/db/:dbId/projects/:projectId/stack-previews/job-a/cancel', () => {
+        currentJob = {
+          ...currentJob,
+          state: 'cancelled',
+          groups: [{ ...rebuildingGroup, state: 'cancelled', phase: 'cancelled' }],
+        };
+        return ok(currentJob);
+      }),
+    );
+
+    render(
+      <StackPreviewPanel
+        dbId="test"
+        projectId={1}
+        images={images}
+        selectionSource="visible"
+        onOpenImage={() => undefined}
+      />,
+      { wrapper: wrapper() }
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Rebuild current set' }));
+
+    const completed = await screen.findByRole('region', {
+      name: 'Sh2 86 Ha completed stack signal-to-noise analysis',
+    });
+    expect(within(completed).getByText('Exact measurements (3)')).toBeInTheDocument();
+
+    const live = await screen.findByRole('region', { name: 'Live build SNR progress' });
+    expect(within(live).getByText('Live rebuild progress')).toBeInTheDocument();
+    expect(within(live).getByText('Exact measurements (2)')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Stop' }));
+    expect(await screen.findByText('Stack stopped')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole('region', { name: 'Live build SNR progress' })).not.toBeInTheDocument()
+    );
+    expect(screen.getByRole('region', {
+      name: 'Sh2 86 Ha completed stack signal-to-noise analysis',
+    })).toBeInTheDocument();
+  });
+
+  it('marks a different order stale and resets quality order on navigation', async () => {
+    const rememberedGroup = {
+      ...group,
+      state: 'ready',
+      phase: 'ready',
+      processed_frames: 2,
+      accepted_frames: 2,
+    };
+    server.use(
+      http.get(
+        '/api/db/:dbId/projects/:projectId/stack-previews/latest',
+        ({ params }) => ok({
+          schema_version: 2,
+          database_id: params.dbId,
+          project_id: Number(params.projectId),
+          updated_unix_seconds: 100,
+          groups: params.projectId === '1'
+            ? [{
+                job_id: 'completed-job',
+                artifact_revision: 'completed-revision',
+                accepted_only: false,
+                created_unix_seconds: 90,
+                cache_version: 7,
+                order: 'capture',
+                group: rememberedGroup,
+              }]
+            : [],
+        })
+      ),
+      http.get('/api/db/:dbId/projects/:projectId/stack-previews/color', ({ params }) => ok({
+        schema_version: 1,
+        database_id: params.dbId,
+        project_id: Number(params.projectId),
+        targets: [],
+        jobs: [],
+      })),
+    );
+
+    const view = render(
+      <StackPreviewPanel
+        dbId="test"
+        projectId={1}
+        images={images}
+        selectionSource="visible"
+        onOpenImage={() => undefined}
+      />,
+      { wrapper: wrapper() }
+    );
+
+    const order = await screen.findByLabelText('Order');
+    await userEvent.selectOptions(order, 'quality');
+    expect(await screen.findByText('Out of date — frame order changed')).toBeInTheDocument();
+
+    view.rerender(
+      <StackPreviewPanel
+        dbId="other"
+        projectId={2}
+        images={images}
+        selectionSource="visible"
+        onOpenImage={() => undefined}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('Order')).toHaveValue('capture'));
+    await waitFor(() =>
+      expect(screen.queryByText('Out of date — frame order changed')).not.toBeInTheDocument()
+    );
+  });
+
   it('stops a running build and reports the channel as stopped', async () => {
     let cancelled = false;
     server.use(

--- a/static/src/components/__tests__/StackSnrCurve.test.tsx
+++ b/static/src/components/__tests__/StackSnrCurve.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 import StackSnrCurve from '../StackSnrCurve';
 import type { ProgressiveSnr, SnrPoint } from '../../api/types';
@@ -54,7 +55,7 @@ describe('StackSnrCurve', () => {
     expect(screen.getByText('+7')).toBeInTheDocument();
     expect(screen.getByText(/frames \(0.6 h\) for 10% more/)).toBeInTheDocument();
     expect(
-      screen.getByRole('img', { name: /M31 Ha: signal-to-noise ratio against frame count/ }),
+      screen.getByRole('img', { name: /M31 Ha: measured signal-to-noise ratio/ }),
     ).toBeInTheDocument();
   });
 
@@ -65,6 +66,53 @@ describe('StackSnrCurve', () => {
     expect(container.querySelector('.stack-snr-measured')).not.toBeNull();
     expect(container.querySelector('.stack-snr-ideal')).not.toBeNull();
     expect(container.querySelectorAll('.stack-snr-chart circle')).toHaveLength(6);
+    expect(screen.getByText('Measured')).toBeInTheDocument();
+    expect(screen.getByText('Ideal square-root trend')).toBeInTheDocument();
+  });
+
+  it('makes every exact measurement available without hovering the chart', async () => {
+    render(<StackSnrCurve curve={curve()} label="M31 Ha" />);
+
+    await userEvent.click(screen.getByText('Exact measurements (6)'));
+    const table = screen.getByRole('table', { name: 'M31 Ha signal-to-noise measurements' });
+    expect(within(table).getAllByRole('row')).toHaveLength(7);
+    expect(within(table).getByRole('cell', { name: '9600' })).toBeInTheDocument();
+    expect(within(table).getByRole('cell', { name: '141.421' })).toBeInTheDocument();
+  });
+
+  it('shows measured data only when the exposures cannot support a trend', () => {
+    const { container } = render(
+      <StackSnrCurve
+        curve={curve({ analysis_reason: 'Exposure durations vary across the selected frames.' })}
+        label="M31 Ha"
+      />,
+    );
+
+    expect(screen.getByText(/Exposure durations vary/)).toBeInTheDocument();
+    expect(container.querySelector('.stack-snr-measured')).not.toBeNull();
+    expect(container.querySelector('.stack-snr-ideal')).toBeNull();
+    expect(screen.queryByText('Ideal square-root trend')).not.toBeInTheDocument();
+    expect(screen.queryByText('Still improving')).not.toBeInTheDocument();
+    expect(screen.queryByText('+7')).not.toBeInTheDocument();
+  });
+
+  it('labels an inconsistent fit without showing a directional projection', () => {
+    const inconclusive = curve();
+    inconclusive.analysis = {
+      ...inconclusive.analysis!,
+      fit_r_squared: 0.27,
+      verdict: 'uncertain',
+      projections: [],
+      summary: 'The deeper measurements are too inconsistent to establish a trend.',
+    };
+
+    render(<StackSnrCurve curve={inconclusive} label="M31 Ha" />);
+
+    expect(screen.getByText('Inconclusive')).toBeInTheDocument();
+    expect(screen.getByText('27%')).toBeInTheDocument();
+    expect(screen.getByText('fit consistency; no projection')).toBeInTheDocument();
+    expect(screen.queryByText('of ideal averaging')).not.toBeInTheDocument();
+    expect(screen.queryByText('+7')).not.toBeInTheDocument();
   });
 
   it('names the frames that made the stack noisier, and what that means in quality order', () => {

--- a/tests/integration_stack_snr.rs
+++ b/tests/integration_stack_snr.rs
@@ -126,7 +126,7 @@ fn sixteen_frames_measure_a_quarter_of_one_frame_s_noise() {
         points.push(snr::point(sample, depth as f64 * 300.0));
     }
 
-    let progressive = snr::ProgressiveSnr::new(snr::StackFrameOrder::Capture, points);
+    let progressive = snr::ProgressiveSnr::new(snr::StackFrameOrder::Capture, points, &[300.0; 16]);
     let points = &progressive.points;
     for pair in points.windows(2) {
         assert!(


### PR DESCRIPTION
## Summary

- Make progressive stack SNR estimate noise in both axes, remove planar gradients, and avoid projections when exposure metadata or fit confidence cannot support them.
- Make resumes exact and crash-safe, invalidate unsafe artifacts and checkpoints, and retry transient frame-read failures from a clean stack.
- Keep completed and live curve identity honest, preserve frame order, and improve chart sizing and accessibility.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -j 1 --lib server::stack_preview` (126 passed)
- `cargo test -j 1 --test integration_stack_snr` (1 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm test -- --run` (309 passed)
- `npm run lint`
- `npm run build`

## Dependency

This is stacked on #357 because it hardens the feature introduced there. Retarget it to `main` after #357 merges.