### PR TITLE
Take the coherent-subset rule from Seiza rather than keeping a copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4964,9 +4964,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-calibration"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4310f7d0a37f45d4df72262291fe831f1af92f2232cbf31267ac43a701f3f257"
+checksum = "a9d4e5d39295d42a6681272d18330a96137c8b14e35d4e74e2cd045f10babc21"
 dependencies = [
  "seiza-imgproc",
  "seiza-stats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7119cb2aaad7b26ee829836937a8c96901633482c0998bd0ae9906e13e67fc98"
+checksum = "1c6639411436b7359655f7f3eb90e85b2269387ef765e69b1b48d256aa5a8762"
 dependencies = [
  "directories",
  "image",
@@ -5073,9 +5073,9 @@ checksum = "02427eea0eebef160eba79502519b73272924ccea855462292006af2320ef9e2"
 
 [[package]]
 name = "seiza-stretch"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e449c39ffe12c989a715479ce8e60990d0c9e8108d18d4f272a4631abbac27"
+checksum = "33bdfe46bd6c8433637ae4aed63b409b795549cab5be6ea5d00b9c046955f078"
 dependencies = [
  "rayon",
  "seiza-stats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,13 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.18.0"
+seiza = "0.18.1"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.1"
 seiza-satellites = { version = "0.7.0", features = ["serde"] }
 seiza-stacking = "0.10.0"
-seiza-stretch = "0.2.0"
+seiza-stretch = "0.2.1"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.
 seiza-xisf = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ seiza-stretch = "0.2.0"
 # containers into the same `seiza_fits::FitsImage`.
 seiza-xisf = "0.2.0"
 seiza-background = "0.2.1"
-seiza-calibration = "0.4.0"
+seiza-calibration = "0.4.1"
 seiza-deconvolution = "0.1.0"
 sha2 = "0.11"
 base64 = "0.23"

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -2748,10 +2748,6 @@ fn flat_matches(light: &FrameMeta, candidate: &CalibrationFrame) -> bool {
     )
 }
 
-fn rotation_matches(left: Option<f64>, right: Option<f64>) -> bool {
-    seiza_calibration::rotation_matches(left, right, tolerances().rotation_deg)
-}
-
 fn frame_pair_matches(left: &CalibrationFrame, right: &CalibrationFrame) -> bool {
     seiza_calibration::sensor_matches(&frame_signature(left), &frame_signature(right))
 }
@@ -2786,53 +2782,26 @@ fn temperature_matches(left: Option<f64>, right: Option<f64>) -> bool {
 /// per-light selection fingerprint (per-light trimming split fingerprints
 /// across multi-night stack groups, which refuse mixed selections).
 ///
-/// Each candidate in order anchors a cluster: frames within
-/// [`MASTER_TEMPERATURE_COHERENCE_C`] of the anchor (unknown temperatures
-/// cannot prove incoherence and join), and for flats also captured within
-/// [`FLAT_SESSION_WINDOW_SECONDS`] of it. The first cluster with enough
-/// frames to build wins, so a stray single flat shot near the lights does
-/// not orphan a complete session from a week earlier. With no viable
-/// cluster the first cluster is returned and the build skips quietly.
+/// The rule itself belongs to `seiza-calibration`, which anchors a cluster on
+/// each candidate in turn and takes the first with enough frames to build, so
+/// a stray single flat shot near the lights does not orphan a complete session
+/// from a week earlier. All that is left here is naming the frames: Seiza
+/// hands back positions rather than copies of its own signatures, so the rows
+/// that come out are the caller's, with their ids and paths intact.
 fn coherent_master_subset(
     kind: CalibrationKind,
     frames: &[CalibrationFrame],
 ) -> Vec<CalibrationFrame> {
-    let coherent = |anchor: &CalibrationFrame, frame: &CalibrationFrame| -> bool {
-        let temperature_ok = match (anchor.camera_temp, frame.camera_temp) {
-            (Some(a), Some(b)) => (a - b).abs() <= tolerances().master_temperature_c,
-            _ => true,
-        };
-        let session_ok = if kind == CalibrationKind::Flat {
-            match (anchor.captured_at, frame.captured_at) {
-                (Some(a), Some(b)) => a.abs_diff(b) <= tolerances().flat_session_seconds,
-                _ => true,
-            }
-        } else {
-            true
-        };
-        let rotation_ok = if kind == CalibrationKind::Flat {
-            rotation_matches(anchor.rotation, frame.rotation)
-        } else {
-            true
-        };
-        temperature_ok && session_ok && rotation_ok
+    let signatures: Vec<_> = frames.iter().map(frame_signature).collect();
+    let role = if kind == CalibrationKind::Flat {
+        seiza_calibration::FrameRole::Flat
+    } else {
+        seiza_calibration::FrameRole::Other
     };
-
-    let mut first_cluster: Option<Vec<CalibrationFrame>> = None;
-    for anchor in frames {
-        let cluster: Vec<CalibrationFrame> = frames
-            .iter()
-            .filter(|frame| coherent(anchor, frame))
-            .cloned()
-            .collect();
-        if cluster.len() >= MIN_MASTER_FRAMES {
-            return cluster;
-        }
-        if first_cluster.is_none() {
-            first_cluster = Some(cluster);
-        }
-    }
-    first_cluster.unwrap_or_default()
+    seiza_calibration::coherent_subset_indices(&signatures, role, MIN_MASTER_FRAMES, &tolerances())
+        .into_iter()
+        .map(|index| frames[index].clone())
+        .collect()
 }
 
 fn sort_candidates(frames: &mut [CalibrationFrame], reference_at: Option<i64>) {
@@ -3534,21 +3503,6 @@ mod tests {
         assert!(meta.readable, "the frame parses");
         assert_eq!(meta.camera_temp, None, "NaN is absent, not a reading");
         assert_eq!(meta.rotator_position, None);
-    }
-
-    #[test]
-    fn flats_match_rotation_within_tolerance_and_across_the_wrap() {
-        // Same axis expressed on either side of 0°/360° still matches;
-        // a quarter turn does not.
-        assert!(rotation_matches(Some(120.0), Some(120.6)));
-        assert!(rotation_matches(Some(359.8), Some(0.4)));
-        assert!(!rotation_matches(Some(120.0), Some(122.0)));
-        assert!(!rotation_matches(Some(0.0), Some(90.0)));
-        // Unknown on either side is compatible: rigs without rotators, and
-        // flats catalogued before the column existed, keep matching.
-        assert!(rotation_matches(None, Some(45.0)));
-        assert!(rotation_matches(Some(45.0), None));
-        assert!(rotation_matches(None, None));
     }
 
     #[test]


### PR DESCRIPTION
Follows [#364](https://github.com/theatrus/psf-guard/pull/364), which moved the calibration matching rules to `seiza-calibration` but left one behind.

## The one that stayed

`coherent_master_subset` was the last piece of calibration policy psf-guard still implemented itself. Not because the rule differed — Seiza's was the same anchor-and-cluster loop, line for line — but because Seiza returned copies of its own signatures. A signature carries only what decides whether two frames belong together; psf-guard needs the row back, with its id and its path, to hand to a build.

So the choice was a duplicate rule or no rule at all, and psf-guard kept the duplicate.

[seiza#140](https://github.com/theatrus/seiza/pull/140) added `coherent_subset_indices`, released as `seiza-calibration` **0.4.1**. It hands back positions, so the rule comes from the crate and the frames stay ours:

```rust
seiza_calibration::coherent_subset_indices(&signatures, role, MIN_MASTER_FRAMES, &tolerances())
    .into_iter()
    .map(|index| frames[index].clone())
    .collect()
```

Two implementations that agree today become one. That is the arrangement that would have caught the six-fold exposure disagreement the last pass turned up, where two `FrameSignature` types had quietly drifted apart at 300 s.

**Net −46 lines.** The local `rotation_matches` wrapper went dead with it, and so did a test that only exercised Seiza's own routine through the wrapper — [Seiza covers the wrap-around and the unrecorded-angle cases itself](https://github.com/theatrus/seiza/blob/main/seiza-calibration/src/matching.rs), so no coverage was dropped.

## Why 0.4.1 and not 0.5.0

Purely additive on a leaf crate. Pre-1.0 a minor bump *is* a break — `^0.4.0` cannot resolve 0.5.0 — so 0.5.0 would have forced five untouched crates to re-release. A patch says "compatible, safe to take", which is what is true, and this side picks it up on a pin bump alone. The reasoning is spelled out in [seiza#141](https://github.com/theatrus/seiza/pull/141) if it is worth revisiting.

## Behaviour

Unchanged, and the eight `coherent_master_subset` tests say so — they assert on frame **ids**, which is exactly what the old signature-copying interface could not give back, and they pass unaltered.

One small hardening comes along: Seiza reads a non-finite temperature as *unrecorded*, where a direct `(a - b).abs() <= tol` reads it as incompatible with everything, itself included. Whether a `psf_guard_calibration_frame` row can actually hold a NaN is doubtful — SQLite stores one as NULL, and [#364](https://github.com/theatrus/psf-guard/pull/364) already filters non-finite values at header read — so treat this as one less way to be wrong rather than a bug being fixed.

No release note: nothing here is visible to a user.

## Checks

Run locally on this branch:

- `cargo fmt -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — **694 unit tests** plus every integration suite, 0 failed
- `git diff --check` — clean

Frontend untouched, so its checks were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
