### PR TITLE
Fold the SNR chart away from its own heading

### DIFF
--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -211,13 +211,20 @@ Only what follows it changes. A resumed capture sequence is used only when its
 saved ledger is an exact prefix of the new sequence; a backfilled exposure or a
 changed reference forces a full restack.
 
-### Turning the chart off
+### Folding the chart away
 
-**SNR curve** beside the build buttons hides the chart on every card, and the
-choice is remembered across reloads. Nothing else changes: the build measures
-the curve either way, and still writes it to the FITS header, the JSON sidecar,
-and the resume checkpoint. The chart is hidden only by this switch — it never
-disappears on its own because a channel is small or a reading looks dull.
+Click **Signal-to-noise vs depth** on any card to fold the chart away, the same
+way frame decisions and view processing fold. The choice is remembered across
+reloads and applies to every card, so folding it once is enough.
+
+Folded is not hidden. The heading keeps the frame order and the verdict beside
+it, so a glance still answers whether more frames are worth shooting — you lose
+the chart, not the answer. And nothing about the build changes: it measures the
+curve either way and still writes it to the FITS header, the JSON sidecar, and
+the resume checkpoint.
+
+The chart is folded only by this control. It never collapses on its own because
+a channel is small or a reading looks dull.
 
 ### Where the curve goes
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -17,9 +17,10 @@
   time ends with one curve over the whole season. A new **Order** control
   switches the reading: capture sequence follows the frames after a fixed
   high-quality reference, while quality order asks which frames are worth
-  keeping. An **SNR curve** switch
-  hides the chart on every card and is remembered; builds measure and publish
-  the curve either way. `psf-guard stack-snr`
+  keeping. The chart folds away from its own heading, the way frame decisions
+  and view processing do, and the choice is remembered — folded still shows the
+  frame order and the verdict, so you lose the chart rather than the answer.
+  `psf-guard stack-snr`
   runs the same analysis over a folder of frames without a catalog. See
   [stack previews](https://github.com/theatrus/psf-guard/blob/main/docs/STACKING_PREVIEWS.md).
 - Remote image intake now accepts bias, dark, dark-flat, and flat frames as

--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -557,24 +557,33 @@ test('builds a real three-frame Seiza stack and exposes its frame decisions', as
     .getAttribute('src');
   expect(rebuiltSrc).not.toBe(cachedSrc);
 
-  // The curve is hidden only by its own switch, and the choice is remembered:
-  // someone who does not want the chart should not dismiss it once a session.
-  const curveSwitch = page.locator('.stack-preview-panel')
-    .getByRole('checkbox', { name: 'SNR curve' });
-  await expect(page.locator('.stack-snr')).toBeVisible();
-  await curveSwitch.uncheck();
-  await expect(page.locator('.stack-snr')).toHaveCount(0);
+  // The chart folds away from its own heading, and the choice is remembered:
+  // someone who folds it should not fold it again every session, or per card.
+  const curveSection = page.locator('.stack-preview-panel .stack-snr');
+  const curveHeading = curveSection.getByText('Signal-to-noise vs depth');
+  await expect(curveSection).toHaveAttribute('open', '');
+  await expect(curveSection.locator('.stack-snr-chart')).toBeVisible();
+
+  await curveHeading.click();
+  await expect(curveSection).not.toHaveAttribute('open', '');
+  await expect(curveSection.locator('.stack-snr-chart')).toBeHidden();
+  // Folded is not hidden: the heading and the verdict stay on the card, so
+  // the answer is still one line rather than gone.
+  await expect(curveHeading).toBeVisible();
+  await expect(curveSection.locator('.stack-snr-verdict')).toBeVisible();
+
   await page.reload();
   await expect(page.locator('.stack-preview-card')).toHaveCount(1);
-  await expect(page.locator('.stack-snr')).toHaveCount(0);
-  // Hiding the chart hides nothing else: the build still measured the curve
-  // and still publishes it.
+  await expect(page.locator('.stack-preview-panel .stack-snr')).not.toHaveAttribute('open', '');
+
+  // Folding changes nothing that was measured or published.
   const stillPublished = await page.request.get(snrHref!);
   expect(stillPublished.status()).toBe(200);
-  await page.locator('.stack-preview-panel')
-    .getByRole('checkbox', { name: 'SNR curve' })
-    .check();
-  await expect(page.locator('.stack-snr')).toBeVisible();
+
+  await page.locator('.stack-preview-panel .stack-snr')
+    .getByText('Signal-to-noise vs depth')
+    .click();
+  await expect(page.locator('.stack-preview-panel .stack-snr')).toHaveAttribute('open', '');
 });
 
 test('keeps a running stack visible in the header and re-attaches the panel', async ({

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3987,6 +3987,33 @@
   align-items: center;
   gap: 0.45rem;
   font-size: 0.78rem;
+  cursor: pointer;
+  user-select: none;
+  /* The row already carries a heading, an order and a verdict chip; the
+     default disclosure triangle sits awkwardly against a flex layout, so the
+     caret below is drawn explicitly and kept at the start. */
+  list-style: none;
+}
+
+.stack-snr-head::-webkit-details-marker {
+  display: none;
+}
+
+.stack-snr-head::before {
+  content: '▸';
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  transition: transform 0.12s ease;
+}
+
+.stack-snr[open] > .stack-snr-head::before {
+  transform: rotate(90deg);
+}
+
+/* Folded, the summary is the whole section, so it should not look like a
+   heading with a gap under it. */
+.stack-snr:not([open]) {
+  padding-bottom: 0.6rem;
 }
 
 .stack-snr-order {

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -77,17 +77,18 @@ function readCalibrationMode(): CalibrationMode {
 }
 
 /**
- * Whether the cards draw their signal-to-noise curve. Remembered across
- * reloads, like the calibration mode: someone who does not want the chart
- * should not have to dismiss it once per session.
+ * Whether the cards show their signal-to-noise chart expanded. Remembered
+ * across reloads, like the calibration mode: someone who folds it away should
+ * not have to fold it again every session, or once per card.
  *
- * The curve is hidden only by this switch. It never disappears because a
- * build is short, a channel is small, or a value looks uninteresting — an
- * element that comes and goes on its own reads as a bug.
+ * Folded is not hidden. The heading and the verdict stay on the card, so the
+ * answer is still there in one line — the chart never disappears because a
+ * build is short or a value looks uninteresting, which is the sort of thing
+ * that reads as a bug.
  */
 const SNR_CURVE_KEY = 'psf-guard.stack-snr-curve';
 
-function readShowSnrCurve(): boolean {
+function readSnrCurveOpen(): boolean {
   try {
     return window.localStorage.getItem(SNR_CURVE_KEY) !== 'off';
   } catch {
@@ -250,11 +251,11 @@ export default function StackPreviewPanel({
   // build produces, and quality order is a deliberate one-off question about
   // culling that should never be the state someone comes back to.
   const [frameOrder, setFrameOrder] = useState<StackFrameOrder>('capture');
-  const [showSnrCurve, setShowSnrCurve] = useState(readShowSnrCurve);
-  const chooseShowSnrCurve = (show: boolean) => {
-    setShowSnrCurve(show);
+  const [snrCurveOpen, setSnrCurveOpen] = useState(readSnrCurveOpen);
+  const chooseSnrCurveOpen = (open: boolean) => {
+    setSnrCurveOpen(open);
     try {
-      window.localStorage.setItem(SNR_CURVE_KEY, show ? 'on' : 'off');
+      window.localStorage.setItem(SNR_CURVE_KEY, open ? 'on' : 'off');
     } catch {
       // Keep the in-memory preference even when it cannot be persisted.
     }
@@ -645,21 +646,6 @@ export default function StackPreviewPanel({
               </select>
             </label>
             <label
-              className="stack-preview-checkbox"
-              title={
-                'Draw the signal-to-noise curve on each card. Builds measure it either ' +
-                'way, so turning this off hides the chart without changing what is ' +
-                'recorded; the curve stays in the stack FITS and its JSON sidecar.'
-              }
-            >
-              <input
-                type="checkbox"
-                checked={showSnrCurve}
-                onChange={(event) => chooseShowSnrCurve(event.target.checked)}
-              />
-              SNR curve
-            </label>
-            <label
               className="stack-preview-frame-order"
               title={
                 'The order the next build integrates its frames in, which decides what its ' +
@@ -1023,18 +1009,22 @@ export default function StackPreviewPanel({
                       </div>
                     )}
 
-                    {showSnrCurve && artifactCurve && (
+                    {artifactCurve && (
                       <StackSnrCurve
                         curve={artifactCurve}
                         label={`${targetName} ${filterName || 'no filter'} completed stack`}
+                        open={snrCurveOpen}
+                        onOpenChange={chooseSnrCurveOpen}
                       />
                     )}
-                    {showSnrCurve && liveCurve && (
+                    {liveCurve && (
                       <section className="stack-snr-live" aria-label="Live build SNR progress">
                         <strong>{artifact ? 'Live rebuild progress' : 'Live build progress'}</strong>
                         <StackSnrCurve
                           curve={liveCurve}
                           label={`${targetName} ${filterName || 'no filter'} live build`}
+                          open={snrCurveOpen}
+                          onOpenChange={chooseSnrCurveOpen}
                         />
                       </section>
                     )}

--- a/static/src/components/StackSnrCurve.tsx
+++ b/static/src/components/StackSnrCurve.tsx
@@ -5,6 +5,9 @@ interface StackSnrCurveProps {
   curve: ProgressiveSnr;
   /** Names the chart for a screen reader. */
   label: string;
+  /** Whether the chart is expanded. The panel owns it so the choice sticks. */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
 const VERDICT_COPY: Record<SnrVerdict, string> = {
@@ -37,7 +40,12 @@ function formatMeasurement(value: number) {
  * measured depth; the solid line is what the frames actually did. The gap
  * between them is the whole reading.
  */
-export default function StackSnrCurve({ curve, label }: StackSnrCurveProps) {
+export default function StackSnrCurve({
+  curve,
+  label,
+  open,
+  onOpenChange,
+}: StackSnrCurveProps) {
   const points = useMemo(
     () => curve.points.filter((point) => point.frames >= 1 && point.snr > 0),
     [curve.points]
@@ -86,14 +94,30 @@ export default function StackSnrCurve({ curve, label }: StackSnrCurveProps) {
   const verdict = analysis?.verdict;
 
   return (
-    <section className="stack-snr" aria-label={`${label} signal-to-noise analysis`}>
-      <div className="stack-snr-head">
+    <details
+      className="stack-snr"
+      aria-label={`${label} signal-to-noise analysis`}
+      open={open}
+      // Only report a state that differs from the one we were given. The
+      // nested measurements table's toggle reaches this handler too, and a
+      // re-render re-applies `open`, so a handler that reported every event
+      // would rewrite the remembered state of the chart whenever someone
+      // opened the table beneath it.
+      onToggle={(event) => {
+        if (event.currentTarget.open !== open) {
+          onOpenChange(event.currentTarget.open);
+        }
+      }}
+    >
+      {/* The verdict rides in the summary, so folding the chart away leaves
+          the answer on one line rather than taking it off the card. */}
+      <summary className="stack-snr-head">
         <strong>Signal-to-noise vs depth</strong>
         <span className="stack-snr-order">
           {curve.order === 'capture' ? 'Reference-first capture' : 'Quality order'}
         </span>
         {verdict && <span className={`stack-snr-verdict ${verdict}`}>{VERDICT_COPY[verdict]}</span>}
-      </div>
+      </summary>
 
       {geometry && (
         <svg
@@ -236,6 +260,6 @@ export default function StackSnrCurve({ curve, label }: StackSnrCurveProps) {
           </table>
         </div>
       </details>
-    </section>
+    </details>
   );
 }

--- a/static/src/components/__tests__/StackPreviewPanel.stop.test.tsx
+++ b/static/src/components/__tests__/StackPreviewPanel.stop.test.tsx
@@ -159,7 +159,7 @@ describe('StackPreviewPanel stop', () => {
 
     await userEvent.click(await screen.findByRole('button', { name: 'Rebuild current set' }));
 
-    const completed = await screen.findByRole('region', {
+    const completed = await screen.findByRole('group', {
       name: 'Sh2 86 Ha completed stack signal-to-noise analysis',
     });
     expect(within(completed).getByText('Exact measurements (3)')).toBeInTheDocument();
@@ -173,7 +173,7 @@ describe('StackPreviewPanel stop', () => {
     await waitFor(() =>
       expect(screen.queryByRole('region', { name: 'Live build SNR progress' })).not.toBeInTheDocument()
     );
-    expect(screen.getByRole('region', {
+    expect(screen.getByRole('group', {
       name: 'Sh2 86 Ha completed stack signal-to-noise analysis',
     })).toBeInTheDocument();
   });

--- a/static/src/components/__tests__/StackSnrCurve.test.tsx
+++ b/static/src/components/__tests__/StackSnrCurve.test.tsx
@@ -47,7 +47,7 @@ function curve(overrides: Partial<ProgressiveSnr> = {}): ProgressiveSnr {
 
 describe('StackSnrCurve', () => {
   it('shows the verdict, the fitted exponent and what more frames would buy', () => {
-    render(<StackSnrCurve curve={curve()} label="M31 Ha" />);
+    render(<StackSnrCurve curve={curve()} label="M31 Ha" open onOpenChange={() => {}} />);
 
     expect(screen.getByText('Still improving')).toBeInTheDocument();
     expect(screen.getByText('-0.50')).toBeInTheDocument();
@@ -59,8 +59,45 @@ describe('StackSnrCurve', () => {
     ).toBeInTheDocument();
   });
 
+  it('folds away to a summary that still carries the answer', () => {
+    const { rerender, container } = render(
+      <StackSnrCurve curve={curve()} label="M31 Ha" open onOpenChange={() => {}} />,
+    );
+    expect(container.querySelector('.stack-snr-chart')).not.toBeNull();
+
+    rerender(
+      <StackSnrCurve curve={curve()} label="M31 Ha" open={false} onOpenChange={() => {}} />,
+    );
+    // Folded is not hidden: the heading and the verdict stay, so a glance
+    // still answers "is this worth more frames?".
+    expect(screen.getByText('Signal-to-noise vs depth')).toBeInTheDocument();
+    expect(screen.getByText('Still improving')).toBeInTheDocument();
+    expect(container.querySelector('details.stack-snr')).not.toHaveAttribute('open');
+  });
+
+  it('reports its own toggle and ignores the measurements table beneath it', async () => {
+    const user = userEvent.setup();
+    const changes: boolean[] = [];
+    render(
+      <StackSnrCurve
+        curve={curve()}
+        label="M31 Ha"
+        open
+        onOpenChange={(next) => changes.push(next)}
+      />,
+    );
+
+    // Opening the nested table must not rewrite the chart's remembered state:
+    // React delivers its toggle to this handler too.
+    await user.click(screen.getByText(/Exact measurements/));
+    expect(changes).toEqual([]);
+
+    await user.click(screen.getByText('Signal-to-noise vs depth'));
+    expect(changes).toEqual([false]);
+  });
+
   it('draws the ideal square-root line beside the measured one', () => {
-    const { container } = render(<StackSnrCurve curve={curve()} label="M31 Ha" />);
+    const { container } = render(<StackSnrCurve curve={curve()} label="M31 Ha" open onOpenChange={() => {}} />);
 
     // Both lines are needed: the reading is the gap between them.
     expect(container.querySelector('.stack-snr-measured')).not.toBeNull();
@@ -71,7 +108,7 @@ describe('StackSnrCurve', () => {
   });
 
   it('makes every exact measurement available without hovering the chart', async () => {
-    render(<StackSnrCurve curve={curve()} label="M31 Ha" />);
+    render(<StackSnrCurve curve={curve()} label="M31 Ha" open onOpenChange={() => {}} />);
 
     await userEvent.click(screen.getByText('Exact measurements (6)'));
     const table = screen.getByRole('table', { name: 'M31 Ha signal-to-noise measurements' });
@@ -85,6 +122,8 @@ describe('StackSnrCurve', () => {
       <StackSnrCurve
         curve={curve({ analysis_reason: 'Exposure durations vary across the selected frames.' })}
         label="M31 Ha"
+        open
+        onOpenChange={() => {}}
       />,
     );
 
@@ -106,7 +145,7 @@ describe('StackSnrCurve', () => {
       summary: 'The deeper measurements are too inconsistent to establish a trend.',
     };
 
-    render(<StackSnrCurve curve={inconclusive} label="M31 Ha" />);
+    render(<StackSnrCurve curve={inconclusive} label="M31 Ha" open onOpenChange={() => {}} />);
 
     expect(screen.getByText('Inconclusive')).toBeInTheDocument();
     expect(screen.getByText('27%')).toBeInTheDocument();
@@ -127,6 +166,8 @@ describe('StackSnrCurve', () => {
           },
         })}
         label="M31 Ha"
+        open
+        onOpenChange={() => {}}
       />,
     );
 
@@ -142,6 +183,8 @@ describe('StackSnrCurve', () => {
       <StackSnrCurve
         curve={curve({ points: points((n) => 20 / Math.sqrt(n), [1, 2]), analysis: null })}
         label="M31 Ha"
+        open
+        onOpenChange={() => {}}
       />,
     );
 
@@ -154,6 +197,8 @@ describe('StackSnrCurve', () => {
       <StackSnrCurve
         curve={curve({ points: points((n) => 20 / Math.sqrt(n), [1]), analysis: null })}
         label="M31 Ha"
+        open
+        onOpenChange={() => {}}
       />,
     );
 


### PR DESCRIPTION
The chart could only be turned off from a switch in the panel toolbar, away from the card it governed. Folding it should work the way everything else on a card folds — click the heading — so now it does, matching **Frame decisions** and **View processing**.

The choice is remembered across reloads and applies to every card, so folding it once is enough.

## Folded is not hidden

The heading keeps the frame order and the verdict chip beside it. A glance still answers *"is this worth more frames?"* — you lose the chart, not the answer.

That is also why the toolbar switch is **gone** rather than kept alongside. A remembered fold does what the switch did, in the place you are already looking, and two controls for one job is worse than either. Say the word if you want it back.

Nothing about the build changes: it measures the curve either way and still writes it to the FITS header, the JSON sidecar and the resume checkpoint.

## Two bugs the tests caught that reading would not have

**The nested table rewrote the fold.** React delivers the inner "Exact measurements" `<details>` toggle to the chart's own handler, and a re-render re-applies `open`. My first guard compared `event.target` to `event.currentTarget` and did not hold — the outer element fires its own toggle too. The handler now reports only a state that *differs* from the one it was given, which is correct regardless of what fired it.

**A `<details>` is a `group`, not a `region`.** Swapping the element changed the accessible role, which the panel's existing test found by failing. Native semantics are right for a disclosure widget, so the queries follow the element rather than the element being forced back into a landmark with an explicit `role`.

## Checks

- `npm run lint`, `npx tsc --noEmit` — clean
- `npx vitest run` — **311 passing**, including two new tests: that folding leaves the heading and verdict on the card, and that opening the measurements table does not rewrite the remembered fold
- `npx playwright test stack-preview` — **3 passing**, with the browser test rewritten to fold, reload, confirm it stayed folded, and unfold

🤖 Generated with [Claude Code](https://claude.com/claude-code)
