### PR TITLE
Replace the picker's nested database dropdown with a grouping preference

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -381,14 +381,15 @@
   turns away for calibration are summarized in the same warning — count and
   reason — instead of hiding in the per-frame list. Forced calibration keeps
   hard errors.
-- The Overview and the header's project picker can now filter by database: a
+- The Overview and the header's project picker got database-aware: a
   **Database** select in the Overview's projects toolbar narrows the project
   list to one catalog (kept in the URL, so reload and shared links restore
-  it), and the picker's popover gained the same filter for its tree. The
-  header also stopped letting the picker swallow the whole bar — it caps at a
-  sensible width and the freed space goes to the activity and cache status,
-  which was squeezed to a sliver before. Opening the picker now lands on the
-  current selection instead of the top of the list.
+  it), and a new **Top bar** preference in Settings → Review switches the
+  picker's list between grouping by recent activity and one group per
+  database. The header also stopped letting the picker swallow the whole
+  bar — it caps at a sensible width and the freed space goes to the activity
+  and cache status, which was squeezed to a sliver before. Opening the picker
+  now lands on the current selection instead of the top of the list.
 - The export layout is now chosen at export time. Every Export action opens a
   small dialog offering grouped-by-target and WBPP with an explanation of
   each, instead of one page-wide mode select at the top of the Overview. What

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -485,32 +485,6 @@
   outline: 2px solid var(--color-primary-alpha-20);
 }
 
-.selector-db-filter {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 7px;
-  color: var(--color-text-muted);
-  font-size: 0.78rem;
-}
-
-.selector-db-filter select {
-  flex: 1 1 auto;
-  min-width: 0;
-  padding: 5px 8px;
-  border: 1px solid var(--color-border-secondary);
-  border-radius: 6px;
-  background: var(--color-bg-input);
-  color: var(--color-text-primary);
-  font: inherit;
-  font-size: 0.82rem;
-}
-
-.selector-db-filter select:focus {
-  border-color: var(--color-primary);
-  outline: 2px solid var(--color-primary-alpha-20);
-}
-
 .selector-options {
   max-height: min(62vh, 480px);
   margin-top: 7px;

--- a/static/src/components/ProjectTargetSelector.tsx
+++ b/static/src/components/ProjectTargetSelector.tsx
@@ -10,6 +10,7 @@ import {
   type NavigationTarget,
 } from '../utils/projectTargetNavigation';
 import { useAccess } from '../auth/access';
+import { useDisplayPreferences } from '../hooks/useDisplayPreferences';
 import ProjectTreeOption from './projectSelector/ProjectTreeOption';
 
 export default function ProjectTargetSelector() {
@@ -31,10 +32,10 @@ export default function ProjectTargetSelector() {
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
-  // Picker-local: narrows the popover tree to one catalog without changing
-  // the selected scope until a row is chosen.
-  const [dbFilter, setDbFilter] = useState<string | null>(null);
   const [relativeNow, setRelativeNow] = useState(Date.now);
+  // How the list is organized — by activity or by database — set in
+  // Settings → Review and stored in this browser.
+  const { projectPickerGrouping } = useDisplayPreferences();
 
   const invalidateAllForDb = () => {
     if (!dbId) return;
@@ -71,9 +72,9 @@ export default function ProjectTargetSelector() {
         databases: databases ?? [],
         search,
         relativeNow,
-        dbFilter,
+        grouping: projectPickerGrouping,
       }),
-    [projects, targets, databases, search, relativeNow, dbFilter]
+    [projects, targets, databases, search, relativeNow, projectPickerGrouping]
   );
 
   useEffect(() => {
@@ -260,25 +261,6 @@ export default function ProjectTargetSelector() {
               placeholder="Type to find a project or target"
               aria-label="Search projects or targets"
             />
-            {(databases?.length ?? 0) > 1 && (
-              <label className="selector-db-filter">
-                <span>Database</span>
-                <select
-                  value={dbFilter ?? 'all'}
-                  onChange={(event) =>
-                    setDbFilter(event.target.value === 'all' ? null : event.target.value)
-                  }
-                  aria-label="Filter the list by database"
-                >
-                  <option value="all">All databases</option>
-                  {databases!.map((database) => (
-                    <option key={database.id} value={database.id}>
-                      {database.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
             {targetsError && (
               <div className="selector-load-error" role="alert">
                 <span>Some targets could not be loaded.</span>

--- a/static/src/components/ReviewPreferences.tsx
+++ b/static/src/components/ReviewPreferences.tsx
@@ -58,6 +58,30 @@ export default function ReviewPreferences() {
         </span>
       </label>
 
+      <h3>Top bar</h3>
+      <label className="review-preference">
+        <span>
+          Project list grouping
+          <small>
+            How the project picker in the top bar organizes its list: by how
+            recently each project was worked, or one group per database.
+          </small>
+        </span>
+        <select
+          value={preferences.projectPickerGrouping}
+          aria-label="Project list grouping"
+          onChange={(event) =>
+            set({
+              projectPickerGrouping:
+                event.target.value === 'database' ? 'database' : 'activity',
+            })
+          }
+        >
+          <option value="activity">By recent activity</option>
+          <option value="database">By database</option>
+        </select>
+      </label>
+
       <p className="review-preferences-note">
         These preferences live in this browser and apply immediately.
       </p>

--- a/static/src/components/__tests__/ProjectTargetSelector.grouping.test.tsx
+++ b/static/src/components/__tests__/ProjectTargetSelector.grouping.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
@@ -6,6 +6,11 @@ import type { ReactNode } from 'react';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../test/msw-server';
 import ProjectTargetSelector from '../ProjectTargetSelector';
+import {
+  setDisplayPreferences,
+  useDisplayPreferences,
+} from '../../hooks/useDisplayPreferences';
+import { renderHook } from '@testing-library/react';
 
 function ok(data: unknown) {
   return HttpResponse.json({ success: true, data, error: null, status: 'ready' });
@@ -53,28 +58,48 @@ function renderSelector() {
   return render(<ProjectTargetSelector />, { wrapper: Wrapper });
 }
 
-describe('the project picker database filter', () => {
-  it('narrows the tree to one catalog without changing the scope', async () => {
-    serveTwoCatalogs();
-    renderSelector();
+async function openPicker() {
+  const trigger = document.querySelector<HTMLButtonElement>('#scope-select')!;
+  await waitFor(() => expect(trigger).not.toBeDisabled());
+  fireEvent.click(trigger);
+}
 
-    const trigger = document.querySelector<HTMLButtonElement>('#scope-select')!;
-    await waitFor(() => expect(trigger).not.toBeDisabled());
-    fireEvent.click(trigger);
+function groupHeadings(): string[] {
+  return Array.from(
+    document.querySelectorAll('.selector-group-heading > span:first-child')
+  ).map((el) => el.textContent ?? '');
+}
+
+afterEach(() => {
+  const { result } = renderHook(() => useDisplayPreferences());
+  setDisplayPreferences({ ...result.current, projectPickerGrouping: 'activity' });
+});
+
+describe('the project picker grouping preference', () => {
+  it('groups by database when the preference says so', async () => {
+    serveTwoCatalogs();
+    const { result } = renderHook(() => useDisplayPreferences());
+    setDisplayPreferences({ ...result.current, projectPickerGrouping: 'database' });
+
+    renderSelector();
+    await openPicker();
 
     await screen.findByText('Sh2 86');
-    await screen.findByText('NGC 6820');
-    // One "All projects · catalog" row per catalog while unfiltered.
-    expect(screen.getAllByText('All projects')).toHaveLength(2);
+    expect(groupHeadings()).toEqual(['Attic catalog', 'Shed catalog']);
+    const attic = document.querySelector('[aria-label="Attic catalog"]')!;
+    expect(attic.textContent).toContain('Sh2 86');
+    expect(attic.textContent).not.toContain('NGC 6820');
+  });
 
-    fireEvent.change(screen.getByLabelText('Filter the list by database'), {
-      target: { value: 'shed' },
-    });
+  it('groups by activity by default, with no database headings', async () => {
+    serveTwoCatalogs();
+    renderSelector();
+    await openPicker();
 
-    await waitFor(() => expect(screen.queryByText('Sh2 86')).toBeNull());
-    expect(screen.getByText('NGC 6820')).toBeInTheDocument();
-    expect(screen.getAllByText('All projects')).toHaveLength(1);
-    // Filtering alone never navigates: the trigger still awaits a choice.
-    expect(screen.getByText('Choose project or target')).toBeInTheDocument();
+    await screen.findByText('Sh2 86');
+    expect(groupHeadings()).not.toContain('Attic catalog');
+    // Both catalogs' projects share one activity group instead.
+    const headings = groupHeadings();
+    expect(headings.length).toBeGreaterThan(0);
   });
 });

--- a/static/src/hooks/__tests__/useDisplayPreferences.test.tsx
+++ b/static/src/hooks/__tests__/useDisplayPreferences.test.tsx
@@ -8,7 +8,12 @@ import {
 describe('display preferences', () => {
   beforeEach(() => {
     window.localStorage.removeItem('psf-guard.display-preferences');
-    setDisplayPreferences({ showNightChip: true, showAllChip: true, advanceOnGrade: true });
+    setDisplayPreferences({
+      showNightChip: true,
+      showAllChip: true,
+      advanceOnGrade: true,
+      projectPickerGrouping: 'activity',
+    });
   });
 
   it('defaults to showing both chip types and advancing after a grade', () => {
@@ -17,12 +22,18 @@ describe('display preferences', () => {
       showNightChip: true,
       showAllChip: true,
       advanceOnGrade: true,
+      projectPickerGrouping: 'activity',
     });
   });
 
   it('toggles each chip type independently', () => {
     act(() => {
-      setDisplayPreferences({ showNightChip: false, showAllChip: true, advanceOnGrade: true });
+      setDisplayPreferences({
+        showNightChip: false,
+        showAllChip: true,
+        advanceOnGrade: true,
+        projectPickerGrouping: 'activity',
+      });
     });
     const { result } = renderHook(() => useDisplayPreferences());
     expect(result.current.showNightChip).toBe(false);
@@ -35,7 +46,12 @@ describe('display preferences', () => {
     const grid = renderHook(() => useDisplayPreferences());
     const sequence = renderHook(() => useDisplayPreferences());
     act(() => {
-      setDisplayPreferences({ showNightChip: true, showAllChip: false, advanceOnGrade: true });
+      setDisplayPreferences({
+        showNightChip: true,
+        showAllChip: false,
+        advanceOnGrade: true,
+        projectPickerGrouping: 'activity',
+      });
     });
     expect(grid.result.current.showAllChip).toBe(false);
     expect(sequence.result.current.showAllChip).toBe(false);
@@ -43,11 +59,21 @@ describe('display preferences', () => {
 
   it('persists the choice to localStorage', () => {
     act(() => {
-      setDisplayPreferences({ showNightChip: false, showAllChip: false, advanceOnGrade: false });
+      setDisplayPreferences({
+        showNightChip: false,
+        showAllChip: false,
+        advanceOnGrade: false,
+        projectPickerGrouping: 'database',
+      });
     });
     expect(
       JSON.parse(window.localStorage.getItem('psf-guard.display-preferences')!),
-    ).toEqual({ showNightChip: false, showAllChip: false, advanceOnGrade: false });
+    ).toEqual({
+      showNightChip: false,
+      showAllChip: false,
+      advanceOnGrade: false,
+      projectPickerGrouping: 'database',
+    });
   });
 
   it('falls back to the default on malformed stored values', () => {
@@ -55,9 +81,11 @@ describe('display preferences', () => {
       showNightChip: 'yes' as unknown as boolean,
       showAllChip: true,
       advanceOnGrade: true,
+      projectPickerGrouping: 'sideways' as unknown as 'activity',
     });
     const { result } = renderHook(() => useDisplayPreferences());
     expect(result.current.showNightChip).toBe(true);
+    expect(result.current.projectPickerGrouping).toBe('activity');
   });
 
   it('honors the earlier single-switch stored form', () => {

--- a/static/src/hooks/useDisplayPreferences.ts
+++ b/static/src/hooks/useDisplayPreferences.ts
@@ -5,6 +5,9 @@ import { useSyncExternalStore } from 'react';
  * One preference, not one per view: the grid and the Sequence view must
  * never disagree about what a card shows.
  */
+/** How the top-bar project picker organizes its list. */
+export type ProjectPickerGrouping = 'activity' | 'database';
+
 export interface DisplayPreferences {
   /** Show the smaller "night <score>" chip — the per-session basis shown
    * when the main badge is the all-sessions score. */
@@ -15,6 +18,8 @@ export interface DisplayPreferences {
   /** Move to the next image after accept/reject/pending. Holding Shift
    * while grading does the opposite of this setting for that one grade. */
   advanceOnGrade: boolean;
+  /** Group the top-bar project picker by recent activity or by database. */
+  projectPickerGrouping: ProjectPickerGrouping;
 }
 
 const STORAGE_KEY = 'psf-guard.display-preferences';
@@ -22,6 +27,7 @@ const DEFAULTS: DisplayPreferences = {
   showNightChip: true,
   showAllChip: true,
   advanceOnGrade: true,
+  projectPickerGrouping: 'activity',
 };
 
 type Listener = () => void;
@@ -51,6 +57,8 @@ function sanitize(parsed: StoredPreferences): DisplayPreferences {
       typeof parsed.advanceOnGrade === 'boolean'
         ? parsed.advanceOnGrade
         : DEFAULTS.advanceOnGrade,
+    projectPickerGrouping:
+      parsed.projectPickerGrouping === 'database' ? 'database' : DEFAULTS.projectPickerGrouping,
   };
 }
 

--- a/static/src/utils/__tests__/projectTargetNavigation.test.ts
+++ b/static/src/utils/__tests__/projectTargetNavigation.test.ts
@@ -93,4 +93,46 @@ describe('buildProjectTargetNavigation', () => {
     expect([...model.matchingTargetProjectKeys]).toEqual([]);
     expect(model.targetsForProject(projects[0]).map((target) => target.id)).toEqual([10]);
   });
+
+  it('groups one section per database when asked, in configured order', () => {
+    const shed: DatabaseSummary = { ...database, id: 'shed', name: 'Shed catalog' };
+    const shedProject: WithDb<Project> = {
+      ...projects[0],
+      id: 7,
+      name: 'Shed survey',
+      display_name: 'Shed survey',
+      db_id: shed.id,
+      db_name: shed.name,
+    };
+
+    const model = buildProjectTargetNavigation({
+      projects: [...projects, shedProject],
+      targets,
+      databases: [database, shed],
+      search: '',
+      relativeNow: 1_000_000,
+      grouping: 'database',
+    });
+
+    expect(model.projectGroups.map((group) => group.label)).toEqual([
+      'Imaging Rig',
+      'Shed catalog',
+    ]);
+    expect(model.projectGroups[0].projects.map((project) => project.id)).toEqual([2, 1]);
+    expect(model.projectGroups[1].projects.map((project) => project.id)).toEqual([7]);
+  });
+
+  it('drops a database section that has nothing to show', () => {
+    const empty: DatabaseSummary = { ...database, id: 'empty', name: 'Empty catalog' };
+    const model = buildProjectTargetNavigation({
+      projects,
+      targets,
+      databases: [database, empty],
+      search: '',
+      relativeNow: 1_000_000,
+      grouping: 'database',
+    });
+
+    expect(model.projectGroups.map((group) => group.label)).toEqual(['Imaging Rig']);
+  });
 });

--- a/static/src/utils/projectTargetNavigation.ts
+++ b/static/src/utils/projectTargetNavigation.ts
@@ -14,14 +14,17 @@ export function projectNavigationKey(project: NavigationProject): string {
   return `${project.db_id}:${project.id}`;
 }
 
+/** How the picker organizes its project list. */
+export type NavigationGrouping = 'activity' | 'database';
+
 interface NavigationModelInput {
   projects: NavigationProject[];
   targets: NavigationTarget[];
   databases: DatabaseSummary[];
   search: string;
   relativeNow: number;
-  /** Narrows the whole tree to one database; null shows every catalog. */
-  dbFilter?: string | null;
+  /** Group projects by recent activity (default) or one group per catalog. */
+  grouping?: NavigationGrouping;
 }
 
 export function buildProjectTargetNavigation({
@@ -30,13 +33,9 @@ export function buildProjectTargetNavigation({
   databases,
   search,
   relativeNow,
-  dbFilter = null,
+  grouping = 'activity',
 }: NavigationModelInput) {
   const normalizedSearch = search.trim().toLocaleLowerCase();
-  if (dbFilter) {
-    projects = projects.filter((project) => project.db_id === dbFilter);
-    databases = databases.filter((database) => database.id === dbFilter);
-  }
   const targetsByProject = new Map<string, NavigationTarget[]>();
   for (const target of targets) {
     const key = `${target.db_id}:${target.project_id}`;
@@ -69,12 +68,27 @@ export function buildProjectTargetNavigation({
       .map(projectNavigationKey)
   );
 
+  const activeProjects = matchingProjects.filter((project) => !isArchivedProject(project));
+  // Database grouping keeps the catalogs in their configured order and skips
+  // the ones with nothing to show. Archived projects stay in the shared
+  // section below either way; every row there already names its database.
+  const projectGroups =
+    grouping === 'database'
+      ? databases
+          .map((database) => ({
+            id: `db:${database.id}`,
+            label: database.name,
+            projects: sortProjects(
+              activeProjects.filter((project) => project.db_id === database.id),
+              'recent'
+            ),
+          }))
+          .filter((group) => group.projects.length > 0)
+      : groupProjectsByActivity(activeProjects, relativeNow);
+
   return {
     normalizedSearch,
-    projectGroups: groupProjectsByActivity(
-      matchingProjects.filter((project) => !isArchivedProject(project)),
-      relativeNow
-    ),
+    projectGroups,
     archivedProjects: sortProjects(matchingProjects.filter(isArchivedProject), 'recent'),
     matchingDatabases: databases.filter(
       (database) =>


### PR DESCRIPTION
A select inside the popover was awkward. The top-bar project picker now organizes its list per a browser-local preference — **by recent activity** (the default, today's behavior) or **one group per database**, in configured catalog order with empty catalogs skipped — set under a new **Top bar** heading in Settings → Review. The nested dropdown is gone; the "All projects · catalog" scope rows and the shared archived section are unchanged (archived rows already name their database).

The Overview toolbar's database filter from #376 is untouched — the complaint was specifically the dropdown inside the dropdown.

## Checks run locally

- `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (322 passed — grouping unit tests on the navigation builder, a component test for both modes, updated display-preference tests), `npm run build`
- No Rust changes.
- Playwright not run locally; relying on CI for that layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)