### PR TITLE
Close every auto-mode calibration escape, and make the master cache honest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1366,7 +1366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4168,7 +4168,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4719,7 +4719,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4776,7 +4776,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6073,7 +6073,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7128,7 +7128,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -364,3 +364,20 @@
   Calibration matching takes a value in degrees, applies it to the next stack
   without a restart, and an empty field returns to the default. The setting
   is server-wide and shared by the desktop and browser apps.
+- Stacking OIII and SII no longer fails against calibration masters generated
+  before mid-August. Two causes, both fixed. Validation treated a reading the
+  master never recorded — telescope, focal length — as a disagreement, when
+  an unrecorded reading proves nothing; masters now validate on what both
+  sides actually recorded. And those old masters should have rebuilt
+  themselves: the master cache records a generation number but reuse never
+  checked it, so masters from before metadata preservation were served
+  forever. Reuse now requires the current generation, and every older master
+  rebuilds itself once, with full metadata. "Clear generated masters" in the
+  Calibration Library remains the manual lever.
+- Auto-mode calibration now keeps its promise everywhere: a stack is never
+  abandoned over calibration. A plan that cannot be built, a reference frame
+  whose masters are refused, and a mid-stack master swap that fails all
+  degrade to stacking raw with a warning that says why; frames the stacker
+  turns away for calibration are summarized in the same warning — count and
+  reason — instead of hiding in the per-frame list. Forced calibration keeps
+  hard errors.

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -25,7 +25,11 @@ use std::time::UNIX_EPOCH;
 ///    shot at the same rotator angle.
 pub const CALIBRATION_SCHEMA_VERSION: i64 = 3;
 // 2: flat masters suppress defective pixels spatially after integration.
-pub const MASTER_CACHE_VERSION: u32 = 2;
+/// Version 3: masters preserve sensor, optics, exposure and capture-time
+/// metadata (seiza-stacking 0.11.1). Masters written before that carry no
+/// TELESCOP or FOCALLEN, which weakens validation and later matching to
+/// "nothing recorded, nothing to check" — so they rebuild once.
+pub const MASTER_CACHE_VERSION: u32 = 3;
 const MIN_MASTER_FRAMES: usize = 2;
 const MAX_MASTER_FRAMES: usize = 64;
 
@@ -2176,6 +2180,18 @@ pub struct CalibrationPlan {
 }
 
 impl CalibrationPlan {
+    /// A plan that calibrates nothing, for an automatic mode falling back
+    /// after the real plan could not be built. Distinct from mode Off: the
+    /// fingerprint says the fallback happened, so a later run whose plan
+    /// builds again does not resume an uncalibrated accumulator.
+    pub fn without_calibration(lights: usize) -> Self {
+        let (masters, mut applied) = calibration_off();
+        applied.mode = CalibrationMode::Auto;
+        applied.state = "unavailable".into();
+        applied.fingerprint = "auto-fallback-uncalibrated".into();
+        Self::single(masters, applied, lights)
+    }
+
     fn single(
         masters: seiza_stacking::CalibrationMasters,
         applied: AppliedCalibration,
@@ -2453,18 +2469,35 @@ fn build_master(
             CalibrationKind::Dark | CalibrationKind::DarkFlat => "DARK",
             CalibrationKind::Flat => "FLAT",
         };
-        let row_exists = conn
+        let recorded_version: Option<i64> = conn
             .query_row(
-                "SELECT 1 FROM psf_guard_calibration_master WHERE cache_path = ?1",
+                "SELECT cache_version FROM psf_guard_calibration_master WHERE cache_path = ?1",
                 [path.to_string_lossy().as_ref()],
-                |_| Ok(()),
+                |row| row.get(0),
             )
-            .optional()?
-            .is_some();
+            .optional()?;
+        // The version is what makes the cache honest: a master written by an
+        // older generation is not the artifact this build would produce from
+        // the same sources, so it is a miss, not a hit. Files predating
+        // metadata preservation sat in this cache validating as "nothing
+        // recorded, nothing to check" for a week because reuse never asked.
+        // The exception is a blocked recorder: it cannot rebuild, and an old
+        // master under today's validation still beats no master at all.
+        let row_current = recorded_version == Some(i64::from(MASTER_CACHE_VERSION));
         let file_valid = crate::image_io::open_linear_frame(&path)
             .and_then(|frame| frame.validate_master_kind(expected_kind))
             .is_ok();
-        if row_exists && file_valid {
+        if recorded_version.is_some()
+            && file_valid
+            && (row_current || recording_blocker.is_some())
+        {
+            if !row_current {
+                tracing::info!(
+                    "serving generation-{} master {} without rebuilding: recording is blocked",
+                    recorded_version.unwrap_or_default(),
+                    path.display()
+                );
+            }
             return Ok(Some(BuiltMaster {
                 path,
                 master_uuid,
@@ -4769,6 +4802,24 @@ mod tests {
     }
 
     #[test]
+    fn the_auto_fallback_plan_cannot_be_mistaken_for_off_or_resumed_into() {
+        // When the real plan cannot be built, auto mode stacks raw rather
+        // than failing — the edict is that calibration problems warn, never
+        // kill. The fallback must still be honest about what it is: mode
+        // auto (the user did not choose off), a state that says calibration
+        // was unavailable, and a fingerprint distinct from both "off" and
+        // any real selection, so a later run whose plan builds again does
+        // not resume an accumulator whose frames went in uncalibrated.
+        let plan = CalibrationPlan::without_calibration(3);
+        assert_eq!(plan.assignments, vec![0, 0, 0]);
+        assert_eq!(plan.applied.mode, CalibrationMode::Auto);
+        assert_eq!(plan.applied.state, "unavailable");
+        assert_ne!(plan.applied.fingerprint, "off");
+        assert_ne!(plan.applied.fingerprint, "none");
+        assert!(plan.sessions[0].masters.is_empty());
+    }
+
+    #[test]
     fn calibration_off_skips_matching_and_cannot_collide_with_a_real_selection() {
         // `Off` must not read the library at all, and its fingerprint must
         // differ from both a real selection and the empty-selection "none"
@@ -5074,6 +5125,97 @@ mod tests {
 
         assert!(!reused.is_empty());
         assert_eq!(applied.state, "applied");
+        assert_eq!(applied.bias_master, first.bias_master);
+    }
+
+    #[test]
+    fn a_master_from_an_older_generation_is_a_miss_not_a_hit() {
+        // What let masters without optics metadata survive for a week: reuse
+        // compared only the path and the file's kind, so bumping
+        // MASTER_CACHE_VERSION invalidated nothing. The version is part of
+        // what the cache promises — an older generation's file is not the
+        // artifact this build would produce from the same sources.
+        let temp = tempfile::tempdir().unwrap();
+        let (database_path, cache, light_path) = file_backed_bias_library(&temp);
+        let conn = Connection::open(&database_path).unwrap();
+        resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE psf_guard_calibration_master SET cache_version = ?1",
+            [i64::from(MASTER_CACHE_VERSION) - 1],
+        )
+        .unwrap();
+
+        let (rebuilt, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        assert!(!rebuilt.is_empty());
+        assert_eq!(applied.state, "applied");
+        let version: i64 = conn
+            .query_row(
+                "SELECT cache_version FROM psf_guard_calibration_master LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            version,
+            i64::from(MASTER_CACHE_VERSION),
+            "the stale master was rebuilt at the current generation"
+        );
+    }
+
+    #[test]
+    fn a_blocked_recorder_still_serves_an_older_generation_master() {
+        // A read-only flow cannot rebuild, and an old master under today's
+        // validation still beats no master at all.
+        let temp = tempfile::tempdir().unwrap();
+        let (database_path, cache, light_path) = file_backed_bias_library(&temp);
+        let conn = Connection::open(&database_path).unwrap();
+        let (_, first) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE psf_guard_calibration_master SET cache_version = ?1",
+            [i64::from(MASTER_CACHE_VERSION) - 1],
+        )
+        .unwrap();
+        drop(conn);
+
+        let read_only = Connection::open_with_flags(
+            &database_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .unwrap();
+        let (masters, applied) = resolve_or_build_masters(
+            &read_only,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        assert!(!masters.is_empty());
         assert_eq!(applied.bias_master, first.bias_master);
     }
 

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -2487,9 +2487,7 @@ fn build_master(
         let file_valid = crate::image_io::open_linear_frame(&path)
             .and_then(|frame| frame.validate_master_kind(expected_kind))
             .is_ok();
-        if recorded_version.is_some()
-            && file_valid
-            && (row_current || recording_blocker.is_some())
+        if recorded_version.is_some() && file_valid && (row_current || recording_blocker.is_some())
         {
             if !row_current {
                 tracing::info!(
@@ -5201,11 +5199,9 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        let read_only = Connection::open_with_flags(
-            &database_path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
-        )
-        .unwrap();
+        let read_only =
+            Connection::open_with_flags(&database_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .unwrap();
         let (masters, applied) = resolve_or_build_masters(
             &read_only,
             &cache,

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -1946,10 +1946,29 @@ fn run_group(
     // `{:#}` keeps the whole anyhow chain: "building master flat: <why>".
     // `to_string()` printed only the outermost context, which reported a
     // failed master build with no cause at all.
-    let plan = plan.map_err(|error| {
-        tracing::warn!("Stack group calibration failed: {error:#}");
-        format!("{error:#}")
-    })?;
+    //
+    // Auto mode's contract reaches here too: a plan that cannot be built —
+    // an unreadable cached master, a selection query refused — is a reason
+    // to stack raw and say why, never to abandon the group. The cancel
+    // check above already returned, so this cannot swallow a stop. Forced
+    // calibration keeps the hard error.
+    let plan = match plan {
+        Ok(plan) => plan,
+        Err(error) if group.calibration != crate::calibration::CalibrationMode::On => {
+            tracing::warn!("calibration plan failed; stacking raw: {error:#}");
+            let mut plan =
+                crate::calibration::CalibrationPlan::without_calibration(group.frames.len());
+            plan.applied.warning = Some(format!(
+                "Stacked without calibration: the calibration plan could not be built — \
+                 {error:#}"
+            ));
+            plan
+        }
+        Err(error) => {
+            tracing::warn!("Stack group calibration failed: {error:#}");
+            return Err(format!("{error:#}"));
+        }
+    };
     let mut applied_calibration = plan.applied.clone();
     // With no dark master anywhere in the plan, the lights keep their hot
     // pixels and the stack runs the spatial impulse filter over each frame.
@@ -2166,9 +2185,46 @@ fn run_group(
                 };
                 // The reference calibrates with its own session's masters;
                 // later sessions swap theirs in per batch.
+                //
+                // Creation validates the reference against those masters, so
+                // this is a place a calibration refusal can escape — it did
+                // once, killing two filters at frame zero over cached masters
+                // that predate optics metadata. Auto mode's contract instead:
+                // degrade to a raw stack, and say so and why. Forced
+                // calibration keeps the hard error.
                 let reference_masters = plan.sessions[plan.assignments[0]].masters.clone();
-                let stacker = LiveStacker::new(reference_frame, reference_masters, options)
-                    .map_err(|error| error.to_string())?;
+                let stacker = match LiveStacker::new(reference_frame, reference_masters, options.clone()) {
+                    Ok(stacker) => stacker,
+                    Err(error)
+                        if group.calibration != crate::calibration::CalibrationMode::On =>
+                    {
+                        tracing::warn!(
+                            "reference refused its session masters; stacking raw: {error}"
+                        );
+                        let note = format!(
+                            "Stacked without calibration: the reference frame's masters were \
+                             refused — {error}"
+                        );
+                        state.stack_previews.update(job_id, |job| {
+                            let calibration = &mut job.groups[group.index].calibration;
+                            calibration.warning = Some(match calibration.warning.take() {
+                                Some(previous) if previous.contains(&note) => previous,
+                                Some(previous) => format!("{previous}. {note}"),
+                                None => note,
+                            });
+                        });
+                        let reference_frame =
+                            crate::image_io::open_linear_frame(&group.frames[0].path)
+                                .map_err(|error| error.to_string())?;
+                        LiveStacker::new(
+                            reference_frame,
+                            seiza_stacking::CalibrationMasters::default(),
+                            options,
+                        )
+                        .map_err(|error| error.to_string())?
+                    }
+                    Err(error) => return Err(error.to_string()),
+                };
                 let reference_mapping = stacker.reference_mapping();
                 let reference_decision = StackFrameDecision {
                     image_id: group.frames[0].image_id,
@@ -2293,6 +2349,11 @@ fn run_group(
         // batch and a single-session group is exactly one call. On a
         // resumed stack this also replaces whatever masters the checkpoint
         // stored with the ones this batch needs.
+        // Frames the stacker turned away for calibration, folded into the
+        // group warning below: each carries its reason in the frame list,
+        // but nobody reads a hundred rows to learn that six frames shared
+        // one cause.
+        let mut calibration_rejections: Vec<String> = Vec::new();
         let mut batch_start = 0usize;
         while batch_start < pending.len() && !cancelled {
             let session = plan.assignments[pending[batch_start].0];
@@ -2378,6 +2439,11 @@ fn run_group(
                         // read are both "not integrated" to a caller reading the
                         // group's decisions; only the reason differs.
                         Ok(FrameDisposition::Rejected(reason)) => {
+                            if let seiza_stacking::FrameRejectionReason::Calibration(message) =
+                                &reason
+                            {
+                                calibration_rejections.push(message.clone());
+                            }
                             (rejected_decision(frame, reason.to_string()), false)
                         }
                         Err(error) => (rejected_decision(frame, error.to_string()), true),
@@ -2456,6 +2522,34 @@ fn run_group(
         // The accumulator is complete: checkpoint it before the snapshot
         // consumes the stacker, so an additive rebuild can pick it up here.
         save_checkpoint(&stacker, &ledger, &points);
+        // The per-frame reasons live in the frame list; the summary is what a
+        // person actually reads. One line per distinct cause, with a count.
+        if !calibration_rejections.is_empty() {
+            let mut counts: Vec<(String, usize)> = Vec::new();
+            for reason in &calibration_rejections {
+                match counts.iter_mut().find(|(existing, _)| existing == reason) {
+                    Some((_, count)) => *count += 1,
+                    None => counts.push((reason.clone(), 1)),
+                }
+            }
+            let note = format!(
+                "{} frame(s) could not be calibrated and were left out — {}",
+                calibration_rejections.len(),
+                counts
+                    .iter()
+                    .map(|(reason, count)| format!("{count}× {reason}"))
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            );
+            state.stack_previews.update(job_id, |job| {
+                let calibration = &mut job.groups[group.index].calibration;
+                calibration.warning = Some(match calibration.warning.take() {
+                    Some(previous) if previous.contains(&note) => previous,
+                    Some(previous) => format!("{previous}. {note}"),
+                    None => note,
+                });
+            });
+        }
         // Last exit before the job writes anything. Orienting and rendering
         // follow, and a stop after this point would have to clean up published
         // artifacts.


### PR DESCRIPTION
The OIII/SII stacks were still failing after the session-swap fix — at frame zero this time, invisibly, for days. This PR is the response to the two standing edicts that failure violated a second time: **auto mode never abandons a stack over calibration**, and **every degradation reaches the user with its reason**.

## What actually happened, verified on supergateway's cache

The failing filters' cached master flats were written **2026-08-14, before optics-metadata preservation** — read off the files: no `TELESCOP`, no `FOCALLEN`. Validation asked the candidate-selection question, where an unrecorded reading disqualifies. The other five filters worked only because the rotation backfill changed their subsets and forced fresh masters. The group error lived in job memory while `latest-project-11.json` served stale last-good groups; the journal showed nothing. The field-naming errors from [seiza#148](https://github.com/theatrus/seiza/pull/148) made the cause legible in one line: `telescope light="C925", master did not record one`.

## Fix 1 — judge a chosen master by consistency (seiza-stacking **0.11.4**)

Two recorded readings must agree; silence proves nothing. Candidate semantics stay where they belong, at selection time. A recorded-vs-recorded disagreement still refuses — asserted both ways in the upstream regression test built from the production signature shape.

## Fix 2 — the master cache becomes honest, and rebuilds what it should have

**Yes, those masters should have rebuilt themselves.** `MASTER_CACHE_VERSION` was written into every record and read by nothing — a dead lever, violating this repo's own cache invariant. Reuse now requires the current generation; the version is bumped to 3; **every pre-metadata master rebuilds itself once**, with full metadata. A blocked (read-only) recorder still serves an old master — it cannot rebuild, and an old master under consistency validation beats none. The manual lever already existed and stays: Calibration Library → *Clear generated masters*.

## Fix 3 — the audit the edict demanded, not just the symptom

Every path a calibration error can escape `run_group`:

| Path | Before | Now |
|---|---|---|
| mid-stack `set_calibration` | guarded (#370) | unchanged |
| **stacker creation** (reference validation) — the path that killed OIII | hard fail | raw + warning |
| **plan construction** (unreadable cached master, refused query) | hard fail | raw + warning, with a distinct fingerprint (`auto-fallback-uncalibrated`) so a later healthy run cannot resume an uncalibrated accumulator; the cancel path is checked first |
| per-frame push | rejected individually, reasons buried per-frame | also **aggregated into the group warning** — `N frame(s) could not be calibrated … 6× rotation light=…` |

Forced calibration keeps hard errors everywhere: there the user explicitly asked for those masters.

## Checks

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — **834 tests**, 0 failed, against published `seiza-stacking` 0.11.4
- New tests: old-generation master is a miss and rebuilds at the current generation; a blocked recorder still serves it; the fallback plan is distinct from mode-off and unresumable; upstream, the production master shape validates and a real disagreement still refuses
- Frontend untouched

## After merge

Merge deploys. The proof is on supergateway's real cache state — the state that hid this failure from a fresh-cache local repro once: restack OIII/SII; the stale masters rebuild themselves on the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
