### PR TITLE
Move to Seiza 0.18.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f819e7f97d8bb8e6c177f51cfb39ea84deea206343b70b12e2ebb2efdab055"
+checksum = "61e5f0166ac95b3ff69a7da0c840b6ebd45ea4f3e0761053df4af83e9053d53b"
 dependencies = [
  "directories",
  "image",
@@ -5045,9 +5045,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db4aa361a765ac1a80058dba7e67255cf2f2253ba6afebcf8cd5162f5352096"
+checksum = "c63b4b0ef7762fe27a2228cfd85435e9e1a65d021ff4beff711892c504176c22"
 dependencies = [
  "rayon",
  "seiza",
@@ -7098,9 +7098,9 @@ checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "wide"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.18.2"
+seiza = "0.18.3"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.1"
 seiza-satellites = { version = "0.7.0", features = ["serde"] }
-seiza-stacking = "0.11.0"
+seiza-stacking = "0.11.1"
 seiza-stretch = "0.2.1"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.


### PR DESCRIPTION
`seiza` 0.18.2 → **0.18.3** and `seiza-stacking` 0.11.0 → **0.11.1**, carrying two upstream changes released as [seiza#147](https://github.com/theatrus/seiza/pull/147).

## What comes with it

**[seiza#146](https://github.com/theatrus/seiza/pull/146)** — a master build now maps per-input statistics to accepted paths only. After a middle frame is set aside, the remaining statistics line up with the frames that actually combined instead of shifting onto the wrong paths. It also preserves the normalized sensor, optics, exposure, temperature and capture-time fields needed to match a written master later, and collapses header aliases to one canonical FITS card.

**[seiza#145](https://github.com/theatrus/seiza/pull/145)** — `thiserror` 2.0.20, `ureq` 3.4.0, `wide` 1.6.1, which raises `wide` to 1.6 here as well.

## Effect on psf-guard

None that a user sees. psf-guard reads neither `input_statistics` nor `input_frames` — I checked rather than assumed — so the statistics fix is invisible here, though the frames it does read are now described correctly. The `skipped_inputs` reporting this branch already surfaces in the calibration warning was available in 0.11.0 and is unchanged.

No release note, per the contributor guide's rule for dependency bumps.

## Checks

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — **803 tests**, 0 failed
- `git diff --check` — clean

Frontend untouched, so its checks were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
