### PR TITLE
Handle delayed files after remote scheduler sync

### DIFF
--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -471,6 +471,11 @@ modification time before decoding a tracked source. Preview generation also
 checks that fingerprint again before publishing its artifact. A decoder failure
 is reported without exposing the server path and becomes retryable after the
 source fingerprint changes. Grade-only transfers do not start an arrival window.
+When the ten-minute wait expires, requests stop reporting the source as pending,
+but the running server keeps requiring matching capture headers for that row. A
+matching file can still resolve later. This strict marker is in memory and shares
+the 4096-entry cap; a restart or displacement by newer remote captures returns
+the row to ordinary catalog lookup.
 
 A file found after the directory scan is added to the directory and navigation
 caches in place. This does not reset either cache's age and does not trigger a

--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -449,6 +449,36 @@ row first, the upload attaches the file to that row without importing a
 duplicate. An ambiguous registered basename or an existing receive file with
 different content returns `409 Conflict`.
 
+### Files copied after scheduler sync
+
+Scheduler metadata may arrive before an external copy puts the corresponding
+frame below one of the database's image roots. File lookup checks the usual
+target/date layout first, then safe suffixes of the remote `FileName` below
+each configured root, flattened copies at the root, and filenames already in
+the directory cache. A suffix is never allowed to escape its root. PSF Guard
+reads candidate headers and requires a matching filter and `DATE-OBS` within
+two seconds of metadata `ExposureStartTime` (or `acquireddate` when the metadata
+omitted it). It treats more than one matching file as a terminal ambiguity
+instead of showing or grading an arbitrary same-named frame.
+
+After a successful remote merge, newly inserted captures and captures whose
+file-discovery identity changed get a ten-minute arrival window. Status requests
+probe cached candidates after one, two, then five seconds without starting a
+directory scan. A large merge seeds navigation for every changed project and
+target but tracks only the newest 4096 captures for this automatic wait. Preview
+and detail requests require two unchanged observations of path, size, and
+modification time before decoding a tracked source. Preview generation also
+checks that fingerprint again before publishing its artifact. A decoder failure
+is reported without exposing the server path and becomes retryable after the
+source fingerprint changes. Grade-only transfers do not start an arrival window.
+
+A file found after the directory scan is added to the directory and navigation
+caches in place. This does not reset either cache's age and does not trigger a
+tree-wide scan; ordinary expiry still revalidates everything. External copy
+tools should write to a temporary non-frame name and rename it atomically when
+complete. The automatic wait is bounded, so atomic publication remains the
+reliable way to prevent a partially copied FITS or XISF file from being read.
+
 ## Security
 
 Remote sync is disabled by default.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -151,6 +151,13 @@
 
 ## Fixed
 
+- Scheduler rows can now find image files copied into a PSF Guard image root
+  shortly after remote sync, without waiting for the directory cache to expire.
+  PSF Guard waits up to ten minutes with backed-off checks, retries preview
+  failures when a growing source changes, and keeps local paths out of errors.
+  Remote path suffixes stay confined to configured roots; candidates must agree
+  on capture time and filter, and ambiguous copies are refused instead of
+  opening the first one found.
 - A catalog written by an earlier PSF Guard is now upgraded the moment it is
   opened, instead of whenever some later write happened to notice. Stacking a
   project whose catalog predated rotator-aware flat matching failed outright

--- a/src/commands/sync/mod.rs
+++ b/src/commands/sync/mod.rs
@@ -24,8 +24,8 @@ pub(crate) use grades::sync_grades_in_transaction;
 pub use grades::{sync_grades, GradeChange, SyncGradesOptions, SyncSummary};
 pub(crate) use planning::sync_planning_in_transaction;
 pub use planning::{sync_planning, PlanningOptions, PlanningSummary};
-pub(crate) use pull::sync_pull_in_transaction;
 pub use pull::{sync_pull, PullOptions, PullSummary, TableCounts};
+pub(crate) use pull::{sync_pull_in_transaction, ChangedAcquiredImage};
 pub use remote::{
     print_summary as print_remote_summary, sync_remote, RemoteDirection, RemoteSyncOptions,
     RemoteSyncOutcome,

--- a/src/commands/sync/pull.rs
+++ b/src/commands/sync/pull.rs
@@ -62,8 +62,20 @@ pub struct PullSummary {
     pub calibration_rigs: TableCounts,
     pub calibration_rig_bindings: TableCounts,
     pub calibration_frames: TableCounts,
+    /// Destination acquiredimage IDs inserted or updated by this pull. Server
+    /// callers use these to watch briefly for files copied after the database
+    /// transaction; CLI reporting intentionally ignores them.
+    pub(crate) changed_acquiredimages: Vec<ChangedAcquiredImage>,
     /// Per-entity trace lines (for `--verbose`).
     pub changes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ChangedAcquiredImage {
+    pub id: i64,
+    pub project_id: i64,
+    pub target_id: i64,
+    pub acquired_date: Option<i64>,
 }
 
 impl PullSummary {
@@ -121,6 +133,43 @@ fn value_eq(a: &Value, b: &Value) -> bool {
 
 fn values_equal(a: &[Value], b: &[Value]) -> bool {
     a.len() == b.len() && a.iter().zip(b).all(|(x, y)| value_eq(x, y))
+}
+
+fn metadata_file_identity(value: &Value) -> Option<(String, Option<String>, Option<String>)> {
+    let Value::Text(metadata) = value else {
+        return None;
+    };
+    let metadata: serde_json::Value = serde_json::from_str(metadata).ok()?;
+    Some((
+        metadata.get("FileName")?.as_str()?.to_string(),
+        metadata
+            .get("ExposureStartTime")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        metadata
+            .get("FilterName")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+    ))
+}
+
+fn file_discovery_identity_changed(
+    columns: &[&str],
+    incoming: &[Value],
+    current: &[Value],
+) -> bool {
+    columns.iter().enumerate().any(|(index, column)| {
+        if column.eq_ignore_ascii_case("metadata") {
+            metadata_file_identity(&incoming[index]) != metadata_file_identity(&current[index])
+        } else if ["projectId", "targetId", "acquireddate", "filtername"]
+            .iter()
+            .any(|identity| column.eq_ignore_ascii_case(identity))
+        {
+            !value_eq(&incoming[index], &current[index])
+        } else {
+            false
+        }
+    })
 }
 
 /// Column names of `table` in declared order.
@@ -483,9 +532,10 @@ fn upsert_acquired_images(
     let guid_w = wpos("guid").unwrap();
     let grade_w = wpos("gradingStatus").ok_or_else(|| anyhow!("gradingStatus missing"))?;
     let reason_w = wpos("rejectreason");
-    let proj_w = wpos("projectId");
-    let tgt_w = wpos("targetId");
+    let proj_w = wpos("projectId").ok_or_else(|| anyhow!("projectId missing"))?;
+    let tgt_w = wpos("targetId").ok_or_else(|| anyhow!("targetId missing"))?;
     let expo_w = wpos("exposureId");
+    let acquired_date_w = wpos("acquireddate");
 
     // Pre-pull destination state + duplicate-guid sets (ambiguous rows skipped).
     let (dest_map, dest_dups) = dest_guid_map(tx, table, &write_cols, guid_w)?;
@@ -545,8 +595,8 @@ fn upsert_acquired_images(
         // projectId/targetId are required FKs: skip the row if either parent
         // wasn't pulled, rather than retaining a source id that points at an
         // unrelated destination row.
-        if !remap_fk_checked(&mut write_values, proj_w, proj_map)
-            || !remap_fk_checked(&mut write_values, tgt_w, tgt_map)
+        if !remap_fk_checked(&mut write_values, Some(proj_w), proj_map)
+            || !remap_fk_checked(&mut write_values, Some(tgt_w), tgt_map)
         {
             summary.acquiredimage.skipped += 1;
             summary
@@ -561,6 +611,11 @@ fn upsert_acquired_images(
         {
             write_values[p] = Value::Integer(plan_map.get(&src_plan).copied().unwrap_or(0));
         }
+        let project_id = as_i64(&write_values[proj_w])
+            .ok_or_else(|| anyhow!("acquiredimage.projectId is not an integer"))?;
+        let target_id = as_i64(&write_values[tgt_w])
+            .ok_or_else(|| anyhow!("acquiredimage.targetId is not an integer"))?;
+        let acquired_date = acquired_date_w.and_then(|position| as_i64(&write_values[position]));
 
         match dest_map.get(&guid) {
             Some((dest_id, cur_vals)) => {
@@ -581,12 +636,22 @@ fn upsert_acquired_images(
                 if values_equal(&write_values, cur_vals) {
                     summary.acquiredimage.unchanged += 1;
                 } else {
+                    let discovery_identity_changed =
+                        file_discovery_identity_changed(&write_cols, &write_values, cur_vals);
                     let mut p: Vec<&dyn ToSql> =
                         write_values.iter().map(|v| v as &dyn ToSql).collect();
                     let did = *dest_id;
                     p.push(&did);
                     upd_stmt.execute(p.as_slice())?;
                     summary.acquiredimage.updated += 1;
+                    if discovery_identity_changed {
+                        summary.changed_acquiredimages.push(ChangedAcquiredImage {
+                            id: did,
+                            project_id,
+                            target_id,
+                            acquired_date,
+                        });
+                    }
                     summary
                         .changes
                         .push(format!("update acquiredimage {}", guid));
@@ -597,6 +662,12 @@ fn upsert_acquired_images(
                 let dest_id = tx.last_insert_rowid();
                 id_map.insert(src_id, dest_id);
                 summary.acquiredimage.inserted += 1;
+                summary.changed_acquiredimages.push(ChangedAcquiredImage {
+                    id: dest_id,
+                    project_id,
+                    target_id,
+                    acquired_date,
+                });
                 summary
                     .changes
                     .push(format!("insert acquiredimage {}", guid));
@@ -1032,6 +1103,12 @@ mod tests {
         assert_eq!(s.exposureplan.inserted, 1);
         assert_eq!(s.acquiredimage.inserted, 2);
         assert_eq!(s.ruleweight.inserted, 1);
+        assert_eq!(s.changed_acquiredimages.len(), 2);
+        assert!(s.changed_acquiredimages.iter().all(|image| {
+            image.project_id == 1
+                && image.target_id == 1
+                && matches!(image.acquired_date, Some(1000 | 2000))
+        }));
 
         // Referential integrity: target.projectid points at the new project Id,
         // and acquiredimage FKs resolve.
@@ -1058,12 +1135,17 @@ mod tests {
              INSERT INTO target (Id,name,active,ra,dec,epochcode,projectid,guid) VALUES (70,'OtherT',1,0,0,0,50,'other-tg');",
         ).unwrap();
 
-        sync_pull(&src, &dest, &opts()).unwrap();
+        let summary = sync_pull(&src, &dest, &opts()).unwrap();
         // Pulled project got a fresh Id (not 1); its target points at it.
         let proj_id: i64 = one(&dest, "SELECT Id FROM project WHERE guid='pg'");
         assert_ne!(proj_id, 1);
         let tgt_proj: i64 = one(&dest, "SELECT projectid FROM target WHERE guid='tg'");
         assert_eq!(tgt_proj, proj_id);
+        let target_id: i64 = one(&dest, "SELECT Id FROM target WHERE guid='tg'");
+        assert!(summary
+            .changed_acquiredimages
+            .iter()
+            .all(|image| { image.project_id == proj_id && image.target_id == target_id }));
         // acquiredimage.exposureId remapped to the dest plan Id.
         let plan_id: i64 = one(&dest, "SELECT Id FROM exposureplan WHERE guid='lg'");
         assert_eq!(
@@ -1126,6 +1208,24 @@ mod tests {
     }
 
     #[test]
+    fn grade_only_update_does_not_register_a_file_arrival() {
+        let src = telescope();
+        let dest = empty_local();
+        sync_pull(&src, &dest, &opts()).unwrap();
+        dest.execute(
+            "UPDATE acquiredimage SET gradingStatus=0 WHERE guid='img1'",
+            [],
+        )
+        .unwrap();
+
+        let summary = sync_pull(&src, &dest, &opts()).unwrap();
+
+        assert_eq!(summary.grade_filled, 1);
+        assert_eq!(summary.acquiredimage.updated, 1);
+        assert!(summary.changed_acquiredimages.is_empty());
+    }
+
+    #[test]
     fn pull_derives_accepted_counts_from_merged_grades() {
         // The telescope's counter says 8, but only one of its images is
         // actually Accepted. The pull must not copy the stale counter — the
@@ -1157,6 +1257,7 @@ mod tests {
         assert_eq!(s.exposureplan.inserted + s.exposureplan.updated, 0);
         assert_eq!(s.acquiredimage.inserted + s.acquiredimage.updated, 0);
         assert_eq!(s.acquiredimage.unchanged, 2);
+        assert!(s.changed_acquiredimages.is_empty());
     }
 
     #[test]

--- a/src/directory_tree.rs
+++ b/src/directory_tree.rs
@@ -191,6 +191,70 @@ impl DirectoryTree {
         self.file_map.get(filename).and_then(|paths| paths.first())
     }
 
+    pub(crate) fn contains_path(&self, path: &Path) -> bool {
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|filename| self.file_map.get(filename))
+            .is_some_and(|paths| paths.iter().any(|known| known == path))
+    }
+
+    /// Add one file discovered after the tree was built.
+    ///
+    /// This is intentionally narrower than a refresh: a request that proves a
+    /// delayed copy has arrived can make later lookups see it without changing
+    /// the tree's age or walking the image roots again.
+    pub(crate) fn insert_file(&mut self, path: &Path) -> bool {
+        let Some(root_index) = self.roots.iter().position(|root| path.starts_with(root)) else {
+            return false;
+        };
+        let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+
+        let insert_at = {
+            let paths = self.file_map.entry(filename.to_string()).or_default();
+            if paths.iter().any(|known| known == path) {
+                return false;
+            }
+            paths
+                .iter()
+                .position(|known| {
+                    self.roots
+                        .iter()
+                        .position(|root| known.starts_with(root))
+                        .unwrap_or(self.roots.len())
+                        > root_index
+                })
+                .unwrap_or(paths.len())
+        };
+        self.file_map
+            .get_mut(filename)
+            .expect("filename entry was just created")
+            .insert(insert_at, path.to_path_buf());
+
+        // Keep directory browsing coherent too. Each parent contains its
+        // immediate child, up to and including the configured root.
+        let root = &self.roots[root_index];
+        let mut child = path.to_path_buf();
+        let mut parent = path.parent();
+        while let Some(directory) = parent {
+            if !directory.starts_with(root) {
+                break;
+            }
+            let contents = self.dir_map.entry(directory.to_path_buf()).or_default();
+            if !contents.iter().any(|known| known == &child) {
+                contents.push(child.clone());
+            }
+            if directory == root {
+                break;
+            }
+            child = directory.to_path_buf();
+            parent = directory.parent();
+        }
+
+        true
+    }
+
     /// Find files matching a pattern in the filename
     pub fn find_files_matching<F>(&self, predicate: F) -> Vec<&PathBuf>
     where
@@ -353,6 +417,53 @@ mod tests {
         assert!(tree.find_file("good.fits").is_some());
         assert!(tree.find_file("dark1.fits").is_some());
         assert!(tree.find_file("config").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn inserts_a_delayed_file_without_refreshing_the_tree_age() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let root = temp_dir.path();
+        let mut tree = DirectoryTree::build(root)?;
+        std::thread::sleep(Duration::from_millis(5));
+        let age_before = tree.stats().age;
+
+        let nested = root.join("target/night/LIGHT");
+        fs::create_dir_all(&nested)?;
+        let delayed = nested.join("delayed.fits");
+        fs::write(&delayed, "test")?;
+
+        assert!(tree.insert_file(&delayed));
+        assert_eq!(tree.find_file_first("delayed.fits"), Some(&delayed));
+        assert!(tree.stats().age >= age_before);
+        assert!(tree
+            .get_directory_contents(root)
+            .is_some_and(|entries| entries.contains(&root.join("target"))));
+        assert!(!tree.insert_file(&delayed), "a retry stays idempotent");
+
+        Ok(())
+    }
+
+    #[test]
+    fn delayed_insert_keeps_configured_root_priority() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let first_root = temp_dir.path().join("first");
+        let second_root = temp_dir.path().join("second");
+        fs::create_dir_all(&first_root)?;
+        fs::create_dir_all(&second_root)?;
+        let second = second_root.join("same.fits");
+        fs::write(&second, "second")?;
+        let mut tree = DirectoryTree::build_multiple(&[&first_root, &second_root])?;
+
+        let first = first_root.join("same.fits");
+        fs::write(&first, "first")?;
+        assert!(tree.insert_file(&first));
+        assert_eq!(tree.find_file("same.fits"), Some(&vec![first, second]));
+
+        let outside = temp_dir.path().join("outside.fits");
+        fs::write(&outside, "outside")?;
+        assert!(!tree.insert_file(&outside));
 
         Ok(())
     }

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -13,10 +13,12 @@ use crate::directory_tree::DirectoryTree;
 use crate::server::state::{FileCheckCache, RefreshProgress, RefreshStage, RefreshStatus};
 use anyhow::Result;
 use rusqlite::{Connection, OpenFlags};
-use std::path::PathBuf;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex as TokioMutex;
 
 /// Flags used to (re)open a writable scheduler database connection. `NO_MUTEX`
@@ -267,6 +269,15 @@ pub struct DatabaseContext {
     reopen_lock: Arc<Mutex<()>>,
     pub file_check_cache: Arc<RwLock<FileCheckCache>>,
     pub directory_tree_cache: Arc<RwLock<Option<DirectoryTree>>>,
+    /// Files proven by requests since the current tree scan began. A rebuild
+    /// merges these just before publishing so it cannot overwrite a late hit.
+    directory_tree_additions: Arc<RwLock<HashSet<PathBuf>>>,
+    /// Navigation facts proven since the current file-cache refresh began.
+    file_check_additions: Arc<RwLock<HashMap<(i32, i32), FileCheckAddition>>>,
+    /// Images changed by a scheduler pull whose source files may arrive
+    /// shortly afterwards. Status polling advances each entry through a
+    /// bounded, nonblocking probe schedule.
+    delayed_remote_images: Arc<Mutex<HashMap<i32, DelayedRemoteImage>>>,
     /// Serializes cold directory-tree builds so N concurrent requests on an
     /// empty cache share one filesystem scan instead of starting N.
     tree_build_lock: Arc<Mutex<()>>,
@@ -292,6 +303,116 @@ pub struct DatabaseContext {
     /// Serializes publish/import for remotely posted images within one
     /// database, keeping basename checks and database inserts coherent.
     pub image_import_mutex: Arc<TokioMutex<()>>,
+}
+
+const DELAYED_REMOTE_IMAGE_GRACE: Duration = Duration::from_secs(10 * 60);
+const DELAYED_REMOTE_IMAGE_BACKOFF_SECS: [u64; 3] = [1, 2, 5];
+const MAX_DELAYED_REMOTE_IMAGES: usize = 4096;
+
+#[derive(Debug, Clone)]
+struct DelayedRemoteImage {
+    expires_at: Instant,
+    next_probe_at: Instant,
+    backoff_step: usize,
+    observed_source: Option<ArrivalSourceFingerprint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ArrivalSourceFingerprint {
+    canonical_path: PathBuf,
+    len: u64,
+    modified: Option<std::time::SystemTime>,
+}
+
+fn arrival_source_fingerprint(path: &Path) -> Option<ArrivalSourceFingerprint> {
+    let metadata = std::fs::metadata(path).ok()?;
+    Some(ArrivalSourceFingerprint {
+        canonical_path: std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()),
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+fn advance_delayed_probe(arrival: &mut DelayedRemoteImage, now: Instant) {
+    let delay = DELAYED_REMOTE_IMAGE_BACKOFF_SECS[arrival
+        .backoff_step
+        .min(DELAYED_REMOTE_IMAGE_BACKOFF_SECS.len() - 1)];
+    arrival.next_probe_at = now + Duration::from_secs(delay);
+    arrival.backoff_step =
+        (arrival.backoff_step + 1).min(DELAYED_REMOTE_IMAGE_BACKOFF_SECS.len() - 1);
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FileCheckAddition {
+    has_files: bool,
+    latest_image_date: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DelayedFileProbe {
+    NotPending,
+    Wait,
+    Probe,
+}
+
+fn publish_directory_tree_cache(
+    cache: &RwLock<Option<DirectoryTree>>,
+    additions: &RwLock<HashSet<PathBuf>>,
+    mut rebuilt: DirectoryTree,
+) -> DirectoryTree {
+    // Lock order matches record_resolved_image_file. The filesystem scan is
+    // already finished; only small in-memory merges happen while held.
+    let mut additions = additions.write().unwrap();
+    // The set is normally tiny. Check liveness before taking the tree cache
+    // lock so a file deleted while the scan ran is not published as a stale
+    // positive, and no filesystem call runs under the tree write lock.
+    let live_additions: Vec<PathBuf> = additions
+        .iter()
+        .filter(|path| path.is_file())
+        .cloned()
+        .collect();
+    let mut cache = cache.write().unwrap();
+    for path in &live_additions {
+        rebuilt.insert_file(path);
+    }
+    *cache = Some(rebuilt.clone());
+    additions.clear();
+    rebuilt
+}
+
+fn publish_file_check_cache(
+    cache: &RwLock<FileCheckCache>,
+    additions: &RwLock<HashMap<(i32, i32), FileCheckAddition>>,
+    projects_with_files: HashMap<i32, bool>,
+    project_latest_image_dates: HashMap<i32, i64>,
+    targets_with_files: HashMap<i32, bool>,
+) {
+    // Lock order matches record_resolved_image_file. A request that proves a
+    // late file while this refresh is publishing either lands in this merge
+    // or waits and patches the published snapshot immediately afterwards.
+    let mut additions = additions.write().unwrap();
+    let mut cache = cache.write().unwrap();
+    cache.projects_with_files = projects_with_files;
+    cache.project_latest_image_dates = project_latest_image_dates;
+    cache.targets_with_files = targets_with_files;
+    cache.has_initial_data = true;
+    for (&(project_id, target_id), addition) in additions.iter() {
+        if addition.has_files {
+            cache.record_resolved_image(project_id, target_id, addition.latest_image_date);
+        } else {
+            cache.projects_with_files.entry(project_id).or_insert(false);
+            cache.targets_with_files.entry(target_id).or_insert(false);
+            if let Some(acquired_date) = addition.latest_image_date {
+                cache
+                    .project_latest_image_dates
+                    .entry(project_id)
+                    .and_modify(|latest| *latest = (*latest).max(acquired_date))
+                    .or_insert(acquired_date);
+            }
+        }
+    }
+    additions.clear();
+    cache.last_updated = std::time::Instant::now();
 }
 
 impl DatabaseContext {
@@ -380,6 +501,9 @@ impl DatabaseContext {
             reopen_lock: Arc::new(Mutex::new(())),
             file_check_cache: Arc::new(RwLock::new(FileCheckCache::new())),
             directory_tree_cache: Arc::new(RwLock::new(None)),
+            directory_tree_additions: Arc::new(RwLock::new(HashSet::new())),
+            file_check_additions: Arc::new(RwLock::new(HashMap::new())),
+            delayed_remote_images: Arc::new(Mutex::new(HashMap::new())),
             tree_build_lock: Arc::new(Mutex::new(())),
             tree_rebuild_inflight: Arc::new(AtomicBool::new(false)),
             refresh_mutex: Arc::new(TokioMutex::new(())),
@@ -567,8 +691,11 @@ impl DatabaseContext {
         };
         let ctx = self.clone();
         std::thread::spawn(move || {
-            let _inflight = inflight;
             let _build_guard = lock_recover(ctx.tree_build_lock.as_ref());
+            // Drop the in-flight marker before releasing the build lock. A
+            // waiter that acquires the lock next can then own the marker for
+            // its actual scan instead of observing the prior scanner's flag.
+            let _inflight = inflight;
             {
                 let cache = ctx.directory_tree_cache.read().unwrap();
                 if let Some(ref tree) = *cache
@@ -611,6 +738,11 @@ impl DatabaseContext {
         let roots: Vec<&std::path::Path> =
             self.image_dir_paths.iter().map(|p| p.as_path()).collect();
         let tree = DirectoryTree::build_multiple(&roots)?;
+        let tree = publish_directory_tree_cache(
+            self.directory_tree_cache.as_ref(),
+            self.directory_tree_additions.as_ref(),
+            tree,
+        );
         let stats = tree.stats();
 
         tracing::debug!(
@@ -621,11 +753,6 @@ impl DatabaseContext {
             stats.roots.len(),
             stats.format_age()
         );
-
-        {
-            let mut cache = self.directory_tree_cache.write().unwrap();
-            *cache = Some(tree.clone());
-        }
 
         Ok(Arc::new(tree))
     }
@@ -674,6 +801,275 @@ impl DatabaseContext {
     pub fn get_directory_tree_stats(&self) -> Option<crate::directory_tree::DirectoryTreeStats> {
         let cache = self.directory_tree_cache.read().unwrap();
         cache.as_ref().map(|tree| tree.stats())
+    }
+
+    /// Record one source file that a request found after the cached tree was
+    /// built. This updates only the proven path and its navigation rows; it
+    /// does not reset either cache's age or scan the configured roots.
+    pub(crate) fn record_resolved_image_file(
+        &self,
+        image: &crate::models::AcquiredImage,
+        path: &std::path::Path,
+    ) {
+        let tree_needs_update = self.tree_rebuild_inflight.load(Ordering::SeqCst) || {
+            let cache = self.directory_tree_cache.read().unwrap();
+            cache
+                .as_ref()
+                .is_none_or(|directory_tree| !directory_tree.contains_path(path))
+        };
+        let inserted = if tree_needs_update {
+            let mut additions = self.directory_tree_additions.write().unwrap();
+            let mut cache = self.directory_tree_cache.write().unwrap();
+            let preserve_for_rebuild =
+                self.tree_rebuild_inflight.load(Ordering::SeqCst) || cache.is_none();
+            if preserve_for_rebuild {
+                additions.insert(path.to_path_buf());
+            }
+            cache
+                .as_mut()
+                .is_some_and(|directory_tree| directory_tree.insert_file(path))
+        } else {
+            false
+        };
+
+        let file_cache_needs_update = {
+            let cache = self.file_check_cache.read().unwrap();
+            cache.refresh_in_progress
+                || !cache.has_initial_data
+                || cache.projects_with_files.get(&image.project_id) != Some(&true)
+                || cache.targets_with_files.get(&image.target_id) != Some(&true)
+                || image.acquired_date.is_some_and(|acquired_date| {
+                    cache
+                        .project_latest_image_dates
+                        .get(&image.project_id)
+                        .is_none_or(|latest| *latest < acquired_date)
+                })
+        };
+        if file_cache_needs_update {
+            let mut additions = self.file_check_additions.write().unwrap();
+            let mut cache = self.file_check_cache.write().unwrap();
+            if cache.refresh_in_progress || !cache.has_initial_data {
+                additions
+                    .entry((image.project_id, image.target_id))
+                    .and_modify(|addition| {
+                        addition.has_files = true;
+                        if image.acquired_date > addition.latest_image_date {
+                            addition.latest_image_date = image.acquired_date;
+                        }
+                    })
+                    .or_insert(FileCheckAddition {
+                        has_files: true,
+                        latest_image_date: image.acquired_date,
+                    });
+            }
+            cache.record_resolved_image(image.project_id, image.target_id, image.acquired_date);
+        }
+        if inserted {
+            tracing::debug!(
+                "Added delayed image {} to the directory cache for db={}",
+                path.display(),
+                self.id
+            );
+        }
+    }
+
+    /// Give acquired-image rows changed by a successful scheduler pull a
+    /// bounded window in which their separately copied source files may
+    /// arrive. Also seed navigation as known-but-missing immediately, so a
+    /// fresh project or target is visible before the file cache refreshes.
+    pub(crate) fn register_remote_image_arrivals(
+        &self,
+        changed_images: &[crate::commands::sync::ChangedAcquiredImage],
+    ) {
+        if changed_images.is_empty() {
+            return;
+        }
+        let mut navigation: HashMap<(i32, i32), Option<i64>> = HashMap::new();
+        let mut candidate_dates: HashMap<i32, i64> = HashMap::new();
+        let mut newest = BinaryHeap::with_capacity(MAX_DELAYED_REMOTE_IMAGES + 1);
+        for image in changed_images {
+            let (Ok(image_id), Ok(project_id), Ok(target_id)) = (
+                i32::try_from(image.id),
+                i32::try_from(image.project_id),
+                i32::try_from(image.target_id),
+            ) else {
+                continue;
+            };
+            navigation
+                .entry((project_id, target_id))
+                .and_modify(|latest| {
+                    if image.acquired_date > *latest {
+                        *latest = image.acquired_date;
+                    }
+                })
+                .or_insert(image.acquired_date);
+
+            candidate_dates
+                .entry(image_id)
+                .and_modify(|date| {
+                    *date = (*date).max(image.acquired_date.unwrap_or(i64::MIN));
+                })
+                .or_insert(image.acquired_date.unwrap_or(i64::MIN));
+        }
+        for (image_id, acquired_date) in candidate_dates {
+            newest.push(Reverse((acquired_date, image_id)));
+            if newest.len() > MAX_DELAYED_REMOTE_IMAGES {
+                newest.pop();
+            }
+        }
+
+        {
+            let mut additions = self.file_check_additions.write().unwrap();
+            let mut cache = self.file_check_cache.write().unwrap();
+            for (&(project_id, target_id), &acquired_date) in &navigation {
+                if cache.refresh_in_progress || !cache.has_initial_data {
+                    additions
+                        .entry((project_id, target_id))
+                        .and_modify(|addition| {
+                            if acquired_date > addition.latest_image_date {
+                                addition.latest_image_date = acquired_date;
+                            }
+                        })
+                        .or_insert(FileCheckAddition {
+                            has_files: false,
+                            latest_image_date: acquired_date,
+                        });
+                }
+                cache.projects_with_files.entry(project_id).or_insert(false);
+                cache.targets_with_files.entry(target_id).or_insert(false);
+                if let Some(acquired_date) = acquired_date {
+                    cache
+                        .project_latest_image_dates
+                        .entry(project_id)
+                        .and_modify(|latest| *latest = (*latest).max(acquired_date))
+                        .or_insert(acquired_date);
+                }
+            }
+        }
+
+        let now = Instant::now();
+        let mut pending = self.delayed_remote_images.lock().unwrap();
+        pending.retain(|_, arrival| arrival.expires_at > now);
+        for Reverse((_, image_id)) in newest {
+            pending.insert(
+                image_id,
+                DelayedRemoteImage {
+                    expires_at: now + DELAYED_REMOTE_IMAGE_GRACE,
+                    next_probe_at: now,
+                    backoff_step: 0,
+                    observed_source: None,
+                },
+            );
+        }
+        if pending.len() > MAX_DELAYED_REMOTE_IMAGES {
+            let mut by_recency: Vec<(i32, Instant)> = pending
+                .iter()
+                .map(|(&image_id, arrival)| (image_id, arrival.expires_at))
+                .collect();
+            by_recency.sort_unstable_by_key(|entry| Reverse(entry.1));
+            let keep: HashSet<i32> = by_recency
+                .into_iter()
+                .take(MAX_DELAYED_REMOTE_IMAGES)
+                .map(|(image_id, _)| image_id)
+                .collect();
+            pending.retain(|image_id, _| keep.contains(image_id));
+        }
+    }
+
+    /// Advance one delayed source through its 1s, 2s, then 5s capped probe
+    /// schedule. Callers do no filesystem work for `Wait`.
+    pub(crate) fn delayed_file_probe(&self, image_id: i32) -> DelayedFileProbe {
+        let now = Instant::now();
+        let mut pending = self.delayed_remote_images.lock().unwrap();
+        let Some(arrival) = pending.get_mut(&image_id) else {
+            return DelayedFileProbe::NotPending;
+        };
+        if arrival.expires_at <= now {
+            pending.remove(&image_id);
+            return DelayedFileProbe::NotPending;
+        }
+        if arrival.next_probe_at > now {
+            return DelayedFileProbe::Wait;
+        }
+        advance_delayed_probe(arrival, now);
+        DelayedFileProbe::Probe
+    }
+
+    /// Claim at most `limit` due probes for a status batch under one tracker
+    /// lock. Oldest deadlines win, so deferred images are selected before the
+    /// previous batch's probes become due again.
+    pub(crate) fn delayed_file_probes_for_batch(
+        &self,
+        image_ids: &[i32],
+        limit: usize,
+    ) -> HashMap<i32, DelayedFileProbe> {
+        let now = Instant::now();
+        let requested: HashSet<i32> = image_ids.iter().copied().collect();
+        let mut pending = self.delayed_remote_images.lock().unwrap();
+        pending.retain(|_, arrival| arrival.expires_at > now);
+
+        let mut result = HashMap::with_capacity(requested.len());
+        let mut due = Vec::new();
+        for image_id in requested {
+            match pending.get(&image_id) {
+                None => {
+                    result.insert(image_id, DelayedFileProbe::NotPending);
+                }
+                Some(arrival) if arrival.next_probe_at > now => {
+                    result.insert(image_id, DelayedFileProbe::Wait);
+                }
+                Some(arrival) => {
+                    result.insert(image_id, DelayedFileProbe::Wait);
+                    due.push((arrival.next_probe_at, image_id));
+                }
+            }
+        }
+        due.sort_unstable();
+        for (_, image_id) in due.into_iter().take(limit) {
+            if let Some(arrival) = pending.get_mut(&image_id) {
+                advance_delayed_probe(arrival, now);
+                result.insert(image_id, DelayedFileProbe::Probe);
+            }
+        }
+        result
+    }
+
+    /// Retire a delayed-arrival probe after a completed artifact has been
+    /// validated against the source's current fingerprint. The next browser
+    /// reload can then take the ordinary cache-hit path instead of re-entering
+    /// the probe backoff.
+    pub(crate) fn complete_delayed_file_probe(&self, image_id: i32, source_path: &Path) -> bool {
+        let fingerprint = arrival_source_fingerprint(source_path);
+        let mut pending = self.delayed_remote_images.lock().unwrap();
+        let validated = pending.get(&image_id).is_some_and(|arrival| {
+            fingerprint.is_some() && arrival.observed_source.as_ref() == fingerprint.as_ref()
+        });
+        if validated {
+            pending.remove(&image_id);
+        }
+        validated
+    }
+
+    /// A tracked source must present the same path/size/mtime on two scheduled
+    /// observations before decoding. This narrows the window where a copy
+    /// pauses at a decodable prefix and would otherwise produce a permanent
+    /// preview before more pixels arrive.
+    pub(crate) fn delayed_source_is_stable(&self, image_id: i32, path: &Path) -> bool {
+        let fingerprint = arrival_source_fingerprint(path);
+        let mut pending = self.delayed_remote_images.lock().unwrap();
+        let Some(arrival) = pending.get_mut(&image_id) else {
+            return true;
+        };
+        if arrival.expires_at <= Instant::now() {
+            pending.remove(&image_id);
+            return true;
+        }
+        if arrival.observed_source.as_ref() == fingerprint.as_ref() && fingerprint.is_some() {
+            true
+        } else {
+            arrival.observed_source = fingerprint;
+            false
+        }
     }
 
     pub fn ensure_cache_available(&self) -> RefreshStatus {
@@ -853,14 +1249,13 @@ impl DatabaseContext {
                 .set_stage(RefreshStage::UpdatingCache);
         }
 
-        {
-            let mut cache = self.file_check_cache.write().unwrap();
-            cache.projects_with_files = project_cache_updates;
-            cache.project_latest_image_dates = project_latest_image_updates;
-            cache.targets_with_files = target_cache_updates;
-            cache.last_updated = std::time::Instant::now();
-            cache.has_initial_data = true;
-        }
+        publish_file_check_cache(
+            self.file_check_cache.as_ref(),
+            self.file_check_additions.as_ref(),
+            project_cache_updates,
+            project_latest_image_updates,
+            target_cache_updates,
+        );
 
         let duration = start_time.elapsed();
         let total_checked = projects.len() + total_targets;
@@ -976,8 +1371,6 @@ impl DatabaseContext {
             }
         }
 
-        let _inflight = self.try_mark_directory_tree_rebuild();
-
         tracing::info!(
             "🌳 Building directory tree cache for db={} ({} directories) with progress tracking",
             self.id,
@@ -1001,7 +1394,9 @@ impl DatabaseContext {
 
         let image_dir_paths = self.image_dir_paths.clone();
         let directory_tree_cache = Arc::clone(&self.directory_tree_cache);
+        let directory_tree_additions = Arc::clone(&self.directory_tree_additions);
         let tree_build_lock = Arc::clone(&self.tree_build_lock);
+        let tree_rebuild_inflight = Arc::clone(&self.tree_rebuild_inflight);
         let tree_result = tokio::task::spawn_blocking(move || -> Result<(DirectoryTree, bool)> {
             let _build_guard = lock_recover(tree_build_lock.as_ref());
             {
@@ -1012,6 +1407,13 @@ impl DatabaseContext {
                     return Ok((tree.clone(), false));
                 }
             }
+            let _inflight = if tree_rebuild_inflight.swap(true, Ordering::SeqCst) {
+                None
+            } else {
+                Some(TreeRebuildInflight {
+                    flag: Arc::clone(&tree_rebuild_inflight),
+                })
+            };
 
             let roots: Vec<&std::path::Path> =
                 image_dir_paths.iter().map(|p| p.as_path()).collect();
@@ -1029,11 +1431,11 @@ impl DatabaseContext {
                 &roots,
                 &mut progress_callback,
             )?;
-
-            {
-                let mut cache = directory_tree_cache.write().unwrap();
-                *cache = Some(tree.clone());
-            }
+            let tree = publish_directory_tree_cache(
+                directory_tree_cache.as_ref(),
+                directory_tree_additions.as_ref(),
+                tree,
+            );
 
             Ok((tree, true))
         })
@@ -1097,6 +1499,9 @@ impl DatabaseContext {
             reopen_lock: Arc::new(Mutex::new(())),
             file_check_cache: Arc::new(RwLock::new(FileCheckCache::new())),
             directory_tree_cache: Arc::new(RwLock::new(None)),
+            directory_tree_additions: Arc::new(RwLock::new(HashSet::new())),
+            file_check_additions: Arc::new(RwLock::new(HashMap::new())),
+            delayed_remote_images: Arc::new(Mutex::new(HashMap::new())),
             tree_build_lock: Arc::new(Mutex::new(())),
             tree_rebuild_inflight: Arc::new(AtomicBool::new(false)),
             refresh_mutex: Arc::new(TokioMutex::new(())),
@@ -1129,6 +1534,9 @@ impl Clone for DatabaseContext {
             reopen_lock: self.reopen_lock.clone(),
             file_check_cache: self.file_check_cache.clone(),
             directory_tree_cache: self.directory_tree_cache.clone(),
+            directory_tree_additions: self.directory_tree_additions.clone(),
+            file_check_additions: self.file_check_additions.clone(),
+            delayed_remote_images: self.delayed_remote_images.clone(),
             tree_build_lock: self.tree_build_lock.clone(),
             tree_rebuild_inflight: self.tree_rebuild_inflight.clone(),
             refresh_mutex: self.refresh_mutex.clone(),
@@ -1346,6 +1754,175 @@ mod tests {
         assert_eq!(cache.targets_with_files.get(&10), Some(&true));
         assert_eq!(cache.targets_with_files.get(&20), Some(&false));
         assert_eq!(cache.targets_with_files.get(&30), Some(&false));
+    }
+
+    #[test]
+    fn cold_remote_arrival_seeds_navigation_without_suppressing_refresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("sched.sqlite");
+        make_file_refresh_db(&db_path);
+        let ctx = build_ctx(tmp.path(), &db_path);
+        let changed = [crate::commands::sync::ChangedAcquiredImage {
+            id: 500,
+            project_id: 42,
+            target_id: 84,
+            acquired_date: Some(12_345),
+        }];
+
+        ctx.register_remote_image_arrivals(&changed);
+
+        {
+            let cache = ctx.file_check_cache.read().unwrap();
+            assert!(!cache.has_initial_data);
+            assert_eq!(cache.projects_with_files.get(&42), Some(&false));
+            assert_eq!(cache.targets_with_files.get(&84), Some(&false));
+            assert_eq!(cache.project_latest_image_dates.get(&42), Some(&12_345));
+            assert_eq!(cache.get_refresh_status(), RefreshStatus::NeedsRefresh);
+        }
+
+        publish_file_check_cache(
+            ctx.file_check_cache.as_ref(),
+            ctx.file_check_additions.as_ref(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+        let cache = ctx.file_check_cache.read().unwrap();
+        assert_eq!(cache.projects_with_files.get(&42), Some(&false));
+        assert_eq!(cache.targets_with_files.get(&84), Some(&false));
+        assert_eq!(cache.project_latest_image_dates.get(&42), Some(&12_345));
+    }
+
+    #[test]
+    fn delayed_arrival_probe_backs_off_expires_and_requires_stability() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("sched.sqlite");
+        make_file_refresh_db(&db_path);
+        let ctx = build_ctx(tmp.path(), &db_path);
+        ctx.register_remote_image_arrivals(&[crate::commands::sync::ChangedAcquiredImage {
+            id: 500,
+            project_id: 42,
+            target_id: 84,
+            acquired_date: Some(12_345),
+        }]);
+
+        assert_eq!(ctx.delayed_file_probe(500), DelayedFileProbe::Probe);
+        assert_eq!(ctx.delayed_file_probe(500), DelayedFileProbe::Wait);
+        {
+            let mut pending = ctx.delayed_remote_images.lock().unwrap();
+            pending.get_mut(&500).unwrap().next_probe_at = Instant::now();
+        }
+        assert_eq!(ctx.delayed_file_probe(500), DelayedFileProbe::Probe);
+
+        let source = tmp.path().join("images/arriving.fits");
+        std::fs::write(&source, b"first observation").unwrap();
+        assert!(!ctx.delayed_source_is_stable(500, &source));
+        assert!(ctx.delayed_source_is_stable(500, &source));
+        std::fs::write(&source, b"the source grew after a pause").unwrap();
+        assert!(!ctx.delayed_source_is_stable(500, &source));
+
+        ctx.delayed_remote_images
+            .lock()
+            .unwrap()
+            .get_mut(&500)
+            .unwrap()
+            .expires_at = Instant::now();
+        assert_eq!(ctx.delayed_file_probe(500), DelayedFileProbe::NotPending);
+    }
+
+    #[test]
+    fn delayed_batch_claim_is_bounded_fair_and_does_not_advance_deferred_ids() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("sched.sqlite");
+        make_file_refresh_db(&db_path);
+        let ctx = build_ctx(tmp.path(), &db_path);
+        let changed: Vec<_> = (1..=10)
+            .map(|id| crate::commands::sync::ChangedAcquiredImage {
+                id,
+                project_id: 42,
+                target_id: 84,
+                acquired_date: Some(12_345 + id),
+            })
+            .collect();
+        ctx.register_remote_image_arrivals(&changed);
+        let ids: Vec<i32> = (1..=10).collect();
+
+        let first = ctx.delayed_file_probes_for_batch(&ids, 8);
+        let first_probes: HashSet<i32> = first
+            .iter()
+            .filter_map(|(&id, &probe)| (probe == DelayedFileProbe::Probe).then_some(id))
+            .collect();
+        assert_eq!(first_probes.len(), 8);
+
+        let second = ctx.delayed_file_probes_for_batch(&ids, 8);
+        let second_probes: HashSet<i32> = second
+            .iter()
+            .filter_map(|(&id, &probe)| (probe == DelayedFileProbe::Probe).then_some(id))
+            .collect();
+        assert_eq!(second_probes.len(), 2);
+        assert!(first_probes.is_disjoint(&second_probes));
+    }
+
+    #[test]
+    fn delayed_completion_does_not_remove_a_concurrently_reregistered_arrival() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("sched.sqlite");
+        make_file_refresh_db(&db_path);
+        let ctx = build_ctx(tmp.path(), &db_path);
+        let changed = [crate::commands::sync::ChangedAcquiredImage {
+            id: 500,
+            project_id: 42,
+            target_id: 84,
+            acquired_date: Some(12_345),
+        }];
+        let source = tmp.path().join("arriving.fits");
+        std::fs::write(&source, b"complete").unwrap();
+        ctx.register_remote_image_arrivals(&changed);
+        assert!(!ctx.delayed_source_is_stable(500, &source));
+        assert!(ctx.delayed_source_is_stable(500, &source));
+
+        ctx.register_remote_image_arrivals(&changed);
+        assert!(!ctx.complete_delayed_file_probe(500, &source));
+        assert_eq!(ctx.delayed_file_probe(500), DelayedFileProbe::Probe);
+    }
+
+    #[test]
+    fn cache_publication_keeps_live_late_additions_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("images");
+        std::fs::create_dir_all(&root).unwrap();
+        let stale = DirectoryTree::build(&root).unwrap();
+        let live = root.join("late.fits");
+        let deleted = root.join("deleted.fits");
+        std::fs::write(&live, b"live").unwrap();
+        std::fs::write(&deleted, b"gone soon").unwrap();
+
+        let cache = RwLock::new(None);
+        let additions = RwLock::new(HashSet::from([live.clone(), deleted.clone()]));
+        std::fs::remove_file(&deleted).unwrap();
+        let published = publish_directory_tree_cache(&cache, &additions, stale);
+        assert!(published.contains_path(&live));
+        assert!(!published.contains_path(&deleted));
+
+        let file_cache = RwLock::new(FileCheckCache::new());
+        let file_additions = RwLock::new(HashMap::from([(
+            (7, 3),
+            FileCheckAddition {
+                has_files: true,
+                latest_image_date: Some(99),
+            },
+        )]));
+        publish_file_check_cache(
+            &file_cache,
+            &file_additions,
+            HashMap::from([(7, false)]),
+            HashMap::new(),
+            HashMap::from([(3, false)]),
+        );
+        let file_cache = file_cache.read().unwrap();
+        assert_eq!(file_cache.projects_with_files.get(&7), Some(&true));
+        assert_eq!(file_cache.targets_with_files.get(&3), Some(&true));
+        assert_eq!(file_cache.project_latest_image_dates.get(&7), Some(&99));
     }
 
     // Unix-only: the proactive reopen this exercises is itself `#[cfg(unix)]`

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -276,7 +276,8 @@ pub struct DatabaseContext {
     file_check_additions: Arc<RwLock<HashMap<(i32, i32), FileCheckAddition>>>,
     /// Images changed by a scheduler pull whose source files may arrive
     /// shortly afterwards. Status polling advances each entry through a
-    /// bounded, nonblocking probe schedule.
+    /// bounded, nonblocking probe schedule; expired entries remain as strict
+    /// identity markers until displaced by the bounded-cap policy.
     delayed_remote_images: Arc<Mutex<HashMap<i32, DelayedRemoteImage>>>,
     /// Serializes cold directory-tree builds so N concurrent requests on an
     /// empty cache share one filesystem scan instead of starting N.
@@ -949,7 +950,6 @@ impl DatabaseContext {
 
         let now = Instant::now();
         let mut pending = self.delayed_remote_images.lock().unwrap();
-        pending.retain(|_, arrival| arrival.expires_at > now);
         for Reverse((_, image_id)) in newest {
             pending.insert(
                 image_id,
@@ -985,7 +985,6 @@ impl DatabaseContext {
             return DelayedFileProbe::NotPending;
         };
         if arrival.expires_at <= now {
-            pending.remove(&image_id);
             return DelayedFileProbe::NotPending;
         }
         if arrival.next_probe_at > now {
@@ -993,6 +992,30 @@ impl DatabaseContext {
         }
         advance_delayed_probe(arrival, now);
         DelayedFileProbe::Probe
+    }
+
+    /// Whether every consumer of this row must use remote-arrival identity
+    /// validation. Unlike [`Self::delayed_file_probe`], this does not claim a
+    /// probe or advance its backoff; analysis, stacking, and pre-generation
+    /// still need the strict resolver while previews control polling cadence.
+    /// The identity requirement remains after polling expires.
+    pub(crate) fn requires_delayed_file_identity(&self, image_id: i32) -> bool {
+        self.delayed_remote_images
+            .lock()
+            .unwrap()
+            .contains_key(&image_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn expire_delayed_remote_image_for_test(&self, image_id: i32) {
+        if let Some(arrival) = self
+            .delayed_remote_images
+            .lock()
+            .unwrap()
+            .get_mut(&image_id)
+        {
+            arrival.expires_at = Instant::now();
+        }
     }
 
     /// Claim at most `limit` due probes for a status batch under one tracker
@@ -1006,13 +1029,15 @@ impl DatabaseContext {
         let now = Instant::now();
         let requested: HashSet<i32> = image_ids.iter().copied().collect();
         let mut pending = self.delayed_remote_images.lock().unwrap();
-        pending.retain(|_, arrival| arrival.expires_at > now);
 
         let mut result = HashMap::with_capacity(requested.len());
         let mut due = Vec::new();
         for image_id in requested {
             match pending.get(&image_id) {
                 None => {
+                    result.insert(image_id, DelayedFileProbe::NotPending);
+                }
+                Some(arrival) if arrival.expires_at <= now => {
                     result.insert(image_id, DelayedFileProbe::NotPending);
                 }
                 Some(arrival) if arrival.next_probe_at > now => {
@@ -1034,20 +1059,22 @@ impl DatabaseContext {
         result
     }
 
-    /// Retire a delayed-arrival probe after a completed artifact has been
-    /// validated against the source's current fingerprint. The next browser
-    /// reload can then take the ordinary cache-hit path instead of re-entering
-    /// the probe backoff.
+    /// Retire delayed-arrival polling after a completed artifact has been
+    /// validated against the source's current fingerprint. The entry remains
+    /// as a strict identity marker, so another consumer cannot later bind the
+    /// row to a stale same-basename file if the validated source disappears.
     pub(crate) fn complete_delayed_file_probe(&self, image_id: i32, source_path: &Path) -> bool {
         let fingerprint = arrival_source_fingerprint(source_path);
         let mut pending = self.delayed_remote_images.lock().unwrap();
-        let validated = pending.get(&image_id).is_some_and(|arrival| {
-            fingerprint.is_some() && arrival.observed_source.as_ref() == fingerprint.as_ref()
-        });
-        if validated {
-            pending.remove(&image_id);
+        let Some(arrival) = pending.get_mut(&image_id) else {
+            return false;
+        };
+        if fingerprint.is_some() && arrival.observed_source.as_ref() == fingerprint.as_ref() {
+            arrival.expires_at = Instant::now();
+            true
+        } else {
+            false
         }
-        validated
     }
 
     /// A tracked source must present the same path/size/mtime on two scheduled
@@ -1061,7 +1088,6 @@ impl DatabaseContext {
             return true;
         };
         if arrival.expires_at <= Instant::now() {
-            pending.remove(&image_id);
             return true;
         }
         if arrival.observed_source.as_ref() == fingerprint.as_ref() && fingerprint.is_some() {
@@ -1828,6 +1854,9 @@ mod tests {
             .unwrap()
             .expires_at = Instant::now();
         assert_eq!(ctx.delayed_file_probe(500), DelayedFileProbe::NotPending);
+        assert!(ctx.requires_delayed_file_identity(500));
+        assert!(ctx.delayed_source_is_stable(500, &source));
+        assert!(ctx.requires_delayed_file_identity(500));
     }
 
     #[test]
@@ -1884,6 +1913,29 @@ mod tests {
         ctx.register_remote_image_arrivals(&changed);
         assert!(!ctx.complete_delayed_file_probe(500, &source));
         assert_eq!(ctx.delayed_file_probe(500), DelayedFileProbe::Probe);
+    }
+
+    #[test]
+    fn delayed_completion_stops_polling_but_retains_identity_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("sched.sqlite");
+        make_file_refresh_db(&db_path);
+        let ctx = build_ctx(tmp.path(), &db_path);
+        let changed = [crate::commands::sync::ChangedAcquiredImage {
+            id: 500,
+            project_id: 42,
+            target_id: 84,
+            acquired_date: Some(12_345),
+        }];
+        let source = tmp.path().join("arriving.fits");
+        std::fs::write(&source, b"complete").unwrap();
+        ctx.register_remote_image_arrivals(&changed);
+        assert!(!ctx.delayed_source_is_stable(500, &source));
+        assert!(ctx.delayed_source_is_stable(500, &source));
+
+        assert!(ctx.complete_delayed_file_probe(500, &source));
+        assert_eq!(ctx.delayed_file_probe(500), DelayedFileProbe::NotPending);
+        assert!(ctx.requires_delayed_file_identity(500));
     }
 
     #[test]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -8,8 +8,10 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::fmt::Write as _;
+use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
@@ -650,7 +652,11 @@ pub(crate) async fn execute_scheduler_sync_paths(
     let destination_id_for_cache = destination_id.clone();
 
     let response = tokio::task::spawn_blocking(
-        move || -> anyhow::Result<(SchedulerSyncResponse, Option<String>)> {
+        move || -> anyhow::Result<(
+            SchedulerSyncResponse,
+            Option<String>,
+            Vec<crate::commands::sync::ChangedAcquiredImage>,
+        )> {
             let source_canon =
                 std::fs::canonicalize(&source_path).unwrap_or_else(|_| source_path.clone());
             let destination_canon = std::fs::canonicalize(&destination_path)
@@ -665,22 +671,25 @@ pub(crate) async fn execute_scheduler_sync_paths(
             let destination =
                 Connection::open_with_flags(&destination_path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
 
-            let run =
-                |transaction: Option<&Transaction<'_>>| -> anyhow::Result<SchedulerSyncResponse> {
-                    let response = match kind {
+            let run = |transaction: Option<&Transaction<'_>>| -> anyhow::Result<(
+                SchedulerSyncResponse,
+                Vec<crate::commands::sync::ChangedAcquiredImage>,
+            )> {
+                    let (response, changed_image_ids) = match kind {
                         SchedulerSyncKind::Pull => {
                             let options = PullOptions {
                                 dry_run,
                                 with_image_data,
                                 project_filter: project.clone(),
                             };
-                            let summary = match transaction {
+                        let mut summary = match transaction {
                                 Some(transaction) => {
                                     sync_pull_in_transaction(&source, transaction, &options)?
                                 }
                                 None => sync_pull(&source, &destination, &options)?,
                             };
-                            SchedulerSyncResponse {
+                        let changed_images = std::mem::take(&mut summary.changed_acquiredimages);
+                            (SchedulerSyncResponse {
                                 kind,
                                 dry_run,
                                 source_db_id: source_id,
@@ -701,7 +710,7 @@ pub(crate) async fn execute_scheduler_sync_paths(
                                 total_inserted: summary.total_inserted(),
                                 total_updated: summary.total_updated(),
                                 changes: capped_change_lines(summary.changes),
-                            }
+                            }, changed_images)
                         }
                         SchedulerSyncKind::PushPlanning => {
                             let options = PlanningOptions {
@@ -714,7 +723,7 @@ pub(crate) async fn execute_scheduler_sync_paths(
                                 }
                                 None => sync_planning(&source, &destination, &options)?,
                             };
-                            SchedulerSyncResponse {
+                            (SchedulerSyncResponse {
                                 kind,
                                 dry_run,
                                 source_db_id: source_id,
@@ -733,7 +742,7 @@ pub(crate) async fn execute_scheduler_sync_paths(
                                 total_inserted: summary.total_inserted(),
                                 total_updated: summary.total_updated(),
                                 changes: capped_change_lines(summary.changes),
-                            }
+                            }, Vec::new())
                         }
                         SchedulerSyncKind::PushGrades => {
                             let options = SyncGradesOptions {
@@ -749,7 +758,7 @@ pub(crate) async fn execute_scheduler_sync_paths(
                                 }
                                 None => sync_grades(&source, &destination, &options)?,
                             };
-                            SchedulerSyncResponse {
+                            (SchedulerSyncResponse {
                                 kind,
                                 dry_run,
                                 source_db_id: source_id,
@@ -797,14 +806,17 @@ pub(crate) async fn execute_scheduler_sync_paths(
                                         })
                                         .collect(),
                                 ),
-                            }
+                            }, Vec::new())
                         }
                     };
-                    Ok(response)
+                    Ok((response, changed_image_ids))
                 };
 
             match guard_mode {
-                SyncGuardMode::None => Ok((run(None)?, None)),
+                SyncGuardMode::None => {
+                    let (response, changed_image_ids) = run(None)?;
+                    Ok((response, None, changed_image_ids))
+                }
                 SyncGuardMode::Preview => {
                     let transaction =
                         Transaction::new_unchecked(&destination, TransactionBehavior::Deferred)?;
@@ -812,9 +824,9 @@ pub(crate) async fn execute_scheduler_sync_paths(
                         &transaction,
                         &fingerprint_queries,
                     )?;
-                    let response = run(Some(&transaction))?;
+                    let (response, _) = run(Some(&transaction))?;
                     transaction.rollback()?;
-                    Ok((response, Some(fingerprint)))
+                    Ok((response, Some(fingerprint), Vec::new()))
                 }
                 SyncGuardMode::Apply {
                     destination_fingerprint,
@@ -828,9 +840,9 @@ pub(crate) async fn execute_scheduler_sync_paths(
                     if fingerprint != destination_fingerprint {
                         return Err(StaleSyncPreview.into());
                     }
-                    let response = run(Some(&transaction))?;
+                    let (response, changed_image_ids) = run(Some(&transaction))?;
                     transaction.commit()?;
-                    Ok((response, None))
+                    Ok((response, None, changed_image_ids))
                 }
             }
         },
@@ -848,10 +860,25 @@ pub(crate) async fn execute_scheduler_sync_paths(
         }
     })?;
 
-    if !dry_run && let Some(destination_ctx) = state.get_database(&destination_id_for_cache) {
-        let _ = destination_ctx.ensure_cache_available();
+    let (response, fingerprint, changed_images) = response;
+    if !dry_run
+        && let Some(destination_ctx) = state.get_database(&destination_id_for_cache)
+        && let Err(error) = tokio::task::spawn_blocking(move || {
+            destination_ctx.register_remote_image_arrivals(&changed_images);
+            let _ = destination_ctx.ensure_cache_available();
+        })
+        .await
+    {
+        // The database transaction already committed. A cache bookkeeping
+        // panic must not report the apply as failed and invite a duplicate
+        // retry; the ordinary refresh remains the fallback.
+        tracing::error!(
+            "scheduler cache update panicked for db={}: {}",
+            destination_id_for_cache,
+            error
+        );
     }
-    Ok(response)
+    Ok((response, fingerprint))
 }
 
 fn sync_endpoint_paths(
@@ -2599,14 +2626,13 @@ pub async fn list_projects(
             db.ambiguous_project_names().map_err(AppError::db)?,
         )
     };
-    // `projects_with_files` has one entry for every project that owns an
-    // acquisition, even when no source file was found. Keep the picker's old
-    // scope without querying `acquiredimage` again here.
+    // Keep the established acquisition-backed scope. A scheduler pull seeds
+    // newly changed projects into this map as known-but-missing, so they stay
+    // visible without exposing planning-only projects.
     let projects = projects
         .into_iter()
         .filter(|(project, _)| file_existence_map.contains_key(&project.project.id))
         .collect::<Vec<_>>();
-
     let response: Vec<ProjectResponse> = projects
         .into_iter()
         .map(|(project_with_profile, state)| {
@@ -2852,42 +2878,71 @@ pub async fn get_image(
         (image, proj_name, target_name, metadata, ambiguous_names)
     }; // Database connection is dropped here
 
-    // Now we can do async operations
-    let stats_cache_filename = format!(
-        "stats_{}_{}_{}_{}.json",
-        image_id,
-        image.project_id,
-        image.target_id,
-        image.acquired_date.unwrap_or(0)
-    );
-    let stats_cache_path = ctx.get_cache_path("stats", &stats_cache_filename);
+    // Try to resolve the filesystem path for the FITS file
+    let delayed_probe = ctx.delayed_file_probe(image.id);
+    let resolved_fits_path = metadata["FileName"].as_str().and_then(|filename| {
+        let file_only = filename.split(&['\\', '/'][..]).next_back()?;
+        if delayed_probe == crate::server::database_context::DelayedFileProbe::Wait {
+            return None;
+        }
+        let resolved = if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe
+        {
+            find_fits_file_cached(&ctx, &image, &target_name, file_only)
+        } else {
+            find_fits_file(&ctx, &image, &target_name, file_only)
+        };
+        // Detail metadata remains usable for a missing or ambiguous source;
+        // preview generation-status carries the specific terminal message.
+        resolved.ok().filter(|path| {
+            delayed_probe != crate::server::database_context::DelayedFileProbe::Probe
+                || ctx.delayed_source_is_stable(image.id, path)
+        })
+    });
 
-    // Ensure cache directory exists
-    if let Some(parent) = stats_cache_path.parent() {
+    let filesystem_path_string = resolved_fits_path
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string());
+
+    // Statistics are keyed by both scheduler identity and the resolved source
+    // fingerprint. A same-ID remote path update or a copy that resumes after a
+    // stable prefix therefore cannot reuse statistics from the old pixels.
+    let stats_cache = resolved_fits_path.as_ref().and_then(|fits_path| {
+        source_file_cache_token(fits_path).map(|source_token| {
+            let filename = format!(
+                "stats_v2_{}_{}_{}_{}_{}_{}.json",
+                image_id,
+                image.project_id,
+                image.target_id,
+                image.acquired_date.unwrap_or(0),
+                image_file_identity_cache_token(&image),
+                source_token,
+            );
+            (ctx.get_cache_path("stats", &filename), source_token)
+        })
+    });
+    if let Some((stats_cache_path, _)) = stats_cache.as_ref()
+        && let Some(parent) = stats_cache_path.parent()
+    {
         let _ = tokio::fs::create_dir_all(parent).await;
     }
 
-    // Try to resolve the filesystem path for the FITS file
-    let filesystem_path = metadata["FileName"].as_str().and_then(|filename| {
-        filename
-            .split(&['\\', '/'][..])
-            .next_back()
-            .map(|file_only| find_fits_file(&ctx, &image, &target_name, file_only))
-    });
-
-    let resolved_fits_path = filesystem_path
-        .as_ref()
-        .and_then(|result| result.as_ref().ok());
-    let filesystem_path_string = resolved_fits_path.map(|p| p.to_string_lossy().to_string());
-
-    // Check if statistics are already cached
-    let fits_stats = if tokio::fs::metadata(&stats_cache_path).await.is_ok() {
-        // Load from cache
-        match tokio::fs::read_to_string(&stats_cache_path).await {
-            Ok(cached_data) => serde_json::from_str::<serde_json::Value>(&cached_data).ok(),
-            Err(_) => None,
+    let cached_fits_stats = if let Some((stats_cache_path, _)) = stats_cache.as_ref() {
+        let cached = tokio::fs::read_to_string(stats_cache_path)
+            .await
+            .ok()
+            .and_then(|cached_data| serde_json::from_str::<serde_json::Value>(&cached_data).ok());
+        if cached.is_none() && stats_cache_path.is_file() {
+            let _ = tokio::fs::remove_file(stats_cache_path).await;
         }
-    } else if let Some(fits_path) = resolved_fits_path {
+        cached
+    } else {
+        None
+    };
+    let fits_stats = if cached_fits_stats.is_some() {
+        cached_fits_stats
+    } else if let (Some(fits_path), Some((stats_cache_path, source_token))) =
+        (resolved_fits_path.as_ref(), stats_cache.as_ref())
+    {
         // Calculate statistics from FITS file
         if let Ok(fits) = FitsImage::from_file(fits_path) {
             let stats = fits.calculate_basic_statistics();
@@ -2915,12 +2970,16 @@ pub async fn get_image(
                 stats_json["Camera"] = serde_json::json!(camera);
             }
 
-            // Cache the statistics
-            if let Ok(cached_data) = serde_json::to_string(&stats_json) {
-                let _ = tokio::fs::write(&stats_cache_path, cached_data).await;
+            // Do not publish statistics if the source changed while it was
+            // decoded. The next request will use the new fingerprint key.
+            if source_file_cache_token(fits_path).as_ref() != Some(source_token) {
+                None
+            } else {
+                if let Ok(cached_data) = serde_json::to_string(&stats_json) {
+                    let _ = write_cache_atomic(stats_cache_path, cached_data.as_bytes()).await;
+                }
+                Some(stats_json)
             }
-
-            Some(stats_json)
         } else {
             None
         }
@@ -2958,6 +3017,25 @@ pub async fn get_image(
     };
 
     Ok(Json(ApiResponse::success(response)))
+}
+
+fn source_file_cache_token(path: &FsPath) -> Option<String> {
+    let metadata = std::fs::metadata(path).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(
+        std::fs::canonicalize(path)
+            .unwrap_or_else(|_| path.to_path_buf())
+            .to_string_lossy()
+            .as_bytes(),
+    );
+    hasher.update([0]);
+    hasher.update(metadata.len().to_le_bytes());
+    if let Ok(modified) = metadata.modified()
+        && let Ok(since_epoch) = modified.duration_since(std::time::UNIX_EPOCH)
+    {
+        hasher.update(since_epoch.as_nanos().to_le_bytes());
+    }
+    Some(finish_cache_token(hasher))
 }
 
 pub async fn update_image_grade(
@@ -3112,7 +3190,7 @@ pub(crate) fn preview_cache_key(
     // The colour marker only appears when colour was asked for, so every
     // greyscale preview already on disk keeps its key and stays valid.
     format!(
-        "{}_{}_{}_{}_{}_{}_{}_{}_{}{}",
+        "{}_{}_{}_{}_{}_{}_{}_{}_{}_{}{}",
         image.id,
         image.project_id,
         image.target_id,
@@ -3122,12 +3200,77 @@ pub(crate) fn preview_cache_key(
         if stretch { "stretch" } else { "linear" },
         (midtone * 10000.0) as i32,
         (shadow * 10000.0) as i32,
+        image_file_identity_cache_token(image),
         if color { "_color" } else { "" },
     )
 }
 
+fn image_file_identity_cache_token(image: &crate::models::AcquiredImage) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(image.metadata.as_bytes());
+    hasher.update([0]);
+    hasher.update(image.filter_name.as_bytes());
+    hasher.update([0]);
+    hasher.update(image.acquired_date.unwrap_or_default().to_le_bytes());
+    finish_cache_token(hasher)
+}
+
+fn finish_cache_token(hasher: Sha256) -> String {
+    let digest = hasher.finalize();
+    let mut token = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        let _ = write!(&mut token, "{byte:02x}");
+    }
+    token
+}
+
+fn star_detection_cache_key(
+    image: &crate::models::AcquiredImage,
+    file_only: &str,
+    source_token: &str,
+) -> String {
+    format!(
+        "stars_v4_{}_{}_{}_{}_{}_{}_{}",
+        image.id,
+        image.project_id,
+        image.target_id,
+        image.acquired_date.unwrap_or(0),
+        file_only.replace(&['.', ' ', '-'][..], "_"),
+        image_file_identity_cache_token(image),
+        source_token,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn psf_multi_cache_key(
+    image: &crate::models::AcquiredImage,
+    file_only: &str,
+    num_stars: usize,
+    psf_type: &str,
+    sort_by: &str,
+    selection: &str,
+    grid_cols: Option<usize>,
+    source_token: &str,
+) -> String {
+    format!(
+        "psf_multi_v2_{}_{}_{}_{}_{}_{}_{}_{}_{}_{}_{}_{}",
+        image.id,
+        image.project_id,
+        image.target_id,
+        image.acquired_date.unwrap_or(0),
+        file_only.replace(&['.', ' ', '-'][..], "_"),
+        num_stars,
+        psf_type,
+        sort_by,
+        selection,
+        grid_cols.unwrap_or(0),
+        image_file_identity_cache_token(image),
+        source_token,
+    )
+}
+
 /// Cache key for an annotated (star-marked) PNG. Same stability requirement.
-fn annotated_cache_key(
+pub(crate) fn annotated_cache_key(
     image: &crate::models::AcquiredImage,
     file_only: &str,
     size: &str,
@@ -3136,7 +3279,7 @@ fn annotated_cache_key(
     // v3: stars now carry HFR labels (v2: telescope-class presets), so
     // earlier renders are stale.
     format!(
-        "annotated_v3_{}_{}_{}_{}_{}_{}_{}",
+        "annotated_v4_{}_{}_{}_{}_{}_{}_{}_{}",
         image.id,
         image.project_id,
         image.target_id,
@@ -3144,6 +3287,7 @@ fn annotated_cache_key(
         file_only.replace(&['.', ' ', '-'][..], "_"),
         size,
         max_stars,
+        image_file_identity_cache_token(image),
     )
 }
 
@@ -3186,6 +3330,53 @@ async fn serve_cached_png(cache_path: &std::path::Path) -> Result<Response, AppE
         .into_response())
 }
 
+async fn write_cache_atomic(path: &FsPath, contents: &[u8]) -> std::io::Result<()> {
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or("cache");
+    let temporary =
+        path.with_extension(format!("{extension}.tmp.{}", uuid::Uuid::new_v4().simple()));
+    if let Err(error) = tokio::fs::write(&temporary, contents).await {
+        let _ = tokio::fs::remove_file(&temporary).await;
+        return Err(error);
+    }
+    if let Err(error) = tokio::fs::rename(&temporary, path).await {
+        let _ = tokio::fs::remove_file(&temporary).await;
+        if !path.is_file() {
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+fn tracked_cache_matches_source(
+    state: &AppState,
+    cache_path: &FsPath,
+    source_path: &FsPath,
+) -> Result<bool, AppError> {
+    if !cache_path.is_file() {
+        return Ok(false);
+    }
+    if state
+        .preview_queue
+        .cached_source_matches(cache_path, source_path)
+    {
+        return Ok(true);
+    }
+    if let Err(error) = std::fs::remove_file(cache_path) {
+        tracing::warn!(
+            "Could not invalidate a preview whose delayed source changed: {}",
+            error
+        );
+        return Err(AppError::InternalError(
+            "Cached preview could not be refreshed".to_string(),
+        ));
+    }
+    state.preview_queue.forget_completed_source(cache_path);
+    Ok(false)
+}
+
 /// The immediate "not ready — poll for it" response on a cache miss. `<img>`
 /// treats the non-image body as an error and the frontend then batch-polls the
 /// generation-status endpoint.
@@ -3224,13 +3415,43 @@ pub async fn get_image_preview(
     let cache_key = preview_cache_key(&image, &file_only, size, stretch, midtone, shadow, color);
     let cache_path = artifact_cache_path(&ctx, "previews", &cache_key, state.preview_encoding())?;
 
-    if cache_path.exists() {
+    let delayed_probe = ctx.delayed_file_probe(image.id);
+    if delayed_probe == crate::server::database_context::DelayedFileProbe::NotPending
+        && cache_path.exists()
+    {
         return serve_cached_png(&cache_path).await;
     }
 
     // Miss: resolve the source (404 if truly missing), hand generation to the
     // bounded interactive queue, and tell the client to poll.
-    let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
+    if delayed_probe == crate::server::database_context::DelayedFileProbe::Wait {
+        return Ok(generating_response());
+    }
+    let source = if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe {
+        find_fits_file_cached(&ctx, &image, &target_name, &file_only)
+    } else {
+        find_fits_file(&ctx, &image, &target_name, &file_only)
+    };
+    let fits_path = match source {
+        Ok(path) => path,
+        Err(AppError::NotFound)
+            if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe =>
+        {
+            return Ok(generating_response());
+        }
+        Err(error) => return Err(error),
+    };
+    if !ctx.delayed_source_is_stable(image.id, &fits_path) {
+        return Ok(generating_response());
+    }
+    if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe
+        && tracked_cache_matches_source(&state, &cache_path, &fits_path)?
+    {
+        if ctx.complete_delayed_file_probe(image.id, &fits_path) {
+            return serve_cached_png(&cache_path).await;
+        }
+        return Ok(generating_response());
+    }
     state.enqueue_preview(crate::server::preview_queue::GenJob {
         fits_path,
         cache_path,
@@ -3252,6 +3473,43 @@ pub fn find_fits_file(
     target_name: &str,
     filename: &str,
 ) -> Result<std::path::PathBuf, AppError> {
+    find_fits_file_inner(ctx, image, target_name, filename, true, None)
+}
+
+fn find_fits_file_cached(
+    ctx: &DatabaseContext,
+    image: &crate::models::AcquiredImage,
+    target_name: &str,
+    filename: &str,
+) -> Result<std::path::PathBuf, AppError> {
+    find_fits_file_inner(ctx, image, target_name, filename, false, None)
+}
+
+fn find_fits_file_cached_with_roots(
+    ctx: &DatabaseContext,
+    image: &crate::models::AcquiredImage,
+    target_name: &str,
+    filename: &str,
+    canonical_roots: &[PathBuf],
+) -> Result<std::path::PathBuf, AppError> {
+    find_fits_file_inner(
+        ctx,
+        image,
+        target_name,
+        filename,
+        false,
+        Some(canonical_roots),
+    )
+}
+
+fn find_fits_file_inner(
+    ctx: &DatabaseContext,
+    image: &crate::models::AcquiredImage,
+    target_name: &str,
+    filename: &str,
+    allow_tree_build: bool,
+    shared_canonical_roots: Option<&[PathBuf]>,
+) -> Result<std::path::PathBuf, AppError> {
     use crate::commands::filter_rejected::get_possible_paths;
 
     tracing::debug!(
@@ -3261,28 +3519,38 @@ pub fn find_fits_file(
         target_name,
         ctx.image_dirs
     );
+    let owned_canonical_roots = shared_canonical_roots
+        .is_none()
+        .then(|| canonical_image_roots(ctx));
+    let canonical_roots = shared_canonical_roots
+        .or(owned_canonical_roots.as_deref())
+        .unwrap_or_default();
 
-    // Extract date from acquired_date
-    let acquired_date = image
-        .acquired_date
-        .and_then(|d| chrono::DateTime::from_timestamp(d, 0))
-        .ok_or_else(|| {
-            tracing::error!(
-                "❌ Invalid date for image {}: {:?}",
-                image.id,
-                image.acquired_date
-            );
-            AppError::BadRequest("Invalid date".to_string())
-        })?;
-
-    let date_str = acquired_date.format("%Y-%m-%d").to_string();
-    tracing::debug!("📅 Date string for image {}: {}", image.id, date_str);
-
-    // Try to find the file in different possible locations across all directories
+    // Date-based layouts are a fast path, not a prerequisite. A remote sync
+    // can legitimately carry no acquireddate while retaining the original
+    // FileName and ExposureStartTime in metadata.
     let mut all_possible_paths = Vec::new();
-    for base_dir in &ctx.image_dirs {
-        let paths = get_possible_paths(base_dir, &date_str, target_name, filename);
-        all_possible_paths.extend(paths);
+    let layout_timestamp = image
+        .acquired_date
+        .or_else(|| metadata_exposure_start(image));
+    if let Some(acquired_date) =
+        layout_timestamp.and_then(|timestamp| chrono::DateTime::from_timestamp(timestamp, 0))
+    {
+        let date_str = acquired_date.format("%Y-%m-%d").to_string();
+        tracing::debug!("📅 Date string for image {}: {}", image.id, date_str);
+        for base_dir in &ctx.image_dirs {
+            all_possible_paths.extend(get_possible_paths(
+                base_dir,
+                &date_str,
+                target_name,
+                filename,
+            ));
+        }
+    } else {
+        tracing::debug!(
+            "Skipping date-layout probes for image {} because no usable capture time is available",
+            image.id
+        );
     }
 
     tracing::debug!(
@@ -3298,15 +3566,33 @@ pub fn find_fits_file(
     }
 
     for (idx, path) in all_possible_paths.iter().enumerate() {
-        tracing::debug!(
-            "  📁 Path {}: {:?} (exists: {})",
-            idx + 1,
-            path,
-            path.exists()
-        );
-        if path.exists() {
+        tracing::debug!("  📁 Path {}: {:?}", idx + 1, path);
+        if let Some(path) = existing_file_under_configured_root(path, canonical_roots) {
             tracing::info!("✅ Found file at path {}: {:?}", idx + 1, path);
-            return Ok(path.clone());
+            ctx.record_resolved_image_file(image, &path);
+            return Ok(path);
+        }
+    }
+
+    // A scheduler row sent by another N.I.N.A. host carries that host's
+    // absolute FileName. Remote copy tools commonly preserve the meaningful
+    // tail (target/night/LIGHT/file) below a different local image root. Probe
+    // those tails directly so a file that arrived after the directory scan is
+    // visible immediately. Components are joined one at a time and the final
+    // canonical path must remain under a configured root.
+    let mut delayed_candidates = metadata_file_name(image)
+        .map(|metadata_path| metadata_suffix_candidates(ctx, &metadata_path, filename))
+        .unwrap_or_default();
+    // Some copy tools flatten the remote hierarchy directly into an image
+    // root. Treat those as identity candidates, never exact-path hits: their
+    // capture headers must agree and multiple matches remain a conflict.
+    delayed_candidates.extend(ctx.image_dir_paths.iter().map(|root| root.join(filename)));
+    if !allow_tree_build {
+        let cache = ctx.directory_tree_cache.read().unwrap();
+        if let Some(tree) = cache.as_ref()
+            && let Some(candidates) = tree.find_file(filename)
+        {
+            delayed_candidates.extend(candidates.iter().cloned());
         }
     }
 
@@ -3317,42 +3603,33 @@ pub fn find_fits_file(
 
     // Try directory tree cache lookup as fallback
     let search_start = std::time::Instant::now();
-    let directory_tree = ctx.get_directory_tree().map_err(|e| {
-        tracing::error!("Failed to get directory tree cache: {}", e);
-        AppError::InternalError("Directory cache error".to_string())
-    })?;
-
-    tracing::debug!(
-        "🌳 Directory tree cache has {} total files, {} unique filenames",
-        directory_tree.stats().total_files,
-        directory_tree.stats().unique_filenames
-    );
-
-    if let Some(first_path) = directory_tree.find_file_first(filename) {
-        tracing::debug!(
-            "🔍 Found first match in directory tree cache for {}",
-            filename
-        );
-
-        if first_path.exists() {
-            tracing::info!(
-                "✅ Found file via directory tree cache in {:?}: {:?}",
-                search_start.elapsed(),
-                first_path
-            );
-            return Ok(first_path.clone());
-        } else {
-            tracing::warn!(
-                "❌ First cached path is stale for {}: {:?}",
-                filename,
-                first_path
-            );
-        }
+    let basename_candidates = if allow_tree_build {
+        let tree = ctx.get_directory_tree().map_err(|e| {
+            tracing::error!("Failed to get directory tree cache: {}", e);
+            AppError::InternalError("Directory cache error".to_string())
+        })?;
+        tree.find_file(filename).cloned().unwrap_or_default()
     } else {
+        Vec::new()
+    };
+    if basename_candidates.is_empty() {
         tracing::debug!(
             "🔍 No matches in directory tree cache for filename: {}",
             filename
         );
+    }
+
+    delayed_candidates.extend(basename_candidates);
+    if let Some(path) =
+        unique_header_matched_file(image, filename, delayed_candidates, canonical_roots)?
+    {
+        tracing::info!(
+            "✅ Found header-matched file via directory tree cache in {:?}: {:?}",
+            search_start.elapsed(),
+            path
+        );
+        ctx.record_resolved_image_file(image, &path);
+        return Ok(path);
     }
 
     tracing::warn!(
@@ -3362,6 +3639,181 @@ pub fn find_fits_file(
         filename
     );
     Err(AppError::NotFound)
+}
+
+const CAPTURE_IDENTITY_TIME_TOLERANCE_SECS: u64 = 2;
+
+fn metadata_file_name(image: &crate::models::AcquiredImage) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(&image.metadata)
+        .ok()?
+        .get("FileName")?
+        .as_str()
+        .map(str::to_string)
+}
+
+fn metadata_exposure_start(image: &crate::models::AcquiredImage) -> Option<i64> {
+    serde_json::from_str::<serde_json::Value>(&image.metadata)
+        .ok()?
+        .get("ExposureStartTime")?
+        .as_str()
+        .and_then(crate::commands::import::headers::parse_fits_datetime)
+}
+
+/// Candidate paths made only from safe suffixes of a remote scheduler path.
+/// At least one parent component is retained: basename-only discovery belongs
+/// to the header-validated fallback below.
+fn metadata_suffix_candidates(
+    ctx: &DatabaseContext,
+    metadata_path: &str,
+    filename: &str,
+) -> Vec<PathBuf> {
+    const MAX_METADATA_PATH_BYTES: usize = 4096;
+    const MAX_METADATA_PATH_COMPONENTS: usize = 128;
+    if metadata_path.len() > MAX_METADATA_PATH_BYTES || metadata_path.chars().any(char::is_control)
+    {
+        return Vec::new();
+    }
+    let components: Vec<&str> = metadata_path
+        .split(['/', '\\'])
+        .filter(|component| !component.is_empty())
+        .collect();
+    if components.len() < 2
+        || components.len() > MAX_METADATA_PATH_COMPONENTS
+        || !components
+            .last()
+            .is_some_and(|last| last.eq_ignore_ascii_case(filename))
+        || components
+            .iter()
+            .any(|component| matches!(*component, "." | "..") || component.contains('\0'))
+    {
+        return Vec::new();
+    }
+
+    let mut candidates = Vec::new();
+    for start in 0..components.len() - 1 {
+        let suffix = &components[start..];
+        if suffix.iter().any(|component| component.contains(':')) {
+            continue;
+        }
+        for root in &ctx.image_dir_paths {
+            let mut candidate = root.clone();
+            for component in suffix {
+                candidate.push(component);
+            }
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+    }
+    candidates
+}
+
+fn existing_file_under_configured_root(
+    candidate: &FsPath,
+    canonical_roots: &[PathBuf],
+) -> Option<PathBuf> {
+    if !candidate.is_file() {
+        return None;
+    }
+    canonical_file_under_roots(candidate, canonical_roots)
+}
+
+fn canonical_image_roots(ctx: &DatabaseContext) -> Vec<PathBuf> {
+    ctx.image_dir_paths
+        .iter()
+        .filter_map(|root| std::fs::canonicalize(root).ok())
+        .collect()
+}
+
+fn canonical_file_under_roots(candidate: &FsPath, canonical_roots: &[PathBuf]) -> Option<PathBuf> {
+    let canonical_candidate = std::fs::canonicalize(candidate).ok()?;
+    let is_configured = canonical_roots
+        .iter()
+        .any(|root| canonical_candidate.starts_with(root));
+    is_configured.then(|| candidate.to_path_buf())
+}
+
+fn unique_header_matched_file(
+    image: &crate::models::AcquiredImage,
+    filename: &str,
+    candidates: Vec<PathBuf>,
+    canonical_roots: &[PathBuf],
+) -> Result<Option<PathBuf>, AppError> {
+    let mut validated: Option<(PathBuf, PathBuf)> = None;
+    let candidates: Vec<PathBuf> = candidates
+        .into_iter()
+        .filter(|candidate| candidate.is_file())
+        .collect();
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+    for candidate in candidates {
+        let Some(candidate) = canonical_file_under_roots(&candidate, canonical_roots) else {
+            continue;
+        };
+        if !basename_headers_match(&candidate, image) {
+            tracing::debug!(
+                "Ignoring path whose capture headers disagree for image {}: {:?}",
+                image.id,
+                candidate
+            );
+            continue;
+        }
+        let identity = std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
+        match validated.as_ref() {
+            None => validated = Some((identity, candidate)),
+            Some((known, _)) if known == &identity => {}
+            Some(_) => {
+                tracing::warn!(
+                    "Refusing multiple header-matched files named {} for image {}",
+                    filename,
+                    image.id
+                );
+                return Err(AppError::Conflict(format!(
+                    "{filename} matches multiple files with the same capture time and filter"
+                )));
+            }
+        }
+    }
+
+    Ok(validated.map(|(_, path)| path))
+}
+
+fn basename_headers_match(path: &FsPath, image: &crate::models::AcquiredImage) -> bool {
+    let headers = crate::commands::import::headers::read_frame_meta(path);
+    if !headers.readable {
+        return false;
+    }
+    // ExposureStartTime and FITS DATE-OBS describe the same camera event.
+    // Prefer that direct pairing; acquireddate remains the fallback for older
+    // scheduler rows whose metadata did not retain an exposure start.
+    let expected_timestamp = metadata_exposure_start(image).or(image.acquired_date);
+    let Some(expected_timestamp) = expected_timestamp else {
+        return false;
+    };
+    let Some(actual_timestamp) = headers.timestamp else {
+        return false;
+    };
+    if expected_timestamp.abs_diff(actual_timestamp) > CAPTURE_IDENTITY_TIME_TOLERANCE_SECS {
+        return false;
+    }
+
+    let expected_filter = if image.filter_name.trim().is_empty() {
+        serde_json::from_str::<serde_json::Value>(&image.metadata)
+            .ok()
+            .and_then(|metadata| {
+                metadata
+                    .get("FilterName")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+            })
+    } else {
+        Some(image.filter_name.clone())
+    };
+    match (expected_filter.as_deref(), headers.filter.as_deref()) {
+        (Some(expected), Some(actual)) => crate::utils::filter_names_match(expected, actual),
+        _ => false,
+    }
 }
 
 #[axum::debug_handler(state = Arc<AppState>)]
@@ -3408,17 +3860,14 @@ pub async fn get_image_stars(
         (image, file_only, target_name)
     };
 
+    let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
+    let source_token = source_file_cache_token(&fits_path)
+        .ok_or_else(|| AppError::Conflict("Source file is not ready".to_string()))?;
+
     // Create comprehensive cache key for star detection results. v2: the
     // detector picks a telescope-class preset from the frame's headers, so
     // v1 entries (fixed defaults) are stale for wide/long rigs.
-    let cache_key = format!(
-        "stars_v3_{}_{}_{}_{}_{}",
-        image_id,
-        image.project_id,
-        image.target_id,
-        image.acquired_date.unwrap_or(0),
-        file_only.replace(&['.', ' ', '-'][..], "_")
-    );
+    let cache_key = star_detection_cache_key(&image, &file_only, &source_token);
     let cache_manager = CacheManager::new(PathBuf::from(&ctx.cache_dir));
     cache_manager
         .ensure_category_dir("stars")
@@ -3427,19 +3876,13 @@ pub async fn get_image_stars(
 
     // Check if cached version exists
     if cache_manager.is_cached(&cache_path) {
-        // Read from cache
-        let cached_data = tokio::fs::read_to_string(&cache_path)
-            .await
-            .map_err(|_| AppError::InternalError("Failed to read cache".to_string()))?;
-
-        let response: StarDetectionResponse = serde_json::from_str(&cached_data)
-            .map_err(|_| AppError::InternalError("Invalid cached data".to_string()))?;
-
-        return Ok(Json(ApiResponse::success(response)));
+        if let Ok(cached_data) = tokio::fs::read_to_string(&cache_path).await
+            && let Ok(response) = serde_json::from_str::<StarDetectionResponse>(&cached_data)
+        {
+            return Ok(Json(ApiResponse::success(response)));
+        }
+        let _ = tokio::fs::remove_file(&cache_path).await;
     }
-
-    // Find FITS file path first (this is fast)
-    let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
 
     // Move expensive operations to spawn_blocking
     let fits_path_str = fits_path.to_string_lossy().to_string();
@@ -3516,7 +3959,12 @@ pub async fn get_image_stars(
     let cached_data = serde_json::to_string(&response)
         .map_err(|_| AppError::InternalError("Failed to serialize response".to_string()))?;
 
-    tokio::fs::write(&cache_path, cached_data)
+    if source_file_cache_token(&fits_path).as_deref() != Some(source_token.as_str()) {
+        return Err(AppError::Conflict(
+            "Source file changed during star detection; retry shortly".to_string(),
+        ));
+    }
+    write_cache_atomic(&cache_path, cached_data.as_bytes())
         .await
         .map_err(|_| AppError::InternalError("Failed to write cache".to_string()))?;
 
@@ -3539,11 +3987,41 @@ pub async fn get_annotated_image(
     let cache_key = annotated_cache_key(&image, &file_only, size, max_stars);
     let cache_path = artifact_cache_path(&ctx, "annotated", &cache_key, state.preview_encoding())?;
 
-    if cache_path.exists() {
+    let delayed_probe = ctx.delayed_file_probe(image.id);
+    if delayed_probe == crate::server::database_context::DelayedFileProbe::NotPending
+        && cache_path.exists()
+    {
         return serve_cached_png(&cache_path).await;
     }
 
-    let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
+    if delayed_probe == crate::server::database_context::DelayedFileProbe::Wait {
+        return Ok(generating_response());
+    }
+    let source = if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe {
+        find_fits_file_cached(&ctx, &image, &target_name, &file_only)
+    } else {
+        find_fits_file(&ctx, &image, &target_name, &file_only)
+    };
+    let fits_path = match source {
+        Ok(path) => path,
+        Err(AppError::NotFound)
+            if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe =>
+        {
+            return Ok(generating_response());
+        }
+        Err(error) => return Err(error),
+    };
+    if !ctx.delayed_source_is_stable(image.id, &fits_path) {
+        return Ok(generating_response());
+    }
+    if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe
+        && tracked_cache_matches_source(&state, &cache_path, &fits_path)?
+    {
+        if ctx.complete_delayed_file_probe(image.id, &fits_path) {
+            return serve_cached_png(&cache_path).await;
+        }
+        return Ok(generating_response());
+    }
     state.enqueue_preview(crate::server::preview_queue::GenJob {
         fits_path,
         cache_path,
@@ -3591,6 +4069,26 @@ pub struct GenerationStatusBatch {
     pub statuses: Vec<crate::server::preview_queue::GenerationStatus>,
 }
 
+const MAX_DELAYED_FILE_PROBES_PER_STATUS_BATCH: usize = 8;
+
+fn consume_delayed_batch_probe(
+    probes: &HashMap<i32, crate::server::database_context::DelayedFileProbe>,
+    image_id: i32,
+    consumed_probe_ids: &mut std::collections::HashSet<i32>,
+) -> crate::server::database_context::DelayedFileProbe {
+    let probe = probes
+        .get(&image_id)
+        .copied()
+        .unwrap_or(crate::server::database_context::DelayedFileProbe::NotPending);
+    if probe == crate::server::database_context::DelayedFileProbe::Probe
+        && !consumed_probe_ids.insert(image_id)
+    {
+        crate::server::database_context::DelayedFileProbe::Wait
+    } else {
+        probe
+    }
+}
+
 /// POST /api/db/{db_id}/images/generation-status
 ///
 /// Batch readiness poll for on-demand previews / annotated images. For each
@@ -3625,11 +4123,38 @@ pub async fn post_generation_status(
         )
     };
 
-    let statuses = req
-        .requests
-        .iter()
-        .map(|item| status_for_item(&state, &ctx, item, &images_by_id, &target_names))
-        .collect();
+    let delayed_probes =
+        ctx.delayed_file_probes_for_batch(&ids, MAX_DELAYED_FILE_PROBES_PER_STATUS_BATCH);
+    let ctx = Arc::clone(&ctx.0);
+    let requests = req.requests;
+    let statuses = tokio::task::spawn_blocking(move || {
+        let mut canonical_roots = None;
+        let mut consumed_probe_ids = std::collections::HashSet::new();
+        requests
+            .iter()
+            .map(|item| {
+                let delayed_probe = consume_delayed_batch_probe(
+                    &delayed_probes,
+                    item.image_id,
+                    &mut consumed_probe_ids,
+                );
+                status_for_item(
+                    &state,
+                    &ctx,
+                    item,
+                    &images_by_id,
+                    &target_names,
+                    delayed_probe,
+                    &mut canonical_roots,
+                )
+            })
+            .collect()
+    })
+    .await
+    .map_err(|error| {
+        tracing::error!("generation-status filesystem task failed: {error}");
+        AppError::InternalError("Preview status could not be checked".to_string())
+    })?;
     Ok(Json(ApiResponse::success(GenerationStatusBatch {
         statuses,
     })))
@@ -3646,12 +4171,18 @@ fn status_for_item(
     item: &GenStatusItem,
     images_by_id: &HashMap<i32, crate::models::AcquiredImage>,
     target_names: &HashMap<i32, String>,
+    delayed_probe: crate::server::database_context::DelayedFileProbe,
+    canonical_roots: &mut Option<Vec<PathBuf>>,
 ) -> crate::server::preview_queue::GenerationStatus {
     use crate::server::preview_queue::{GenJob, GenKind, GenerationState, GenerationStatus};
 
     let err = |msg: &str| GenerationStatus {
         state: GenerationState::Error,
         error: Some(msg.to_string()),
+    };
+    let generating = || GenerationStatus {
+        state: GenerationState::Generating,
+        error: None,
     };
     // One read of each, used for both the path this polls and the job it may
     // enqueue, so a setting change mid-request cannot split the two.
@@ -3708,24 +4239,76 @@ fn status_for_item(
     };
 
     if let Some(status) = state.preview_queue.status(&cache_path) {
-        return status;
+        match status.state {
+            GenerationState::Ready
+                if delayed_probe
+                    == crate::server::database_context::DelayedFileProbe::NotPending =>
+            {
+                return status;
+            }
+            GenerationState::Generating => return status,
+            GenerationState::Ready | GenerationState::Error => {}
+        }
+    }
+
+    if delayed_probe == crate::server::database_context::DelayedFileProbe::Wait {
+        return generating();
     }
 
     // Neither cached, in-flight, nor errored: ensure it's enqueued to generate.
-    match find_fits_file(ctx, image, target_name, &file_only) {
+    let source = if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe {
+        let canonical_roots = canonical_roots.get_or_insert_with(|| canonical_image_roots(ctx));
+        find_fits_file_cached_with_roots(ctx, image, target_name, &file_only, canonical_roots)
+    } else {
+        find_fits_file(ctx, image, target_name, &file_only)
+    };
+    match source {
         Ok(fits_path) => {
+            if !ctx.delayed_source_is_stable(image.id, &fits_path) {
+                return generating();
+            }
+            if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe {
+                match tracked_cache_matches_source(state, &cache_path, &fits_path) {
+                    Ok(true) => {
+                        if ctx.complete_delayed_file_probe(image.id, &fits_path) {
+                            return state
+                                .preview_queue
+                                .status(&cache_path)
+                                .unwrap_or_else(generating);
+                        }
+                        return generating();
+                    }
+                    Ok(false) => {}
+                    Err(_) => return err("cached preview could not be refreshed"),
+                }
+            }
+            if let Some(status) = state
+                .preview_queue
+                .status_for_source(&cache_path, &fits_path)
+            {
+                if status.state == GenerationState::Error
+                    && delayed_probe == crate::server::database_context::DelayedFileProbe::Probe
+                {
+                    return generating();
+                }
+                return status;
+            }
             state.enqueue_preview(GenJob {
                 fits_path,
                 cache_path,
                 kind,
                 encoding,
             });
-            GenerationStatus {
-                state: GenerationState::Generating,
-                error: None,
-            }
+            generating()
         }
-        Err(_) => err("source file not found"),
+        Err(AppError::Conflict(message)) => err(&message),
+        Err(AppError::NotFound)
+            if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe =>
+        {
+            generating()
+        }
+        Err(AppError::NotFound) => err("source file not found"),
+        Err(_) => err("source file is unavailable"),
     }
 }
 
@@ -3795,19 +4378,20 @@ pub async fn get_psf_visualization(
 
     let psf_type: PSFType = psf_type_str.parse().unwrap_or(PSFType::Moffat4);
 
+    let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
+    let source_token = source_file_cache_token(&fits_path)
+        .ok_or_else(|| AppError::Conflict("Source file is not ready".to_string()))?;
+
     // Create comprehensive cache key for PSF multi image
-    let cache_key = format!(
-        "psf_multi_{}_{}_{}_{}_{}_{}_{}_{}_{}_{}",
-        image_id,
-        image.project_id,
-        image.target_id,
-        image.acquired_date.unwrap_or(0),
-        file_only.replace(&['.', ' ', '-'][..], "_"),
+    let cache_key = psf_multi_cache_key(
+        &image,
+        &file_only,
         num_stars,
-        psf_type_str,
-        sort_by,
-        selection,
-        grid_cols.unwrap_or(0)
+        &psf_type_str,
+        &sort_by,
+        &selection,
+        grid_cols,
+        &source_token,
     );
     let cache_manager = CacheManager::new(PathBuf::from(&ctx.cache_dir));
     cache_manager
@@ -3837,15 +4421,15 @@ pub async fn get_psf_visualization(
         ));
     }
 
-    // Find FITS file path first (this is fast)
-    let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
-
     // Move expensive operations to spawn_blocking
-    let fits_path_str = fits_path.to_string_lossy().to_string();
+    let fits_path_clone = fits_path.clone();
     let cache_path_clone = cache_path.clone();
+    let source_token_clone = source_token.clone();
     tokio::task::spawn_blocking(move || {
+        let temporary =
+            cache_path_clone.with_extension(format!("png.tmp.{}", uuid::Uuid::new_v4().simple()));
         // Load FITS file
-        let fits = FitsImage::from_file(std::path::Path::new(&fits_path_str))
+        let fits = FitsImage::from_file(&fits_path_clone)
             .map_err(|e| anyhow::anyhow!("Failed to load FITS: {}", e))?;
 
         // Create PSF multi visualization using the common function
@@ -3854,7 +4438,7 @@ pub async fn get_psf_visualization(
                 .map_err(|e| anyhow::anyhow!("Failed to create PSF visualization: {}", e))?;
 
         // Save to cache
-        let cache_file = std::fs::File::create(&cache_path_clone)
+        let cache_file = std::fs::File::create(&temporary)
             .map_err(|e| anyhow::anyhow!("Failed to create cache file: {}", e))?;
         let writer = std::io::BufWriter::new(cache_file);
         let encoder =
@@ -3868,6 +4452,18 @@ pub async fn get_psf_visualization(
                 ColorType::Rgba8.into(),
             )
             .map_err(|e| anyhow::anyhow!("Failed to encode PNG: {}", e))?;
+
+        if source_file_cache_token(&fits_path_clone).as_deref() != Some(source_token_clone.as_str())
+        {
+            let _ = std::fs::remove_file(&temporary);
+            anyhow::bail!("source file changed while rendering");
+        }
+        if let Err(error) = std::fs::rename(&temporary, &cache_path_clone) {
+            let _ = std::fs::remove_file(&temporary);
+            if !cache_path_clone.is_file() {
+                return Err(error.into());
+            }
+        }
 
         Ok::<(), anyhow::Error>(())
     })
@@ -4936,7 +5532,7 @@ async fn start_spatial_scan_with_priority(
                         *need_astrometry,
                         *need_satellite,
                     )),
-                    Err(_) => {
+                    Err(error) => {
                         let mut s = ctx_arc.spatial_metrics.write().unwrap();
                         // The stage total counts only spatial work; advancing
                         // it for an astrometry-only item would overshoot it.
@@ -4944,7 +5540,18 @@ async fn start_spatial_scan_with_priority(
                             s.progress.processed += 1;
                         }
                         s.progress.errors += 1;
-                        s.progress.last_error = Some(format!("{}: FITS file not found", file_only));
+                        s.progress.last_error = Some(match error {
+                            AppError::Conflict(message) => message,
+                            AppError::NotFound => format!("{file_only}: FITS file not found"),
+                            other => {
+                                tracing::warn!(
+                                    "Source resolution failed during quality scan for image {}: {:?}",
+                                    img.id,
+                                    other
+                                );
+                                format!("{file_only}: source file could not be resolved")
+                            }
+                        });
                     }
                 }
             }
@@ -5275,8 +5882,233 @@ impl IntoResponse for AppError {
 }
 
 #[cfg(test)]
+mod delayed_ready_tests {
+    use super::*;
+    use crate::commands::sync::ChangedAcquiredImage;
+    use crate::db_registry::DbEntry;
+    use crate::server::preview_queue::GenerationState;
+    use rusqlite::Connection;
+    use std::io::Write;
+
+    const IMAGE_ID: i32 = 700;
+    const PROJECT_ID: i32 = 7;
+    const TARGET_ID: i32 = 70;
+    const CAPTURE_TIME: i64 = 1_784_869_200;
+
+    fn write_header(path: &FsPath) {
+        let mut header = Vec::new();
+        for card in [
+            "SIMPLE  =                    T",
+            "BITPIX  =                    8",
+            "NAXIS   =                    0",
+            "FILTER  = 'Ha'",
+            "DATE-OBS= '2026-07-24T05:00:00'",
+            "END",
+        ] {
+            let mut padded = format!("{card:<80}").into_bytes();
+            padded.truncate(80);
+            header.extend(padded);
+        }
+        header.resize(2880, b' ');
+        std::fs::File::create(path)
+            .unwrap()
+            .write_all(&header)
+            .unwrap();
+    }
+
+    fn setup() -> (
+        tempfile::TempDir,
+        Arc<AppState>,
+        Arc<DatabaseContext>,
+        crate::models::AcquiredImage,
+        PathBuf,
+    ) {
+        let temp = tempfile::tempdir().unwrap();
+        let database_path = temp.path().join("scheduler.sqlite");
+        crate::ts_schema::create_fresh_db(&database_path).unwrap();
+        let image_root = temp.path().join("images");
+        std::fs::create_dir_all(&image_root).unwrap();
+        let source = image_root.join("arrived.fits");
+        write_header(&source);
+        let metadata = serde_json::json!({
+            "FileName": source.to_string_lossy(),
+            "ExposureStartTime": "2026-07-24T05:00:00Z",
+        });
+        let connection = Connection::open(&database_path).unwrap();
+        connection
+            .execute_batch(&format!(
+                "INSERT INTO project (Id, profileId, name) VALUES ({PROJECT_ID}, 'default', 'Project');
+                 INSERT INTO target (Id, name, active, epochcode, projectid)
+                    VALUES ({TARGET_ID}, 'Target', 1, 0, {PROJECT_ID});"
+            ))
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO acquiredimage
+                    (Id, projectId, targetId, acquireddate, filtername, gradingStatus, metadata, profileId)
+                 VALUES (?1, ?2, ?3, ?4, 'Ha', 0, ?5, 'default')",
+                rusqlite::params![IMAGE_ID, PROJECT_ID, TARGET_ID, CAPTURE_TIME, metadata.to_string()],
+            )
+            .unwrap();
+        drop(connection);
+
+        let state = Arc::new(
+            AppState::from_databases(
+                vec![DbEntry {
+                    id: "test".into(),
+                    name: "Test".into(),
+                    db_path: database_path.to_string_lossy().into_owned(),
+                    image_dirs: vec![image_root.to_string_lossy().into_owned()],
+                    reject_archive: None,
+                    remote_image_upload: None,
+                    export_dir: None,
+                }],
+                temp.path().join("cache").to_string_lossy().into_owned(),
+                crate::cli::PregenerationConfig::default(),
+            )
+            .unwrap(),
+        );
+        let ctx = state.get_database("test").unwrap();
+        let image = {
+            let connection = ctx.db();
+            let connection = connection.lock().unwrap();
+            Database::new(&connection)
+                .get_images_by_ids(&[IMAGE_ID])
+                .unwrap()
+                .pop()
+                .unwrap()
+        };
+        (temp, state, ctx, image, source)
+    }
+
+    #[tokio::test]
+    async fn validated_ready_status_makes_immediate_preview_and_annotated_gets_cache_hits() {
+        let (_temp, state, ctx, image, source) = setup();
+        let images = HashMap::from([(IMAGE_ID, image.clone())]);
+        let targets = HashMap::from([(TARGET_ID, "Target".to_string())]);
+
+        for kind in ["preview", "annotated"] {
+            ctx.register_remote_image_arrivals(&[ChangedAcquiredImage {
+                id: i64::from(IMAGE_ID),
+                project_id: i64::from(PROJECT_ID),
+                target_id: i64::from(TARGET_ID),
+                acquired_date: Some(CAPTURE_TIME),
+            }]);
+            let cache_path = if kind == "annotated" {
+                artifact_cache_path(
+                    &ctx,
+                    "annotated",
+                    &annotated_cache_key(&image, "arrived.fits", "screen", 1000),
+                    state.preview_encoding(),
+                )
+                .unwrap()
+            } else {
+                artifact_cache_path(
+                    &ctx,
+                    "previews",
+                    &preview_cache_key(
+                        &image,
+                        "arrived.fits",
+                        "screen",
+                        true,
+                        0.2,
+                        -2.8,
+                        state.preview_color_default(),
+                    ),
+                    state.preview_encoding(),
+                )
+                .unwrap()
+            };
+            std::fs::write(&cache_path, b"cached image").unwrap();
+            state
+                .preview_queue
+                .remember_completed_source_for_test(cache_path, &source);
+            assert!(!ctx.delayed_source_is_stable(IMAGE_ID, &source));
+
+            let delayed_probe = ctx.delayed_file_probes_for_batch(
+                &[IMAGE_ID],
+                MAX_DELAYED_FILE_PROBES_PER_STATUS_BATCH,
+            )[&IMAGE_ID];
+            let mut canonical_roots = None;
+            let status = status_for_item(
+                &state,
+                &ctx,
+                &GenStatusItem {
+                    image_id: IMAGE_ID,
+                    kind: Some(kind.to_string()),
+                    size: Some("screen".to_string()),
+                    stretch: None,
+                    midtone: None,
+                    shadow: None,
+                    max_stars: None,
+                    color: None,
+                },
+                &images,
+                &targets,
+                delayed_probe,
+                &mut canonical_roots,
+            );
+            assert_eq!(status.state, GenerationState::Ready);
+            assert!(canonical_roots.is_some());
+            assert_eq!(
+                ctx.delayed_file_probe(IMAGE_ID),
+                crate::server::database_context::DelayedFileProbe::NotPending
+            );
+
+            let options = PreviewOptions {
+                size: Some("screen".into()),
+                stretch: None,
+                midtone: None,
+                shadow: None,
+                max_stars: None,
+                color: None,
+            };
+            let response = if kind == "annotated" {
+                get_annotated_image(
+                    State(Arc::clone(&state)),
+                    DbContext(Arc::clone(&ctx)),
+                    Path(("test".into(), IMAGE_ID)),
+                    Query(options),
+                )
+                .await
+                .unwrap()
+            } else {
+                get_image_preview(
+                    State(Arc::clone(&state)),
+                    DbContext(Arc::clone(&ctx)),
+                    Path(("test".into(), IMAGE_ID)),
+                    Query(options),
+                )
+                .await
+                .unwrap()
+            };
+            assert_eq!(response.status(), StatusCode::OK, "{kind}");
+        }
+    }
+
+    #[test]
+    fn delayed_duplicate_descriptors_consume_one_probe_observation() {
+        use crate::server::database_context::DelayedFileProbe;
+
+        let probes = HashMap::from([(IMAGE_ID, DelayedFileProbe::Probe)]);
+        let mut consumed = std::collections::HashSet::new();
+        assert_eq!(
+            consume_delayed_batch_probe(&probes, IMAGE_ID, &mut consumed),
+            DelayedFileProbe::Probe
+        );
+        assert_eq!(
+            consume_delayed_batch_probe(&probes, IMAGE_ID, &mut consumed),
+            DelayedFileProbe::Wait
+        );
+    }
+}
+
+#[cfg(test)]
 mod preview_cache_key_tests {
-    use super::preview_cache_key;
+    use super::{
+        annotated_cache_key, image_file_identity_cache_token, preview_cache_key,
+        psf_multi_cache_key, star_detection_cache_key,
+    };
     use crate::models::AcquiredImage;
 
     fn image() -> AcquiredImage {
@@ -5340,5 +6172,285 @@ mod preview_cache_key_tests {
                 preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, color);
             assert_eq!(warmed, requested);
         }
+    }
+
+    #[test]
+    fn scheduler_file_identity_changes_invalidate_derived_artifact_keys() {
+        let mut first = image();
+        first.metadata =
+            r#"{"FileName":"D:\\old\\one.fits","ExposureStartTime":"2025-06-15T00:00:00Z"}"#.into();
+        let mut moved = first.clone();
+        moved.metadata =
+            r#"{"FileName":"E:\\new\\one.fits","ExposureStartTime":"2025-06-15T00:00:00Z"}"#.into();
+
+        assert_ne!(
+            image_file_identity_cache_token(&first),
+            image_file_identity_cache_token(&moved)
+        );
+        assert_ne!(
+            preview_cache_key(&first, "one.fits", "screen", true, 0.2, -2.8, false),
+            preview_cache_key(&moved, "one.fits", "screen", true, 0.2, -2.8, false)
+        );
+        assert_ne!(
+            annotated_cache_key(&first, "one.fits", "screen", 1000),
+            annotated_cache_key(&moved, "one.fits", "screen", 1000)
+        );
+        assert_ne!(
+            star_detection_cache_key(&first, "one.fits", "source-a"),
+            star_detection_cache_key(&moved, "one.fits", "source-a")
+        );
+        assert_ne!(
+            psf_multi_cache_key(&first, "one.fits", 9, "moffat", "r2", "top-n", None, "source-a",),
+            psf_multi_cache_key(&moved, "one.fits", 9, "moffat", "r2", "top-n", None, "source-a",)
+        );
+    }
+}
+
+#[cfg(test)]
+mod file_resolution_tests {
+    use super::{
+        find_fits_file, find_fits_file_cached, metadata_suffix_candidates, AppError,
+        DatabaseContext,
+    };
+    use crate::models::AcquiredImage;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    const CAPTURE_TIME: i64 = 1_784_869_200;
+
+    fn context(temp: &tempfile::TempDir) -> (DatabaseContext, PathBuf) {
+        let (ctx, roots) = context_with_roots(temp, &["images"]);
+        (ctx, roots.into_iter().next().unwrap())
+    }
+
+    fn context_with_roots(
+        temp: &tempfile::TempDir,
+        names: &[&str],
+    ) -> (DatabaseContext, Vec<PathBuf>) {
+        let database = temp.path().join("scheduler.sqlite");
+        crate::ts_schema::create_fresh_db(&database).unwrap();
+        let image_roots: Vec<PathBuf> = names.iter().map(|name| temp.path().join(name)).collect();
+        for image_root in &image_roots {
+            std::fs::create_dir_all(image_root).unwrap();
+        }
+        let ctx = DatabaseContext::new(
+            "test".into(),
+            "Test".into(),
+            database.to_string_lossy().into_owned(),
+            image_roots
+                .iter()
+                .map(|path| path.to_string_lossy().into_owned())
+                .collect(),
+            None,
+            None,
+            temp.path().join("cache").to_string_lossy().into_owned(),
+        )
+        .unwrap();
+        (ctx, image_roots)
+    }
+
+    fn image(metadata_path: &str, filter: &str) -> AcquiredImage {
+        AcquiredImage {
+            id: 42,
+            project_id: 7,
+            target_id: 3,
+            acquired_date: Some(CAPTURE_TIME),
+            filter_name: filter.into(),
+            grading_status: 0,
+            metadata: serde_json::json!({
+                "FileName": metadata_path,
+                "ExposureStartTime": "2026-07-24T05:00:00Z",
+                "FilterName": filter,
+            })
+            .to_string(),
+            reject_reason: None,
+            profile_id: None,
+            guid: None,
+        }
+    }
+
+    fn fits_card(output: &mut Vec<u8>, text: &str) {
+        let mut bytes = text.as_bytes().to_vec();
+        assert!(bytes.len() <= 80);
+        bytes.resize(80, b' ');
+        output.extend_from_slice(&bytes);
+    }
+
+    fn write_fits(path: &Path, filter: &str, date_obs: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut header = Vec::new();
+        fits_card(&mut header, "SIMPLE  =                    T");
+        fits_card(&mut header, "BITPIX  =                   16");
+        fits_card(&mut header, "NAXIS   =                    2");
+        fits_card(&mut header, "NAXIS1  =                   10");
+        fits_card(&mut header, "NAXIS2  =                   10");
+        fits_card(&mut header, "IMAGETYP= 'LIGHT'");
+        fits_card(&mut header, &format!("FILTER  = '{filter}'"));
+        fits_card(&mut header, &format!("DATE-OBS= '{date_obs}'"));
+        fits_card(&mut header, "EXPTIME =                300.0");
+        fits_card(&mut header, "END");
+        header.resize(header.len().div_ceil(2880) * 2880, b' ');
+        let mut file = std::fs::File::create(path).unwrap();
+        file.write_all(&header).unwrap();
+        file.write_all(&[0u8; 2880]).unwrap();
+    }
+
+    #[test]
+    fn delayed_metadata_suffix_is_found_and_folded_into_both_caches() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+
+        ctx.get_directory_tree().unwrap();
+        let tree_age_before = ctx.get_directory_tree_stats().unwrap().age;
+        let file_cache_updated_at = {
+            let mut cache = ctx.file_check_cache.write().unwrap();
+            cache.has_initial_data = true;
+            cache.projects_with_files.insert(7, false);
+            cache.targets_with_files.insert(3, false);
+            cache
+                .project_latest_image_dates
+                .insert(7, CAPTURE_TIME - 60);
+            cache.last_updated
+        };
+        std::thread::sleep(Duration::from_millis(5));
+
+        let delayed = image_root.join("rig-a/odd-layout/delayed.fits");
+        write_fits(&delayed, "Ha", "2026-07-24T05:00:00");
+        let image = image(r"C:\remote-captures\rig-a\odd-layout\delayed.fits", "Ha");
+
+        let resolved = find_fits_file(&ctx, &image, "Unrelated Target", "delayed.fits").unwrap();
+        assert_eq!(resolved, delayed);
+
+        {
+            let tree = ctx.directory_tree_cache.read().unwrap();
+            let tree = tree.as_ref().unwrap();
+            assert_eq!(tree.find_file_first("delayed.fits"), Some(&delayed));
+            assert!(tree.stats().age >= tree_age_before);
+        }
+
+        let cache = ctx.file_check_cache.read().unwrap();
+        assert_eq!(cache.projects_with_files.get(&7), Some(&true));
+        assert_eq!(cache.targets_with_files.get(&3), Some(&true));
+        assert_eq!(
+            cache.project_latest_image_dates.get(&7),
+            Some(&CAPTURE_TIME)
+        );
+        assert_eq!(cache.last_updated, file_cache_updated_at);
+    }
+
+    #[test]
+    fn delayed_flattened_copy_is_found_without_rebuilding_the_tree() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+        ctx.get_directory_tree().unwrap();
+
+        let flattened = image_root.join("flattened.fits");
+        write_fits(&flattened, "Ha", "2026-07-24T05:00:00");
+        let mut image = image(r"C:\remote\deep\layout\flattened.fits", "Ha");
+        image.acquired_date = None;
+
+        assert_eq!(
+            find_fits_file_cached(&ctx, &image, "M 31", "flattened.fits").unwrap(),
+            flattened
+        );
+    }
+
+    #[test]
+    fn metadata_suffixes_cannot_traverse_or_degrade_to_a_basename() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+
+        assert!(
+            metadata_suffix_candidates(&ctx, r"C:\remote\..\outside\frame.fits", "frame.fits")
+                .is_empty()
+        );
+        let candidates =
+            metadata_suffix_candidates(&ctx, r"C:\remote\rig\night\frame.fits", "frame.fits");
+        assert!(candidates.iter().all(|path| path.starts_with(&image_root)));
+        assert!(candidates.contains(&image_root.join("rig/night/frame.fits")));
+        assert!(!candidates.contains(&image_root.join("frame.fits")));
+    }
+
+    #[test]
+    fn basename_fallback_requires_one_header_match() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+        let wrong = image_root.join("archive-a/repeated.fits");
+        let correct = image_root.join("archive-b/repeated.fits");
+        write_fits(&wrong, "OIII", "2026-07-24T05:00:00");
+        write_fits(&correct, "Ha", "2026-07-24T05:00:00");
+        ctx.get_directory_tree().unwrap();
+        let image = image(r"C:\elsewhere\repeated.fits", "Ha");
+
+        assert_eq!(
+            find_fits_file(&ctx, &image, "M 31", "repeated.fits").unwrap(),
+            correct
+        );
+
+        write_fits(&wrong, "Ha", "2026-07-24T05:00:00");
+        match find_fits_file(&ctx, &image, "M 31", "repeated.fits") {
+            Err(AppError::Conflict(message)) => {
+                assert!(message.contains("matches multiple files"), "{message}");
+            }
+            _ => panic!("two header-matched basenames must be refused"),
+        }
+    }
+
+    #[test]
+    fn basename_fallback_rejects_a_timestamp_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+        write_fits(
+            &image_root.join("archive/repeated.fits"),
+            "Ha",
+            "2026-07-24T05:00:03",
+        );
+        ctx.get_directory_tree().unwrap();
+        let image = image(r"C:\elsewhere\repeated.fits", "Ha");
+
+        assert!(matches!(
+            find_fits_file(&ctx, &image, "M 31", "repeated.fits"),
+            Err(AppError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn metadata_suffix_requires_one_header_matched_path_across_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, roots) = context_with_roots(&temp, &["images-a", "images-b"]);
+        ctx.get_directory_tree().unwrap();
+        let first = roots[0].join("rig/night/repeated.fits");
+        let second = roots[1].join("rig/night/repeated.fits");
+        write_fits(&first, "OIII", "2026-07-24T05:00:00");
+        write_fits(&second, "Ha", "2026-07-24T05:00:00");
+        let image = image(r"C:\remote\rig\night\repeated.fits", "Ha");
+
+        assert_eq!(
+            find_fits_file(&ctx, &image, "M 31", "repeated.fits").unwrap(),
+            second
+        );
+
+        write_fits(&first, "Ha", "2026-07-24T05:00:00");
+        assert!(matches!(
+            find_fits_file(&ctx, &image, "M 31", "repeated.fits"),
+            Err(AppError::Conflict(_))
+        ));
+    }
+
+    #[test]
+    fn basename_fallback_prefers_exposure_start_over_acquired_date() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+        let expected = image_root.join("archive/repeated.fits");
+        write_fits(&expected, "Ha", "2026-07-24T05:00:00");
+        ctx.get_directory_tree().unwrap();
+        let mut image = image(r"C:\elsewhere\repeated.fits", "Ha");
+        image.acquired_date = Some(CAPTURE_TIME + 3_600);
+
+        assert_eq!(
+            find_fits_file(&ctx, &image, "M 31", "repeated.fits").unwrap(),
+            expected
+        );
     }
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -3473,7 +3473,21 @@ pub fn find_fits_file(
     target_name: &str,
     filename: &str,
 ) -> Result<std::path::PathBuf, AppError> {
-    find_fits_file_inner(ctx, image, target_name, filename, true, None)
+    let policy = if ctx.requires_delayed_file_identity(image.id) {
+        FileResolutionPolicy::DelayedRemote
+    } else {
+        FileResolutionPolicy::Ordinary
+    };
+    find_fits_file_inner(ctx, image, target_name, filename, policy, true, None)
+}
+
+/// A delayed remote row needs stronger identity proof than an ordinary local
+/// catalog lookup. Its file may still be in flight, and an older capture with
+/// the same basename may already be present below another configured root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FileResolutionPolicy {
+    Ordinary,
+    DelayedRemote,
 }
 
 fn find_fits_file_cached(
@@ -3482,7 +3496,15 @@ fn find_fits_file_cached(
     target_name: &str,
     filename: &str,
 ) -> Result<std::path::PathBuf, AppError> {
-    find_fits_file_inner(ctx, image, target_name, filename, false, None)
+    find_fits_file_inner(
+        ctx,
+        image,
+        target_name,
+        filename,
+        FileResolutionPolicy::DelayedRemote,
+        false,
+        None,
+    )
 }
 
 fn find_fits_file_cached_with_roots(
@@ -3497,6 +3519,7 @@ fn find_fits_file_cached_with_roots(
         image,
         target_name,
         filename,
+        FileResolutionPolicy::DelayedRemote,
         false,
         Some(canonical_roots),
     )
@@ -3507,6 +3530,7 @@ fn find_fits_file_inner(
     image: &crate::models::AcquiredImage,
     target_name: &str,
     filename: &str,
+    policy: FileResolutionPolicy,
     allow_tree_build: bool,
     shared_canonical_roots: Option<&[PathBuf]>,
 ) -> Result<std::path::PathBuf, AppError> {
@@ -3565,12 +3589,14 @@ fn find_fits_file_inner(
         tracing::debug!("✅ Base directory exists: {}", base_dir);
     }
 
-    for (idx, path) in all_possible_paths.iter().enumerate() {
-        tracing::debug!("  📁 Path {}: {:?}", idx + 1, path);
-        if let Some(path) = existing_file_under_configured_root(path, canonical_roots) {
-            tracing::info!("✅ Found file at path {}: {:?}", idx + 1, path);
-            ctx.record_resolved_image_file(image, &path);
-            return Ok(path);
+    if policy == FileResolutionPolicy::Ordinary {
+        for (idx, path) in all_possible_paths.iter().enumerate() {
+            tracing::debug!("  📁 Path {}: {:?}", idx + 1, path);
+            if let Some(path) = existing_file_under_configured_root(path, canonical_roots) {
+                tracing::info!("✅ Found file at path {}: {:?}", idx + 1, path);
+                ctx.record_resolved_image_file(image, &path);
+                return Ok(path);
+            }
         }
     }
 
@@ -3580,19 +3606,27 @@ fn find_fits_file_inner(
     // those tails directly so a file that arrived after the directory scan is
     // visible immediately. Components are joined one at a time and the final
     // canonical path must remain under a configured root.
-    let mut delayed_candidates = metadata_file_name(image)
-        .map(|metadata_path| metadata_suffix_candidates(ctx, &metadata_path, filename))
-        .unwrap_or_default();
+    let mut resolution_candidates = if policy == FileResolutionPolicy::DelayedRemote {
+        all_possible_paths
+    } else {
+        Vec::new()
+    };
+    resolution_candidates.extend(
+        metadata_file_name(image)
+            .map(|metadata_path| metadata_suffix_candidates(ctx, &metadata_path, filename))
+            .unwrap_or_default(),
+    );
     // Some copy tools flatten the remote hierarchy directly into an image
-    // root. Treat those as identity candidates, never exact-path hits: their
-    // capture headers must agree and multiple matches remain a conflict.
-    delayed_candidates.extend(ctx.image_dir_paths.iter().map(|root| root.join(filename)));
+    // root. Treat those as basename candidates, never exact-path hits. An
+    // ordinary catalog accepts only one contained candidate; a delayed remote
+    // lookup additionally requires matching capture headers.
+    resolution_candidates.extend(ctx.image_dir_paths.iter().map(|root| root.join(filename)));
     if !allow_tree_build {
         let cache = ctx.directory_tree_cache.read().unwrap();
         if let Some(tree) = cache.as_ref()
             && let Some(candidates) = tree.find_file(filename)
         {
-            delayed_candidates.extend(candidates.iter().cloned());
+            resolution_candidates.extend(candidates.iter().cloned());
         }
     }
 
@@ -3603,7 +3637,7 @@ fn find_fits_file_inner(
 
     // Try directory tree cache lookup as fallback
     let search_start = std::time::Instant::now();
-    let basename_candidates = if allow_tree_build {
+    let tree_candidates = if allow_tree_build {
         let tree = ctx.get_directory_tree().map_err(|e| {
             tracing::error!("Failed to get directory tree cache: {}", e);
             AppError::InternalError("Directory cache error".to_string())
@@ -3612,19 +3646,25 @@ fn find_fits_file_inner(
     } else {
         Vec::new()
     };
-    if basename_candidates.is_empty() {
+    if tree_candidates.is_empty() {
         tracing::debug!(
             "🔍 No matches in directory tree cache for filename: {}",
             filename
         );
     }
 
-    delayed_candidates.extend(basename_candidates);
-    if let Some(path) =
-        unique_header_matched_file(image, filename, delayed_candidates, canonical_roots)?
-    {
+    resolution_candidates.extend(tree_candidates);
+    let resolved = match policy {
+        FileResolutionPolicy::Ordinary => {
+            unique_contained_file(filename, resolution_candidates, canonical_roots)?
+        }
+        FileResolutionPolicy::DelayedRemote => {
+            unique_header_matched_file(image, filename, resolution_candidates, canonical_roots)?
+        }
+    };
+    if let Some(path) = resolved {
         tracing::info!(
-            "✅ Found header-matched file via directory tree cache in {:?}: {:?}",
+            "✅ Found file via directory tree cache in {:?}: {:?}",
             search_start.elapsed(),
             path
         );
@@ -3731,6 +3771,35 @@ fn canonical_file_under_roots(candidate: &FsPath, canonical_roots: &[PathBuf]) -
         .iter()
         .any(|root| canonical_candidate.starts_with(root));
     is_configured.then(|| candidate.to_path_buf())
+}
+
+fn unique_contained_file(
+    filename: &str,
+    candidates: Vec<PathBuf>,
+    canonical_roots: &[PathBuf],
+) -> Result<Option<PathBuf>, AppError> {
+    let mut resolved: Option<(PathBuf, PathBuf)> = None;
+    for candidate in candidates {
+        let Some(candidate) = existing_file_under_configured_root(&candidate, canonical_roots)
+        else {
+            continue;
+        };
+        let identity = std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
+        match resolved.as_ref() {
+            None => resolved = Some((identity, candidate)),
+            Some((known, _)) if known == &identity => {}
+            Some(_) => {
+                tracing::warn!(
+                    "Refusing multiple files named {} in configured image directories",
+                    filename
+                );
+                return Err(AppError::Conflict(format!(
+                    "{filename} matches multiple files in configured image directories"
+                )));
+            }
+        }
+    }
+    Ok(resolved.map(|(_, path)| path))
 }
 
 fn unique_header_matched_file(
@@ -6212,6 +6281,7 @@ mod file_resolution_tests {
         find_fits_file, find_fits_file_cached, metadata_suffix_candidates, AppError,
         DatabaseContext,
     };
+    use crate::commands::sync::ChangedAcquiredImage;
     use crate::models::AcquiredImage;
     use std::io::Write;
     use std::path::{Path, PathBuf};
@@ -6319,7 +6389,8 @@ mod file_resolution_tests {
         write_fits(&delayed, "Ha", "2026-07-24T05:00:00");
         let image = image(r"C:\remote-captures\rig-a\odd-layout\delayed.fits", "Ha");
 
-        let resolved = find_fits_file(&ctx, &image, "Unrelated Target", "delayed.fits").unwrap();
+        let resolved =
+            find_fits_file_cached(&ctx, &image, "Unrelated Target", "delayed.fits").unwrap();
         assert_eq!(resolved, delayed);
 
         {
@@ -6373,7 +6444,97 @@ mod file_resolution_tests {
     }
 
     #[test]
-    fn basename_fallback_requires_one_header_match() {
+    fn ordinary_unique_basename_accepts_legacy_coarse_timestamp() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+        let expected = image_root.join("archive/legacy.fits");
+        write_fits(&expected, "Ha", "2026-07-24T05:00:00");
+        ctx.get_directory_tree().unwrap();
+        let mut image = image("legacy.fits", "Ha");
+        image.acquired_date = Some(CAPTURE_TIME + 3_600);
+        image.metadata = r#"{"FileName":"legacy.fits"}"#.into();
+
+        assert_eq!(
+            find_fits_file(&ctx, &image, "M 31", "legacy.fits").unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn expired_remote_arrival_stops_polling_but_keeps_strict_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+        write_fits(
+            &image_root.join("archive/remote.fits"),
+            "Ha",
+            "2026-07-24T05:00:03",
+        );
+        ctx.get_directory_tree().unwrap();
+        let image = image(r"C:\remote\remote.fits", "Ha");
+        ctx.register_remote_image_arrivals(&[ChangedAcquiredImage {
+            id: i64::from(image.id),
+            project_id: i64::from(image.project_id),
+            target_id: i64::from(image.target_id),
+            acquired_date: image.acquired_date,
+        }]);
+
+        assert!(matches!(
+            find_fits_file(&ctx, &image, "M 31", "remote.fits"),
+            Err(AppError::NotFound)
+        ));
+        assert_eq!(
+            ctx.delayed_file_probe(image.id),
+            crate::server::database_context::DelayedFileProbe::Probe,
+            "strict resolution must not consume the preview probe"
+        );
+
+        ctx.expire_delayed_remote_image_for_test(image.id);
+        assert_eq!(
+            ctx.delayed_file_probe(image.id),
+            crate::server::database_context::DelayedFileProbe::NotPending
+        );
+        assert!(ctx.requires_delayed_file_identity(image.id));
+        assert!(matches!(
+            find_fits_file(&ctx, &image, "M 31", "remote.fits"),
+            Err(AppError::NotFound)
+        ));
+
+        let expected = image_root.join("archive/remote.fits");
+        write_fits(&expected, "Ha", "2026-07-24T05:00:00");
+        assert_eq!(
+            find_fits_file(&ctx, &image, "M 31", "remote.fits").unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn ordinary_basename_fallback_rejects_ambiguity() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+        write_fits(
+            &image_root.join("archive-a/repeated.fits"),
+            "OIII",
+            "2026-07-24T06:00:00",
+        );
+        write_fits(
+            &image_root.join("archive-b/repeated.fits"),
+            "Ha",
+            "2026-07-24T05:00:00",
+        );
+        ctx.get_directory_tree().unwrap();
+        let mut image = image("repeated.fits", "Ha");
+        image.metadata = r#"{"FileName":"repeated.fits"}"#.into();
+
+        match find_fits_file(&ctx, &image, "M 31", "repeated.fits") {
+            Err(AppError::Conflict(message)) => {
+                assert!(message.contains("matches multiple files"), "{message}");
+            }
+            _ => panic!("ordinary basename ambiguity must be refused"),
+        }
+    }
+
+    #[test]
+    fn delayed_basename_fallback_requires_one_header_match() {
         let temp = tempfile::tempdir().unwrap();
         let (ctx, image_root) = context(&temp);
         let wrong = image_root.join("archive-a/repeated.fits");
@@ -6384,12 +6545,12 @@ mod file_resolution_tests {
         let image = image(r"C:\elsewhere\repeated.fits", "Ha");
 
         assert_eq!(
-            find_fits_file(&ctx, &image, "M 31", "repeated.fits").unwrap(),
+            find_fits_file_cached(&ctx, &image, "M 31", "repeated.fits").unwrap(),
             correct
         );
 
         write_fits(&wrong, "Ha", "2026-07-24T05:00:00");
-        match find_fits_file(&ctx, &image, "M 31", "repeated.fits") {
+        match find_fits_file_cached(&ctx, &image, "M 31", "repeated.fits") {
             Err(AppError::Conflict(message)) => {
                 assert!(message.contains("matches multiple files"), "{message}");
             }
@@ -6398,7 +6559,7 @@ mod file_resolution_tests {
     }
 
     #[test]
-    fn basename_fallback_rejects_a_timestamp_mismatch() {
+    fn delayed_basename_fallback_rejects_a_timestamp_mismatch() {
         let temp = tempfile::tempdir().unwrap();
         let (ctx, image_root) = context(&temp);
         write_fits(
@@ -6410,13 +6571,13 @@ mod file_resolution_tests {
         let image = image(r"C:\elsewhere\repeated.fits", "Ha");
 
         assert!(matches!(
-            find_fits_file(&ctx, &image, "M 31", "repeated.fits"),
+            find_fits_file_cached(&ctx, &image, "M 31", "repeated.fits"),
             Err(AppError::NotFound)
         ));
     }
 
     #[test]
-    fn metadata_suffix_requires_one_header_matched_path_across_roots() {
+    fn delayed_metadata_suffix_requires_one_header_matched_path_across_roots() {
         let temp = tempfile::tempdir().unwrap();
         let (ctx, roots) = context_with_roots(&temp, &["images-a", "images-b"]);
         ctx.get_directory_tree().unwrap();
@@ -6427,19 +6588,19 @@ mod file_resolution_tests {
         let image = image(r"C:\remote\rig\night\repeated.fits", "Ha");
 
         assert_eq!(
-            find_fits_file(&ctx, &image, "M 31", "repeated.fits").unwrap(),
+            find_fits_file_cached(&ctx, &image, "M 31", "repeated.fits").unwrap(),
             second
         );
 
         write_fits(&first, "Ha", "2026-07-24T05:00:00");
         assert!(matches!(
-            find_fits_file(&ctx, &image, "M 31", "repeated.fits"),
+            find_fits_file_cached(&ctx, &image, "M 31", "repeated.fits"),
             Err(AppError::Conflict(_))
         ));
     }
 
     #[test]
-    fn basename_fallback_prefers_exposure_start_over_acquired_date() {
+    fn delayed_basename_fallback_prefers_exposure_start_over_acquired_date() {
         let temp = tempfile::tempdir().unwrap();
         let (ctx, image_root) = context(&temp);
         let expected = image_root.join("archive/repeated.fits");
@@ -6449,7 +6610,7 @@ mod file_resolution_tests {
         image.acquired_date = Some(CAPTURE_TIME + 3_600);
 
         assert_eq!(
-            find_fits_file(&ctx, &image, "M 31", "repeated.fits").unwrap(),
+            find_fits_file_cached(&ctx, &image, "M 31", "repeated.fits").unwrap(),
             expected
         );
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1092,8 +1092,20 @@ async fn pregenerate_preview(
     tracing::debug!("🎨 Pre-generating {} preview for image {}", size, image_id);
 
     // Find FITS file using existing function
-    let fits_path = handlers::find_fits_file(ctx, &image_data, target_name, file_only)
-        .map_err(|_| anyhow::anyhow!("FITS file not found for image {}", image_id))?;
+    let fits_path =
+        handlers::find_fits_file(ctx, &image_data, target_name, file_only).map_err(|error| {
+            match error {
+                handlers::AppError::Conflict(message) => anyhow::anyhow!(message),
+                handlers::AppError::NotFound => {
+                    anyhow::anyhow!("FITS file not found for image {}", image_id)
+                }
+                other => anyhow::anyhow!(
+                    "Source resolution failed for image {}: {:?}",
+                    image_id,
+                    other
+                ),
+            }
+        })?;
 
     // Determine target dimensions
     let max_dimensions = match size {
@@ -1154,16 +1166,7 @@ async fn pregenerate_annotated(
     // Create cache key matching the on-demand annotated format for consistency
     let size = "screen"; // Pre-generation uses screen size for annotated images
     let max_stars = 1000; // Pre-generation uses default max_stars
-    let cache_key = format!(
-        "annotated_{}_{}_{}_{}_{}_{}_{}",
-        image_id,
-        image_data.project_id,
-        image_data.target_id,
-        image_data.acquired_date.unwrap_or(0),
-        file_only.replace(&['.', ' ', '-'][..], "_"),
-        size,
-        max_stars
-    );
+    let cache_key = handlers::annotated_cache_key(&image_data, file_only, size, max_stars);
 
     let cache_manager = CacheManager::new(std::path::PathBuf::from(&ctx.cache_dir));
     cache_manager.ensure_category_dir("annotated")?;
@@ -1186,8 +1189,20 @@ async fn pregenerate_annotated(
     tracing::debug!("🎨 Pre-generating annotated image for image {}", image_id);
 
     // Find FITS file
-    let fits_path = handlers::find_fits_file(ctx, &image_data, target_name, file_only)
-        .map_err(|_| anyhow::anyhow!("FITS file not found for image {}", image_id))?;
+    let fits_path =
+        handlers::find_fits_file(ctx, &image_data, target_name, file_only).map_err(|error| {
+            match error {
+                handlers::AppError::Conflict(message) => anyhow::anyhow!(message),
+                handlers::AppError::NotFound => {
+                    anyhow::anyhow!("FITS file not found for image {}", image_id)
+                }
+                other => anyhow::anyhow!(
+                    "Source resolution failed for image {}: {:?}",
+                    image_id,
+                    other
+                ),
+            }
+        })?;
 
     // Generate atomically via the shared queue helper — consistent sizing with
     // the on-demand path, and temp-then-rename so a viewer never sees a partial
@@ -1196,7 +1211,7 @@ async fn pregenerate_annotated(
         fits_path,
         cache_path,
         kind: crate::server::preview_queue::GenKind::Annotated {
-            max_stars: max_stars as usize,
+            max_stars,
             size: size.to_string(),
         },
         encoding: state.preview_encoding(),

--- a/src/server/preview_queue.rs
+++ b/src/server/preview_queue.rs
@@ -21,6 +21,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
 
 use serde::Serialize;
 use tokio::sync::Semaphore;
@@ -97,13 +98,42 @@ impl GenerationStatus {
 
 /// Recent-error map cap, so a run of unresolvable frames can't grow it forever.
 const MAX_RECENT_ERRORS: usize = 512;
+const GENERATION_ERROR_MESSAGE: &str =
+    "preview generation failed; it will retry when the source file changes";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SourceFingerprint {
+    canonical_path: PathBuf,
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+fn source_fingerprint(path: &Path) -> Option<SourceFingerprint> {
+    let metadata = std::fs::metadata(path).ok()?;
+    Some(SourceFingerprint {
+        canonical_path: std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()),
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+#[derive(Debug, Clone)]
+struct RecentError {
+    source_fingerprint: Option<SourceFingerprint>,
+}
 
 #[derive(Default)]
 struct QueueInner {
     /// `cache_path`s currently being generated (dedup).
     in_flight: HashSet<PathBuf>,
-    /// `cache_path` -> last generation error message.
-    recent_errors: HashMap<PathBuf, String>,
+    /// `cache_path` -> fingerprint of the source that failed. Error text is
+    /// deliberately not retained for API responses because decoder messages
+    /// can include a server-local path.
+    recent_errors: HashMap<PathBuf, RecentError>,
+    /// Source identity that produced a completed artifact in this process.
+    /// Tracked remote arrivals use it to invalidate a preview if the copy
+    /// resumes after an apparently stable prefix was rendered.
+    completed_sources: HashMap<PathBuf, SourceFingerprint>,
 }
 
 /// Process-global interactive preview/annotated generation queue. Held on
@@ -118,6 +148,32 @@ pub struct PreviewQueue {
 }
 
 impl PreviewQueue {
+    pub fn cached_source_matches(&self, cache_path: &Path, source_path: &Path) -> bool {
+        let current = source_fingerprint(source_path);
+        let inner = self.inner.lock().unwrap();
+        inner.completed_sources.get(cache_path) == current.as_ref()
+    }
+
+    pub fn forget_completed_source(&self, cache_path: &Path) {
+        self.inner
+            .lock()
+            .unwrap()
+            .completed_sources
+            .remove(cache_path);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn remember_completed_source_for_test(
+        &self,
+        cache_path: PathBuf,
+        source_path: &Path,
+    ) {
+        self.inner.lock().unwrap().completed_sources.insert(
+            cache_path,
+            source_fingerprint(source_path).expect("test source fingerprint"),
+        );
+    }
+
     /// Report the state of one artifact by its `cache_path`. Pure read — does
     /// not enqueue (the caller enqueues when appropriate).
     pub fn status(&self, cache_path: &Path) -> Option<GenerationStatus> {
@@ -132,8 +188,36 @@ impl PreviewQueue {
         }
         inner
             .recent_errors
-            .get(cache_path)
-            .map(|e| GenerationStatus::error(e.clone()))
+            .contains_key(cache_path)
+            .then(|| GenerationStatus::error(GENERATION_ERROR_MESSAGE.to_string()))
+    }
+
+    /// Report status for a resolved source. A previous failure is forgotten
+    /// once that source's size or modification time changes, allowing a file
+    /// copied in place to resume preview generation without a server restart.
+    pub fn status_for_source(
+        &self,
+        cache_path: &Path,
+        source_path: &Path,
+    ) -> Option<GenerationStatus> {
+        if cache_path.exists() {
+            return Some(GenerationStatus::ready());
+        }
+        let fingerprint = source_fingerprint(source_path);
+        let mut inner = self.inner.lock().unwrap();
+        if inner.in_flight.contains(cache_path) {
+            return Some(GenerationStatus::generating());
+        }
+        match inner.recent_errors.get(cache_path) {
+            Some(error) if error.source_fingerprint.as_ref() == fingerprint.as_ref() => Some(
+                GenerationStatus::error(GENERATION_ERROR_MESSAGE.to_string()),
+            ),
+            Some(_) => {
+                inner.recent_errors.remove(cache_path);
+                None
+            }
+            None => None,
+        }
     }
 
     /// Lazily create (and reuse) the concurrency-bounding semaphore, sized from
@@ -162,13 +246,23 @@ impl AppState {
     /// a no-op, so the same artifact is never generated twice concurrently and
     /// re-requests are cheap.
     pub fn enqueue_preview(self: &Arc<Self>, job: GenJob) {
+        let current_source = source_fingerprint(&job.fits_path);
         // Dedup + claim the slot under the lock. `insert` returns false when
         // the path was already in-flight.
         {
             let mut inner = self.preview_queue.inner.lock().unwrap();
-            if job.cache_path.exists() || !inner.in_flight.insert(job.cache_path.clone()) {
+            if job.cache_path.exists()
+                || inner
+                    .recent_errors
+                    .get(&job.cache_path)
+                    .is_some_and(|error| {
+                        error.source_fingerprint.as_ref() == current_source.as_ref()
+                    })
+                || !inner.in_flight.insert(job.cache_path.clone())
+            {
                 return;
             }
+            inner.recent_errors.remove(&job.cache_path);
         }
 
         let sem = self
@@ -184,31 +278,60 @@ impl AppState {
             let _permit = sem.acquire_owned().await;
 
             let cache_path = job.cache_path.clone();
-            let outcome = tokio::task::spawn_blocking(move || generate(&job)).await;
+            let attempted_source = source_fingerprint(&job.fits_path);
+            let worker_source = attempted_source.clone();
+            let outcome =
+                tokio::task::spawn_blocking(move || generate_with_fingerprint(&job, worker_source))
+                    .await;
 
             let mut inner = state.preview_queue.inner.lock().unwrap();
             inner.in_flight.remove(&cache_path);
             match outcome {
                 Ok(Ok(())) => {
                     inner.recent_errors.remove(&cache_path);
+                    if let Some(source) = attempted_source {
+                        if inner.completed_sources.len() >= MAX_RECENT_ERRORS * 16
+                            && let Some(oldest) = inner.completed_sources.keys().next().cloned()
+                        {
+                            inner.completed_sources.remove(&oldest);
+                        }
+                        inner.completed_sources.insert(cache_path, source);
+                    }
                 }
-                Ok(Err(e)) => record_error(&mut inner, cache_path, e.to_string()),
-                Err(join) => record_error(&mut inner, cache_path, format!("panicked: {join}")),
+                Ok(Err(error)) => {
+                    inner.completed_sources.remove(&cache_path);
+                    record_error(&mut inner, cache_path, attempted_source, error.to_string())
+                }
+                Err(join) => record_error(
+                    &mut inner,
+                    cache_path,
+                    attempted_source,
+                    format!("panicked: {join}"),
+                ),
             }
         });
     }
 }
 
-fn record_error(inner: &mut QueueInner, cache_path: PathBuf, msg: String) {
+fn record_error(
+    inner: &mut QueueInner,
+    cache_path: PathBuf,
+    source_fingerprint: Option<SourceFingerprint>,
+    detail: String,
+) {
     tracing::warn!(
         "🖼️ Preview generation failed for {}: {}",
         cache_path.display(),
-        msg
+        detail
     );
-    if inner.recent_errors.len() >= MAX_RECENT_ERRORS {
-        inner.recent_errors.clear();
+    if inner.recent_errors.len() >= MAX_RECENT_ERRORS
+        && let Some(oldest) = inner.recent_errors.keys().next().cloned()
+    {
+        inner.recent_errors.remove(&oldest);
     }
-    inner.recent_errors.insert(cache_path, msg);
+    inner
+        .recent_errors
+        .insert(cache_path, RecentError { source_fingerprint });
 }
 
 /// Generate one artifact to a unique temp path, then atomically rename into
@@ -217,6 +340,14 @@ fn record_error(inner: &mut QueueInner, cache_path: PathBuf, msg: String) {
 /// both are atomic and a pregen/queue double-generate can't clobber a reader.
 /// Blocking; call from `spawn_blocking`.
 pub fn generate(job: &GenJob) -> anyhow::Result<()> {
+    let attempted_source = source_fingerprint(&job.fits_path);
+    generate_with_fingerprint(job, attempted_source)
+}
+
+fn generate_with_fingerprint(
+    job: &GenJob,
+    attempted_source: Option<SourceFingerprint>,
+) -> anyhow::Result<()> {
     let tmp = temp_path(&job.cache_path);
     let result = match &job.kind {
         GenKind::Preview {
@@ -245,7 +376,14 @@ pub fn generate(job: &GenJob) -> anyhow::Result<()> {
 
     // Clean up the temp file on both a generation failure and a rename
     // failure, so a failed run never orphans a `.tmp.*` file.
-    match result.and_then(|()| std::fs::rename(&tmp, &job.cache_path).map_err(Into::into)) {
+    let result = result.and_then(|()| {
+        anyhow::ensure!(
+            source_fingerprint(&job.fits_path).as_ref() == attempted_source.as_ref(),
+            "source file changed while the preview was generated"
+        );
+        std::fs::rename(&tmp, &job.cache_path).map_err(Into::into)
+    });
+    match result {
         Ok(()) => Ok(()),
         Err(e) => {
             let _ = std::fs::remove_file(&tmp);
@@ -425,14 +563,101 @@ mod tests {
         assert_eq!(q.status(&p).unwrap().state, GenerationState::Generating);
 
         q.inner.lock().unwrap().in_flight.remove(&p);
-        q.inner
-            .lock()
-            .unwrap()
-            .recent_errors
-            .insert(p.clone(), "boom".into());
+        record_error(
+            &mut q.inner.lock().unwrap(),
+            p.clone(),
+            None,
+            r"decoder failed at \\server\private\frame.fits".into(),
+        );
         let s = q.status(&p).unwrap();
         assert_eq!(s.state, GenerationState::Error);
-        assert_eq!(s.error.as_deref(), Some("boom"));
+        assert_eq!(s.error.as_deref(), Some(GENERATION_ERROR_MESSAGE));
+        assert!(!s.error.unwrap().contains("private"));
+    }
+
+    #[test]
+    fn source_change_clears_a_cached_generation_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("arriving.fits");
+        let cache = dir.path().join("preview.png");
+        std::fs::write(&source, b"partial").unwrap();
+
+        let q = PreviewQueue::default();
+        q.inner.lock().unwrap().recent_errors.insert(
+            cache.clone(),
+            RecentError {
+                source_fingerprint: source_fingerprint(&source),
+            },
+        );
+        assert_eq!(
+            q.status_for_source(&cache, &source).unwrap().state,
+            GenerationState::Error
+        );
+
+        std::fs::write(&source, b"a larger complete frame").unwrap();
+        assert!(q.status_for_source(&cache, &source).is_none());
+        assert!(!q.inner.lock().unwrap().recent_errors.contains_key(&cache));
+    }
+
+    #[test]
+    fn a_different_source_path_clears_an_equal_sized_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.fits");
+        let second = dir.path().join("second.fits");
+        let cache = dir.path().join("preview.png");
+        std::fs::write(&first, b"same bytes").unwrap();
+        std::fs::write(&second, b"same bytes").unwrap();
+
+        let q = PreviewQueue::default();
+        q.inner.lock().unwrap().recent_errors.insert(
+            cache.clone(),
+            RecentError {
+                source_fingerprint: source_fingerprint(&first),
+            },
+        );
+        assert!(q.status_for_source(&cache, &second).is_none());
+    }
+
+    #[test]
+    fn a_completed_artifact_is_invalid_after_its_source_grows() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("arriving.fits");
+        let cache = dir.path().join("preview.png");
+        std::fs::write(&source, b"stable prefix").unwrap();
+        std::fs::write(&cache, b"rendered prefix").unwrap();
+
+        let q = PreviewQueue::default();
+        q.inner.lock().unwrap().completed_sources.insert(
+            cache.clone(),
+            source_fingerprint(&source).expect("source fingerprint"),
+        );
+        assert!(q.cached_source_matches(&cache, &source));
+
+        std::fs::write(&source, b"stable prefix followed by the remaining pixels").unwrap();
+        assert!(!q.cached_source_matches(&cache, &source));
+    }
+
+    #[test]
+    fn recording_one_more_error_evicts_only_one_entry() {
+        let mut inner = QueueInner::default();
+        for index in 0..MAX_RECENT_ERRORS {
+            inner.recent_errors.insert(
+                PathBuf::from(format!("/cache/{index}.png")),
+                RecentError {
+                    source_fingerprint: None,
+                },
+            );
+        }
+        record_error(
+            &mut inner,
+            PathBuf::from("/cache/new.png"),
+            None,
+            "failed".into(),
+        );
+        assert_eq!(inner.recent_errors.len(), MAX_RECENT_ERRORS);
+        assert!(inner
+            .recent_errors
+            .contains_key(Path::new("/cache/new.png")));
     }
 
     #[test]

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -1367,7 +1367,8 @@ fn prepare_job(
             };
             let path = match super::handlers::find_fits_file(ctx, &image, &target_name, &filename) {
                 Ok(path) => path,
-                Err(_) => {
+                Err(AppError::Conflict(message)) => return Err(AppError::Conflict(message)),
+                Err(AppError::NotFound) => {
                     missing_files += 1;
                     decisions.push(excluded_decision(
                         &image,
@@ -1376,6 +1377,7 @@ fn prepare_job(
                     ));
                     continue;
                 }
+                Err(error) => return Err(error),
             };
             let source_fingerprint = source_fingerprint(&path);
             hasher.update(source_fingerprint.as_bytes());

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -338,6 +338,32 @@ impl FileCheckCache {
         self.has_initial_data && self.refresh_in_progress
     }
 
+    /// Fold one newly resolved image into an already initialized navigation
+    /// cache without turning the discovery into a full refresh.
+    pub fn record_resolved_image(
+        &mut self,
+        project_id: i32,
+        target_id: i32,
+        acquired_date: Option<i64>,
+    ) {
+        // A partial map must not masquerade as the initial full scan. The
+        // running refresh will include the file through the directory tree,
+        // or a later request will record it after initialization completes.
+        if !self.has_initial_data {
+            return;
+        }
+        self.projects_with_files.insert(project_id, true);
+        self.targets_with_files.insert(target_id, true);
+        if let Some(acquired_date) = acquired_date {
+            self.project_latest_image_dates
+                .entry(project_id)
+                .and_modify(|latest| *latest = (*latest).max(acquired_date))
+                .or_insert(acquired_date);
+        }
+        // Deliberately leave last_updated alone. One positive observation does
+        // not make every other cached file check fresh.
+    }
+
     pub fn get_refresh_status(&self) -> RefreshStatus {
         if self.refresh_in_progress {
             if self.has_initial_data {
@@ -345,11 +371,7 @@ impl FileCheckCache {
             } else {
                 RefreshStatus::InProgressWait
             }
-        } else if self.is_expired()
-            || (!self.has_initial_data
-                && self.projects_with_files.is_empty()
-                && self.targets_with_files.is_empty())
-        {
+        } else if !self.has_initial_data || self.is_expired() {
             RefreshStatus::NeedsRefresh
         } else {
             RefreshStatus::NotNeeded

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -6721,6 +6721,8 @@
 
 .preview-status-label {
   font-size: 0.8rem;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .preview-status-error {

--- a/static/src/components/ImageComparisonView.tsx
+++ b/static/src/components/ImageComparisonView.tsx
@@ -569,7 +569,7 @@ export default function ImageComparisonView({
                         <line x1="9" y1="9" x2="15" y2="15" />
                         <line x1="15" y1="9" x2="9" y2="15" />
                       </svg>
-                      <p style={{ margin: 0, fontSize: '0.9rem', color: '#666' }}>Image not available</p>
+                      <p style={{ margin: 0, fontSize: '0.9rem', color: '#666' }}>{asyncLeft.error ?? 'Image not available'}</p>
                     </div>
                   </div>
                 ) : (
@@ -742,7 +742,7 @@ export default function ImageComparisonView({
                             <line x1="9" y1="9" x2="15" y2="15" />
                             <line x1="15" y1="9" x2="9" y2="15" />
                           </svg>
-                          <p style={{ margin: 0, fontSize: '0.9rem', color: '#666' }}>Image not available</p>
+                          <p style={{ margin: 0, fontSize: '0.9rem', color: '#666' }}>{asyncRight.error ?? 'Image not available'}</p>
                         </div>
                       </div>
                     ) : (() => {

--- a/static/src/components/ImageDetailView.tsx
+++ b/static/src/components/ImageDetailView.tsx
@@ -537,7 +537,7 @@ export default function ImageDetailView({
                       <line x1="15" y1="9" x2="9" y2="15" />
                     </svg>
                     <h3 style={{ margin: '0 0 8px 0', fontSize: '1.2rem', fontWeight: 'normal' }}>Image not available</h3>
-                    <p style={{ margin: 0, fontSize: '0.9rem', color: '#666' }}>The requested image could not be found on the server</p>
+                    <p style={{ margin: 0, fontSize: '0.9rem', color: '#666' }}>{asyncImg.error ?? 'The requested image could not be found on the server'}</p>
                   </div>
                 </div>
               ) : (

--- a/static/src/components/Overview.tsx
+++ b/static/src/components/Overview.tsx
@@ -863,11 +863,6 @@ export default function Overview() {
                                   }}
                                   alt={`${image.target_name}, ${filter}`}
                                   loading="lazy"
-                                  fallback={
-                                    <span className="project-frame-fallback">
-                                      Preview unavailable
-                                    </span>
-                                  }
                                 />
                                 {isNew && <span className="project-frame-new">New</span>}
                                 {isNewest && (

--- a/static/src/components/PreviewImage.tsx
+++ b/static/src/components/PreviewImage.tsx
@@ -67,7 +67,7 @@ export default function PreviewImage({
           )}
         </div>
       )}
-      {img.state === 'error' && (fallback ?? <PreviewError />)}
+      {img.state === 'error' && (fallback ?? <PreviewError message={img.error} />)}
       {/* The img stays in layout (never display:none) so it actually loads —
           a lazy + display:none image has no box and the browser never fetches
           it, so onError/onLoad would never fire. While pending/error it is
@@ -85,7 +85,7 @@ export default function PreviewImage({
   );
 }
 
-function PreviewError() {
+function PreviewError({ message }: { message?: string }) {
   return (
     <div className="preview-status-box preview-status-error">
       <svg
@@ -100,7 +100,7 @@ function PreviewError() {
         <line x1="9" y1="9" x2="15" y2="15" />
         <line x1="15" y1="9" x2="9" y2="15" />
       </svg>
-      <span className="preview-status-label">Image not found</span>
+      <span className="preview-status-label">{message ?? 'Image not found'}</span>
     </div>
   );
 }

--- a/static/src/hooks/__tests__/useAsyncImage.test.tsx
+++ b/static/src/hooks/__tests__/useAsyncImage.test.tsx
@@ -1,13 +1,23 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAsyncImage } from '../useAsyncImage';
 import type { PreviewDescriptor } from '../../api/types';
+
+const { registerPendingMock } = vi.hoisted(() => ({
+  registerPendingMock: vi.fn(),
+}));
+
+vi.mock('../previewPoll', () => ({ registerPending: registerPendingMock }));
 
 function preview(imageId: number): PreviewDescriptor {
   return { imageId, kind: 'preview', size: 'screen' };
 }
 
 describe('useAsyncImage', () => {
+  beforeEach(() => {
+    registerPendingMock.mockReset();
+  });
+
   it('does not carry ready state across source changes', () => {
     const firstSrc = '/api/db/test/images/1/preview?size=screen';
     const secondSrc = '/api/db/test/images/2/preview?size=screen';
@@ -28,5 +38,30 @@ describe('useAsyncImage', () => {
 
     expect(result.current.src).toBe(secondSrc);
     expect(result.current.state).toBe('loading');
+  });
+
+  it('surfaces the sanitized terminal message from the shared poller', () => {
+    let reportError: ((message: string) => void) | undefined;
+    registerPendingMock.mockImplementation(
+      (_dbId, _descriptor, callbacks: { onError: (message: string) => void }) => {
+        reportError = callbacks.onError;
+        return vi.fn();
+      }
+    );
+    const { result } = renderHook(() =>
+      useAsyncImage(
+        'test',
+        '/api/db/test/images/1/preview?size=screen',
+        preview(1)
+      )
+    );
+
+    act(() => result.current.onError());
+    act(() => reportError?.('frame.fits matches multiple capture candidates'));
+
+    expect(result.current.state).toBe('error');
+    expect(result.current.error).toBe(
+      'frame.fits matches multiple capture candidates'
+    );
   });
 });

--- a/static/src/hooks/useAsyncImage.ts
+++ b/static/src/hooks/useAsyncImage.ts
@@ -8,6 +8,8 @@ export interface AsyncImageResult {
   /** Feed this to `<img src>` (carries a cache-buster after a reload). */
   src: string;
   state: AsyncImageState;
+  /** Sanitized terminal message returned by the generation-status endpoint. */
+  error?: string;
   onLoad: () => void;
   onError: () => void;
 }
@@ -16,6 +18,7 @@ interface AsyncImageRecord {
   baseSrc: string;
   state: AsyncImageState;
   reloadTick: number;
+  error?: string;
 }
 
 /**
@@ -49,7 +52,7 @@ export function useAsyncImage(
     setRecord((current) =>
       current.baseSrc === src
         ? current
-        : { baseSrc: src, state: 'loading', reloadTick: 0 }
+        : { baseSrc: src, state: 'loading', reloadTick: 0, error: undefined }
     );
     return () => {
       unregisterRef.current?.();
@@ -64,6 +67,7 @@ export function useAsyncImage(
       baseSrc: src,
       state: 'ready',
       reloadTick: current.baseSrc === src ? current.reloadTick : 0,
+      error: undefined,
     }));
   }, [src]);
 
@@ -75,6 +79,7 @@ export function useAsyncImage(
         baseSrc: src,
         state: 'error',
         reloadTick: current.baseSrc === src ? current.reloadTick : 0,
+        error: undefined,
       }));
       return;
     }
@@ -82,6 +87,7 @@ export function useAsyncImage(
       baseSrc: src,
       state: 'generating',
       reloadTick: current.baseSrc === src ? current.reloadTick : 0,
+      error: undefined,
     }));
     unregisterRef.current = registerPending(dbId, descRef.current, {
       onReady: () => {
@@ -90,14 +96,16 @@ export function useAsyncImage(
           baseSrc: src,
           state: 'loading',
           reloadTick: (current.baseSrc === src ? current.reloadTick : 0) + 1,
+          error: undefined,
         })); // force <img> to re-fetch (now cached)
       },
-      onError: () => {
+      onError: (message) => {
         unregisterRef.current = null;
         setRecord((current) => ({
           baseSrc: src,
           state: 'error',
           reloadTick: current.baseSrc === src ? current.reloadTick : 0,
+          error: message,
         }));
       },
     });
@@ -105,9 +113,10 @@ export function useAsyncImage(
 
   const state = record.baseSrc === src ? record.state : 'loading';
   const reloadTick = record.baseSrc === src ? record.reloadTick : 0;
+  const error = record.baseSrc === src ? record.error : undefined;
   const displaySrc =
     reloadTick > 0 ? withParam(src, 'v', String(reloadTick)) : src;
-  return { src: displaySrc, state, onLoad, onError };
+  return { src: displaySrc, state, error, onLoad, onError };
 }
 
 function withParam(url: string, key: string, value: string): string {

--- a/tests/integration_remote_sync.rs
+++ b/tests/integration_remote_sync.rs
@@ -13,7 +13,7 @@ use http_body_util::BodyExt;
 use psf_guard::{
     cli::PregenerationConfig,
     db_registry::{DbEntry, RemoteImageUploadConfig},
-    server::{remote_sync, state::AppState},
+    server::{handlers, remote_sync, state::AppState},
 };
 use rusqlite::Connection;
 use serde_json::{json, Value};
@@ -84,6 +84,10 @@ fn app(state: Arc<AppState>) -> Router {
             "/api/sync/v1/jobs/{job_id}",
             get(remote_sync::get_preview_job),
         )
+        .route(
+            "/api/db/{db_id}/images/generation-status",
+            post(handlers::post_generation_status),
+        )
         .with_state(state)
 }
 
@@ -144,6 +148,25 @@ async fn create_async_preview(app: Router, operation: &str, bundle: Value) -> (S
     let status = response.status();
     let bytes = response.into_body().collect().await.unwrap().to_bytes();
     (status, serde_json::from_slice(&bytes).unwrap())
+}
+
+async fn preview_generation_state(harness: &Harness, image_id: i64) -> Value {
+    let (status, response) = call(
+        harness.router.clone(),
+        "POST",
+        "/api/db/destination/images/generation-status",
+        None,
+        Some(json!({
+            "requests": [{
+                "image_id": image_id,
+                "kind": "preview",
+                "size": "screen"
+            }]
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{response:#}");
+    response["data"]["statuses"][0].clone()
 }
 
 /// Two token-scoped catalogs wired to one router, the shape every remote sync
@@ -512,6 +535,20 @@ async fn merge_brings_a_remote_catalogs_projects_targets_and_captures_across() {
     assert_eq!(count(&destination, "project"), 1);
     assert_eq!(count(&destination, "target"), 1);
     assert_eq!(count(&destination, "acquiredimage"), 2);
+    let first_id: i64 = destination
+        .query_row(
+            "SELECT Id FROM acquiredimage WHERE guid = 'image-one'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    drop(destination);
+    assert_eq!(
+        preview_generation_state(&harness, first_id).await["state"],
+        "generating",
+        "a committed capture merge should wait for its separately copied file"
+    );
+    let destination = harness.destination();
     let (grade, reason): (i64, Option<String>) = destination
         .query_row(
             "SELECT gradingStatus, rejectreason FROM acquiredimage WHERE guid = 'image-two'",
@@ -598,6 +635,13 @@ async fn push_grades_moves_grading_state_and_leaves_planning_alone() {
         .query_row("SELECT description FROM project", [], |row| row.get(0))
         .unwrap();
     assert_eq!(description, "local settings");
+    drop(statement);
+    drop(destination);
+    assert_eq!(
+        preview_generation_state(&harness, 60).await["state"],
+        "error",
+        "a grade-only apply must not start a delayed-file grace window"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- track captures committed by remote scheduler merge while separately copied files arrive
- resolve delayed files safely from bounded, root-confined candidates without rescanning remote storage on each poll
- retry partial-copy preview failures after the source changes, preserve cache identity, and surface sanitized ambiguity errors
- keep project/target navigation coherent while files are pending

Pairs with theatrus/psf-guard-nina-plugin#15, which delivers Target Scheduler metadata before a dependent image upload.

## Validation
- `PSF_GUARD_SKIP_FRONTEND_BUILD=1 cargo test --lib -j1` (719 passed, 5 ignored)
- `PSF_GUARD_SKIP_FRONTEND_BUILD=1 cargo test --test integration_remote_sync -j1` (13 passed)
- `cargo test delayed_ --lib -j1` (9 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `npm run lint`
- `npx vitest run` (65 files, 312 tests)
- `npm run build`
- `git diff --check`