### PR TITLE
Filter by database, fix the header split, and choose export layout at export time

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -206,8 +206,9 @@ lights. Two targets shot on different nights can need different flats for one
 filter, and merging them would have WBPP integrate both into a single master.
 
 Choose the layout with `--layout wbpp` on the CLI, the `layout` query parameter
-on the export download, or the **Export layout** control on the overview, which
-applies to every export on the page.
+on the export download, or in the dialog every Export action on the overview
+opens. The dialog starts from the **Export** default in Settings → Setups,
+which is server-wide and shared by the desktop and browser apps.
 
 A WBPP export also carries `run-wbpp.sh` and `run-wbpp.cmd`, which hand it to
 PixInsight. WBPP 3.x is driven from PixInsight's command line rather than

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -387,7 +387,8 @@
   it), and the picker's popover gained the same filter for its tree. The
   header also stopped letting the picker swallow the whole bar — it caps at a
   sensible width and the freed space goes to the activity and cache status,
-  which was squeezed to a sliver before.
+  which was squeezed to a sliver before. Opening the picker now lands on the
+  current selection instead of the top of the list.
 - The export layout is now chosen at export time. Every Export action opens a
   small dialog offering grouped-by-target and WBPP with an explanation of
   each, instead of one page-wide mode select at the top of the Overview. What

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -381,6 +381,18 @@
   turns away for calibration are summarized in the same warning — count and
   reason — instead of hiding in the per-frame list. Forced calibration keeps
   hard errors.
+- The Overview and the header's project picker can now filter by database: a
+  **Database** select in the Overview's projects toolbar narrows the project
+  list to one catalog (kept in the URL, so reload and shared links restore
+  it), and the picker's popover gained the same filter for its tree. The
+  header also stopped letting the picker swallow the whole bar — it caps at a
+  sensible width and the freed space goes to the activity and cache status,
+  which was squeezed to a sliver before.
+- The export layout is now chosen at export time. Every Export action opens a
+  small dialog offering grouped-by-target and WBPP with an explanation of
+  each, instead of one page-wide mode select at the top of the Overview. What
+  the dialog starts from is a new **Export** default in Settings → Setups,
+  server-wide and shared by the desktop and browser apps.
 - The tilt inspector now draws ASTAP's tilt figure: each corner's HFD becomes
   a vertex distance from center, so a flat field draws the dashed reference
   square and a tilted sensor a quadrilateral leaning toward its soft corner.

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -304,6 +304,11 @@ pub struct DbRegistry {
     /// means the library defaults.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub calibration: Option<CalibrationSettings>,
+    /// Process-global export defaults shared by every database, edited from
+    /// the settings panel. Additive within registry v2; absent means the
+    /// standard layout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub export: Option<ExportSettings>,
 }
 
 /// How far apart two readings may sit and still calibrate each other.
@@ -320,6 +325,16 @@ pub struct CalibrationSettings {
     pub rotation_tolerance_deg: Option<f64>,
 }
 
+/// What the export dialog starts from. The dialog still offers every layout
+/// on each export; this only seeds the choice.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ExportSettings {
+    /// Layout new exports start from. Absent means the standard
+    /// grouped-by-target tree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_layout: Option<crate::commands::export::ExportLayout>,
+}
+
 impl Default for DbRegistry {
     fn default() -> Self {
         Self {
@@ -329,6 +344,7 @@ impl Default for DbRegistry {
             astrometry: None,
             peers: Vec::new(),
             calibration: None,
+            export: None,
         }
     }
 }
@@ -714,6 +730,30 @@ mod tests {
         bare.save(&path).unwrap();
         let serialized = std::fs::read_to_string(&path).unwrap();
         assert!(!serialized.contains("calibration"));
+    }
+
+    #[test]
+    fn round_trips_export_settings_and_absence_stays_absent() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let reg = DbRegistry {
+            export: Some(ExportSettings {
+                default_layout: Some(crate::commands::export::ExportLayout::Wbpp),
+            }),
+            ..Default::default()
+        };
+        reg.save(&path).unwrap();
+
+        let reloaded = DbRegistry::load_or_init(&path).unwrap();
+        assert_eq!(reloaded.export, reg.export);
+        let serialized = std::fs::read_to_string(&path).unwrap();
+        assert!(serialized.contains("\"export\""));
+        assert!(serialized.contains("wbpp"));
+
+        let bare = DbRegistry::default();
+        bare.save(&path).unwrap();
+        let serialized = std::fs::read_to_string(&path).unwrap();
+        assert!(!serialized.contains("\"export\""));
     }
 
     #[test]

--- a/src/server/export_settings.rs
+++ b/src/server/export_settings.rs
@@ -1,0 +1,82 @@
+//! The export defaults settings panel: one process-global block in the
+//! database registry, shared by every database and both serving modes.
+//!
+//! GET is open to viewers so the panel and the export dialog can show the
+//! current default; PUT lands in `requires_write`. The dialog still offers
+//! every layout on each export — this only seeds the choice.
+
+use axum::{extract::State, Json};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::commands::export::ExportLayout;
+use crate::db_registry::{DbRegistry, ExportSettings};
+use crate::server::{
+    api::ApiResponse,
+    handlers::{require_registry_path, AppError},
+    state::AppState,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExportSettingsResponse {
+    /// The layout the export dialog starts from. Never absent: an
+    /// unconfigured registry resolves to the standard layout.
+    pub default_layout: ExportLayout,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateExportSettingsRequest {
+    pub default_layout: ExportLayout,
+}
+
+fn current_response(settings: Option<&ExportSettings>) -> ExportSettingsResponse {
+    ExportSettingsResponse {
+        default_layout: settings
+            .and_then(|settings| settings.default_layout)
+            .unwrap_or_default(),
+    }
+}
+
+/// GET /api/settings/export
+pub async fn get_export_settings(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<ApiResponse<ExportSettingsResponse>>, AppError> {
+    // A server without a persistent registry still has a current value: the
+    // default. The panel shows it read-only rather than erroring.
+    let settings = match require_registry_path(&state) {
+        Ok(path) => {
+            DbRegistry::load_or_init(&path)
+                .map_err(|error| AppError::InternalError(error.to_string()))?
+                .export
+        }
+        Err(_) => None,
+    };
+    Ok(Json(ApiResponse::success(current_response(
+        settings.as_ref(),
+    ))))
+}
+
+/// PUT /api/settings/export
+pub async fn update_export_settings(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<UpdateExportSettingsRequest>,
+) -> Result<Json<ApiResponse<ExportSettingsResponse>>, AppError> {
+    let path = require_registry_path(&state)?;
+    let _registry_guard = state.registry_write.lock().await;
+    let mut registry = DbRegistry::load_or_init(&path)
+        .map_err(|error| AppError::InternalError(error.to_string()))?;
+    // Standard is what an absent block already means; storing nothing keeps
+    // the registry clean for older builds reading the same file.
+    registry.export = match request.default_layout {
+        ExportLayout::Standard => None,
+        layout => Some(ExportSettings {
+            default_layout: Some(layout),
+        }),
+    };
+    registry
+        .save(&path)
+        .map_err(|error| AppError::InternalError(error.to_string()))?;
+    Ok(Json(ApiResponse::success(current_response(
+        registry.export.as_ref(),
+    ))))
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,6 +6,7 @@ pub mod catalog_install;
 pub mod database_context;
 pub mod embedded_static;
 pub mod export_job;
+pub mod export_settings;
 pub mod extract;
 pub mod handlers;
 pub mod import_job;
@@ -561,6 +562,10 @@ async fn run_server_internal(
             "/settings/calibration",
             get(calibration_settings::get_calibration_settings)
                 .put(calibration_settings::update_calibration_settings),
+        )
+        .route(
+            "/settings/export",
+            get(export_settings::get_export_settings).put(export_settings::update_export_settings),
         )
         .route(
             "/processing-setups",

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -544,6 +544,7 @@ mod tests {
             active_db_id: None,
             astrometry: None,
             calibration: None,
+            export: None,
             peers: Vec::new(),
         }
     }

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -240,17 +240,19 @@
   outline-offset: 2px;
 }
 
+/* The picker is capped so a wide window feeds the leftover width to the
+   status slot instead of stretching the picker button across the header. */
 .header-context {
   grid-area: context;
   display: grid;
-  grid-template-columns: minmax(19rem, 1fr) 17rem;
+  grid-template-columns: minmax(19rem, 30rem) minmax(17rem, 1fr);
   align-items: center;
   gap: 0.5rem;
   min-width: 0;
 }
 
 .header-context.header-context--overview {
-  grid-template-columns: 17rem;
+  grid-template-columns: minmax(17rem, 28rem);
   justify-content: end;
 }
 
@@ -258,9 +260,11 @@
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  width: 17rem;
-  height: 32px;
+  width: 100%;
   min-width: 0;
+  max-width: 28rem;
+  justify-self: end;
+  height: 32px;
   overflow: hidden;
 }
 
@@ -481,6 +485,32 @@
   outline: 2px solid var(--color-primary-alpha-20);
 }
 
+.selector-db-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 7px;
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+}
+
+.selector-db-filter select {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 5px 8px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: 6px;
+  background: var(--color-bg-input);
+  color: var(--color-text-primary);
+  font: inherit;
+  font-size: 0.82rem;
+}
+
+.selector-db-filter select:focus {
+  border-color: var(--color-primary);
+  outline: 2px solid var(--color-primary-alpha-20);
+}
+
 .selector-options {
   max-height: min(62vh, 480px);
   margin-top: 7px;
@@ -683,7 +713,7 @@
   }
 
   .header-context {
-    grid-template-columns: minmax(19rem, 1fr) 17rem;
+    grid-template-columns: minmax(19rem, 30rem) minmax(17rem, 1fr);
   }
 
   .header-context.header-context--overview {
@@ -734,6 +764,8 @@
      both reduced to their indicators. */
   .header-cache-slot {
     width: 4.5rem;
+    min-width: 0;
+    max-width: none;
     height: 28px;
   }
 
@@ -6330,6 +6362,57 @@
 .dialog-intro {
   margin: 0 0 0.75rem;
   color: var(--color-text-muted);
+}
+
+/* Export dialog: the per-export layout choice */
+.export-dialog {
+  width: min(30rem, calc(100vw - 2rem));
+}
+
+.export-dialog-scope {
+  margin: 0 0 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.export-layout-options {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0.6rem 0.75rem 0.75rem;
+  border: 1px solid var(--color-border-primary);
+  border-radius: 6px;
+}
+
+.export-layout-options legend {
+  padding: 0 0.3rem;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.export-layout-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  cursor: pointer;
+}
+
+.export-layout-option input {
+  margin-top: 0.2rem;
+}
+
+.export-layout-option span {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.export-layout-option small {
+  color: var(--color-text-muted);
+}
+
+.dialog-footer .export-dialog-download {
+  flex: 0 0 auto;
+  padding: 0.45rem 0.8rem;
+  text-decoration: none;
 }
 
 .reject-review-list {

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -6,6 +6,7 @@ import type {
   CalibrationSettings,
   ApiResponse,
   ExportLayout,
+  ExportSettings,
   Project,
   Target,
   TargetNavigation,
@@ -248,6 +249,22 @@ export const apiClient = {
       { rotation_tolerance_deg: rotationToleranceDeg }
     );
     if (!data.data) throw new Error(data.error || 'Failed to update calibration settings');
+    return data.data;
+  },
+
+  getExportSettings: async (): Promise<ExportSettings> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<ExportSettings>>('/settings/export');
+    if (!data.data) throw new Error(data.error || 'Failed to get export settings');
+    return data.data;
+  },
+
+  updateExportSettings: async (defaultLayout: ExportLayout): Promise<ExportSettings> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.put<ApiResponse<ExportSettings>>('/settings/export', {
+      default_layout: defaultLayout,
+    });
+    if (!data.data) throw new Error(data.error || 'Failed to update export settings');
     return data.data;
   },
 

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1101,6 +1101,11 @@ export interface CalibrationSettings {
   default_rotation_tolerance_deg: number;
 }
 
+export interface ExportSettings {
+  /** The layout the export dialog starts from. */
+  default_layout: ExportLayout;
+}
+
 export interface ServerInfo {
   version: string;
   cache_directory: string;

--- a/static/src/components/ExportDefaultsSettings.tsx
+++ b/static/src/components/ExportDefaultsSettings.tsx
@@ -1,0 +1,62 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import type { ExportLayout } from '../api/types';
+
+/**
+ * The export default: which layout the export dialog starts from. Server-wide,
+ * persisted in the registry; every export still offers both layouts at export
+ * time.
+ */
+export default function ExportDefaultsSettings() {
+  const queryClient = useQueryClient();
+  const settings = useQuery({
+    queryKey: ['export-settings'],
+    queryFn: apiClient.getExportSettings,
+  });
+
+  const save = useMutation({
+    mutationFn: (layout: ExportLayout) => apiClient.updateExportSettings(layout),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['export-settings'], updated);
+    },
+  });
+
+  if (settings.isLoading) return null;
+  if (settings.isError) {
+    return (
+      <div className="export-defaults-settings">
+        <h3>Export</h3>
+        <p className="muted">Could not load export settings.</p>
+      </div>
+    );
+  }
+
+  const current = settings.data!;
+
+  return (
+    <div className="export-defaults-settings">
+      <h3>Export</h3>
+      <label className="review-preference">
+        <span>
+          Default layout
+          <small>
+            What the export dialog starts from. Grouped by target is PSF
+            Guard&apos;s own tree; WBPP gives each frame type one root for
+            PixInsight&apos;s WeightedBatchPreprocessing and writes its runner
+            scripts. Every export still offers both.
+          </small>
+        </span>
+        <select
+          value={current.default_layout}
+          aria-label="Default export layout"
+          disabled={save.isPending}
+          onChange={(event) => save.mutate(event.target.value as ExportLayout)}
+        >
+          <option value="standard">Grouped by target</option>
+          <option value="wbpp">WBPP</option>
+        </select>
+      </label>
+      {save.isError && <p className="error-text">{(save.error as Error).message}</p>}
+    </div>
+  );
+}

--- a/static/src/components/ExportDialog.tsx
+++ b/static/src/components/ExportDialog.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { apiClient } from '../api/client';
+import type { ExportLayout } from '../api/types';
+import Dialog from './Dialog';
+
+/** One export the user has asked for, awaiting its layout choice. */
+export interface ExportRequest {
+  dbId: string;
+  scope: { project_id?: number; target_id?: number };
+  label: string;
+  /**
+   * Which affordance applies: `local` picks a folder through the native
+   * picker (desktop), `server` runs in the server's export directory,
+   * `download` streams a zip.
+   */
+  kind: 'local' | 'server' | 'download';
+}
+
+interface ExportDialogProps {
+  request: ExportRequest;
+  /** What the layout choice starts from, per the settings panel. */
+  defaultLayout: ExportLayout;
+  busy: boolean;
+  onClose: () => void;
+  /** Runs the local or server export with the chosen layout. */
+  onConfirm: (layout: ExportLayout) => void;
+}
+
+const LAYOUT_HELP: Record<ExportLayout, string> = {
+  standard:
+    'Grouped by target: <target>/LIGHT/<filter>, with BIAS, DARK and DARKFLAT at the root.',
+  wbpp: 'One folder per frame type, with dark flats among the darks, ready for WeightedBatchPreprocessing. Includes run-wbpp scripts.',
+};
+
+/**
+ * The layout choice made at export time. Every export affordance funnels
+ * through here so the choice is per export, not a page-wide mode.
+ */
+export default function ExportDialog({
+  request,
+  defaultLayout,
+  busy,
+  onClose,
+  onConfirm,
+}: ExportDialogProps) {
+  const [layout, setLayout] = useState<ExportLayout>(defaultLayout);
+
+  const confirmLabel =
+    request.kind === 'local'
+      ? 'Choose folder…'
+      : request.kind === 'server'
+        ? 'Start export'
+        : 'Download zip';
+
+  return (
+    <Dialog
+      open
+      title={`Export ${request.label}`}
+      onClose={onClose}
+      className="export-dialog"
+      footer={
+        <>
+          <button type="button" className="header-button" onClick={onClose}>
+            Cancel
+          </button>
+          {request.kind === 'download' ? (
+            <a
+              className="action-button export-dialog-download"
+              href={apiClient.exportDownloadUrl(request.dbId, {
+                ...request.scope,
+                layout,
+              })}
+              onClick={onClose}
+            >
+              {confirmLabel}
+            </a>
+          ) : (
+            <button
+              type="button"
+              className="action-button"
+              disabled={busy}
+              onClick={() => onConfirm(layout)}
+            >
+              {confirmLabel}
+            </button>
+          )}
+        </>
+      }
+    >
+      <p className="export-dialog-scope">
+        Accepted lights and their calibration frames; rejects excluded.
+      </p>
+      <fieldset className="export-layout-options">
+        <legend>Layout</legend>
+        {(['standard', 'wbpp'] as const).map((option) => (
+          <label key={option} className="export-layout-option">
+            <input
+              type="radio"
+              name="export-layout"
+              value={option}
+              checked={layout === option}
+              onChange={() => setLayout(option)}
+            />
+            <span>
+              <strong>{option === 'wbpp' ? 'WBPP' : 'Grouped by target'}</strong>
+              <small>{LAYOUT_HELP[option]}</small>
+            </span>
+          </label>
+        ))}
+      </fieldset>
+    </Dialog>
+  );
+}

--- a/static/src/components/Overview.css
+++ b/static/src/components/Overview.css
@@ -61,32 +61,6 @@
   white-space: nowrap;
 }
 
-/* Applies to every export affordance on the page, so it sits with the
-   catalog summary rather than beside any one of them. */
-.export-layout-choice {
-  display: flex;
-  flex-direction: column;
-  min-width: 132px;
-}
-
-.export-layout-choice > span {
-  color: var(--color-text-muted);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.export-layout-choice > select {
-  margin-top: 2px;
-  padding: 2px 4px;
-  border: 1px solid var(--color-border-primary);
-  border-radius: 4px;
-  background: var(--color-bg-secondary);
-  color: var(--color-text-primary);
-  font-size: 0.85rem;
-}
-
 .summary-metrics {
   display: grid;
   grid-template-columns: repeat(5, minmax(76px, 1fr));
@@ -246,7 +220,8 @@
 }
 
 .project-search input,
-.project-sort select {
+.project-sort select,
+.project-db-filter select {
   box-sizing: border-box;
   min-height: 36px;
   border: 1px solid var(--color-border-secondary);
@@ -262,19 +237,22 @@
   padding: 7px 10px;
 }
 
-.project-sort {
+.project-sort,
+.project-db-filter {
   display: grid;
   gap: 3px;
   color: var(--color-text-muted);
   font-size: 0.7rem;
 }
 
-.project-sort select {
+.project-sort select,
+.project-db-filter select {
   padding: 6px 26px 6px 9px;
 }
 
 .project-search input:focus,
-.project-sort select:focus {
+.project-sort select:focus,
+.project-db-filter select:focus {
   border-color: var(--color-primary);
   outline: 2px solid var(--color-primary-alpha-20);
 }

--- a/static/src/components/Overview.tsx
+++ b/static/src/components/Overview.tsx
@@ -29,7 +29,7 @@ import {
   saveProjectSeenState,
 } from '../utils/projectRecency';
 import { formatRelativeTime } from '../utils/relativeTime';
-import { useDbProjectTarget } from '../hooks/useUrlState';
+import { useDbProjectTarget, useUrlParams } from '../hooks/useUrlState';
 import { imageDetailPath } from '../utils/imageDetailRoutes';
 import {
   groupProjectsByActivity,
@@ -41,6 +41,7 @@ import {
 } from '../utils/projectNavigation';
 import ProjectSchedulerDialog from './ProjectSchedulerDialog';
 import CalibrationReportDialog from './CalibrationReportDialog';
+import ExportDialog, { type ExportRequest } from './ExportDialog';
 import PreviewImage from './PreviewImage';
 import { useColorPreview } from '../hooks/useColorPreview';
 import './Overview.css';
@@ -64,6 +65,11 @@ export default function Overview() {
   const queryClient = useQueryClient();
   const [projectSearch, setProjectSearch] = useState('');
   const [projectSort, setProjectSort] = useState<ProjectSort>('recent');
+  // Narrows the projects list to one catalog. Lives in URL state (`dbfilter`)
+  // so reload restores it. Distinct from the parked `db` return-scope slug,
+  // which marks where the user came from and never filters this view.
+  const { getParam, updateParams } = useUrlParams();
+  const dbFilter = getParam('dbfilter');
   const [archivedOpen, setArchivedOpen] = useState(false);
   const [organizing, setOrganizing] = useState<Organizing | null>(null);
   const [organizeBusy, setOrganizeBusy] = useState(false);
@@ -105,20 +111,33 @@ export default function Overview() {
   // The database whose server export this page last started (or found
   // running); drives the progress line under the catalog summary.
   const [exportJobDb, setExportJobDb] = useState<string | null>(null);
-  // One choice for every export affordance on the page. Kept here rather than
-  // per row so a project and its targets cannot disagree about the tree they
-  // land in.
-  const [exportLayout, setExportLayout] = useState<ExportLayout>('standard');
-  const handleLocalExport = async (
+  // The export the user clicked, awaiting its layout choice in the dialog.
+  const [pendingExport, setPendingExport] = useState<ExportRequest | null>(null);
+  // Seeds the dialog's layout choice; edited in the settings panel.
+  const { data: exportSettings } = useQuery({
+    queryKey: ['export-settings'],
+    queryFn: apiClient.getExportSettings,
+    staleTime: 5 * 60 * 1000,
+  });
+  const openExport = (
+    kind: ExportRequest['kind'],
     dbId: string,
     scope: { project_id?: number; target_id?: number },
     label: string
+  ) => {
+    if (!exportBusy) setPendingExport({ kind, dbId, scope, label });
+  };
+  const handleLocalExport = async (
+    dbId: string,
+    scope: { project_id?: number; target_id?: number },
+    label: string,
+    layout: ExportLayout
   ) => {
     try {
       const dest = await tauriFileSystem.pickImageDirectory();
       if (!dest) return;
       setExportBusy(true);
-      const summary = await apiClient.exportLocal(dbId, { dest, layout: exportLayout, ...scope });
+      const summary = await apiClient.exportLocal(dbId, { dest, layout, ...scope });
       const placed = summary.copied + summary.linked;
       alert(
         `Exported ${label}: ${placed} file(s) placed` +
@@ -140,13 +159,14 @@ export default function Overview() {
   const handleServerExport = async (
     dbId: string,
     scope: { project_id?: number; target_id?: number },
-    label: string
+    label: string,
+    layout: ExportLayout
   ) => {
     try {
       setExportBusy(true);
       const status = await apiClient.startServerExport(dbId, {
         ...scope,
-        layout: exportLayout,
+        layout,
         subdirectory: label,
         scope_label: label,
       });
@@ -226,13 +246,14 @@ export default function Overview() {
   const filteredProjects = useMemo(() => {
     const search = projectSearch.trim().toLocaleLowerCase();
     return projects.filter((project) => {
+      if (dbFilter && project.db_id !== dbFilter) return false;
       if (projectMatchesSearch(project, projectSearch)) return true;
       if (!search) return true;
       return (targetsByProject[`${project.db_id}:${project.id}`] || []).some((target) =>
         target.name.toLocaleLowerCase().includes(search)
       );
     });
-  }, [projectSearch, projects, targetsByProject]);
+  }, [dbFilter, projectSearch, projects, targetsByProject]);
 
   const activeProjectGroups = useMemo(
     () =>
@@ -482,21 +503,6 @@ export default function Overview() {
             <span>Catalog</span>
             <strong>{overallStats.total_images.toLocaleString()} images</strong>
           </div>
-          <label className="export-layout-choice">
-            <span>Export layout</span>
-            <select
-              value={exportLayout}
-              onChange={(event) => setExportLayout(event.target.value as ExportLayout)}
-              title={
-                exportLayout === 'wbpp'
-                  ? 'One folder per frame type, with dark flats among the darks, ready for WeightedBatchPreprocessing'
-                  : "Grouped by target: <target>/LIGHT/<filter>, with BIAS, DARK and DARKFLAT at the root"
-              }
-            >
-              <option value="standard">Grouped by target</option>
-              <option value="wbpp">WBPP</option>
-            </select>
-          </label>
           {exportJobLine && (
             <div
               className={`server-export-status${
@@ -596,6 +602,23 @@ export default function Overview() {
               <p>Grouped by the latest captured frame.</p>
             </div>
             <div className="projects-toolbar-controls">
+              {databases && databases.length > 1 && (
+                <label className="project-db-filter">
+                  <span>Database</span>
+                  <select
+                    value={dbFilter ?? 'all'}
+                    onChange={(event) => updateParams({ dbfilter: event.target.value })}
+                    aria-label="Filter projects by database"
+                  >
+                    <option value="all">All databases</option>
+                    {databases.map((db) => (
+                      <option key={db.id} value={db.id}>
+                        {db.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
               <label className="project-search">
                 <span className="sr-only">Search projects or targets</span>
                 <input
@@ -967,53 +990,31 @@ export default function Overview() {
                       <span>{project.filters_used.join(', ')}</span>
                     )}
                     {project.has_files && project.accepted_images > 0 && (
-                      isTauri ? (
-                        <span
-                          className="export-link"
-                          title="Export this project's accepted lights to a local folder (hardlink or copy, rejects excluded)"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            if (!exportBusy) {
-                              handleLocalExport(
-                                project.db_id,
-                                { project_id: project.id },
-                                project.display_name
-                              );
-                            }
-                          }}
-                        >
-                          ⬇ Export
-                        </span>
-                      ) : serverExportDir(project.db_id) ? (
-                        <span
-                          className="export-link"
-                          title={`Export this project's accepted lights to the server's export directory (${serverExportDir(project.db_id)}), reflinking where the filesystem supports it`}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            if (!exportBusy) {
-                              handleServerExport(
-                                project.db_id,
-                                { project_id: project.id },
-                                project.display_name
-                              );
-                            }
-                          }}
-                        >
-                          ⬇ Export
-                        </span>
-                      ) : (
-                        <a
-                          className="export-link"
-                          href={apiClient.exportDownloadUrl(project.db_id, {
-                            project_id: project.id,
-                            layout: exportLayout,
-                          })}
-                          title={`Download this project's accepted lights as a zip (${exportLayout === 'wbpp' ? 'WBPP layout' : 'grouped by target'}, rejects excluded)`}
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          ⬇ Export
-                        </a>
-                      )
+                      <span
+                        className="export-link"
+                        title={
+                          isTauri
+                            ? "Export this project's accepted lights to a local folder (hardlink or copy, rejects excluded)"
+                            : serverExportDir(project.db_id)
+                              ? `Export this project's accepted lights to the server's export directory (${serverExportDir(project.db_id)}), reflinking where the filesystem supports it`
+                              : "Download this project's accepted lights as a zip (rejects excluded)"
+                        }
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openExport(
+                            isTauri
+                              ? 'local'
+                              : serverExportDir(project.db_id)
+                                ? 'server'
+                                : 'download',
+                            project.db_id,
+                            { project_id: project.id },
+                            project.display_name
+                          );
+                        }}
+                      >
+                        ⬇ Export
+                      </span>
                     )}
                   </div>
 
@@ -1105,52 +1106,31 @@ export default function Overview() {
                                 </button>
                               )}
                               {target.has_files && target.accepted_count > 0 && (
-                                isTauri ? (
-                                  <button
-                                    type="button"
-                                    className="target-settings-button"
-                                    title="Export this target's accepted lights to a local folder"
-                                    onClick={() => {
-                                      if (!exportBusy) {
-                                        handleLocalExport(
-                                          target.db_id,
-                                          { target_id: target.id },
-                                          target.name
-                                        );
-                                      }
-                                    }}
-                                  >
-                                    ↓ Export
-                                  </button>
-                                ) : serverExportDir(target.db_id) ? (
-                                  <button
-                                    type="button"
-                                    className="target-settings-button"
-                                    title={`Export this target's accepted lights to the server's export directory (${serverExportDir(target.db_id)})`}
-                                    onClick={() => {
-                                      if (!exportBusy) {
-                                        handleServerExport(
-                                          target.db_id,
-                                          { target_id: target.id },
-                                          target.name
-                                        );
-                                      }
-                                    }}
-                                  >
-                                    ↓ Export
-                                  </button>
-                                ) : (
-                                  <a
-                                    className="target-settings-button"
-                                    href={apiClient.exportDownloadUrl(target.db_id, {
-                                      target_id: target.id,
-                                      layout: exportLayout,
-                                    })}
-                                    title={`Download this target's accepted lights as a zip (${exportLayout === 'wbpp' ? 'WBPP layout' : 'grouped by target'})`}
-                                  >
-                                    ↓ Export
-                                  </a>
-                                )
+                                <button
+                                  type="button"
+                                  className="target-settings-button"
+                                  title={
+                                    isTauri
+                                      ? "Export this target's accepted lights to a local folder"
+                                      : serverExportDir(target.db_id)
+                                        ? `Export this target's accepted lights to the server's export directory (${serverExportDir(target.db_id)})`
+                                        : "Download this target's accepted lights as a zip"
+                                  }
+                                  onClick={() =>
+                                    openExport(
+                                      isTauri
+                                        ? 'local'
+                                        : serverExportDir(target.db_id)
+                                          ? 'server'
+                                          : 'download',
+                                      target.db_id,
+                                      { target_id: target.id },
+                                      target.name
+                                    )
+                                  }
+                                >
+                                  ↓ Export
+                                </button>
                               )}
                             </div>
 
@@ -1273,6 +1253,24 @@ export default function Overview() {
           )}
         </div>
       </div>
+
+      {pendingExport && (
+        <ExportDialog
+          request={pendingExport}
+          defaultLayout={exportSettings?.default_layout ?? 'standard'}
+          busy={exportBusy}
+          onClose={() => setPendingExport(null)}
+          onConfirm={(layout) => {
+            const request = pendingExport;
+            setPendingExport(null);
+            if (request.kind === 'local') {
+              handleLocalExport(request.dbId, request.scope, request.label, layout);
+            } else {
+              handleServerExport(request.dbId, request.scope, request.label, layout);
+            }
+          }}
+        />
+      )}
 
       {schedulerProject && (
         <ProjectSchedulerDialog

--- a/static/src/components/ProjectTargetSelector.tsx
+++ b/static/src/components/ProjectTargetSelector.tsx
@@ -29,6 +29,9 @@ export default function ProjectTargetSelector() {
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
+  // Picker-local: narrows the popover tree to one catalog without changing
+  // the selected scope until a row is chosen.
+  const [dbFilter, setDbFilter] = useState<string | null>(null);
   const [relativeNow, setRelativeNow] = useState(Date.now);
 
   const invalidateAllForDb = () => {
@@ -66,8 +69,9 @@ export default function ProjectTargetSelector() {
         databases: databases ?? [],
         search,
         relativeNow,
+        dbFilter,
       }),
-    [projects, targets, databases, search, relativeNow]
+    [projects, targets, databases, search, relativeNow, dbFilter]
   );
 
   useEffect(() => {
@@ -235,6 +239,25 @@ export default function ProjectTargetSelector() {
               placeholder="Type to find a project or target"
               aria-label="Search projects or targets"
             />
+            {(databases?.length ?? 0) > 1 && (
+              <label className="selector-db-filter">
+                <span>Database</span>
+                <select
+                  value={dbFilter ?? 'all'}
+                  onChange={(event) =>
+                    setDbFilter(event.target.value === 'all' ? null : event.target.value)
+                  }
+                  aria-label="Filter the list by database"
+                >
+                  <option value="all">All databases</option>
+                  {databases!.map((database) => (
+                    <option key={database.id} value={database.id}>
+                      {database.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
             {targetsError && (
               <div className="selector-load-error" role="alert">
                 <span>Some targets could not be loaded.</span>

--- a/static/src/components/ProjectTargetSelector.tsx
+++ b/static/src/components/ProjectTargetSelector.tsx
@@ -24,6 +24,8 @@ export default function ProjectTargetSelector() {
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const optionsRef = useRef<HTMLDivElement>(null);
+  const revealedSelectionRef = useRef(false);
   const searchExpansionSeedRef = useRef<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
@@ -100,6 +102,25 @@ export default function ProjectTargetSelector() {
   useEffect(() => {
     if (pickerOpen) searchRef.current?.focus();
   }, [pickerOpen]);
+
+  // Opening the picker lands on the current selection, not the top of the
+  // list. The selected row is the one carrying aria-current; a selected
+  // target's row mounts only after its targets load, so this waits on the
+  // navigation model and scrolls once per open.
+  useEffect(() => {
+    // No database in scope means the current row is "Choose a project" at the
+    // very top, which needs no scrolling to be seen.
+    if (!pickerOpen || dbId === null) {
+      revealedSelectionRef.current = false;
+      return;
+    }
+    if (revealedSelectionRef.current) return;
+    const current = optionsRef.current?.querySelector<HTMLElement>('[aria-current="true"]');
+    if (!current) return;
+    revealedSelectionRef.current = true;
+    // jsdom has no layout, so guard for tests and older embedded webviews.
+    current.scrollIntoView?.({ block: 'center' });
+  }, [pickerOpen, dbId, navigation, targetsLoading]);
 
   // Seed expansion once for each search, and once more if target rows finish
   // loading after the user starts typing. Explicit state owns expansion after
@@ -266,7 +287,7 @@ export default function ProjectTargetSelector() {
                 </button>
               </div>
             )}
-            <div className="selector-options" aria-label="Projects and targets">
+            <div ref={optionsRef} className="selector-options" aria-label="Projects and targets">
               <button
                 type="button"
                 className={`selector-option ${dbId === null ? 'is-selected' : ''}`}

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -13,6 +13,7 @@ import { useAccess } from '../auth/access';
 import type { SettingsIntent } from '../utils/settingsIntent';
 import ReviewPreferences from './ReviewPreferences';
 import CalibrationMatchingSettings from './CalibrationMatchingSettings';
+import ExportDefaultsSettings from './ExportDefaultsSettings';
 import type { DatabaseSummary } from '../api/types';
 import { describeImportProgress, useImportJob } from '../hooks/useImportJob';
 import { starMetadataFillEnabled } from '../hooks/useStarMetadataFill';
@@ -1503,6 +1504,7 @@ export default function TauriSettings({
             <>
               <ProcessingSetupsManager />
               <CalibrationMatchingSettings />
+              <ExportDefaultsSettings />
             </>
           )}
 

--- a/static/src/components/__tests__/ExportDefaultsSettings.test.tsx
+++ b/static/src/components/__tests__/ExportDefaultsSettings.test.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server } from '../../test/msw-server';
+import ExportDefaultsSettings from '../ExportDefaultsSettings';
+
+function wrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const current = (layout: 'standard' | 'wbpp') => ({
+  success: true,
+  data: { default_layout: layout },
+  error: null,
+});
+
+describe('ExportDefaultsSettings', () => {
+  it('shows the configured default', async () => {
+    server.use(http.get('/api/settings/export', () => HttpResponse.json(current('wbpp'))));
+    render(<ExportDefaultsSettings />, { wrapper: wrapper() });
+    const select = await screen.findByLabelText('Default export layout');
+    expect(select).toHaveValue('wbpp');
+  });
+
+  it('saves a change and reflects the server response', async () => {
+    let saved: unknown = null;
+    server.use(
+      http.get('/api/settings/export', () => HttpResponse.json(current('standard'))),
+      http.put('/api/settings/export', async ({ request }) => {
+        saved = await request.json();
+        return HttpResponse.json(current('wbpp'));
+      })
+    );
+    render(<ExportDefaultsSettings />, { wrapper: wrapper() });
+    const select = await screen.findByLabelText('Default export layout');
+    fireEvent.change(select, { target: { value: 'wbpp' } });
+    await waitFor(() => expect(saved).toEqual({ default_layout: 'wbpp' }));
+    await waitFor(() => expect(select).toHaveValue('wbpp'));
+  });
+});

--- a/static/src/components/__tests__/Overview.db-filter-export.test.tsx
+++ b/static/src/components/__tests__/Overview.db-filter-export.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import Overview from '../Overview';
+
+function ok(data: unknown) {
+  return HttpResponse.json({ success: true, data, error: null, status: 'ready' });
+}
+
+function project(id: number, name: string) {
+  return {
+    id,
+    profile_id: 'profile',
+    profile_name: 'Profile',
+    name,
+    display_name: name,
+    has_files: true,
+    state: 1,
+    target_count: 1,
+    total_images: 10,
+    accepted_images: 5,
+    rejected_images: 2,
+    pending_images: 3,
+    total_desired: 20,
+    files_found: 10,
+    files_missing: 0,
+    date_range: { earliest: 1_705_000_000, latest: 1_705_352_400 },
+    filters_used: ['Ha'],
+    recent_images: [],
+  };
+}
+
+const stats = {
+  total_projects: 1,
+  active_projects: 1,
+  total_targets: 1,
+  active_targets: 1,
+  total_images: 10,
+  accepted_images: 5,
+  rejected_images: 2,
+  pending_images: 3,
+  total_desired: 20,
+  files_found: 10,
+  files_missing: 0,
+  unique_filters: ['Ha'],
+  date_range: { earliest: 1_705_000_000, latest: 1_705_352_400 },
+  recent_activity: [],
+};
+
+function wrapper(route = '/') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function useTwoCatalogs() {
+  server.use(
+    http.get('/api/databases', () =>
+      ok([
+        { id: 'alpha', name: 'Alpha catalog', path: '/alpha.sqlite' },
+        { id: 'beta', name: 'Beta catalog', path: '/beta.sqlite' },
+      ])
+    ),
+    http.get('/api/db/:dbId/projects/overview', ({ params }) =>
+      ok(params.dbId === 'alpha' ? [project(1, 'Sh2 86')] : [project(1, 'NGC 6820')])
+    ),
+    http.get('/api/db/:dbId/targets/overview', () => ok([])),
+    http.get('/api/db/:dbId/stats/overall', () => ok(stats)),
+    http.get('/api/settings/export', () =>
+      ok({ default_layout: 'wbpp' })
+    )
+  );
+}
+
+describe('Overview database filter', () => {
+  it('narrows the projects list to the chosen database', async () => {
+    useTwoCatalogs();
+    render(<Overview />, { wrapper: wrapper() });
+
+    await screen.findByText('Sh2 86');
+    await screen.findByText('NGC 6820');
+
+    const filter = screen.getByLabelText('Filter projects by database');
+    fireEvent.change(filter, { target: { value: 'beta' } });
+
+    await waitFor(() => expect(screen.queryByText('Sh2 86')).toBeNull());
+    expect(screen.getByText('NGC 6820')).toBeInTheDocument();
+
+    fireEvent.change(filter, { target: { value: 'all' } });
+    await screen.findByText('Sh2 86');
+  });
+
+  it('offers no filter with a single database', async () => {
+    server.use(
+      http.get('/api/databases', () =>
+        ok([{ id: 'solo', name: 'Only catalog', path: '/solo.sqlite' }])
+      ),
+      http.get('/api/db/:dbId/projects/overview', () => ok([project(1, 'Sh2 86')])),
+      http.get('/api/db/:dbId/targets/overview', () => ok([])),
+      http.get('/api/db/:dbId/stats/overall', () => ok(stats))
+    );
+    render(<Overview />, { wrapper: wrapper() });
+    await screen.findByText('Sh2 86');
+    expect(screen.queryByLabelText('Filter projects by database')).toBeNull();
+  });
+});
+
+describe('Overview export dialog', () => {
+  it('asks for the layout at export time, seeded from the settings default', async () => {
+    useTwoCatalogs();
+    render(<Overview />, { wrapper: wrapper() });
+
+    const card = (await screen.findByText('Sh2 86')).closest('.project-card')!;
+    const exportLink = await screen.findAllByText('⬇ Export');
+    const alphaExport = exportLink.find((el) => card.contains(el))!;
+    fireEvent.click(alphaExport);
+
+    // The dialog offers both layouts and starts from the configured default.
+    const dialog = await screen.findByRole('dialog', { name: 'Export Sh2 86' });
+    expect(dialog).toBeInTheDocument();
+    const wbpp = screen.getByRole('radio', { name: /WBPP/ });
+    expect(wbpp).toBeChecked();
+
+    // The chosen layout lands in the download URL.
+    const download = screen.getByRole('link', { name: 'Download zip' });
+    expect(download.getAttribute('href')).toContain('layout=wbpp');
+
+    fireEvent.click(screen.getByRole('radio', { name: /Grouped by target/ }));
+    expect(
+      screen.getByRole('link', { name: 'Download zip' }).getAttribute('href')
+    ).not.toContain('layout=');
+  });
+});

--- a/static/src/components/__tests__/ProjectTargetSelector.db-filter.test.tsx
+++ b/static/src/components/__tests__/ProjectTargetSelector.db-filter.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import ProjectTargetSelector from '../ProjectTargetSelector';
+
+function ok(data: unknown) {
+  return HttpResponse.json({ success: true, data, error: null, status: 'ready' });
+}
+
+function project(id: number, name: string) {
+  return {
+    id,
+    profile_id: 'profile',
+    profile_name: 'Profile',
+    name,
+    display_name: name,
+    description: null,
+    has_files: true,
+    state: 1,
+    latest_image_date: 1_705_352_400,
+  };
+}
+
+function serveTwoCatalogs() {
+  server.use(
+    http.get('/api/databases', () =>
+      ok([
+        { id: 'attic', name: 'Attic catalog', path: '/attic.sqlite' },
+        { id: 'shed', name: 'Shed catalog', path: '/shed.sqlite' },
+      ])
+    ),
+    http.get('/api/db/attic/projects', () => ok([project(1, 'Sh2 86')])),
+    http.get('/api/db/shed/projects', () => ok([project(1, 'NGC 6820')])),
+    http.get('/api/db/:dbId/targets', () => ok([]))
+  );
+}
+
+function renderSelector() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/grid']}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+  return render(<ProjectTargetSelector />, { wrapper: Wrapper });
+}
+
+describe('the project picker database filter', () => {
+  it('narrows the tree to one catalog without changing the scope', async () => {
+    serveTwoCatalogs();
+    renderSelector();
+
+    const trigger = document.querySelector<HTMLButtonElement>('#scope-select')!;
+    await waitFor(() => expect(trigger).not.toBeDisabled());
+    fireEvent.click(trigger);
+
+    await screen.findByText('Sh2 86');
+    await screen.findByText('NGC 6820');
+    // One "All projects · catalog" row per catalog while unfiltered.
+    expect(screen.getAllByText('All projects')).toHaveLength(2);
+
+    fireEvent.change(screen.getByLabelText('Filter the list by database'), {
+      target: { value: 'shed' },
+    });
+
+    await waitFor(() => expect(screen.queryByText('Sh2 86')).toBeNull());
+    expect(screen.getByText('NGC 6820')).toBeInTheDocument();
+    expect(screen.getAllByText('All projects')).toHaveLength(1);
+    // Filtering alone never navigates: the trigger still awaits a choice.
+    expect(screen.getByText('Choose project or target')).toBeInTheDocument();
+  });
+});

--- a/static/src/components/__tests__/ProjectTargetSelector.reveal.test.tsx
+++ b/static/src/components/__tests__/ProjectTargetSelector.reveal.test.tsx
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import ProjectTargetSelector from '../ProjectTargetSelector';
+
+function ok(data: unknown) {
+  return HttpResponse.json({ success: true, data, error: null, status: 'ready' });
+}
+
+function project(id: number, name: string) {
+  return {
+    id,
+    profile_id: 'profile',
+    profile_name: 'Profile',
+    name,
+    display_name: name,
+    description: null,
+    has_files: true,
+    state: 1,
+    latest_image_date: 1_705_352_400,
+  };
+}
+
+function target(id: number, projectId: number, name: string) {
+  return { id, project_id: projectId, name, active: true, has_files: true };
+}
+
+function serveCatalog() {
+  server.use(
+    http.get('/api/databases', () =>
+      ok([{ id: 'attic', name: 'Attic catalog', path: '/attic.sqlite' }])
+    ),
+    http.get('/api/db/attic/projects', () =>
+      ok([project(1, 'Sh2 86'), project(2, 'NGC 6820')])
+    ),
+    http.get('/api/db/attic/targets', () =>
+      ok([target(4, 1, 'Sh2 86 East'), target(5, 2, 'NGC 6820 Core')])
+    )
+  );
+}
+
+function renderAt(route: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+  return render(<ProjectTargetSelector />, { wrapper: Wrapper });
+}
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+afterEach(() => {
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+});
+
+async function openPicker() {
+  const trigger = document.querySelector<HTMLButtonElement>('#scope-select')!;
+  await waitFor(() => expect(trigger).not.toBeDisabled());
+  fireEvent.click(trigger);
+}
+
+describe('the open project picker', () => {
+  it('lands on the selected target instead of the top of the list', async () => {
+    serveCatalog();
+    const scrolled: Element[] = [];
+    Element.prototype.scrollIntoView = function (this: Element) {
+      scrolled.push(this);
+    };
+    renderAt('/grid?db=attic&project=1&target=4');
+
+    await openPicker();
+
+    await waitFor(() => expect(scrolled).toHaveLength(1));
+    expect(scrolled[0]).toHaveAttribute('aria-current', 'true');
+    expect(scrolled[0].textContent).toContain('Sh2 86 East');
+  });
+
+  it('scrolls nowhere when nothing is selected', async () => {
+    serveCatalog();
+    const scrolled: Element[] = [];
+    Element.prototype.scrollIntoView = function (this: Element) {
+      scrolled.push(this);
+    };
+    renderAt('/grid');
+
+    await openPicker();
+
+    // Give the targets query time to land; the top "Choose a project" row is
+    // marked current with no scope, and it needs no scrolling to be seen.
+    await waitFor(() => expect(document.querySelector('.selector-options')).not.toBeNull());
+    expect(scrolled.filter((el) => el.matches('.selector-option'))).toHaveLength(0);
+  });
+});

--- a/static/src/utils/projectTargetNavigation.ts
+++ b/static/src/utils/projectTargetNavigation.ts
@@ -20,6 +20,8 @@ interface NavigationModelInput {
   databases: DatabaseSummary[];
   search: string;
   relativeNow: number;
+  /** Narrows the whole tree to one database; null shows every catalog. */
+  dbFilter?: string | null;
 }
 
 export function buildProjectTargetNavigation({
@@ -28,8 +30,13 @@ export function buildProjectTargetNavigation({
   databases,
   search,
   relativeNow,
+  dbFilter = null,
 }: NavigationModelInput) {
   const normalizedSearch = search.trim().toLocaleLowerCase();
+  if (dbFilter) {
+    projects = projects.filter((project) => project.db_id === dbFilter);
+    databases = databases.filter((database) => database.id === dbFilter);
+  }
   const targetsByProject = new Map<string, NavigationTarget[]>();
   for (const target of targets) {
     const key = `${target.db_id}:${target.project_id}`;


### PR DESCRIPTION
## What changed

**Database filters.** The Overview's projects toolbar gains a **Database** select that narrows the project list to one catalog. It lives in URL state (`dbfilter`) so reload and shared links restore it, and it is distinct from the parked `db` return-scope slug, which keeps marking where the user came from without filtering the view. The header project picker's popover gains the same filter for its tree; filtering never changes the selected scope until a row is chosen. Both filters only appear with more than one database.

**Header layout.** The picker column used to be `minmax(19rem, 1fr)` — it swallowed all free width while the status slot sat fixed at 17rem. The picker now caps at 30rem and the status slot takes the leftover (up to 28rem), so the activity and cache chips get room instead of a sliver. Small-screen breakpoints keep their compact behavior.

**Export layout at export time.** The page-wide **Export layout** select at the top of the Overview is gone. Every Export action (local folder, server export, zip download) opens a dialog offering grouped-by-target and WBPP with an explanation of each; the zip link carries the chosen layout in its URL. The dialog starts from a new server-wide default: `GET/PUT /api/settings/export`, persisted in the registry beside the calibration settings (PUT is write-gated as every non-GET is), edited in Settings → Setups. Standard is stored as absence so older builds reading the registry see nothing new.

## Checks run locally

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (714 passed)
- `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (322 passed, including 6 new tests), `npm run build`
- Playwright not run locally; no existing e2e spec covers these surfaces — relying on CI for that layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)