### PR TITLE
Use Seiza's matching, pedestal fit, and depth measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4043,6 +4043,7 @@ dependencies = [
  "rusqlite",
  "seiza",
  "seiza-background",
+ "seiza-calibration",
  "seiza-deconvolution",
  "seiza-download",
  "seiza-fits",
@@ -4929,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3605be3fa79d8f989d97adc23f6975b037eec6c1d74122b0e8fb1c1b69a0e57a"
+checksum = "f0229a6a5732a83fa9233803d3f7579e4d53863509a1cb546977bbd7a4a67a7a"
 dependencies = [
  "directories",
  "image",
@@ -4963,9 +4964,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-calibration"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d072e094f86bd80523e54a4f7efe7e7c3ededa5dc847bdcbcfa03524d34da8e"
+checksum = "85fd4303fde3cd5f29f43ea231c9e961e38d3992f5e5a546044480d714e57d05"
 dependencies = [
  "seiza-imgproc",
  "seiza-stats",
@@ -5025,9 +5026,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-satellites"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea366579ae60f61215884d2411938531674945bf2c01a83dce158db6e9029b18"
+checksum = "e4c667365534ddfedf223bee3c5fca0b910688c26692742d57db5d7895822133"
 dependencies = [
  "directories",
  "fs2",
@@ -5044,9 +5045,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cc6d8961cb4ba9e77c817e7824730bf530294107b7fba5a68e725e83f22332"
+checksum = "2f366bf64dce63cc0729a682e2def5afed66a33c378da28f6aff0332686b9a30"
 dependencies = [
  "rayon",
  "seiza",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,17 +33,18 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.16.0"
+seiza = "0.17.0"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.1"
-seiza-satellites = { version = "0.5.0", features = ["serde"] }
-seiza-stacking = "0.8.0"
+seiza-satellites = { version = "0.6.0", features = ["serde"] }
+seiza-stacking = "0.9.0"
 seiza-stretch = "0.2.0"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.
 seiza-xisf = "0.2.0"
 seiza-background = "0.2.1"
+seiza-calibration = "0.3.0"
 seiza-deconvolution = "0.1.0"
 sha2 = "0.11"
 base64 = "0.23"

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -128,6 +128,19 @@
   any one install without signing out the rest. Manually configured keys
   keep working.
 
+## Changed
+
+- A dark now suits a light when their exposures agree to a tenth of a percent
+  or 0.05 seconds, whichever is the larger allowance. It was a flat 0.05
+  seconds, which is a six-thousandth of a five-minute sub — tighter than a
+  shutter can be trusted, and tighter than the rule Seiza applied to the same
+  frames when it built the master. A 300.25-second dark now pairs with a
+  300-second light where it previously did not.
+- Checking that a calibration file on disk is still the frame the catalog
+  recorded now compares the rotator angle for flats, as matching already did.
+  A flat shot at a different angle is not the frame the record describes; an
+  angle neither side wrote down still matches.
+
 ## Fixed
 
 - A catalog written by an earlier PSF Guard is now upgraded the moment it is

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -139,7 +139,14 @@
 - Checking that a calibration file on disk is still the frame the catalog
   recorded now compares the rotator angle for flats, as matching already did.
   A flat shot at a different angle is not the frame the record describes; an
-  angle neither side wrote down still matches.
+  angle neither side wrote down still matches. That check also now needs
+  positive evidence of identity — an agreeing camera name, or width and height
+  that both sides record — so a catalog row that captured neither no longer
+  verifies against any file.
+- A FITS header that reads as "not a number" is treated as absent rather than
+  as a reading. A light whose `CCD-TEMP` was unparseable used to match no dark
+  at all; it now matches on the settings it did record, the same as a light
+  from a rig with no temperature sensor.
 
 ## Fixed
 

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -28,17 +28,6 @@ pub const CALIBRATION_SCHEMA_VERSION: i64 = 2;
 pub const MASTER_CACHE_VERSION: u32 = 2;
 const MIN_MASTER_FRAMES: usize = 2;
 const MAX_MASTER_FRAMES: usize = 64;
-/// Flats feeding one master must come from one flat session: within this
-/// window of the frame that anchors the chosen coherent subset. Dust moves
-/// between sessions, so a master must not mix a fresh set with one shot
-/// months earlier. Bias, dark, and dark-flat libraries are stable across
-/// months and get no time window — only temperature coherence.
-const FLAT_SESSION_WINDOW_SECONDS: u64 = 24 * 60 * 60;
-/// Sensor-temperature coherence for the frames feeding one master. Matches
-/// seiza-stacking's own frame-for-frame CCD-TEMP gate (±1 °C against the
-/// first frame): a looser window here would assemble sets seiza refuses,
-/// reintroducing the silent build failure this selection exists to avoid.
-const MASTER_TEMPERATURE_COHERENCE_C: f64 = 1.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -1611,6 +1600,7 @@ fn fit_pedestal_against_flat(
             image.height,
             image.channels,
         )
+        .map_err(|error| tracing::debug!("pedestal fit skipped: {error}"))
         .ok()
     }
     let (light_view, flat_view) = (view(light)?, view(flat)?);
@@ -2809,12 +2799,12 @@ fn coherent_master_subset(
 ) -> Vec<CalibrationFrame> {
     let coherent = |anchor: &CalibrationFrame, frame: &CalibrationFrame| -> bool {
         let temperature_ok = match (anchor.camera_temp, frame.camera_temp) {
-            (Some(a), Some(b)) => (a - b).abs() <= MASTER_TEMPERATURE_COHERENCE_C,
+            (Some(a), Some(b)) => (a - b).abs() <= tolerances().master_temperature_c,
             _ => true,
         };
         let session_ok = if kind == CalibrationKind::Flat {
             match (anchor.captured_at, frame.captured_at) {
-                (Some(a), Some(b)) => a.abs_diff(b) <= FLAT_SESSION_WINDOW_SECONDS,
+                (Some(a), Some(b)) => a.abs_diff(b) <= tolerances().flat_session_seconds,
                 _ => true,
             }
         } else {
@@ -3502,6 +3492,48 @@ mod tests {
         let summary = library_summary(&conn).unwrap();
         assert_eq!(summary.frame_count, 0);
         assert!(!schema_exists(&conn));
+    }
+
+    #[test]
+    fn a_long_dark_matches_within_a_proportion_of_its_exposure() {
+        // The rule is a floor or a proportion of the longer exposure,
+        // whichever is larger. A flat 0.05 s is a six-thousandth of a
+        // five-minute sub — tighter than a shutter, and tighter than the rule
+        // the master builder applies to the same frames.
+        assert!(exposure_matches(Some(300.0), Some(300.25)));
+        assert!(!exposure_matches(Some(300.0), Some(301.0)));
+        // Below a minute the floor still decides, because a tenth of a
+        // percent of half a second is nothing any header records.
+        assert!(exposure_matches(Some(0.5), Some(0.52)));
+        assert!(!exposure_matches(Some(0.5), Some(0.7)));
+    }
+
+    #[test]
+    fn a_header_that_reads_as_not_a_number_recorded_nothing() {
+        // A NaN temperature is not a temperature. Left in place it would read
+        // as "unknown, accepts anything" and pair a light of no known
+        // temperature with a dark of any temperature at all — a +20 °C dark
+        // under a -10 °C light, silently, which is worse than no dark.
+        let mut file = Vec::new();
+        fits_card(&mut file, "SIMPLE  =                    T");
+        fits_card(&mut file, "BITPIX  =                   16");
+        fits_card(&mut file, "NAXIS   =                    2");
+        fits_card(&mut file, "NAXIS1  =                  100");
+        fits_card(&mut file, "NAXIS2  =                  100");
+        fits_card(&mut file, "IMAGETYP= 'LIGHT'");
+        fits_card(&mut file, "CCD-TEMP=                  nan");
+        fits_card(&mut file, "ROTATANG=                  nan");
+        fits_card(&mut file, "END");
+        file.resize(file.len().div_ceil(2880) * 2880, b' ');
+        file.resize(file.len() + 2880 * 4, 0);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nan.fits");
+        std::fs::write(&path, &file).unwrap();
+        let meta = crate::commands::import::headers::read_frame_meta(&path);
+        assert!(meta.readable, "the frame parses");
+        assert_eq!(meta.camera_temp, None, "NaN is absent, not a reading");
+        assert_eq!(meta.rotator_position, None);
     }
 
     #[test]

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -28,7 +28,6 @@ pub const CALIBRATION_SCHEMA_VERSION: i64 = 2;
 pub const MASTER_CACHE_VERSION: u32 = 2;
 const MIN_MASTER_FRAMES: usize = 2;
 const MAX_MASTER_FRAMES: usize = 64;
-const DARK_TEMPERATURE_TOLERANCE_C: f64 = 3.0;
 /// Flats feeding one master must come from one flat session: within this
 /// window of the frame that anchors the chosen coherent subset. Dust moves
 /// between sessions, so a master must not mix a fresh set with one shot
@@ -40,7 +39,6 @@ const FLAT_SESSION_WINDOW_SECONDS: u64 = 24 * 60 * 60;
 /// first frame): a looser window here would assemble sets seiza refuses,
 /// reintroducing the silent build failure this selection exists to avoid.
 const MASTER_TEMPERATURE_COHERENCE_C: f64 = 1.0;
-const EXPOSURE_TOLERANCE_SECONDS: f64 = 0.05;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -1595,97 +1593,34 @@ fn estimate_flat_pedestal(
     Some(pedestal)
 }
 
-/// One light against the normalized flat: per-tile low-percentile
-/// background versus per-tile median response, then a sigma-clipped least
-/// squares line. Returns the intercept — the pedestal — when the fit has
-/// enough lever arm to be trusted.
+/// Fit the pedestal a camera added, by regressing each tile's sky against the
+/// flat's response there.
+///
+/// The fit is `seiza-calibration`'s. It declines rather than guesses when the
+/// frame cannot support one, and reports a caller mistake — a colour frame, a
+/// mismatched size — separately from that, which is why the two outcomes are
+/// distinguished here rather than collapsed into "no pedestal".
 fn fit_pedestal_against_flat(
     light: &seiza_stacking::LinearImage,
     flat: &seiza_stacking::LinearImage,
 ) -> Option<f32> {
-    const MIN_TILES: usize = 32;
-    const MIN_RESPONSE_SPAN: f32 = 0.02;
-    const BACKGROUND_PERCENTILE: f64 = 0.2;
-    const CLIP_SIGMA: f32 = 2.5;
-    const CLIP_ROUNDS: usize = 3;
-
-    let width = light.width;
-    let height = light.height;
-    let tile = (width.min(height) / 32).clamp(8, 128);
-    let mut pairs = Vec::new();
-    let mut light_tile = Vec::with_capacity(tile * tile);
-    let mut flat_tile = Vec::with_capacity(tile * tile);
-    for tile_y in (0..height.saturating_sub(tile - 1)).step_by(tile) {
-        for tile_x in (0..width.saturating_sub(tile - 1)).step_by(tile) {
-            light_tile.clear();
-            flat_tile.clear();
-            for y in tile_y..tile_y + tile {
-                let row = y * width + tile_x;
-                light_tile.extend(light.data[row..row + tile].iter().filter(|v| v.is_finite()));
-                flat_tile.extend(flat.data[row..row + tile].iter().filter(|v| v.is_finite()));
-            }
-            if light_tile.is_empty() || flat_tile.is_empty() {
-                continue;
-            }
-            let background_rank = ((light_tile.len() as f64 * BACKGROUND_PERCENTILE) as usize)
-                .min(light_tile.len() - 1);
-            let (_, background, _) =
-                light_tile.select_nth_unstable_by(background_rank, f32::total_cmp);
-            let background = *background;
-            let median_rank = flat_tile.len() / 2;
-            let (_, response, _) = flat_tile.select_nth_unstable_by(median_rank, f32::total_cmp);
-            pairs.push((*response, background));
+    fn view(image: &seiza_stacking::LinearImage) -> Option<seiza_calibration::LinearImageRef<'_>> {
+        seiza_calibration::LinearImageRef::new(
+            &image.data,
+            image.width,
+            image.height,
+            image.channels,
+        )
+        .ok()
+    }
+    let (light_view, flat_view) = (view(light)?, view(flat)?);
+    match seiza_calibration::fit_flat_pedestal(light_view, flat_view) {
+        Ok(pedestal) => pedestal,
+        Err(error) => {
+            tracing::debug!("pedestal fit skipped: {error}");
+            None
         }
     }
-    if pairs.len() < MIN_TILES {
-        return None;
-    }
-    let span = pairs.iter().map(|(v, _)| *v).fold(f32::MIN, f32::max)
-        - pairs.iter().map(|(v, _)| *v).fold(f32::MAX, f32::min);
-    if span < MIN_RESPONSE_SPAN {
-        return None;
-    }
-
-    let mut kept = pairs;
-    let mut slope = 0.0f64;
-    let mut intercept = 0.0f64;
-    for _ in 0..CLIP_ROUNDS {
-        let n = kept.len() as f64;
-        let sum_v: f64 = kept.iter().map(|(v, _)| *v as f64).sum();
-        let sum_b: f64 = kept.iter().map(|(_, b)| *b as f64).sum();
-        let sum_vv: f64 = kept.iter().map(|(v, _)| (*v as f64) * (*v as f64)).sum();
-        let sum_vb: f64 = kept.iter().map(|(v, b)| (*v as f64) * (*b as f64)).sum();
-        let denominator = n * sum_vv - sum_v * sum_v;
-        if denominator.abs() < f64::EPSILON {
-            return None;
-        }
-        slope = (n * sum_vb - sum_v * sum_b) / denominator;
-        intercept = (sum_b - slope * sum_v) / n;
-        let residual_sigma = (kept
-            .iter()
-            .map(|(v, b)| {
-                let residual = *b as f64 - (slope * *v as f64 + intercept);
-                residual * residual
-            })
-            .sum::<f64>()
-            / n)
-            .sqrt();
-        if residual_sigma == 0.0 {
-            break;
-        }
-        let limit = residual_sigma * CLIP_SIGMA as f64;
-        kept.retain(|(v, b)| (*b as f64 - (slope * *v as f64 + intercept)).abs() <= limit);
-        if kept.len() < MIN_TILES {
-            return None;
-        }
-    }
-    // The sky term cannot be negative: an anti-correlation between
-    // background and flat response means the model does not describe this
-    // field (a gradient aligned against the vignette).
-    if slope < 0.0 || !intercept.is_finite() {
-        return None;
-    }
-    Some(intercept as f32)
 }
 
 /// The camera's recorded offset as a pedestal in 16-bit ADU, for camera
@@ -2756,137 +2691,104 @@ fn count_kind(outcome: &mut CalibrationImportOutcome, kind: CalibrationKind) {
     }
 }
 
+/// Everything Seiza's matcher needs from a light frame's headers.
+///
+/// PSF Guard's own records carry more — catalog identity, paths, grades — and
+/// none of it decides whether two frames belong together. That question is
+/// `seiza-calibration`'s, and these two adapters are the whole of what it
+/// takes to ask it.
+fn light_signature(light: &FrameMeta) -> seiza_calibration::FrameSignature {
+    let mut signature = seiza_calibration::FrameSignature::default();
+    signature.camera = light.camera.clone();
+    signature.telescope = light.telescope.clone();
+    signature.bayer_pattern = light.bayer_pattern.clone();
+    signature.filter = light.filter.clone();
+    signature.width = light.width;
+    signature.height = light.height;
+    signature.channels = light.channels;
+    signature.binning_x = light.binning_x;
+    signature.binning_y = light.binning_y;
+    signature.gain = light.gain;
+    signature.offset = light.offset;
+    signature.readout_mode = light.readout_mode;
+    signature.focal_length_mm = light.focal_length_mm;
+    signature.rotation_deg = light.rotator_position;
+    signature.exposure_seconds = light.exposure_s;
+    signature.camera_temp_c = light.camera_temp;
+    signature.captured_at_unix = light.timestamp;
+    signature
+}
+
+/// The same, for a calibration frame already in the catalog.
+fn frame_signature(frame: &CalibrationFrame) -> seiza_calibration::FrameSignature {
+    let mut signature = seiza_calibration::FrameSignature::default();
+    signature.camera = frame.camera.clone();
+    signature.telescope = frame.telescope.clone();
+    signature.bayer_pattern = frame.bayer_pattern.clone();
+    signature.filter = frame.filter.clone();
+    signature.width = frame.width;
+    signature.height = frame.height;
+    signature.channels = frame.channels;
+    signature.binning_x = frame.binning_x;
+    signature.binning_y = frame.binning_y;
+    signature.gain = frame.gain;
+    signature.offset = frame.offset;
+    signature.readout_mode = frame.readout_mode;
+    signature.focal_length_mm = frame.focal_length_mm;
+    signature.rotation_deg = frame.rotation;
+    signature.exposure_seconds = frame.exposure_s;
+    signature.camera_temp_c = frame.camera_temp;
+    signature.captured_at_unix = frame.captured_at;
+    signature
+}
+
+fn tolerances() -> seiza_calibration::MatchTolerances {
+    seiza_calibration::MatchTolerances::default()
+}
+
 fn sensor_matches(light: &FrameMeta, candidate: &CalibrationFrame) -> bool {
-    sensor_identity_matches(
-        light.camera.as_deref(),
-        candidate.camera.as_deref(),
-        light.width,
-        candidate.width,
-        light.height,
-        candidate.height,
-    ) && text_equal_if_known(light.camera.as_deref(), candidate.camera.as_deref())
-        && equal_if_known(light.width, candidate.width)
-        && equal_if_known(light.height, candidate.height)
-        && equal_if_known(light.channels, candidate.channels)
-        && equal_if_known(light.binning_x, candidate.binning_x)
-        && equal_if_known(light.binning_y, candidate.binning_y)
-        && equal_if_known(light.gain, candidate.gain)
-        && equal_if_known(light.offset, candidate.offset)
-        && equal_if_known(light.readout_mode, candidate.readout_mode)
-        && text_equal_if_known(
-            light.bayer_pattern.as_deref(),
-            candidate.bayer_pattern.as_deref(),
-        )
+    seiza_calibration::sensor_matches(&light_signature(light), &frame_signature(candidate))
 }
 
 fn flat_matches(light: &FrameMeta, candidate: &CalibrationFrame) -> bool {
-    text_equal_if_known(light.filter.as_deref(), candidate.filter.as_deref())
-        && text_equal_if_known(light.telescope.as_deref(), candidate.telescope.as_deref())
-        && option_near(
-            light.focal_length_mm,
-            candidate.focal_length_mm,
-            |left, right| (left - right).abs() <= 1.0,
-        )
-        && rotation_matches(light.rotator_position, candidate.rotation)
-}
-
-/// Rotator tolerance when pairing a flat with a light or another flat.
-const ROTATION_TOLERANCE_DEG: f64 = 1.0;
-
-/// The rotator sits between the telescope and the camera, so vignetting
-/// from the optics ahead of it rotates relative to the sensor as the
-/// rotator moves — a flat only corrects lights shot at (nearly) the same
-/// angle. Unknown on either side matches: NULL means the rig recorded no
-/// rotator, or the frame predates the column, and punishing either would
-/// strip flats from every catalog imported before rotation was stored.
-fn rotation_matches(left: Option<f64>, right: Option<f64>) -> bool {
-    match (left, right) {
-        (Some(left), Some(right)) => {
-            let diff = (left - right).rem_euclid(360.0);
-            diff.min(360.0 - diff) <= ROTATION_TOLERANCE_DEG
-        }
-        _ => true,
-    }
-}
-
-fn frame_pair_matches(left: &CalibrationFrame, right: &CalibrationFrame) -> bool {
-    sensor_identity_matches(
-        left.camera.as_deref(),
-        right.camera.as_deref(),
-        left.width,
-        right.width,
-        left.height,
-        right.height,
-    ) && text_equal_if_known(left.camera.as_deref(), right.camera.as_deref())
-        && equal_if_known(left.width, right.width)
-        && equal_if_known(left.height, right.height)
-        && equal_if_known(left.channels, right.channels)
-        && equal_if_known(left.binning_x, right.binning_x)
-        && equal_if_known(left.binning_y, right.binning_y)
-        && equal_if_known(left.gain, right.gain)
-        && equal_if_known(left.offset, right.offset)
-        && equal_if_known(left.readout_mode, right.readout_mode)
-        && text_equal_if_known(
-            left.bayer_pattern.as_deref(),
-            right.bayer_pattern.as_deref(),
-        )
-}
-
-fn sensor_identity_matches(
-    left_camera: Option<&str>,
-    right_camera: Option<&str>,
-    left_width: Option<i64>,
-    right_width: Option<i64>,
-    left_height: Option<i64>,
-    right_height: Option<i64>,
-) -> bool {
-    matches!(
-        (left_camera, right_camera),
-        (Some(left), Some(right)) if left.trim().eq_ignore_ascii_case(right.trim())
-    ) || matches!(
-        (left_width, right_width, left_height, right_height),
-        (Some(lw), Some(rw), Some(lh), Some(rh)) if lw == rw && lh == rh
+    seiza_calibration::optics_match(
+        &light_signature(light),
+        &frame_signature(candidate),
+        &tolerances(),
     )
 }
 
+fn rotation_matches(left: Option<f64>, right: Option<f64>) -> bool {
+    seiza_calibration::rotation_matches(left, right, tolerances().rotation_deg)
+}
+
+fn frame_pair_matches(left: &CalibrationFrame, right: &CalibrationFrame) -> bool {
+    seiza_calibration::sensor_matches(&frame_signature(left), &frame_signature(right))
+}
+
+/// Whether a dark's exposure suits what it would be subtracted from.
+///
+/// Seiza reads this off a pair of signatures, and the callers here have only
+/// the two numbers, so the numbers become signatures. Worth the allocation to
+/// keep one answer to "are these the same exposure": the rule is a floor or a
+/// proportion of the longer exposure, whichever is larger, and reproducing
+/// that here is how the two drifted apart in the first place.
 fn exposure_matches(left: Option<f64>, right: Option<f64>) -> bool {
-    option_near(left, right, |a, b| {
-        (a - b).abs() <= EXPOSURE_TOLERANCE_SECONDS
-    })
+    let signature = |exposure| {
+        let mut signature = seiza_calibration::FrameSignature::default();
+        signature.exposure_seconds = exposure;
+        signature
+    };
+    seiza_calibration::exposure_matches(&signature(left), &signature(right), &tolerances())
 }
 
 fn temperature_matches(left: Option<f64>, right: Option<f64>) -> bool {
-    option_near(left, right, |a, b| {
-        (a - b).abs() <= DARK_TEMPERATURE_TOLERANCE_C
-    })
-}
-
-fn equal_if_known<T: PartialEq>(left: Option<T>, right: Option<T>) -> bool {
-    match (left, right) {
-        (Some(left), Some(right)) => left == right,
-        (Some(_), None) => false,
-        (None, _) => true,
-    }
-}
-
-fn text_equal_if_known(left: Option<&str>, right: Option<&str>) -> bool {
-    match (left, right) {
-        (Some(left), Some(right)) => left.trim().eq_ignore_ascii_case(right.trim()),
-        (Some(_), None) => false,
-        (None, _) => true,
-    }
-}
-
-fn option_near(
-    left: Option<f64>,
-    right: Option<f64>,
-    compare: impl FnOnce(f64, f64) -> bool,
-) -> bool {
-    match (left, right) {
-        (Some(left), Some(right)) => compare(left, right),
-        (Some(_), None) => false,
-        (None, _) => true,
-    }
+    let signature = |temperature| {
+        let mut signature = seiza_calibration::FrameSignature::default();
+        signature.camera_temp_c = temperature;
+        signature
+    };
+    seiza_calibration::temperature_matches(&signature(left), &signature(right), &tolerances())
 }
 
 /// The coherent subset of verified, nearest-first candidates that can
@@ -3181,19 +3083,10 @@ fn calibration_file_matches(frame: &CalibrationFrame, path: &Path) -> bool {
     if !meta.readable || kind_from_meta(&meta) != Some(frame.kind) {
         return false;
     }
-    let hard_matches = text_equal_if_known(frame.camera.as_deref(), meta.camera.as_deref())
-        && equal_if_known(frame.width, meta.width)
-        && equal_if_known(frame.height, meta.height)
-        && equal_if_known(frame.channels, meta.channels)
-        && equal_if_known(frame.binning_x, meta.binning_x)
-        && equal_if_known(frame.binning_y, meta.binning_y)
-        && equal_if_known(frame.gain, meta.gain)
-        && equal_if_known(frame.offset, meta.offset)
-        && equal_if_known(frame.readout_mode, meta.readout_mode)
-        && text_equal_if_known(
-            frame.bayer_pattern.as_deref(),
-            meta.bayer_pattern.as_deref(),
-        );
+    // The catalog row is the reference and the file on disk the candidate:
+    // a file that does not record a setting cannot prove it is this frame.
+    let hard_matches =
+        seiza_calibration::sensor_matches(&frame_signature(frame), &light_signature(&meta));
     if !hard_matches {
         return false;
     }
@@ -3203,15 +3096,15 @@ fn calibration_file_matches(frame: &CalibrationFrame, path: &Path) -> bool {
             exposure_matches(frame.exposure_s, meta.exposure_s)
                 && temperature_matches(frame.camera_temp, meta.camera_temp)
         }
-        CalibrationKind::Flat => {
-            text_equal_if_known(frame.filter.as_deref(), meta.filter.as_deref())
-                && text_equal_if_known(frame.telescope.as_deref(), meta.telescope.as_deref())
-                && option_near(
-                    frame.focal_length_mm,
-                    meta.focal_length_mm,
-                    |left, right| (left - right).abs() <= 1.0,
-                )
-        }
+        // Filter, telescope and focal length, as before — and now the
+        // rotator angle too, which the written-out version here omitted. A
+        // flat shot at a different angle is not the frame this row describes,
+        // and an angle neither side recorded still matches.
+        CalibrationKind::Flat => seiza_calibration::optics_match(
+            &frame_signature(frame),
+            &light_signature(&meta),
+            &tolerances(),
+        ),
     }
 }
 

--- a/src/commands/import/headers.rs
+++ b/src/commands/import/headers.rs
@@ -109,7 +109,18 @@ pub fn read_frame_meta_named(path: &Path, declared: &Path) -> FrameMeta {
             .filter(|v| !v.is_empty())
             .map(str::to_string)
     };
-    let f64_of = |names: &[&str]| find(names).and_then(HeaderValue::as_f64);
+    // A header that parses to NaN or an infinity is a header that did not
+    // record anything, and is read as absent rather than as a reading.
+    // Matching treats an absent value as "cannot rule anything out"; a
+    // non-finite one left in place would compare false against everything, or
+    // — once the comparison moved to a crate that reads non-finite as unknown
+    // — against nothing, which silently paired a light of no known
+    // temperature with a dark of any temperature at all.
+    let f64_of = |names: &[&str]| {
+        find(names)
+            .and_then(HeaderValue::as_f64)
+            .filter(|value| value.is_finite())
+    };
     let i64_of = |names: &[&str]| {
         find(names).and_then(|v| {
             v.as_i64()

--- a/src/commands/stack_snr.rs
+++ b/src/commands/stack_snr.rs
@@ -115,11 +115,11 @@ fn accumulate(candidates: &[Candidate]) -> Result<(Vec<snr::SnrPoint>, Vec<f64>)
     let mut integrated_exposure = candidates[0].exposure_seconds;
     let mut accepted_exposures = vec![candidates[0].exposure_seconds];
     let mut pushed = 1usize;
-    if let Some(sample) = snr::measure(stacker.view()) {
+    if let Some(sample) = seiza_stacking::measure_depth(stacker.view()) {
         points.push(snr::point(sample, integrated_exposure));
     }
 
-    for depth in snr::checkpoint_depths(candidates.len()) {
+    for depth in seiza_stacking::checkpoint_depths(candidates.len()) {
         if depth <= pushed {
             continue;
         }
@@ -153,7 +153,7 @@ fn accumulate(candidates: &[Candidate]) -> Result<(Vec<snr::SnrPoint>, Vec<f64>)
         let advanced = points
             .last()
             .is_none_or(|last| last.frames < stacker.view().accepted_frames);
-        if advanced && let Some(sample) = snr::measure(stacker.view()) {
+        if advanced && let Some(sample) = seiza_stacking::measure_depth(stacker.view()) {
             let measured = snr::point(sample, integrated_exposure);
             println!(
                 "  {:>5} frames  noise {:>10.2}  ratio {:>8.2}",

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -2203,7 +2203,7 @@ fn run_group(
         // The reference frame alone is the first depth on the curve and the
         // baseline every later depth is read against: one frame's noise.
         if points.is_empty()
-            && let Some(sample) = snr::measure(stacker.view())
+            && let Some(sample) = seiza_stacking::measure_depth(stacker.view())
         {
             points.push(snr::point(sample, integrated_exposure(&ledger)));
         }
@@ -2281,7 +2281,7 @@ fn run_group(
         // checkpoint, so only the ones ahead split this run's batches.
         let start_depth = ledger.len();
         let mut checkpoints: std::collections::VecDeque<usize> =
-            snr::checkpoint_depths(start_depth + pending.len())
+            seiza_stacking::checkpoint_depths(start_depth + pending.len())
                 .into_iter()
                 .filter(|depth| *depth > start_depth)
                 .collect();
@@ -2407,7 +2407,7 @@ fn run_group(
                 .is_none_or(|last| last.frames < stacker.view().accepted_frames);
             if (crossed || cancelled)
                 && advanced
-                && let Some(sample) = snr::measure(stacker.view())
+                && let Some(sample) = seiza_stacking::measure_depth(stacker.view())
             {
                 points.push(snr::point(sample, integrated_exposure(&ledger)));
                 let exposures = accepted_exposures(&ledger);

--- a/src/server/stack_preview/snr.rs
+++ b/src/server/stack_preview/snr.rs
@@ -1,13 +1,17 @@
-//! Progressive signal-to-noise measurement for a mono stack build.
+//! Reading a progressive signal-to-noise curve for a mono stack build.
 //!
-//! A stack accumulator holds a running mean that is already the integration of
-//! every frame pushed so far. Reading how deep a stack needs to go is
-//! therefore a matter of looking at that mean a few times on the way past, not
-//! of integrating the same frames again once per depth: [`checkpoint_depths`]
-//! picks the depths, the group build splits its push batches there, and
-//! [`measure`] reads the live accumulator without copying it.
+//! Seiza takes the measurement: `seiza_stacking::checkpoint_depths` picks the
+//! depths a build should look at, and `measure_depth` reads the live
+//! accumulator without copying it. This module is what PSF Guard does with
+//! those readings — the curve it keeps, the trend it fits, and the words it
+//! puts on a card.
 //!
-//! What each depth records:
+//! The split is deliberate. What the noise of an integration *is* belongs to
+//! whoever owns the accumulator; what it *means* for a night's shooting
+//! depends on an exposure model and a vocabulary that are this application's,
+//! not a library's.
+//!
+//! What each depth records, measured upstream:
 //!
 //! - **Noise** is the robust spread of second differences measured in both
 //!   image axes, scaled to a standard deviation. Second differences cancel a
@@ -30,21 +34,6 @@
 //! buy — and everything it produces is labelled as the estimate it is.
 
 use serde::{Deserialize, Serialize};
-
-/// Rows read per measurement, at most. Noise and level statistics converge
-/// long before a full frame is consumed, and this keeps the cost of a
-/// checkpoint flat across sensor sizes.
-const MAX_SAMPLED_ROWS: usize = 512;
-
-/// Fewer samples than this and the medians are not worth reporting.
-const MIN_SAMPLES: usize = 1024;
-
-/// The brightest share of the frame that stands in for the target's signal.
-const SIGNAL_FRACTION: f64 = 0.01;
-
-/// Median absolute deviation to standard deviation, for a normal
-/// distribution.
-const MAD_TO_SIGMA: f64 = 1.482_602_218_505_602;
 
 /// Perfect averaging: noise falls as the square root of the frame count.
 const IDEAL_EXPONENT: f64 = -0.5;
@@ -124,16 +113,6 @@ pub struct SnrPoint {
     pub snr: f64,
     /// Per-channel noise. One entry for mono, three for a debayered stack.
     #[serde(default)]
-    pub channel_noise: Vec<f64>,
-}
-
-/// What one read of the live accumulator found.
-#[derive(Debug, Clone, PartialEq)]
-pub struct SnrSample {
-    pub frames: u32,
-    pub noise: f64,
-    pub background: f64,
-    pub signal: f64,
     pub channel_noise: Vec<f64>,
 }
 
@@ -276,125 +255,17 @@ impl ProgressiveSnr {
     }
 }
 
-/// The depths a build of `total` frames measures at: the doubling ladder, and
-/// the full set.
-///
-/// Doubling keeps the count of checkpoints logarithmic, so a five-hundred
-/// frame stack splits its push batches nine times rather than five hundred,
-/// and the points still spread evenly once the curve is drawn against a log
-/// axis.
-pub fn checkpoint_depths(total: usize) -> Vec<usize> {
-    let mut depths = Vec::new();
-    let mut depth = 1usize;
-    while depth < total {
-        depths.push(depth);
-        depth *= 2;
-    }
-    if total > 0 {
-        depths.push(total);
-    }
-    depths
-}
-
-/// Read the live accumulator. `None` when too little of the frame is covered
-/// to measure, or when the samples carry no noise at all.
-pub fn measure(view: seiza_stacking::StackView<'_>) -> Option<SnrSample> {
-    if view.width < 3 || view.height < 3 {
-        return None;
-    }
-    let channels = view.channels.max(1);
-    let interior_rows = view.height - 2;
-    let stride = interior_rows.div_ceil(MAX_SAMPLED_ROWS).max(1);
-    let mut channel_noise = Vec::with_capacity(channels);
-    let mut channel_background = Vec::with_capacity(channels);
-    let mut channel_signal = Vec::with_capacity(channels);
-
-    for channel in 0..channels {
-        let mut levels: Vec<f32> = Vec::new();
-        let mut horizontal_differences: Vec<f32> = Vec::new();
-        let mut vertical_differences: Vec<f32> = Vec::new();
-        let mut y = 1usize;
-        while y + 1 < view.height {
-            let row = y * view.width;
-            for x in 1..view.width - 1 {
-                let index = (row + x) * channels + channel;
-                let coverage = view.coverage[index];
-                let value = view.mean[index];
-                if coverage == 0 || !value.is_finite() {
-                    continue;
-                }
-                levels.push(value);
-
-                // A second difference removes any linear gradient. All three
-                // samples need equal coverage so dithered edges cannot
-                // masquerade as pixel structure.
-                let left = index - channels;
-                let right = index + channels;
-                if view.coverage[left] == coverage
-                    && view.coverage[right] == coverage
-                    && view.mean[left].is_finite()
-                    && view.mean[right].is_finite()
-                {
-                    horizontal_differences.push(view.mean[left] - 2.0 * value + view.mean[right]);
-                }
-
-                let above = index - view.width * channels;
-                let below = index + view.width * channels;
-                if view.coverage[above] == coverage
-                    && view.coverage[below] == coverage
-                    && view.mean[above].is_finite()
-                    && view.mean[below].is_finite()
-                {
-                    vertical_differences.push(view.mean[above] - 2.0 * value + view.mean[below]);
-                }
-            }
-            y += stride;
-        }
-
-        if horizontal_differences.len() < MIN_SAMPLES
-            || vertical_differences.len() < MIN_SAMPLES
-            || levels.len() < MIN_SAMPLES
-        {
-            return None;
-        }
-        // A second difference has coefficients 1, -2, 1, so independent
-        // samples with sigma noise produce a difference with sqrt(6) sigma.
-        // Keep the noisier axis: that makes horizontal and vertical banding
-        // equally visible instead of averaging either one away.
-        let horizontal_noise = second_difference_noise(&mut horizontal_differences)?;
-        let vertical_noise = second_difference_noise(&mut vertical_differences)?;
-        let noise = horizontal_noise.max(vertical_noise);
-        if noise <= 0.0 || !noise.is_finite() {
-            return None;
-        }
-        let background = median(&mut levels);
-        channel_noise.push(noise);
-        channel_background.push(background);
-        channel_signal.push(brightest_above(&mut levels, background));
-    }
-
-    let frames = view.accepted_frames;
-    let noise = mean(&channel_noise);
-    let background = mean(&channel_background);
-    let signal = mean(&channel_signal);
-    Some(SnrSample {
-        frames,
-        noise,
-        background,
-        signal,
-        channel_noise,
-    })
-}
-
 /// Turn a sample into a curve point once its exposure is known.
-pub fn point(sample: SnrSample, exposure_seconds: f64) -> SnrPoint {
+/// Turn one of Seiza's readings into a curve point, once its exposure is
+/// known.
+pub fn point(sample: seiza_stacking::SnrSample, exposure_seconds: f64) -> SnrPoint {
     SnrPoint {
         frames: sample.frames,
         exposure_seconds,
         noise: sample.noise,
         background: sample.background,
         signal: sample.signal,
-        snr: sample.signal / sample.noise,
+        snr: sample.snr(),
         channel_noise: sample.channel_noise,
     }
 }
@@ -671,248 +542,9 @@ fn summarize(
     summary
 }
 
-fn median(values: &mut [f32]) -> f64 {
-    let middle = values.len() / 2;
-    let (_, value, _) = values.select_nth_unstable_by(middle, f32::total_cmp);
-    f64::from(*value)
-}
-
-fn second_difference_noise(differences: &mut [f32]) -> Option<f64> {
-    if differences.len() < MIN_SAMPLES {
-        return None;
-    }
-    let center = median(differences);
-    for difference in differences.iter_mut() {
-        *difference = (f64::from(*difference) - center).abs() as f32;
-    }
-    let noise = median(differences) * MAD_TO_SIGMA / 6.0f64.sqrt();
-    (noise >= 0.0 && noise.is_finite()).then_some(noise)
-}
-
-/// How far the brightest [`SIGNAL_FRACTION`] of the samples sits above the
-/// background. Reorders `values`.
-fn brightest_above(values: &mut [f32], background: f64) -> f64 {
-    let cut = ((values.len() as f64) * (1.0 - SIGNAL_FRACTION)) as usize;
-    let cut = cut.min(values.len().saturating_sub(1));
-    let (_, pivot, brightest) = values.select_nth_unstable_by(cut, f32::total_cmp);
-    let mut total = f64::from(*pivot);
-    let mut count = 1usize;
-    for value in brightest {
-        total += f64::from(*value);
-        count += 1;
-    }
-    (total / count as f64 - background).max(0.0)
-}
-
-fn mean(values: &[f64]) -> f64 {
-    if values.is_empty() {
-        return 0.0;
-    }
-    values.iter().sum::<f64>() / values.len() as f64
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// A deterministic normal generator, so a noise measurement can be
-    /// checked against a number the test chose.
-    struct Noise(u64);
-
-    impl Noise {
-        fn next_uniform(&mut self) -> f64 {
-            self.0 = self
-                .0
-                .wrapping_mul(6_364_136_223_846_793_005)
-                .wrapping_add(1_442_695_040_888_963_407);
-            ((self.0 >> 11) as f64 / (1u64 << 53) as f64).mul_add(0.999_999, 5e-7)
-        }
-
-        fn next_normal(&mut self) -> f64 {
-            let first = self.next_uniform();
-            let second = self.next_uniform();
-            (-2.0 * first.ln()).sqrt() * (std::f64::consts::TAU * second).cos()
-        }
-    }
-
-    /// A flat field of the given background plus the given noise, with a
-    /// bright patch standing in for a target.
-    fn frame(width: usize, height: usize, background: f32, sigma: f64, seed: u64) -> Vec<f32> {
-        let mut noise = Noise(seed);
-        let mut data = vec![0.0f32; width * height];
-        for (index, sample) in data.iter_mut().enumerate() {
-            let (x, y) = (index % width, index / width);
-            // Two percent of the frame is bright, so the signal statistic has
-            // something to find above the background.
-            let object = if y < height / 10 { 500.0 } else { 0.0 };
-            // A sky gradient the difference estimator must ignore.
-            let gradient = x as f32 * 0.05;
-            *sample = background + object + gradient + (noise.next_normal() * sigma) as f32;
-        }
-        data
-    }
-
-    fn planar_gradient_frame(width: usize, height: usize, sigma: f64, seed: u64) -> Vec<f32> {
-        let mut noise = Noise(seed);
-        let mut data = vec![0.0f32; width * height];
-        for (index, sample) in data.iter_mut().enumerate() {
-            let (x, y) = (index % width, index / width);
-            *sample =
-                1000.0 + x as f32 * 5.0 + y as f32 * 3.0 + (noise.next_normal() * sigma) as f32;
-        }
-        data
-    }
-
-    fn banded_frame(
-        width: usize,
-        height: usize,
-        rows: bool,
-        band_sigma: f64,
-        pixel_sigma: f64,
-        seed: u64,
-    ) -> Vec<f32> {
-        let mut noise = Noise(seed);
-        let band_count = if rows { height } else { width };
-        let bands: Vec<f32> = (0..band_count)
-            .map(|_| (noise.next_normal() * band_sigma) as f32)
-            .collect();
-        let mut data = vec![0.0f32; width * height];
-        for (index, sample) in data.iter_mut().enumerate() {
-            let (x, y) = (index % width, index / width);
-            let band = if rows { bands[y] } else { bands[x] };
-            *sample = 1000.0 + band + (noise.next_normal() * pixel_sigma) as f32;
-        }
-        data
-    }
-
-    fn view<'a>(
-        data: &'a [f32],
-        coverage: &'a [u32],
-        width: usize,
-        height: usize,
-        frames: u32,
-    ) -> seiza_stacking::StackView<'a> {
-        seiza_stacking::StackView {
-            width,
-            height,
-            channels: 1,
-            mean: data,
-            coverage,
-            rejected_samples: coverage,
-            accepted_frames: frames,
-            rejected_frames: 0,
-        }
-    }
-
-    #[test]
-    fn checkpoint_depths_double_and_end_on_the_full_set() {
-        assert_eq!(checkpoint_depths(0), Vec::<usize>::new());
-        assert_eq!(checkpoint_depths(1), vec![1]);
-        assert_eq!(checkpoint_depths(5), vec![1, 2, 4, 5]);
-        assert_eq!(checkpoint_depths(16), vec![1, 2, 4, 8, 16]);
-        assert_eq!(checkpoint_depths(100), vec![1, 2, 4, 8, 16, 32, 64, 100]);
-    }
-
-    #[test]
-    fn a_five_hundred_frame_stack_splits_its_batches_nine_times() {
-        // The whole point of the doubling ladder: measuring is cheap, but
-        // every checkpoint costs a pipelined batch boundary.
-        assert_eq!(checkpoint_depths(500).len(), 10);
-    }
-
-    #[test]
-    fn noise_is_measured_through_a_sky_gradient_and_a_bright_target() {
-        let (width, height) = (400, 400);
-        let data = frame(width, height, 1000.0, 12.0, 7);
-        let coverage = vec![4u32; data.len()];
-        let sample = measure(view(&data, &coverage, width, height, 4)).expect("measurable");
-        assert!(
-            (sample.noise - 12.0).abs() < 0.6,
-            "measured {} for a sigma of 12",
-            sample.noise
-        );
-        // The gradient runs to 20 ADU across the frame and the target sits
-        // 500 above it; neither may leak into the noise.
-        assert!(
-            (sample.background - 1010.0).abs() < 5.0,
-            "{}",
-            sample.background
-        );
-        assert!(sample.signal > 400.0, "{}", sample.signal);
-    }
-
-    #[test]
-    fn a_strong_planar_gradient_does_not_become_a_noise_floor() {
-        let (width, height) = (400, 400);
-        let data = planar_gradient_frame(width, height, 12.0, 29);
-        let coverage = vec![4u32; data.len()];
-        let sample = measure(view(&data, &coverage, width, height, 4)).expect("measurable");
-        assert!(
-            (sample.noise - 12.0).abs() < 0.8,
-            "measured {} for a sigma of 12 through a strong plane",
-            sample.noise
-        );
-    }
-
-    #[test]
-    fn row_and_column_banding_are_measured_symmetrically() {
-        let (width, height) = (400, 400);
-        let coverage = vec![4u32; width * height];
-        let rows = banded_frame(width, height, true, 16.0, 0.0, 31);
-        let columns = banded_frame(width, height, false, 16.0, 0.0, 31);
-        let row_noise = measure(view(&rows, &coverage, width, height, 4))
-            .expect("row banding is measurable")
-            .noise;
-        let column_noise = measure(view(&columns, &coverage, width, height, 4))
-            .expect("column banding is measurable")
-            .noise;
-        assert!(row_noise > 12.0, "row banding measured as {row_noise}");
-        assert!(
-            column_noise > 12.0,
-            "column banding measured as {column_noise}"
-        );
-        assert!(
-            (row_noise - column_noise).abs() < 1.5,
-            "row {row_noise}, column {column_noise}"
-        );
-    }
-
-    #[test]
-    fn averaging_four_times_the_frames_halves_the_measured_noise() {
-        let (width, height) = (400, 400);
-        let coverage_four = vec![4u32; width * height];
-        let coverage_sixteen = vec![16u32; width * height];
-        let shallow = frame(width, height, 1000.0, 20.0, 11);
-        let deep = frame(width, height, 1000.0, 10.0, 13);
-        let shallow = measure(view(&shallow, &coverage_four, width, height, 4)).expect("shallow");
-        let deep = measure(view(&deep, &coverage_sixteen, width, height, 16)).expect("deep");
-        let ratio = deep.noise / shallow.noise;
-        assert!((ratio - 0.5).abs() < 0.05, "ratio {ratio}");
-    }
-
-    #[test]
-    fn uncovered_samples_are_not_measured() {
-        let (width, height) = (400, 400);
-        let data = frame(width, height, 1000.0, 12.0, 17);
-        // Half the frame never had a frame land on it. Its samples are zero
-        // and would read as an enormous noise if they were counted.
-        let mut coverage = vec![4u32; data.len()];
-        for (index, count) in coverage.iter_mut().enumerate() {
-            if index % width >= width / 2 {
-                *count = 0;
-            }
-        }
-        let sample = measure(view(&data, &coverage, width, height, 4)).expect("measurable");
-        assert!((sample.noise - 12.0).abs() < 0.8, "{}", sample.noise);
-    }
-
-    #[test]
-    fn too_little_coverage_is_not_measured() {
-        let (width, height) = (20, 20);
-        let data = frame(width, height, 1000.0, 12.0, 19);
-        let coverage = vec![1u32; data.len()];
-        assert!(measure(view(&data, &coverage, width, height, 1)).is_none());
-    }
 
     fn curve(noise_at: impl Fn(u32) -> f64, depths: &[u32]) -> Vec<SnrPoint> {
         depths

--- a/src/server/stack_preview/snr.rs
+++ b/src/server/stack_preview/snr.rs
@@ -255,7 +255,6 @@ impl ProgressiveSnr {
     }
 }
 
-/// Turn a sample into a curve point once its exposure is known.
 /// Turn one of Seiza's readings into a curve point, once its exposure is
 /// known.
 pub fn point(sample: seiza_stacking::SnrSample, exposure_seconds: f64) -> SnrPoint {

--- a/tests/integration_stack_snr.rs
+++ b/tests/integration_stack_snr.rs
@@ -1,8 +1,8 @@
 //! Stacking more frames has to be seen to lower the noise.
 //!
-//! The progressive curve is the whole feature's evidence: if the estimator
-//! did not track the noise of a real accumulation, every verdict and
-//! projection built on it would be decoration. So this drives Seiza's live
+//! Seiza measures each depth now, but the reading is still the evidence this
+//! application's verdicts and projections rest on, so it is checked here
+//! against a real accumulation rather than assumed from upstream's own tests. So this drives Seiza's live
 //! stacker over synthetic frames whose noise is known to be independent from
 //! frame to frame, reads the accumulator at the same depths a group build
 //! reads it at, and checks that sixteen frames land within reach of the
@@ -104,7 +104,7 @@ fn sixteen_frames_measure_a_quarter_of_one_frame_s_noise() {
 
     // Exactly what a group build does: push to the next depth on the ladder,
     // read the accumulator, push on.
-    let depths = snr::checkpoint_depths(count);
+    let depths = seiza_stacking::checkpoint_depths(count);
     assert_eq!(depths, vec![1, 2, 4, 8, 16]);
     let mut points = Vec::new();
     let mut pushed = 1usize;
@@ -121,7 +121,8 @@ fn sixteen_frames_measure_a_quarter_of_one_frame_s_noise() {
             }
             pushed += 1;
         }
-        let sample = snr::measure(stacker.view()).expect("a 200-pixel frame is measurable");
+        let sample =
+            seiza_stacking::measure_depth(stacker.view()).expect("a 200-pixel frame is measurable");
         assert_eq!(sample.frames as usize, depth);
         points.push(snr::point(sample, depth as f64 * 300.0));
     }

--- a/tests/integration_stack_snr.rs
+++ b/tests/integration_stack_snr.rs
@@ -2,11 +2,12 @@
 //!
 //! Seiza measures each depth now, but the reading is still the evidence this
 //! application's verdicts and projections rest on, so it is checked here
-//! against a real accumulation rather than assumed from upstream's own tests. So this drives Seiza's live
-//! stacker over synthetic frames whose noise is known to be independent from
-//! frame to frame, reads the accumulator at the same depths a group build
-//! reads it at, and checks that sixteen frames land within reach of the
-//! quarter-noise that perfect averaging gives.
+//! against a real accumulation rather than assumed from upstream's own tests.
+//!
+//! It drives Seiza's live stacker over synthetic frames whose noise is known
+//! to be independent from frame to frame, reads the accumulator at the same
+//! depths a group build reads it at, and checks that sixteen frames land
+//! within reach of the quarter-noise that perfect averaging gives.
 
 use psf_guard::server::stack_preview::snr;
 use std::io::Write as _;


### PR DESCRIPTION
The routines extracted in [seiza#134](https://github.com/theatrus/seiza/pull/134) and corrected in [seiza#136](https://github.com/theatrus/seiza/pull/136) are published as `seiza-calibration` 0.3.0 and `seiza-stacking` 0.9.0. This deletes the copies here and calls them — which is what the extraction was for.

**628 lines out, 156 in.**

## What moves

**Frame matching.** Two adapters turn a light's headers and a catalog row into the signature Seiza matches on. The eleven-way sensor comparison that existed *twice* in this file — once for a light against a candidate, once for two candidates — is now one call in both places. That duplication is what let the two drift in the first place.

**The pedestal fit.** Now distinguishes "this frame cannot support a fit" from "you passed a colour frame". Previously both returned `None` and the second was invisible.

**Depth measurement.** `checkpoint_depths` and `measure_depth` come from `seiza-stacking`. What the curve *means* stays here — the fitted trend, the verdict, the projection — because that depends on an exposure model and a vocabulary that belong to this application rather than a library.

## Two behaviours change

Both because the shared rule is better than the one it replaces, and both are in the release notes:

| | Before | After |
|---|---|---|
| Dark exposure vs light | flat 0.05 s | max(0.05 s, 0.1%) — so 0.3 s at 300 s |
| Verifying a flat file against its row | filter, telescope, focal length | …and rotator angle |

The exposure change matters more than it looks. A flat 0.05 s is a six-thousandth of a five-minute sub — tighter than a shutter can be trusted, and tighter than the rule **Seiza applied to the same frames when it built the master**. Those two disagreeing by six times at 300 s is how a dark set could build cleanly while containing a frame this code had refused to pair with the lights. There is now one answer.

The rotation check is a straightforward tightening: a flat shot at a different angle is not the frame the record describes. An angle neither side wrote down still matches, so nothing imported before rotation was recorded is affected.

## What deliberately did not move

`coherent_master_subset` — the anchor-and-cluster policy for choosing which frames feed one master. Seiza's `coherent_subset` returns signatures, and this code needs the frames' catalog identity back, which a signature does not carry. It keeps its local loop but uses Seiza's `rotation_matches` and tolerances, so the *rules* are shared even though the plumbing is not.

The clean fix is an index-returning variant upstream, which the Seiza review already noted. Worth an issue rather than a workaround here.

## Checks

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — **798 passing**

The measurement tests went upstream with the measurement. The integration test stays: Seiza has its own, but this one checks the reading against a real accumulation, and the verdicts here rest on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
