### PR TITLE
Run RC-Astro tools (BXT/NXT/SXT) in the stack view-processing tier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,9 +4931,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.18.6"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fd0940ae004f594dc54ee332b48ce7aaf235d6ae2cdbd1e6d666aef777f9e"
+checksum = "abc82fde6c8ea09e1c1cbddcbedf4d68f4269b740b4d3c1baf7307f1f6eac3c7"
 dependencies = [
  "directories",
  "image",
@@ -5046,9 +5046,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48d49764158fda6a78d1e0b6d73a79bdc9a7abacc945178edadf0094a4e9460"
+checksum = "fbdc9c8761fc40a060b3875f14f348d7ead2422b8499e3120d08d0b63b6fd510"
 dependencies = [
  "rayon",
  "seiza",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.18.6"
+seiza = "0.18.9"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.1"
 seiza-satellites = { version = "0.7.0", features = ["serde"] }
-seiza-stacking = "0.11.4"
+seiza-stacking = "0.11.5"
 seiza-stretch = "0.2.1"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -526,7 +526,9 @@ A chain takes minutes on CPU, so an apply that includes RC-Astro tools runs
 detached: the request answers `202 Accepted` and the client re-sends the
 same request until the result is ready — no reverse-proxy timeout can kill
 the run, and identical concurrent requests join the same computation
-instead of duplicating it. A run that stays completely silent for ten
+instead of duplicating it. Each poll answer carries the run's live
+progress — which tool is running and the chain's overall fraction — and
+the **Apply processing** button shows it. A run that stays completely silent for ten
 minutes is killed (a first run downloads ML models; run
 `rc-astro download-models` once ahead of time). Chain results whose
 settings nobody has re-applied for two weeks are swept from the cache.

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -522,6 +522,15 @@ afterward. Find the CLI on `PATH`, or name it with the `PSF_GUARD_RC_ASTRO`
 environment variable for service units with a minimal `PATH`.
 `GET /api/tools/rc-astro` reports the probe the UI uses.
 
+A chain takes minutes on CPU, so an apply that includes RC-Astro tools runs
+detached: the request answers `202 Accepted` and the client re-sends the
+same request until the result is ready — no reverse-proxy timeout can kill
+the run, and identical concurrent requests join the same computation
+instead of duplicating it. A run that stays completely silent for ten
+minutes is killed (a first run downloads ML models; run
+`rc-astro download-models` once ahead of time). Chain results whose
+settings nobody has re-applied for two weeks are swept from the cache.
+
 The controls expose Seiza's identity, explicit linear, asinh,
 percentile-asinh, MTF, Generalized Hyperbolic Stretch (GHS), and Auto-MTF
 models. Auto-MTF with PSF Guard's established target median and shadow clipping

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -502,6 +502,26 @@ Changing only the display stretch reuses the same restored FITS. Its cache key
 depends on the source revision, restoration settings, and Seiza algorithm
 version, not the display model.
 
+**RC-Astro tools are offered when the server has them.** With RC-Astro's
+standalone `rc-astro` CLI installed (and licensed), **View processing** adds
+an **RC-Astro tools** card offering BlurXTerminator, NoiseXTerminator, and
+StarXTerminator on the linear stack, after deconvolution and before the
+stretch. The controls are built from each tool's own machine-readable schema
+(`rc-astro <tool> --json`), so the knobs track the installed CLI version.
+Star removal keeps both halves: the starless image becomes the processed
+linear source, the stars image is stored beside it, and the card gains a
+**Starless / Stars** switch plus a stars FITS download — each stretched
+independently, which is the point: stretch the starless data hard without
+bloating stars, then screen the stars back in your processing tool. Results
+are content-addressed like deconvolution, keyed by the settings and the
+CLI and neural-network model versions, so a tool upgrade rebuilds instead of
+serving stale output. Runs use the tool's saved compute device (GPU where
+supported, CPU fallback) and PSF Guard exchanges 32-bit-float FITS
+normalized to the unit scale the tools expect, restoring the physical scale
+afterward. Find the CLI on `PATH`, or name it with the `PSF_GUARD_RC_ASTRO`
+environment variable for service units with a minimal `PATH`.
+`GET /api/tools/rc-astro` reports the probe the UI uses.
+
 The controls expose Seiza's identity, explicit linear, asinh,
 percentile-asinh, MTF, Generalized Hyperbolic Stretch (GHS), and Auto-MTF
 models. Auto-MTF with PSF Guard's established target median and shadow clipping
@@ -790,8 +810,9 @@ immutable cached response for the rebuilt output.
 - The retained FITS is a quick-look integration, whether calibrated or not. It
   is not a final science product.
 - Color is a visual channel combination, not photometric or
-  spectrophotometric calibration. There is no custom mixing matrix UI, star
-  removal, mosaic, drizzle, or cross-target integration.
+  spectrophotometric calibration. There is no custom mixing matrix UI,
+  mosaic, drizzle, or cross-target integration. Star removal exists only
+  through the RC-Astro tools on mono stacks, not for color composites.
 - Deconvolution requires a user-supplied FWHM and one circular Gaussian PSF for
   the whole channel. It does not estimate a PSF, vary it across the field, or
   replace a final scientific restoration workflow.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -129,6 +129,18 @@
   any one install without signing out the rest. Manually configured keys
   keep working.
 
+- Stack previews can now run RC-Astro's standalone tools. With the
+  `rc-astro` CLI installed and licensed on the server, **View processing**
+  offers BlurXTerminator, NoiseXTerminator, and StarXTerminator on the
+  linear stack, with controls built from each tool's own schema so they
+  track the installed version. Star removal keeps both images — the
+  starless stack and the stars — each with its own stretch, a **Starless /
+  Stars** view switch on the card, and its own FITS download, so the
+  nebulosity can be stretched hard and the stars screened back later.
+  Results cache by settings plus the CLI and model versions, and the
+  integration artifact is never modified. See [stack
+  previews](https://github.com/theatrus/psf-guard/blob/main/docs/STACKING_PREVIEWS.md).
+
 ## Changed
 
 - A dark now suits a light when their exposures agree to a tenth of a percent

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -473,6 +473,14 @@ async fn run_server_internal(
             get(stack_preview::stretch::download_stack_stretch_fits),
         )
         .route(
+            "/stack-previews/stretch/{stretch_id}/stars",
+            get(stack_preview::stretch::get_stack_stretch_stars_image),
+        )
+        .route(
+            "/stack-previews/stretch/{stretch_id}/stars-fits",
+            get(stack_preview::stretch::download_stack_stretch_stars_fits),
+        )
+        .route(
             "/stack-previews/color/{job_id}/fits",
             get(stack_preview::color::download_stack_color_fits),
         )
@@ -583,6 +591,10 @@ async fn run_server_internal(
         .route(
             "/astrometry/capabilities",
             get(handlers::get_astrometry_capabilities),
+        )
+        .route(
+            "/tools/rc-astro",
+            get(stack_preview::rc_astro::get_rc_astro_capabilities),
         )
         .route(
             "/astrometry/catalogs/validate",

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -571,6 +571,7 @@ impl StackPreviewManager {
     pub(super) fn prune_cache(&self, cache_root: &FsPath) {
         let keep = self.cache_keep_set(cache_root);
         janitor::prune(cache_root, &keep, SEIZA_STACKING_VERSION);
+        rc_astro::prune_rc_astro_cache(cache_root);
     }
 
     pub(crate) async fn acquire_maintenance_permit(
@@ -1158,7 +1159,7 @@ pub async fn apply_stack_preview_stretch(
     ctx: DbContext,
     Path((_db_id, job_id, group_index)): Path<(String, String, usize)>,
     Json(request): Json<stretch::StackViewProcessingRequest>,
-) -> Result<Json<ApiResponse<stretch::StackStretchPreview>>, AppError> {
+) -> Result<axum::response::Response, AppError> {
     validate_job_id(&job_id)?;
     let job = if let Some(job) = state.stack_previews.get(&job_id) {
         job
@@ -1188,7 +1189,7 @@ pub async fn apply_stack_preview_stretch(
         request,
     )
     .await?;
-    Ok(stretch::response(result))
+    Ok(stretch::apply_response(result))
 }
 
 fn validate_request(request: &StackPreviewRequest) -> Result<(), AppError> {

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -8,6 +8,7 @@
 pub mod artifact;
 pub mod color;
 mod janitor;
+pub mod rc_astro;
 mod resume;
 pub mod snr;
 pub mod stretch;

--- a/src/server/stack_preview/rc_astro.rs
+++ b/src/server/stack_preview/rc_astro.rs
@@ -160,12 +160,46 @@ pub fn probe_capabilities() -> RcAstroCapabilities {
 
 /// GET /api/tools/rc-astro
 pub async fn get_rc_astro_capabilities(
-    axum::extract::State(_state): axum::extract::State<Arc<AppState>>,
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
 ) -> Result<Json<ApiResponse<RcAstroCapabilities>>, AppError> {
-    let capabilities = tokio::task::spawn_blocking(probe_capabilities)
+    let mut capabilities = tokio::task::spawn_blocking(probe_capabilities)
         .await
         .map_err(|error| AppError::InternalError(format!("RC-Astro probe failed: {error}")))?;
+    // Every viewer may see which tools exist; the license line names the
+    // licensee and the executable names a server path, so those stay with
+    // the operator role.
+    for tool in &mut capabilities.tools {
+        tool.license_message = None;
+    }
+    if !state.database_management_allowed() {
+        capabilities.executable = None;
+    }
     Ok(Json(ApiResponse::success(capabilities)))
+}
+
+/// A short-lived schema cache: every stretch apply needs the schemas to
+/// compute its cache identity, and spawning three probe processes per
+/// request adds latency for an answer that only changes on a CLI upgrade.
+static SCHEMA_CACHE: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, (std::time::Instant, ExternalToolSchema)>>,
+> = std::sync::LazyLock::new(Default::default);
+const SCHEMA_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
+fn cached_tool_schema(cli: &RcAstroCli, tool: &str) -> Result<ExternalToolSchema, String> {
+    if let Ok(cache) = SCHEMA_CACHE.lock()
+        && let Some((read_at, schema)) = cache.get(tool)
+        && read_at.elapsed() < SCHEMA_CACHE_TTL
+    {
+        return Ok(schema.clone());
+    }
+    let schema = cli.tool_schema(tool).map_err(|error| error.to_string())?;
+    if let Ok(mut cache) = SCHEMA_CACHE.lock() {
+        cache.insert(
+            tool.to_string(),
+            (std::time::Instant::now(), schema.clone()),
+        );
+    }
+    Ok(schema)
 }
 
 /// Read the schemas the requested steps need, or say which tool refused.
@@ -176,9 +210,7 @@ pub(super) fn schemas_for(
     let cli = cli().ok_or_else(|| "rc-astro is not installed on this server".to_string())?;
     let mut schemas = Vec::new();
     for step in config.ordered() {
-        let schema = cli
-            .tool_schema(&step.tool)
-            .map_err(|error| error.to_string())?;
+        let schema = cached_tool_schema(&cli, &step.tool)?;
         if !schema.licensed {
             return Err(format!(
                 "{} is not licensed on this server{}",
@@ -195,29 +227,119 @@ pub(super) fn schemas_for(
     Ok(schemas)
 }
 
+/// Canonicalize a request against the live schemas: refuse unknown,
+/// GUI-only, and out-of-range parameters with a clear message before
+/// anything runs, and coerce a whole-number float (which JSON delivers as
+/// an integer) to its float form. Coercion must happen before hashing:
+/// `1` and `1.0` are the same request and must share one cache identity.
+pub(super) fn normalize_against_schemas(
+    config: &RcAstroProcessing,
+    schemas: &[(String, ExternalToolSchema)],
+) -> Result<RcAstroProcessing, String> {
+    let mut steps = Vec::new();
+    for step in config.ordered() {
+        let (_, schema) = schemas
+            .iter()
+            .find(|(tool, _)| tool == &step.tool)
+            .ok_or_else(|| format!("no schema for RC-Astro tool {:?}", step.tool))?;
+        let mut parameters = BTreeMap::new();
+        for (name, value) in &step.parameters {
+            let parameter = schema
+                .parameters
+                .iter()
+                .find(|parameter| &parameter.name == name)
+                .ok_or_else(|| format!("{}: unknown parameter {name:?}", schema.name))?;
+            if parameter.flag.is_none() {
+                return Err(format!(
+                    "{}: parameter {name:?} cannot be set from the CLI",
+                    schema.name
+                ));
+            }
+            let value = match (&parameter.kind, value) {
+                (
+                    seiza_stacking::ExternalParameterKind::Float { min, max, .. },
+                    ExternalParameterValue::Int(raw),
+                ) => {
+                    let coerced = *raw as f64;
+                    if coerced < *min || coerced > *max {
+                        return Err(format!(
+                            "{}: {name} = {coerced} is outside [{min}, {max}]",
+                            schema.name
+                        ));
+                    }
+                    ExternalParameterValue::Float(coerced)
+                }
+                (
+                    seiza_stacking::ExternalParameterKind::Float { min, max, .. },
+                    ExternalParameterValue::Float(v),
+                ) => {
+                    if !v.is_finite() || v < min || v > max {
+                        return Err(format!(
+                            "{}: {name} = {v} is outside [{min}, {max}]",
+                            schema.name
+                        ));
+                    }
+                    ExternalParameterValue::Float(*v)
+                }
+                (
+                    seiza_stacking::ExternalParameterKind::Int { min, max, .. },
+                    ExternalParameterValue::Int(v),
+                ) => {
+                    if v < min || v > max {
+                        return Err(format!(
+                            "{}: {name} = {v} is outside [{min}, {max}]",
+                            schema.name
+                        ));
+                    }
+                    ExternalParameterValue::Int(*v)
+                }
+                (
+                    seiza_stacking::ExternalParameterKind::Bool { .. },
+                    ExternalParameterValue::Bool(v),
+                ) => ExternalParameterValue::Bool(*v),
+                (expected, provided) => {
+                    return Err(format!(
+                        "{}: parameter {name:?} expects {expected:?}, got {provided:?}",
+                        schema.name
+                    ));
+                }
+            };
+            parameters.insert(name.clone(), value);
+        }
+        steps.push(RcAstroStep {
+            tool: step.tool.clone(),
+            parameters,
+        });
+    }
+    Ok(RcAstroProcessing { steps })
+}
+
 /// The cache identity of one processing chain over one source. Includes
-/// each tool's CLI and model versions: an upgrade changes the output for
-/// identical inputs, so it must change the identity too.
+/// each tool's CLI and model versions — an upgrade changes the output for
+/// identical inputs — and the identity of the deconvolution feeding it,
+/// because the chain processes the deconvolved image, not the raw stack.
 pub(super) fn rc_astro_cache_id(
     database_id: &str,
     source_key: &str,
     source_revision: &str,
     config: &RcAstroProcessing,
     schemas: &[(String, ExternalToolSchema)],
+    deconvolution_id: Option<&str>,
 ) -> Result<String, AppError> {
-    let mut ordered = config.ordered().into_iter().cloned().collect::<Vec<_>>();
     // The canonical order is the identity: two requests that run the same
     // steps the same way cache as one.
+    let ordered = config.ordered();
     let encoded = serde_json::to_vec(&ordered).map_err(|error| {
         AppError::InternalError(format!("Failed to encode RC-Astro request: {error}"))
     })?;
-    ordered.clear();
     let mut hasher = Sha256::new();
     hasher.update(database_id.as_bytes());
     hasher.update(source_key.as_bytes());
     hasher.update(source_revision.as_bytes());
     hasher.update(RC_ASTRO_CACHE_VERSION.to_le_bytes());
     hasher.update(&encoded);
+    hasher.update(b"deconvolution");
+    hasher.update(deconvolution_id.unwrap_or("none").as_bytes());
     for (tool, schema) in schemas {
         hasher.update(tool.as_bytes());
         hasher.update(schema.cli_version.as_bytes());
@@ -281,6 +403,11 @@ pub(super) fn apply_rc_astro(
         && fits.is_file()
         && (!cached.result.has_stars || stars_fits.is_file())
     {
+        // A reuse marks the entry as recently useful, so age-based pruning
+        // keeps live variants and drops abandoned ones.
+        if let Ok(file) = std::fs::File::options().append(true).open(&manifest_path) {
+            let _ = file.set_modified(std::time::SystemTime::now());
+        }
         let processed = crate::image_io::open_linear_frame(&fits)
             .map_err(|error| error.to_string())?
             .image;
@@ -361,12 +488,20 @@ pub(super) fn apply_rc_astro(
         .parent()
         .ok_or_else(|| "RC-Astro FITS path has no parent".to_string())?;
     std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
-    let temporary = fits.with_extension(format!("{}.tmp.fits", std::process::id()));
+    // The temp name carries a process-wide counter besides the pid: two
+    // writers within one process must never interleave into one temp file.
+    static TEMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let unique = format!(
+        "{}-{}",
+        std::process::id(),
+        TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    );
+    let temporary = fits.with_extension(format!("{unique}.tmp.fits"));
     write_processed_image_fits_f32(&temporary, &current, reference_headers, &rc_astro_cards())
         .map_err(|error| error.to_string())?;
     std::fs::rename(&temporary, &fits).map_err(|error| error.to_string())?;
     if let Some(stars_image) = &stars {
-        let temporary = stars_fits.with_extension(format!("{}.tmp.fits", std::process::id()));
+        let temporary = stars_fits.with_extension(format!("{unique}.tmp.fits"));
         write_processed_image_fits_f32(
             &temporary,
             stars_image,
@@ -391,6 +526,45 @@ pub(super) fn apply_rc_astro(
         stars,
         result,
     })
+}
+
+/// A chain result whose manifest has gone untouched this long is abandoned:
+/// nobody re-applied those settings for two weeks. A reuse refreshes the
+/// manifest's mtime, so live variants survive.
+const RC_ASTRO_RETENTION: std::time::Duration = std::time::Duration::from_secs(14 * 24 * 3600);
+
+/// Sweep abandoned chain results and orphaned temp files. Each entry can be
+/// hundreds of megabytes (processed plus stars FITS), and version bumps
+/// deliberately mint new identities, so the directory grows without this.
+pub(super) fn prune_rc_astro_cache(cache_root: &FsPath) {
+    let root = cache_root.join("stack-previews").join("rc-astro");
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return;
+    };
+    let stale = |path: &std::path::Path, retention: std::time::Duration| {
+        std::fs::metadata(path)
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|modified| modified.elapsed().ok())
+            .is_some_and(|age| age > retention)
+    };
+    for entry in entries.flatten() {
+        let directory = entry.path();
+        if !directory.is_dir() {
+            continue;
+        }
+        let manifest = directory.join("manifest.json");
+        let remove = if manifest.is_file() {
+            stale(&manifest, RC_ASTRO_RETENTION)
+        } else {
+            // No manifest means a write crashed part way: give a running
+            // build a day, then sweep the debris.
+            stale(&directory, std::time::Duration::from_secs(24 * 3600))
+        };
+        if remove {
+            let _ = std::fs::remove_dir_all(&directory);
+        }
+    }
 }
 
 fn rc_astro_cards() -> Vec<seiza_fits::WriteHeaderCard> {
@@ -454,18 +628,13 @@ mod tests {
     }
 
     #[test]
-    fn the_cache_identity_ignores_request_order_but_tracks_versions() {
+    fn the_cache_identity_ignores_request_order_but_tracks_versions_and_deconvolution() {
         let schemas = vec![("bxt".to_string(), schema("bxt", "2.6.6", 4))];
-        let forward = rc_astro_cache_id(
-            "db",
-            "mono:job:0",
-            "rev",
-            &RcAstroProcessing {
-                steps: vec![step("bxt"), step("sxt")],
-            },
-            &schemas,
-        )
-        .unwrap();
+        let config = RcAstroProcessing {
+            steps: vec![step("bxt"), step("sxt")],
+        };
+        let forward =
+            rc_astro_cache_id("db", "mono:job:0", "rev", &config, &schemas, None).unwrap();
         let reversed = rc_astro_cache_id(
             "db",
             "mono:job:0",
@@ -474,6 +643,7 @@ mod tests {
                 steps: vec![step("sxt"), step("bxt")],
             },
             &schemas,
+            None,
         )
         .unwrap();
         assert_eq!(forward, reversed);
@@ -482,13 +652,81 @@ mod tests {
             "db",
             "mono:job:0",
             "rev",
-            &RcAstroProcessing {
-                steps: vec![step("bxt"), step("sxt")],
-            },
+            &config,
             &[("bxt".to_string(), schema("bxt", "2.7.0", 5))],
+            None,
         )
         .unwrap();
         assert_ne!(forward, upgraded);
+
+        // The chain processes the deconvolved image, so the deconvolution
+        // identity is part of this identity: without it, "BXT after 3px
+        // deconvolution" and "BXT alone" would serve each other's pixels.
+        let deconvolved =
+            rc_astro_cache_id("db", "mono:job:0", "rev", &config, &schemas, Some("abc123"))
+                .unwrap();
+        assert_ne!(forward, deconvolved);
+    }
+
+    #[test]
+    fn normalization_coerces_whole_number_floats_and_refuses_bad_parameters() {
+        let mut sxt = schema("sxt", "2.6.6", 11);
+        sxt.parameters = vec![
+            serde_json::from_value(serde_json::json!({
+                "name": "overlap", "flag": "--overlap", "label": "Overlap",
+                "description": "", "kind": {"type": "float", "default": 0.2, "min": 0.0, "max": 2.0},
+            }))
+            .unwrap(),
+            serde_json::from_value(serde_json::json!({
+                "name": "csep", "flag": null, "label": "Color Separation",
+                "description": "", "kind": {"type": "bool", "default": false},
+            }))
+            .unwrap(),
+        ];
+        let schemas = vec![("sxt".to_string(), sxt)];
+
+        // JSON delivers 1.0 as 1; the same request must hash identically.
+        let with_int = RcAstroProcessing {
+            steps: vec![RcAstroStep {
+                tool: "sxt".into(),
+                parameters: BTreeMap::from([(
+                    "overlap".to_string(),
+                    ExternalParameterValue::Int(1),
+                )]),
+            }],
+        };
+        let with_float = RcAstroProcessing {
+            steps: vec![RcAstroStep {
+                tool: "sxt".into(),
+                parameters: BTreeMap::from([(
+                    "overlap".to_string(),
+                    ExternalParameterValue::Float(1.0),
+                )]),
+            }],
+        };
+        let normalized_int = normalize_against_schemas(&with_int, &schemas).unwrap();
+        let normalized_float = normalize_against_schemas(&with_float, &schemas).unwrap();
+        assert_eq!(normalized_int, normalized_float);
+        let id_int = rc_astro_cache_id("db", "s", "r", &normalized_int, &schemas, None).unwrap();
+        let id_float =
+            rc_astro_cache_id("db", "s", "r", &normalized_float, &schemas, None).unwrap();
+        assert_eq!(id_int, id_float);
+
+        // Unknown, GUI-only, and out-of-range parameters fail before any
+        // tool runs, not minutes into the chain.
+        for parameters in [
+            BTreeMap::from([("nope".to_string(), ExternalParameterValue::Bool(true))]),
+            BTreeMap::from([("csep".to_string(), ExternalParameterValue::Bool(true))]),
+            BTreeMap::from([("overlap".to_string(), ExternalParameterValue::Float(9.0))]),
+        ] {
+            let config = RcAstroProcessing {
+                steps: vec![RcAstroStep {
+                    tool: "sxt".into(),
+                    parameters,
+                }],
+            };
+            assert!(normalize_against_schemas(&config, &schemas).is_err());
+        }
     }
 
     #[test]

--- a/src/server/stack_preview/rc_astro.rs
+++ b/src/server/stack_preview/rc_astro.rs
@@ -1,0 +1,610 @@
+//! RC-Astro post-processing on stacked linear FITS: BlurXTerminator,
+//! NoiseXTerminator, and StarXTerminator through their standalone CLI.
+//!
+//! This is a reversible view-processing tier like deconvolution: the
+//! integration artifact is never touched, results cache under their own
+//! identity, and "Revert processing" simply stops requesting them. Star
+//! removal keeps both halves — the starless image becomes the processed
+//! linear source and the stars image is stored beside it — so each can be
+//! stretched on its own.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::{Path as FsPath, PathBuf};
+use std::sync::Arc;
+
+use axum::Json;
+use seiza_stacking::{
+    write_processed_image_fits_f32, ExternalParameterValue, ExternalToolRequest,
+    ExternalToolSchema, LinearImage, RcAstroCli,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::server::api::ApiResponse;
+use crate::server::handlers::AppError;
+use crate::server::state::AppState;
+
+pub(super) const RC_ASTRO_CACHE_VERSION: u32 = 1;
+
+/// The order steps run when several are enabled: sharpen the linear data,
+/// denoise it, then separate the stars.
+pub const RC_ASTRO_STEP_ORDER: [&str; 3] = ["bxt", "nxt", "sxt"];
+
+/// One tool run with its parameter values, keyed by schema parameter name.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct RcAstroStep {
+    pub tool: String,
+    #[serde(default)]
+    pub parameters: BTreeMap<String, ExternalParameterValue>,
+}
+
+/// The requested chain of tool runs.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct RcAstroProcessing {
+    pub steps: Vec<RcAstroStep>,
+}
+
+impl RcAstroProcessing {
+    /// Refuse a request the run loop would fail on anyway, with a clearer
+    /// message and before anything is hashed or cached.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.steps.is_empty() {
+            return Err("RC-Astro processing lists no steps".into());
+        }
+        let mut seen = Vec::new();
+        for step in &self.steps {
+            if !RC_ASTRO_STEP_ORDER.contains(&step.tool.as_str()) {
+                return Err(format!("unknown RC-Astro tool {:?}", step.tool));
+            }
+            if seen.contains(&step.tool.as_str()) {
+                return Err(format!("RC-Astro tool {:?} is listed twice", step.tool));
+            }
+            seen.push(step.tool.as_str());
+        }
+        Ok(())
+    }
+
+    /// Steps in canonical run order, regardless of request order.
+    fn ordered(&self) -> Vec<&RcAstroStep> {
+        let mut steps: Vec<&RcAstroStep> = self.steps.iter().collect();
+        steps.sort_by_key(|step| {
+            RC_ASTRO_STEP_ORDER
+                .iter()
+                .position(|tool| *tool == step.tool)
+                .unwrap_or(usize::MAX)
+        });
+        steps
+    }
+}
+
+/// One executed step, reported back to the client.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RcAstroStepResult {
+    pub tool: String,
+    pub name: String,
+    pub ml_version: Option<i64>,
+    #[serde(default)]
+    pub device: Option<String>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
+/// The whole chain's outcome, reported back to the client.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct StackRcAstroResult {
+    pub cli_version: String,
+    pub steps: Vec<RcAstroStepResult>,
+    /// Whether a stars image was produced and stored beside the result.
+    pub has_stars: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct CachedRcAstro {
+    schema_version: u32,
+    rc_astro_id: String,
+    config: RcAstroProcessing,
+    result: StackRcAstroResult,
+}
+
+/// What `GET /api/tools/rc-astro` reports: whether the CLI is installed and
+/// each tool's live schema, so the UI can build its controls from the same
+/// contract the run will use.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RcAstroCapabilities {
+    pub available: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executable: Option<String>,
+    #[serde(default)]
+    pub tools: Vec<ExternalToolSchema>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn cli() -> Option<RcAstroCli> {
+    // A service unit often runs with a minimal PATH; PSF_GUARD_RC_ASTRO
+    // names the executable directly.
+    let located = match std::env::var_os("PSF_GUARD_RC_ASTRO") {
+        Some(path) if !path.is_empty() => Some(RcAstroCli::with_executable(PathBuf::from(path))),
+        _ => RcAstroCli::locate(),
+    };
+    located.map(|cli| cli.with_host(format!("psf-guard-{}", env!("CARGO_PKG_VERSION"))))
+}
+
+/// Probe the installed CLI and every tool's schema. Spawns short-lived
+/// processes; callers wrap it in `spawn_blocking`.
+pub fn probe_capabilities() -> RcAstroCapabilities {
+    let Some(cli) = cli() else {
+        return RcAstroCapabilities {
+            available: false,
+            executable: None,
+            tools: Vec::new(),
+            error: None,
+        };
+    };
+    let mut tools = Vec::new();
+    let mut error = None;
+    for tool in RC_ASTRO_STEP_ORDER {
+        match cli.tool_schema(tool) {
+            Ok(schema) => tools.push(schema),
+            Err(problem) => error = Some(problem.to_string()),
+        }
+    }
+    RcAstroCapabilities {
+        available: !tools.is_empty(),
+        executable: Some(cli.executable().display().to_string()),
+        tools,
+        error,
+    }
+}
+
+/// GET /api/tools/rc-astro
+pub async fn get_rc_astro_capabilities(
+    axum::extract::State(_state): axum::extract::State<Arc<AppState>>,
+) -> Result<Json<ApiResponse<RcAstroCapabilities>>, AppError> {
+    let capabilities = tokio::task::spawn_blocking(probe_capabilities)
+        .await
+        .map_err(|error| AppError::InternalError(format!("RC-Astro probe failed: {error}")))?;
+    Ok(Json(ApiResponse::success(capabilities)))
+}
+
+/// Read the schemas the requested steps need, or say which tool refused.
+/// Spawns short-lived processes; callers wrap it in `spawn_blocking`.
+pub(super) fn schemas_for(
+    config: &RcAstroProcessing,
+) -> Result<Vec<(String, ExternalToolSchema)>, String> {
+    let cli = cli().ok_or_else(|| "rc-astro is not installed on this server".to_string())?;
+    let mut schemas = Vec::new();
+    for step in config.ordered() {
+        let schema = cli
+            .tool_schema(&step.tool)
+            .map_err(|error| error.to_string())?;
+        if !schema.licensed {
+            return Err(format!(
+                "{} is not licensed on this server{}",
+                schema.name,
+                schema
+                    .license_message
+                    .as_deref()
+                    .map(|message| format!(" ({message})"))
+                    .unwrap_or_default()
+            ));
+        }
+        schemas.push((step.tool.clone(), schema));
+    }
+    Ok(schemas)
+}
+
+/// The cache identity of one processing chain over one source. Includes
+/// each tool's CLI and model versions: an upgrade changes the output for
+/// identical inputs, so it must change the identity too.
+pub(super) fn rc_astro_cache_id(
+    database_id: &str,
+    source_key: &str,
+    source_revision: &str,
+    config: &RcAstroProcessing,
+    schemas: &[(String, ExternalToolSchema)],
+) -> Result<String, AppError> {
+    let mut ordered = config.ordered().into_iter().cloned().collect::<Vec<_>>();
+    // The canonical order is the identity: two requests that run the same
+    // steps the same way cache as one.
+    let encoded = serde_json::to_vec(&ordered).map_err(|error| {
+        AppError::InternalError(format!("Failed to encode RC-Astro request: {error}"))
+    })?;
+    ordered.clear();
+    let mut hasher = Sha256::new();
+    hasher.update(database_id.as_bytes());
+    hasher.update(source_key.as_bytes());
+    hasher.update(source_revision.as_bytes());
+    hasher.update(RC_ASTRO_CACHE_VERSION.to_le_bytes());
+    hasher.update(&encoded);
+    for (tool, schema) in schemas {
+        hasher.update(tool.as_bytes());
+        hasher.update(schema.cli_version.as_bytes());
+        hasher.update(schema.ml_version.unwrap_or(0).to_le_bytes());
+    }
+    let mut id = String::with_capacity(64);
+    for byte in hasher.finalize() {
+        write!(&mut id, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(id)
+}
+
+pub(super) fn rc_astro_dir(cache_root: &FsPath, rc_astro_id: &str) -> PathBuf {
+    cache_root
+        .join("stack-previews")
+        .join("rc-astro")
+        .join(rc_astro_id)
+}
+
+fn rc_astro_manifest_path(cache_root: &FsPath, rc_astro_id: &str) -> PathBuf {
+    rc_astro_dir(cache_root, rc_astro_id).join("manifest.json")
+}
+
+pub(super) fn rc_astro_fits_path(cache_root: &FsPath, rc_astro_id: &str) -> PathBuf {
+    rc_astro_dir(cache_root, rc_astro_id).join("processed.fits")
+}
+
+pub(super) fn rc_astro_stars_path(cache_root: &FsPath, rc_astro_id: &str) -> PathBuf {
+    rc_astro_dir(cache_root, rc_astro_id).join("stars.fits")
+}
+
+pub(super) struct RcAstroOutcome {
+    /// The processed linear image — the starless one when stars were
+    /// removed.
+    pub image: LinearImage,
+    /// The stars image, when star removal kept one.
+    pub stars: Option<LinearImage>,
+    pub result: StackRcAstroResult,
+}
+
+/// Run (or reuse) the chain over one linear image. The processed FITS and
+/// the stars FITS land in the cache directory; the returned images feed the
+/// stretch renders directly.
+pub(super) fn apply_rc_astro(
+    cache_root: &FsPath,
+    rc_astro_id: &str,
+    config: &RcAstroProcessing,
+    schemas: &[(String, ExternalToolSchema)],
+    image: &LinearImage,
+    reference_headers: &[(String, seiza_fits::HeaderValue)],
+) -> Result<RcAstroOutcome, String> {
+    let fits = rc_astro_fits_path(cache_root, rc_astro_id);
+    let stars_fits = rc_astro_stars_path(cache_root, rc_astro_id);
+    let manifest_path = rc_astro_manifest_path(cache_root, rc_astro_id);
+
+    if let Ok(bytes) = std::fs::read(&manifest_path)
+        && let Ok(cached) = serde_json::from_slice::<CachedRcAstro>(&bytes)
+        && cached.schema_version == RC_ASTRO_CACHE_VERSION
+        && cached.rc_astro_id == rc_astro_id
+        && &cached.config == config
+        && fits.is_file()
+        && (!cached.result.has_stars || stars_fits.is_file())
+    {
+        let processed = crate::image_io::open_linear_frame(&fits)
+            .map_err(|error| error.to_string())?
+            .image;
+        let stars = if cached.result.has_stars {
+            Some(
+                crate::image_io::open_linear_frame(&stars_fits)
+                    .map_err(|error| error.to_string())?
+                    .image,
+            )
+        } else {
+            None
+        };
+        return Ok(RcAstroOutcome {
+            image: processed,
+            stars,
+            result: cached.result,
+        });
+    }
+
+    let cli = cli().ok_or_else(|| "rc-astro is not installed on this server".to_string())?;
+    let mut current = image.clone();
+    let mut stars: Option<LinearImage> = None;
+    let mut steps = Vec::new();
+    let mut cli_version = String::new();
+    for step in config.ordered() {
+        let (_, schema) = schemas
+            .iter()
+            .find(|(tool, _)| tool == &step.tool)
+            .ok_or_else(|| format!("no schema for RC-Astro tool {:?}", step.tool))?;
+        cli_version = schema.cli_version.clone();
+        let request = ExternalToolRequest {
+            tool: step.tool.clone(),
+            parameters: step
+                .parameters
+                .iter()
+                .map(|(name, value)| (name.clone(), *value))
+                .collect(),
+            device: None,
+        };
+        tracing::info!(
+            "RC-Astro {}: running {} on {}x{}x{}",
+            rc_astro_id,
+            schema.name,
+            current.width,
+            current.height,
+            current.channels
+        );
+        let processed = cli
+            .process_image(
+                schema,
+                &request,
+                &current,
+                reference_headers,
+                None,
+                &mut |_| {},
+            )
+            .map_err(|error| error.to_string())?;
+        if let Some(step_stars) = processed.stars {
+            stars = Some(step_stars);
+        }
+        steps.push(RcAstroStepResult {
+            tool: step.tool.clone(),
+            name: schema.name.clone(),
+            ml_version: schema.ml_version,
+            device: processed.device.clone(),
+            warnings: processed.warnings.clone(),
+        });
+        current = processed.image;
+    }
+
+    let result = StackRcAstroResult {
+        cli_version,
+        steps,
+        has_stars: stars.is_some(),
+    };
+
+    let parent = fits
+        .parent()
+        .ok_or_else(|| "RC-Astro FITS path has no parent".to_string())?;
+    std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let temporary = fits.with_extension(format!("{}.tmp.fits", std::process::id()));
+    write_processed_image_fits_f32(&temporary, &current, reference_headers, &rc_astro_cards())
+        .map_err(|error| error.to_string())?;
+    std::fs::rename(&temporary, &fits).map_err(|error| error.to_string())?;
+    if let Some(stars_image) = &stars {
+        let temporary = stars_fits.with_extension(format!("{}.tmp.fits", std::process::id()));
+        write_processed_image_fits_f32(
+            &temporary,
+            stars_image,
+            reference_headers,
+            &rc_astro_cards(),
+        )
+        .map_err(|error| error.to_string())?;
+        std::fs::rename(&temporary, &stars_fits).map_err(|error| error.to_string())?;
+    }
+    super::stretch::write_json_atomic(
+        &manifest_path,
+        &CachedRcAstro {
+            schema_version: RC_ASTRO_CACHE_VERSION,
+            rc_astro_id: rc_astro_id.into(),
+            config: config.clone(),
+            result: result.clone(),
+        },
+    )?;
+
+    Ok(RcAstroOutcome {
+        image: current,
+        stars,
+        result,
+    })
+}
+
+fn rc_astro_cards() -> Vec<seiza_fits::WriteHeaderCard> {
+    vec![
+        seiza_fits::WriteHeaderCard::new(
+            "SEIZARCA",
+            seiza_fits::HeaderValue::String("RC-ASTRO".into()),
+        )
+        .with_comment("processed by RC-Astro standalone tools"),
+        seiza_fits::WriteHeaderCard::new(
+            "SEIZATRF",
+            seiza_fits::HeaderValue::String("LINEAR".into()),
+        )
+        .with_comment("linear sample transfer"),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn step(tool: &str) -> RcAstroStep {
+        RcAstroStep {
+            tool: tool.into(),
+            parameters: BTreeMap::new(),
+        }
+    }
+
+    fn schema(tool: &str, cli_version: &str, ml_version: i64) -> ExternalToolSchema {
+        serde_json::from_value(serde_json::json!({
+            "schema_version": 6,
+            "cli_version": cli_version,
+            "key": tool,
+            "name": format!("RC-Astro {tool}"),
+            "ml_version": ml_version,
+            "licensed": true,
+            "license_message": null,
+            "parameters": [],
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn validation_refuses_unknown_and_duplicate_tools_and_empty_chains() {
+        assert!(RcAstroProcessing { steps: vec![] }.validate().is_err());
+        assert!(RcAstroProcessing {
+            steps: vec![step("gxt")]
+        }
+        .validate()
+        .is_err());
+        assert!(RcAstroProcessing {
+            steps: vec![step("sxt"), step("sxt")]
+        }
+        .validate()
+        .is_err());
+        assert!(RcAstroProcessing {
+            steps: vec![step("bxt"), step("sxt")]
+        }
+        .validate()
+        .is_ok());
+    }
+
+    #[test]
+    fn the_cache_identity_ignores_request_order_but_tracks_versions() {
+        let schemas = vec![("bxt".to_string(), schema("bxt", "2.6.6", 4))];
+        let forward = rc_astro_cache_id(
+            "db",
+            "mono:job:0",
+            "rev",
+            &RcAstroProcessing {
+                steps: vec![step("bxt"), step("sxt")],
+            },
+            &schemas,
+        )
+        .unwrap();
+        let reversed = rc_astro_cache_id(
+            "db",
+            "mono:job:0",
+            "rev",
+            &RcAstroProcessing {
+                steps: vec![step("sxt"), step("bxt")],
+            },
+            &schemas,
+        )
+        .unwrap();
+        assert_eq!(forward, reversed);
+
+        let upgraded = rc_astro_cache_id(
+            "db",
+            "mono:job:0",
+            "rev",
+            &RcAstroProcessing {
+                steps: vec![step("bxt"), step("sxt")],
+            },
+            &[("bxt".to_string(), schema("bxt", "2.7.0", 5))],
+        )
+        .unwrap();
+        assert_ne!(forward, upgraded);
+    }
+
+    #[test]
+    fn steps_run_in_canonical_order() {
+        let config = RcAstroProcessing {
+            steps: vec![step("sxt"), step("bxt"), step("nxt")],
+        };
+        let ordered: Vec<&str> = config
+            .ordered()
+            .iter()
+            .map(|step| step.tool.as_str())
+            .collect();
+        assert_eq!(ordered, vec!["bxt", "nxt", "sxt"]);
+    }
+
+    /// A stand-in rc-astro: copies input to output, writes a stars sidecar
+    /// when asked, and counts its invocations so the cache test can prove a
+    /// second apply never spawned it.
+    #[cfg(unix)]
+    fn fake_rc_astro(directory: &std::path::Path) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = directory.join("rc-astro");
+        let script = format!(
+            r#"#!/bin/sh
+echo run >> "{count}"
+out=""
+input=""
+stars=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    --stars) stars=1; shift ;;
+    --host|--depth|--device) shift 2 ;;
+    --*|sxt|bxt|nxt) shift ;;
+    *) input="$1"; shift ;;
+  esac
+done
+cp "$input" "$out"
+echo '{{"event":"status","phase":"complete","output":"'"$out"'"}}'
+if [ "$stars" = 1 ]; then
+  sidecar="${{out%.fits}}-stars.fits"
+  cp "$input" "$sidecar"
+  echo '{{"event":"status","phase":"complete","output":"'"$sidecar"'"}}'
+fi
+"#,
+            count = directory.join("invocations").display()
+        );
+        std::fs::write(&path, script).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_chain_runs_once_and_the_cache_serves_the_second_apply() {
+        let tool_dir = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let executable = fake_rc_astro(tool_dir.path());
+        // Point the module at the stand-in for this test. Env mutation is
+        // process-wide, so keep the whole flow inside one test.
+        unsafe { std::env::set_var("PSF_GUARD_RC_ASTRO", &executable) };
+
+        let config = RcAstroProcessing {
+            steps: vec![RcAstroStep {
+                tool: "sxt".into(),
+                parameters: BTreeMap::from([(
+                    "stars".to_string(),
+                    ExternalParameterValue::Bool(true),
+                )]),
+            }],
+        };
+        let mut schema = schema("sxt", "2.6.6", 11);
+        schema.parameters = vec![serde_json::from_value(serde_json::json!({
+            "name": "stars",
+            "flag": "--stars",
+            "label": "Generate Star Image",
+            "description": "",
+            "kind": {"type": "bool", "default": false},
+        }))
+        .unwrap()];
+        let schemas = vec![("sxt".to_string(), schema)];
+        let image = LinearImage::new(3, 2, 1, vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0]).unwrap();
+
+        let first = apply_rc_astro(
+            cache.path(),
+            "a".repeat(64).as_str(),
+            &config,
+            &schemas,
+            &image,
+            &[],
+        )
+        .unwrap();
+        assert!(first.result.has_stars);
+        assert!(first.stars.is_some());
+        for (processed, original) in first.image.data.iter().zip(&image.data) {
+            assert!((processed - original).abs() < 1e-2);
+        }
+
+        let second = apply_rc_astro(
+            cache.path(),
+            "a".repeat(64).as_str(),
+            &config,
+            &schemas,
+            &image,
+            &[],
+        )
+        .unwrap();
+        assert!(second.result.has_stars);
+        unsafe { std::env::remove_var("PSF_GUARD_RC_ASTRO") };
+
+        let invocations =
+            std::fs::read_to_string(tool_dir.path().join("invocations")).unwrap_or_default();
+        assert_eq!(
+            invocations.lines().count(),
+            1,
+            "second apply must be a cache hit"
+        );
+    }
+}

--- a/src/server/stack_preview/rc_astro.rs
+++ b/src/server/stack_preview/rc_astro.rs
@@ -293,6 +293,27 @@ pub(super) fn normalize_against_schemas(
                     }
                     ExternalParameterValue::Int(*v)
                 }
+                // The mirror coercion: the schema hands int bounds back as
+                // JSON numbers, so a UI clamping to them sends 2.0 for 2.
+                (
+                    seiza_stacking::ExternalParameterKind::Int { min, max, .. },
+                    ExternalParameterValue::Float(real),
+                ) => {
+                    if !real.is_finite() || real.fract() != 0.0 {
+                        return Err(format!(
+                            "{}: {name} = {real} is not a whole number",
+                            schema.name
+                        ));
+                    }
+                    let v = *real as i64;
+                    if v < *min || v > *max {
+                        return Err(format!(
+                            "{}: {name} = {v} is outside [{min}, {max}]",
+                            schema.name
+                        ));
+                    }
+                    ExternalParameterValue::Int(v)
+                }
                 (
                     seiza_stacking::ExternalParameterKind::Bool { .. },
                     ExternalParameterValue::Bool(v),
@@ -390,6 +411,7 @@ pub(super) fn apply_rc_astro(
     schemas: &[(String, ExternalToolSchema)],
     image: &LinearImage,
     reference_headers: &[(String, seiza_fits::HeaderValue)],
+    on_progress: &mut dyn FnMut(&str, f32),
 ) -> Result<RcAstroOutcome, String> {
     let fits = rc_astro_fits_path(cache_root, rc_astro_id);
     let stars_fits = rc_astro_stars_path(cache_root, rc_astro_id);
@@ -432,7 +454,8 @@ pub(super) fn apply_rc_astro(
     let mut stars: Option<LinearImage> = None;
     let mut steps = Vec::new();
     let mut cli_version = String::new();
-    for step in config.ordered() {
+    let total_steps = config.steps.len().max(1);
+    for (index, step) in config.ordered().into_iter().enumerate() {
         let (_, schema) = schemas
             .iter()
             .find(|(tool, _)| tool == &step.tool)
@@ -455,6 +478,12 @@ pub(super) fn apply_rc_astro(
             current.height,
             current.channels
         );
+        on_progress(&schema.name, index as f32 / total_steps as f32);
+        // The chain's overall fraction: completed steps plus this step's
+        // own fraction, over the step count.
+        let mut step_progress = |fraction: f32| {
+            on_progress(&schema.name, (index as f32 + fraction) / total_steps as f32)
+        };
         let processed = cli
             .process_image(
                 schema,
@@ -462,7 +491,7 @@ pub(super) fn apply_rc_astro(
                 &current,
                 reference_headers,
                 None,
-                &mut |_| {},
+                &mut step_progress,
             )
             .map_err(|error| error.to_string())?;
         if let Some(step_stars) = processed.stars {
@@ -765,6 +794,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 cp "$input" "$out"
+echo '{{"event":"progress","done":100.0}}'
 echo '{{"event":"status","phase":"complete","output":"'"$out"'"}}'
 if [ "$stars" = 1 ]; then
   sidecar="${{out%.fits}}-stars.fits"
@@ -810,6 +840,7 @@ fi
         let schemas = vec![("sxt".to_string(), schema)];
         let image = LinearImage::new(3, 2, 1, vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0]).unwrap();
 
+        let mut reported: Vec<(String, f32)> = Vec::new();
         let first = apply_rc_astro(
             cache.path(),
             "a".repeat(64).as_str(),
@@ -817,6 +848,7 @@ fi
             &schemas,
             &image,
             &[],
+            &mut |stage, fraction| reported.push((stage.to_string(), fraction)),
         )
         .unwrap();
         assert!(first.result.has_stars);
@@ -824,6 +856,14 @@ fi
         for (processed, original) in first.image.data.iter().zip(&image.data) {
             assert!((processed - original).abs() < 1e-2);
         }
+        // A one-step chain reports the step start at 0 and the tool's own
+        // fractions unscaled.
+        assert_eq!(
+            reported.first().map(|(stage, _)| stage.as_str()),
+            Some("RC-Astro sxt")
+        );
+        assert_eq!(reported.first().map(|(_, fraction)| *fraction), Some(0.0));
+        assert!(reported.iter().any(|(_, fraction)| *fraction >= 1.0));
 
         let second = apply_rc_astro(
             cache.path(),
@@ -832,6 +872,7 @@ fi
             &schemas,
             &image,
             &[],
+            &mut |_, _| {},
         )
         .unwrap();
         assert!(second.result.has_stars);

--- a/src/server/stack_preview/stretch.rs
+++ b/src/server/stack_preview/stretch.rs
@@ -405,8 +405,11 @@ pub(super) enum StretchApplyOutcome {
     Ready(Box<StackStretchPreview>),
     /// The work runs detached (RC-Astro chains take minutes — far past any
     /// reverse-proxy timeout); the client re-sends the same request until
-    /// it turns Ready. Keeps generation out of the HTTP request path.
-    Pending,
+    /// it turns Ready, each poll carrying the run's live progress. Keeps
+    /// generation out of the HTTP request path.
+    Pending {
+        stretch_id: String,
+    },
 }
 
 /// One entry per stretch id being computed right now, so identical
@@ -416,14 +419,41 @@ static IN_FLIGHT: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet
 /// The failure of a detached run, held for the next poll of that id.
 static FAILURES: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<String, String>>> =
     std::sync::LazyLock::new(Default::default);
+/// Live progress of an in-flight computation, served to the pending poll:
+/// which tool is running and the chain's overall fraction.
+static PROGRESS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, PendingProgress>>,
+> = std::sync::LazyLock::new(Default::default);
 
-/// Removes its id from the in-flight set on drop — panic or success alike.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct PendingProgress {
+    pub stage: String,
+    pub fraction: f32,
+}
+
+fn report_progress(stretch_id: &str, stage: &str, fraction: f32) {
+    if let Ok(mut progress) = PROGRESS.lock() {
+        progress.insert(
+            stretch_id.to_string(),
+            PendingProgress {
+                stage: stage.to_string(),
+                fraction,
+            },
+        );
+    }
+}
+
+/// Removes its id from the in-flight set (and its progress entry) on drop —
+/// panic or success alike.
 struct InFlightToken(String);
 
 impl Drop for InFlightToken {
     fn drop(&mut self) {
         if let Ok(mut in_flight) = IN_FLIGHT.lock() {
             in_flight.remove(&self.0);
+        }
+        if let Ok(mut progress) = PROGRESS.lock() {
+            progress.remove(&self.0);
         }
     }
 }
@@ -540,7 +570,7 @@ pub(super) async fn apply_to_fits(
     }
     let Some(token) = try_begin_in_flight(&stretch_id) else {
         // The same request is already computing; the caller polls.
-        return Ok(StretchApplyOutcome::Pending);
+        return Ok(StretchApplyOutcome::Pending { stretch_id });
     };
 
     let identity = StretchIdentity {
@@ -566,7 +596,7 @@ pub(super) async fn apply_to_fits(
             rc_astro,
             rc_astro_schemas,
         ));
-        return Ok(StretchApplyOutcome::Pending);
+        return Ok(StretchApplyOutcome::Pending { stretch_id });
     }
 
     // A plain stretch (or deconvolution) is fast enough to answer inline.
@@ -876,6 +906,7 @@ fn render_fits_variant(
             schemas,
             linear,
             &frame.headers,
+            &mut |stage, fraction| report_progress(stretch_id, stage, fraction),
         )?);
     }
     let linear = rc_astro_outcome
@@ -1227,17 +1258,38 @@ pub(super) fn write_json_atomic(path: &FsPath, value: &impl Serialize) -> Result
     std::fs::rename(&temporary, path).map_err(|error| error.to_string())
 }
 
+/// What a 202 poll answer carries: the run's live progress when known.
+#[derive(Debug, Serialize)]
+struct StretchPendingStatus {
+    pending: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fraction: Option<f32>,
+}
+
 /// A ready result answers 200 with the preview; a pending one answers 202
-/// with an empty body, telling the client to re-send the same request.
+/// with the run's live progress, telling the client to re-send the same
+/// request.
 pub(super) fn apply_response(outcome: StretchApplyOutcome) -> axum::response::Response {
     use axum::response::IntoResponse;
     match outcome {
         StretchApplyOutcome::Ready(result) => Json(ApiResponse::success(*result)).into_response(),
-        StretchApplyOutcome::Pending => (
-            StatusCode::ACCEPTED,
-            Json(ApiResponse::<Option<StackStretchPreview>>::success(None)),
-        )
-            .into_response(),
+        StretchApplyOutcome::Pending { stretch_id } => {
+            let progress = PROGRESS
+                .lock()
+                .ok()
+                .and_then(|progress| progress.get(&stretch_id).cloned());
+            (
+                StatusCode::ACCEPTED,
+                Json(ApiResponse::success(StretchPendingStatus {
+                    pending: true,
+                    stage: progress.as_ref().map(|progress| progress.stage.clone()),
+                    fraction: progress.map(|progress| progress.fraction),
+                })),
+            )
+                .into_response()
+        }
     }
 }
 

--- a/src/server/stack_preview/stretch.rs
+++ b/src/server/stack_preview/stretch.rs
@@ -329,6 +329,43 @@ fn render_image_previews_with_details(
     Ok(render)
 }
 
+/// Render one screen/original PNG pair by applying an already-resolved plan
+/// — how the stars image reuses the starless image's transform.
+fn render_previews_with_plan(
+    image: &LinearImage,
+    plan: &StretchPlan,
+    screen_destination: &FsPath,
+    original_destination: &FsPath,
+) -> Result<(), String> {
+    for destination in [screen_destination, original_destination] {
+        let parent = destination
+            .parent()
+            .ok_or_else(|| "Stack preview path has no parent".to_string())?;
+        std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let pixels = plan
+        .apply_u8(&image.data, image.channels)
+        .map_err(|error| error.to_string())?;
+    let dynamic = if image.channels == 1 {
+        image::DynamicImage::ImageLuma8(
+            image::GrayImage::from_raw(image.width as u32, image.height as u32, pixels)
+                .ok_or_else(|| "Stack preview dimensions do not match pixels".to_string())?,
+        )
+    } else {
+        image::DynamicImage::ImageRgb8(
+            image::RgbImage::from_raw(image.width as u32, image.height as u32, pixels)
+                .ok_or_else(|| "Stack preview dimensions do not match pixels".to_string())?,
+        )
+    };
+    save_png_atomic(&dynamic, original_destination)?;
+    let resized = dynamic.resize(
+        PREVIEW_MAX_DIMENSION,
+        PREVIEW_MAX_DIMENSION,
+        image::imageops::FilterType::Lanczos3,
+    );
+    save_png_atomic(&resized, screen_destination)
+}
+
 fn render_dynamic_image(
     image: &LinearImage,
     config: &StretchConfig,
@@ -362,6 +399,56 @@ fn render_dynamic_image(
     Ok((dynamic, StretchRender { plan }))
 }
 
+/// What an apply request produced: the finished preview, or a note that
+/// the same request is being computed and the client should poll.
+pub(super) enum StretchApplyOutcome {
+    Ready(Box<StackStretchPreview>),
+    /// The work runs detached (RC-Astro chains take minutes — far past any
+    /// reverse-proxy timeout); the client re-sends the same request until
+    /// it turns Ready. Keeps generation out of the HTTP request path.
+    Pending,
+}
+
+/// One entry per stretch id being computed right now, so identical
+/// concurrent requests wait on the same run instead of starting duplicates.
+static IN_FLIGHT: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+    std::sync::LazyLock::new(Default::default);
+/// The failure of a detached run, held for the next poll of that id.
+static FAILURES: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<String, String>>> =
+    std::sync::LazyLock::new(Default::default);
+
+/// Removes its id from the in-flight set on drop — panic or success alike.
+struct InFlightToken(String);
+
+impl Drop for InFlightToken {
+    fn drop(&mut self) {
+        if let Ok(mut in_flight) = IN_FLIGHT.lock() {
+            in_flight.remove(&self.0);
+        }
+    }
+}
+
+fn try_begin_in_flight(stretch_id: &str) -> Option<InFlightToken> {
+    let mut in_flight = IN_FLIGHT.lock().ok()?;
+    if in_flight.insert(stretch_id.to_string()) {
+        Some(InFlightToken(stretch_id.to_string()))
+    } else {
+        None
+    }
+}
+
+struct StretchIdentity {
+    stretch_id: String,
+    deconvolution_id: Option<String>,
+    rc_astro_id: Option<String>,
+}
+
+fn read_cached_manifest(cache_root: &FsPath, stretch_id: &str) -> Option<StackStretchPreview> {
+    let bytes = std::fs::read(stretch_manifest_path(cache_root, stretch_id)).ok()?;
+    let cached = serde_json::from_slice::<StackStretchPreview>(&bytes).ok()?;
+    stretch_artifacts_exist(cache_root, stretch_id, &cached).then_some(cached)
+}
+
 pub(super) async fn apply_to_fits(
     state: Arc<AppState>,
     database_id: String,
@@ -370,7 +457,7 @@ pub(super) async fn apply_to_fits(
     source_revision: String,
     source_path: PathBuf,
     request: StackViewProcessingRequest,
-) -> Result<StackStretchPreview, AppError> {
+) -> Result<StretchApplyOutcome, AppError> {
     if let Some(deconvolution) = request.deconvolution {
         deconvolution
             .validate()
@@ -388,8 +475,7 @@ pub(super) async fn apply_to_fits(
         .transpose()?;
     // Reading the tool schemas spawns short-lived rc-astro processes; they
     // also pin the CLI and model versions into the cache identity.
-    let rc_astro = request.rc_astro.clone();
-    let rc_astro_schemas = match rc_astro.clone() {
+    let rc_astro_schemas = match request.rc_astro.clone() {
         Some(config) => Some(
             tokio::task::spawn_blocking(move || super::rc_astro::schemas_for(&config))
                 .await
@@ -400,6 +486,15 @@ pub(super) async fn apply_to_fits(
         ),
         None => None,
     };
+    // Canonicalize before hashing: `1` and `1.0` are one request, and a bad
+    // parameter should be refused here, not minutes into the chain.
+    let rc_astro = match (&request.rc_astro, &rc_astro_schemas) {
+        (Some(config), Some(schemas)) => Some(
+            super::rc_astro::normalize_against_schemas(config, schemas)
+                .map_err(AppError::BadRequest)?,
+        ),
+        _ => None,
+    };
     let rc_astro_id = match (&rc_astro, &rc_astro_schemas) {
         (Some(config), Some(schemas)) => Some(super::rc_astro::rc_astro_cache_id(
             &database_id,
@@ -407,6 +502,7 @@ pub(super) async fn apply_to_fits(
             &source_revision,
             config,
             schemas,
+            deconvolution_id.as_deref(),
         )?),
         _ => None,
     };
@@ -432,57 +528,169 @@ pub(super) async fn apply_to_fits(
     for byte in hasher.finalize() {
         write!(&mut stretch_id, "{byte:02x}").expect("writing to a String cannot fail");
     }
-    let manifest_path = stretch_manifest_path(&cache_root, &stretch_id);
-    if let Ok(bytes) = std::fs::read(&manifest_path)
-        && let Ok(cached) = serde_json::from_slice::<StackStretchPreview>(&bytes)
-        && stretch_artifacts_exist(&cache_root, &stretch_id, &cached)
+    if let Some(cached) = read_cached_manifest(&cache_root, &stretch_id) {
+        return Ok(StretchApplyOutcome::Ready(Box::new(cached)));
+    }
+    // A detached run for this exact request already failed: hand the reason
+    // to this poll instead of computing again unasked.
+    if let Ok(mut failures) = FAILURES.lock()
+        && let Some(message) = failures.remove(&stretch_id)
     {
-        return Ok(cached);
+        return Err(AppError::BadRequest(message));
+    }
+    let Some(token) = try_begin_in_flight(&stretch_id) else {
+        // The same request is already computing; the caller polls.
+        return Ok(StretchApplyOutcome::Pending);
+    };
+
+    let identity = StretchIdentity {
+        stretch_id: stretch_id.clone(),
+        deconvolution_id,
+        rc_astro_id,
+    };
+
+    if rc_astro.is_some() {
+        // Minutes of external-tool work: run detached so no reverse proxy
+        // can kill it mid-flight, and let the client poll. The permit and
+        // the interactive-job guard are taken inside the task and held
+        // until the blocking work finishes.
+        tokio::spawn(compute_stretch_variant(
+            state,
+            database_id,
+            cache_root,
+            token,
+            identity,
+            source_path,
+            config,
+            deconvolution,
+            rc_astro,
+            rc_astro_schemas,
+        ));
+        return Ok(StretchApplyOutcome::Pending);
     }
 
-    let permit = Arc::clone(&state.stack_previews.permit);
-    let _permit = permit
+    // A plain stretch (or deconvolution) is fast enough to answer inline.
+    match compute_stretch_variant(
+        state,
+        database_id,
+        cache_root.clone(),
+        token,
+        identity,
+        source_path,
+        config,
+        deconvolution,
+        None,
+        None,
+    )
+    .await
+    {
+        Some(response) => Ok(StretchApplyOutcome::Ready(Box::new(response))),
+        None => {
+            if let Ok(mut failures) = FAILURES.lock()
+                && let Some(message) = failures.remove(&stretch_id)
+            {
+                return Err(AppError::BadRequest(message));
+            }
+            Err(AppError::InternalError("Stretch rendering failed".into()))
+        }
+    }
+}
+
+/// Acquire the stack permit, render, and publish the manifest. Runs to
+/// completion regardless of the HTTP request that started it. A failure is
+/// parked in [`FAILURES`] for the next poll. Returns the response on
+/// success so the inline path can answer directly.
+#[allow(clippy::too_many_arguments)]
+async fn compute_stretch_variant(
+    state: Arc<AppState>,
+    database_id: String,
+    cache_root: PathBuf,
+    token: InFlightToken,
+    identity: StretchIdentity,
+    source_path: PathBuf,
+    config: StretchConfig,
+    deconvolution: Option<DeconvolutionConfig>,
+    rc_astro: Option<super::rc_astro::RcAstroProcessing>,
+    rc_astro_schemas: Option<Vec<(String, seiza_stacking::ExternalToolSchema)>>,
+) -> Option<StackStretchPreview> {
+    let _token = token;
+    let stretch_id = identity.stretch_id.clone();
+    let park_failure = |message: String| {
+        tracing::warn!("Stack stretch {stretch_id} failed: {message}");
+        if let Ok(mut failures) = FAILURES.lock() {
+            failures.insert(stretch_id.clone(), message);
+        }
+    };
+    let permit = match Arc::clone(&state.stack_previews.permit)
         .acquire_owned()
         .await
-        .map_err(|_| AppError::InternalError("Stack preview processor is unavailable".into()))?;
-    if let Ok(bytes) = std::fs::read(&manifest_path)
-        && let Ok(cached) = serde_json::from_slice::<StackStretchPreview>(&bytes)
-        && stretch_artifacts_exist(&cache_root, &stretch_id, &cached)
     {
-        return Ok(cached);
+        Ok(permit) => permit,
+        Err(_) => {
+            park_failure("Stack preview processor is unavailable".into());
+            return None;
+        }
+    };
+    if let Some(cached) = read_cached_manifest(&cache_root, &identity.stretch_id) {
+        return Some(cached);
     }
     let guard = state.begin_interactive_job();
     let state_for_render = Arc::clone(&state);
     let cache_for_render = cache_root.clone();
-    let id_for_render = stretch_id.clone();
-    let deconvolution_id_for_render = deconvolution_id.clone();
-    let rc_astro_for_render = rc_astro.clone();
-    let rc_astro_id_for_render = rc_astro_id.clone();
-    let rc_astro_schemas_for_render = rc_astro_schemas;
-    let rendered = tokio::task::spawn_blocking(move || {
+    let database_for_render = database_id.clone();
+    let result = tokio::task::spawn_blocking(move || {
         let _guard = guard;
-        render_fits_variant(
+        let _permit = permit;
+        let rendered = render_fits_variant(
             &state_for_render,
             &cache_for_render,
-            &id_for_render,
+            &identity.stretch_id,
             &source_path,
             &config,
             deconvolution,
-            deconvolution_id_for_render.as_deref(),
-            rc_astro_for_render,
-            rc_astro_id_for_render.as_deref(),
-            rc_astro_schemas_for_render,
-        )
+            identity.deconvolution_id.as_deref(),
+            rc_astro,
+            identity.rc_astro_id.as_deref(),
+            rc_astro_schemas,
+        )?;
+        let response = build_stretch_preview(
+            &database_for_render,
+            &identity,
+            deconvolution.is_some(),
+            rendered,
+        );
+        write_json_atomic(
+            &stretch_manifest_path(&cache_for_render, &identity.stretch_id),
+            &response,
+        )?;
+        Ok::<_, String>(response)
     })
-    .await
-    .map_err(|error| AppError::InternalError(format!("Stretch worker failed: {error}")))?
-    .map_err(AppError::BadRequest)?;
+    .await;
+    match result {
+        Ok(Ok(response)) => Some(response),
+        Ok(Err(message)) => {
+            park_failure(message);
+            None
+        }
+        Err(join_error) => {
+            park_failure(format!("Stretch worker failed: {join_error}"));
+            None
+        }
+    }
+}
 
+fn build_stretch_preview(
+    database_id: &str,
+    identity: &StretchIdentity,
+    deconvolution_requested: bool,
+    rendered: RenderedVariant,
+) -> StackStretchPreview {
+    let stretch_id = &identity.stretch_id;
     let has_stars = rendered
         .rc_astro
         .as_ref()
         .is_some_and(|result| result.has_stars);
-    let response = StackStretchPreview {
+    StackStretchPreview {
         schema_version: 2,
         stretch_id: stretch_id.clone(),
         stretch_version: SEIZA_STRETCH_VERSION.into(),
@@ -490,7 +698,7 @@ pub(super) async fn apply_to_fits(
             .deconvolution
             .as_ref()
             .map(|_| deconvolution_version()),
-        deconvolution_id: deconvolution_id.clone(),
+        deconvolution_id: identity.deconvolution_id.clone(),
         config: rendered.config,
         resolved_plan: rendered.resolved_plan,
         source_transfer: rendered.source_transfer,
@@ -500,12 +708,12 @@ pub(super) async fn apply_to_fits(
         luminance_statistics: rendered.luminance_statistics,
         deconvolution: rendered.deconvolution,
         rc_astro: rendered.rc_astro,
-        rc_astro_id: rc_astro_id.clone(),
+        rc_astro_id: identity.rc_astro_id.clone(),
         preview_url: format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/preview"),
         original_preview_url: format!(
             "/api/db/{database_id}/stack-previews/stretch/{stretch_id}/preview?size=original"
         ),
-        fits_url: (deconvolution.is_some() || rc_astro_id.is_some())
+        fits_url: (deconvolution_requested || identity.rc_astro_id.is_some())
             .then(|| format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/fits")),
         stars_preview_url: has_stars
             .then(|| format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/stars")),
@@ -515,9 +723,7 @@ pub(super) async fn apply_to_fits(
         stars_fits_url: has_stars.then(|| {
             format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/stars-fits")
         }),
-    };
-    write_json_atomic(&manifest_path, &response).map_err(AppError::InternalError)?;
-    Ok(response)
+    }
 }
 
 struct RenderedVariant {
@@ -691,31 +897,40 @@ fn render_fits_variant(
     let render = pool.install(|| {
         render_image_previews_with_details(prepared, config, &screen, &original, |_| {})
     })?;
-    // The stars image gets its own stretched pair, normalized on its own
-    // range: it is mostly empty sky with bright peaks, and borrowing the
-    // starless normalization would crush it.
+    // The stars image shares the starless image's display transform —
+    // normalization range and resolved curves alike — so the two previews
+    // compose: screening the stars preview over the starless one
+    // approximates the un-separated stack. Analyzing the stars image on its
+    // own would instead auto-stretch its near-empty background into noise.
     if let Some(outcome) = &rc_astro_outcome
         && let Some(stars) = &outcome.stars
     {
-        let stars_normalized = if source_transfer == StackStretchSourceTransfer::Linear {
-            Some(normalize_linear_image(stars)?)
-        } else {
-            None
+        let stars_prepared = match &input_range {
+            Some(range) => {
+                let span = range.white - range.black;
+                let data = stars
+                    .data
+                    .iter()
+                    .map(|value| {
+                        if value.is_finite() {
+                            (*value - range.black) / span
+                        } else {
+                            f32::NAN
+                        }
+                    })
+                    .collect();
+                Some(
+                    LinearImage::new(stars.width, stars.height, stars.channels, data)
+                        .map_err(|error| error.to_string())?,
+                )
+            }
+            None => None,
         };
-        let stars_prepared = stars_normalized
-            .as_ref()
-            .map(|(image, _)| image)
-            .unwrap_or(stars);
+        let stars_source = stars_prepared.as_ref().unwrap_or(stars);
         let stars_screen = stretch_stars_preview_path(cache_root, stretch_id);
         let stars_original = stretch_stars_original_preview_path(cache_root, stretch_id);
         pool.install(|| {
-            render_image_previews_with_details(
-                stars_prepared,
-                config,
-                &stars_screen,
-                &stars_original,
-                |_| {},
-            )
+            render_previews_with_plan(stars_source, &render.plan, &stars_screen, &stars_original)
         })?;
     }
     Ok(RenderedVariant {
@@ -994,6 +1209,8 @@ fn stretch_artifacts_exist(
         && manifest.rc_astro_id.as_ref().is_none_or(|id| {
             validate_job_id(id).is_ok()
                 && super::rc_astro::rc_astro_fits_path(cache_root, id).is_file()
+                && (manifest.stars_fits_url.is_none()
+                    || super::rc_astro::rc_astro_stars_path(cache_root, id).is_file())
         })
         && (manifest.stars_preview_url.is_none()
             || stretch_stars_preview_path(cache_root, stretch_id).is_file())
@@ -1010,8 +1227,18 @@ pub(super) fn write_json_atomic(path: &FsPath, value: &impl Serialize) -> Result
     std::fs::rename(&temporary, path).map_err(|error| error.to_string())
 }
 
-pub(super) fn response(result: StackStretchPreview) -> Json<ApiResponse<StackStretchPreview>> {
-    Json(ApiResponse::success(result))
+/// A ready result answers 200 with the preview; a pending one answers 202
+/// with an empty body, telling the client to re-send the same request.
+pub(super) fn apply_response(outcome: StretchApplyOutcome) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    match outcome {
+        StretchApplyOutcome::Ready(result) => Json(ApiResponse::success(*result)).into_response(),
+        StretchApplyOutcome::Pending => (
+            StatusCode::ACCEPTED,
+            Json(ApiResponse::<Option<StackStretchPreview>>::success(None)),
+        )
+            .into_response(),
+    }
 }
 
 #[cfg(test)]

--- a/src/server/stack_preview/stretch.rs
+++ b/src/server/stack_preview/stretch.rs
@@ -67,6 +67,11 @@ pub struct StackViewProcessingRequest {
     /// newly created previews retain their original pixels unless requested.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deconvolution: Option<DeconvolutionConfig>,
+    /// Optional RC-Astro tool chain (BXT, NXT, SXT) applied to the linear
+    /// data after deconvolution and before the stretch. Star removal stores
+    /// the stars image beside the starless result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rc_astro: Option<super::rc_astro::RcAstroProcessing>,
 }
 
 impl StackStretchRequest {
@@ -104,10 +109,21 @@ pub struct StackStretchPreview {
     pub luminance_statistics: Option<RobustStatistics>,
     #[serde(default)]
     pub deconvolution: Option<StackDeconvolutionResult>,
+    #[serde(default)]
+    pub rc_astro: Option<super::rc_astro::StackRcAstroResult>,
+    #[serde(default)]
+    pub rc_astro_id: Option<String>,
     pub preview_url: String,
     pub original_preview_url: String,
     #[serde(default)]
     pub fits_url: Option<String>,
+    /// The stretched stars image, present when star removal kept one.
+    #[serde(default)]
+    pub stars_preview_url: Option<String>,
+    #[serde(default)]
+    pub stars_original_preview_url: Option<String>,
+    #[serde(default)]
+    pub stars_fits_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
@@ -360,6 +376,9 @@ pub(super) async fn apply_to_fits(
             .validate()
             .map_err(|error| AppError::BadRequest(error.to_string()))?;
     }
+    if let Some(rc_astro) = &request.rc_astro {
+        rc_astro.validate().map_err(AppError::BadRequest)?;
+    }
     let config = request.stretch.config();
     let deconvolution = request.deconvolution;
     let deconvolution_id = deconvolution
@@ -367,6 +386,30 @@ pub(super) async fn apply_to_fits(
             deconvolution_cache_id(&database_id, &source_key, &source_revision, &request)
         })
         .transpose()?;
+    // Reading the tool schemas spawns short-lived rc-astro processes; they
+    // also pin the CLI and model versions into the cache identity.
+    let rc_astro = request.rc_astro.clone();
+    let rc_astro_schemas = match rc_astro.clone() {
+        Some(config) => Some(
+            tokio::task::spawn_blocking(move || super::rc_astro::schemas_for(&config))
+                .await
+                .map_err(|error| {
+                    AppError::InternalError(format!("RC-Astro probe failed: {error}"))
+                })?
+                .map_err(AppError::BadRequest)?,
+        ),
+        None => None,
+    };
+    let rc_astro_id = match (&rc_astro, &rc_astro_schemas) {
+        (Some(config), Some(schemas)) => Some(super::rc_astro::rc_astro_cache_id(
+            &database_id,
+            &source_key,
+            &source_revision,
+            config,
+            schemas,
+        )?),
+        _ => None,
+    };
     let encoded = serde_json::to_vec(&config).map_err(|error| {
         AppError::InternalError(format!("Failed to encode stretch request: {error}"))
     })?;
@@ -380,6 +423,10 @@ pub(super) async fn apply_to_fits(
     if let Some(deconvolution_id) = &deconvolution_id {
         hasher.update(b"deconvolution");
         hasher.update(deconvolution_id.as_bytes());
+    }
+    if let Some(rc_astro_id) = &rc_astro_id {
+        hasher.update(b"rc-astro");
+        hasher.update(rc_astro_id.as_bytes());
     }
     let mut stretch_id = String::with_capacity(64);
     for byte in hasher.finalize() {
@@ -409,6 +456,9 @@ pub(super) async fn apply_to_fits(
     let cache_for_render = cache_root.clone();
     let id_for_render = stretch_id.clone();
     let deconvolution_id_for_render = deconvolution_id.clone();
+    let rc_astro_for_render = rc_astro.clone();
+    let rc_astro_id_for_render = rc_astro_id.clone();
+    let rc_astro_schemas_for_render = rc_astro_schemas;
     let rendered = tokio::task::spawn_blocking(move || {
         let _guard = guard;
         render_fits_variant(
@@ -419,12 +469,19 @@ pub(super) async fn apply_to_fits(
             &config,
             deconvolution,
             deconvolution_id_for_render.as_deref(),
+            rc_astro_for_render,
+            rc_astro_id_for_render.as_deref(),
+            rc_astro_schemas_for_render,
         )
     })
     .await
     .map_err(|error| AppError::InternalError(format!("Stretch worker failed: {error}")))?
     .map_err(AppError::BadRequest)?;
 
+    let has_stars = rendered
+        .rc_astro
+        .as_ref()
+        .is_some_and(|result| result.has_stars);
     let response = StackStretchPreview {
         schema_version: 2,
         stretch_id: stretch_id.clone(),
@@ -442,12 +499,22 @@ pub(super) async fn apply_to_fits(
         channel_statistics: rendered.channel_statistics,
         luminance_statistics: rendered.luminance_statistics,
         deconvolution: rendered.deconvolution,
+        rc_astro: rendered.rc_astro,
+        rc_astro_id: rc_astro_id.clone(),
         preview_url: format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/preview"),
         original_preview_url: format!(
             "/api/db/{database_id}/stack-previews/stretch/{stretch_id}/preview?size=original"
         ),
-        fits_url: deconvolution
-            .map(|_| format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/fits")),
+        fits_url: (deconvolution.is_some() || rc_astro_id.is_some())
+            .then(|| format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/fits")),
+        stars_preview_url: has_stars
+            .then(|| format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/stars")),
+        stars_original_preview_url: has_stars.then(|| {
+            format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/stars?size=original")
+        }),
+        stars_fits_url: has_stars.then(|| {
+            format!("/api/db/{database_id}/stack-previews/stretch/{stretch_id}/stars-fits")
+        }),
     };
     write_json_atomic(&manifest_path, &response).map_err(AppError::InternalError)?;
     Ok(response)
@@ -462,8 +529,10 @@ struct RenderedVariant {
     channel_statistics: Vec<Option<RobustStatistics>>,
     luminance_statistics: Option<RobustStatistics>,
     deconvolution: Option<StackDeconvolutionResult>,
+    rc_astro: Option<super::rc_astro::StackRcAstroResult>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_fits_variant(
     state: &Arc<AppState>,
     cache_root: &FsPath,
@@ -472,11 +541,14 @@ fn render_fits_variant(
     config: &StretchConfig,
     deconvolution_request: Option<DeconvolutionConfig>,
     deconvolution_id: Option<&str>,
+    rc_astro_request: Option<super::rc_astro::RcAstroProcessing>,
+    rc_astro_id: Option<&str>,
+    rc_astro_schemas: Option<Vec<(String, seiza_stacking::ExternalToolSchema)>>,
 ) -> Result<RenderedVariant, String> {
     let frame =
         crate::image_io::open_linear_frame(source_path).map_err(|error| error.to_string())?;
     let samples = frame.image.data.len();
-    let bytes_per_sample = if deconvolution_request.is_some() {
+    let bytes_per_sample = if deconvolution_request.is_some() || rc_astro_id.is_some() {
         DECONVOLUTION_BYTES_PER_SAMPLE
     } else {
         STRETCH_BYTES_PER_SAMPLE
@@ -521,10 +593,10 @@ fn render_fits_variant(
         config.max_analysis_samples,
     )
     .map_err(|error| error.to_string())?;
-    if deconvolution_request.is_some()
+    if (deconvolution_request.is_some() || rc_astro_request.is_some())
         && source_transfer == StackStretchSourceTransfer::DisplayReferred
     {
-        return Err("Deconvolution requires a linear-light stack source".into());
+        return Err("Linear-light processing requires a linear stack source".into());
     }
     let mut processed = None;
     let mut cached_processed = None;
@@ -585,6 +657,25 @@ fn render_fits_variant(
         .as_ref()
         .or_else(|| cached_processed.as_ref().map(|frame| &frame.image))
         .unwrap_or(&frame.image);
+    // RC-Astro runs after deconvolution: the tools operate on whatever the
+    // linear image has become by this point.
+    let mut rc_astro_outcome = None;
+    if let (Some(rc_astro_config), Some(rc_astro_id), Some(schemas)) =
+        (rc_astro_request, rc_astro_id, rc_astro_schemas.as_ref())
+    {
+        rc_astro_outcome = Some(super::rc_astro::apply_rc_astro(
+            cache_root,
+            rc_astro_id,
+            &rc_astro_config,
+            schemas,
+            linear,
+            &frame.headers,
+        )?);
+    }
+    let linear = rc_astro_outcome
+        .as_ref()
+        .map(|outcome| &outcome.image)
+        .unwrap_or(linear);
     let normalized = if source_transfer == StackStretchSourceTransfer::Linear {
         Some(normalize_linear_image(linear)?)
     } else {
@@ -600,6 +691,33 @@ fn render_fits_variant(
     let render = pool.install(|| {
         render_image_previews_with_details(prepared, config, &screen, &original, |_| {})
     })?;
+    // The stars image gets its own stretched pair, normalized on its own
+    // range: it is mostly empty sky with bright peaks, and borrowing the
+    // starless normalization would crush it.
+    if let Some(outcome) = &rc_astro_outcome
+        && let Some(stars) = &outcome.stars
+    {
+        let stars_normalized = if source_transfer == StackStretchSourceTransfer::Linear {
+            Some(normalize_linear_image(stars)?)
+        } else {
+            None
+        };
+        let stars_prepared = stars_normalized
+            .as_ref()
+            .map(|(image, _)| image)
+            .unwrap_or(stars);
+        let stars_screen = stretch_stars_preview_path(cache_root, stretch_id);
+        let stars_original = stretch_stars_original_preview_path(cache_root, stretch_id);
+        pool.install(|| {
+            render_image_previews_with_details(
+                stars_prepared,
+                config,
+                &stars_screen,
+                &stars_original,
+                |_| {},
+            )
+        })?;
+    }
     Ok(RenderedVariant {
         config: config.clone(),
         resolved_plan: serde_json::to_value(render.plan).map_err(|error| error.to_string())?,
@@ -609,6 +727,7 @@ fn render_fits_variant(
         channel_statistics: source_analysis.channel_statistics(),
         luminance_statistics: source_analysis.luminance_statistics(),
         deconvolution,
+        rc_astro: rc_astro_outcome.map(|outcome| outcome.result),
     })
 }
 
@@ -707,9 +826,22 @@ pub async fn download_stack_stretch_fits(
         .ok()
         .and_then(|bytes| serde_json::from_slice::<StackStretchPreview>(&bytes).ok())
         .ok_or(AppError::NotFound)?;
-    let deconvolution_id = manifest.deconvolution_id.ok_or(AppError::NotFound)?;
-    validate_job_id(&deconvolution_id)?;
-    let path = deconvolution_fits_path(&ctx.cache_dir_path, &deconvolution_id);
+    // The furthest-processed linear image: RC-Astro's output already
+    // includes any deconvolution that ran before it.
+    let (path, label) = if let Some(rc_astro_id) = &manifest.rc_astro_id {
+        validate_job_id(rc_astro_id)?;
+        (
+            super::rc_astro::rc_astro_fits_path(&ctx.cache_dir_path, rc_astro_id),
+            "processed",
+        )
+    } else {
+        let deconvolution_id = manifest.deconvolution_id.ok_or(AppError::NotFound)?;
+        validate_job_id(&deconvolution_id)?;
+        (
+            deconvolution_fits_path(&ctx.cache_dir_path, &deconvolution_id),
+            "deconvolved",
+        )
+    };
     let file = tokio::fs::File::open(&path)
         .await
         .map_err(|_| AppError::NotFound)?;
@@ -720,7 +852,7 @@ pub async fn download_stack_stretch_fits(
             AppError::InternalError(format!("Failed to stat processed FITS: {error}"))
         })?
         .len();
-    let filename = format!("psf-guard-deconvolved-{}.fits", &stretch_id[..12]);
+    let filename = format!("psf-guard-{label}-{}.fits", &stretch_id[..12]);
     Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/fits")
@@ -733,6 +865,77 @@ pub async fn download_stack_stretch_fits(
         .body(Body::from_stream(ReaderStream::new(file)))
         .map_err(|error| {
             AppError::InternalError(format!("Failed to build processed FITS response: {error}"))
+        })
+}
+
+/// GET /api/db/{db}/stack-previews/stretch/{id}/stars
+pub async fn get_stack_stretch_stars_image(
+    ctx: DbContext,
+    Path((_db_id, stretch_id)): Path<(String, String)>,
+    Query(query): Query<StackPreviewImageQuery>,
+) -> Result<Response, AppError> {
+    validate_job_id(&stretch_id)?;
+    let path = match query.size {
+        StackPreviewImageSize::Screen => {
+            stretch_stars_preview_path(&ctx.cache_dir_path, &stretch_id)
+        }
+        StackPreviewImageSize::Original => {
+            stretch_stars_original_preview_path(&ctx.cache_dir_path, &stretch_id)
+        }
+    };
+    let file = tokio::fs::File::open(&path)
+        .await
+        .map_err(|_| AppError::NotFound)?;
+    let length = file
+        .metadata()
+        .await
+        .map_err(|error| AppError::InternalError(format!("Failed to stat stars PNG: {error}")))?
+        .len();
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "image/png")
+        .header(CONTENT_LENGTH, length)
+        .header(CACHE_CONTROL, "private, max-age=31536000, immutable")
+        .body(Body::from_stream(ReaderStream::new(file)))
+        .map_err(|error| {
+            AppError::InternalError(format!("Failed to build stars PNG response: {error}"))
+        })
+}
+
+/// GET /api/db/{db}/stack-previews/stretch/{id}/stars-fits
+pub async fn download_stack_stretch_stars_fits(
+    ctx: DbContext,
+    Path((_db_id, stretch_id)): Path<(String, String)>,
+) -> Result<Response, AppError> {
+    validate_job_id(&stretch_id)?;
+    let manifest = std::fs::read(stretch_manifest_path(&ctx.cache_dir_path, &stretch_id))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<StackStretchPreview>(&bytes).ok())
+        .ok_or(AppError::NotFound)?;
+    let rc_astro_id = manifest.rc_astro_id.ok_or(AppError::NotFound)?;
+    validate_job_id(&rc_astro_id)?;
+    let path = super::rc_astro::rc_astro_stars_path(&ctx.cache_dir_path, &rc_astro_id);
+    let file = tokio::fs::File::open(&path)
+        .await
+        .map_err(|_| AppError::NotFound)?;
+    let length = file
+        .metadata()
+        .await
+        .map_err(|error| AppError::InternalError(format!("Failed to stat stars FITS: {error}")))?
+        .len();
+    let filename = format!("psf-guard-stars-{}.fits", &stretch_id[..12]);
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/fits")
+        .header(CONTENT_LENGTH, length)
+        .header(
+            CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{filename}\""),
+        )
+        .header(CACHE_CONTROL, "private, max-age=31536000, immutable")
+        .body(Body::from_stream(ReaderStream::new(file)))
+        .map_err(|error| {
+            AppError::InternalError(format!("Failed to build stars FITS response: {error}"))
         })
 }
 
@@ -753,6 +956,14 @@ fn stretch_preview_path(cache_root: &FsPath, stretch_id: &str) -> PathBuf {
 
 fn stretch_original_preview_path(cache_root: &FsPath, stretch_id: &str) -> PathBuf {
     stretch_dir(cache_root, stretch_id).join("preview-original.png")
+}
+
+fn stretch_stars_preview_path(cache_root: &FsPath, stretch_id: &str) -> PathBuf {
+    stretch_dir(cache_root, stretch_id).join("stars.png")
+}
+
+fn stretch_stars_original_preview_path(cache_root: &FsPath, stretch_id: &str) -> PathBuf {
+    stretch_dir(cache_root, stretch_id).join("stars-original.png")
 }
 
 fn deconvolution_dir(cache_root: &FsPath, deconvolution_id: &str) -> PathBuf {
@@ -780,9 +991,15 @@ fn stretch_artifacts_exist(
         && manifest.deconvolution_id.as_ref().is_none_or(|id| {
             validate_job_id(id).is_ok() && deconvolution_fits_path(cache_root, id).is_file()
         })
+        && manifest.rc_astro_id.as_ref().is_none_or(|id| {
+            validate_job_id(id).is_ok()
+                && super::rc_astro::rc_astro_fits_path(cache_root, id).is_file()
+        })
+        && (manifest.stars_preview_url.is_none()
+            || stretch_stars_preview_path(cache_root, stretch_id).is_file())
 }
 
-fn write_json_atomic(path: &FsPath, value: &impl Serialize) -> Result<(), String> {
+pub(super) fn write_json_atomic(path: &FsPath, value: &impl Serialize) -> Result<(), String> {
     let parent = path
         .parent()
         .ok_or_else(|| "Stretch manifest path has no parent".to_string())?;

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -4918,6 +4918,118 @@
   font-size: 0.54rem;
 }
 
+/* RC-Astro tool chain: shares the deconvolution card look. */
+.stack-rc-astro-controls {
+  min-width: 0;
+  padding: 0.52rem;
+  border: 1px solid var(--color-bg-tertiary);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--color-bg-primary) 90%, var(--color-primary));
+}
+
+.stack-rc-astro-controls > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.42rem;
+  color: var(--color-primary);
+  font-size: 0.68rem;
+}
+
+.stack-rc-astro-controls > header span,
+.stack-rc-astro-controls > p {
+  color: var(--color-text-muted);
+  font-size: 0.59rem;
+}
+
+.stack-rc-astro-controls > p {
+  margin: 0.35rem 0 0;
+}
+
+.stack-rc-astro-tool {
+  margin-top: 0.45rem;
+}
+
+.stack-rc-astro-tool > label {
+  display: flex;
+  align-items: center;
+  gap: 0.42rem;
+  font-size: 0.64rem;
+}
+
+.stack-rc-astro-tool > label input {
+  accent-color: var(--color-primary);
+}
+
+.stack-rc-astro-tool > label small {
+  color: var(--color-warning);
+  font-size: 0.56rem;
+}
+
+.stack-rc-astro-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(105px, 1fr));
+  gap: 0.42rem;
+  margin-top: 0.4rem;
+}
+
+.stack-rc-astro-switch {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.stack-rc-astro-diagnostics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.stack-rc-astro-diagnostics span {
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.3rem 0.38rem;
+  color: var(--color-text-secondary);
+  border-left: 2px solid var(--color-success);
+  background: var(--color-bg-secondary);
+  font-size: 0.58rem;
+}
+
+.stack-rc-astro-diagnostics small {
+  color: var(--color-warning);
+  font-size: 0.54rem;
+}
+
+/* Starless / Stars view switch over a star-removed preview */
+.stack-preview-stars-toggle {
+  position: absolute;
+  bottom: 6px;
+  left: 6px;
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 5px;
+  background: rgb(0 0 0 / 55%);
+}
+
+.stack-preview-stars-toggle button,
+.stack-preview-stars-toggle a {
+  padding: 2px 7px;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.6rem;
+  text-decoration: none;
+}
+
+.stack-preview-stars-toggle .is-active {
+  color: var(--color-text-primary);
+  background: var(--color-primary-alpha-30);
+}
+
 .stack-color-stage-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/static/src/api/__tests__/applyStackStretch.poll.test.ts
+++ b/static/src/api/__tests__/applyStackStretch.poll.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import { apiClient } from '../client';
+import type { StackStretchPendingProgress } from '../types';
+
+const jobId = 'a'.repeat(64);
+
+const ready = {
+  success: true,
+  data: {
+    schema_version: 2,
+    stretch_id: 'b'.repeat(64),
+    stretch_version: '0.1.0',
+    deconvolution_version: null,
+    deconvolution_id: null,
+    config: { model: { type: 'identity' }, color_strategy: 'linked', max_analysis_samples: 1 },
+    resolved_plan: {},
+    source_transfer: 'linear',
+    input_range: null,
+    linked_statistics: { min: 0, max: 1, median: 0.5, mad: 0.1, count: 4 },
+    channel_statistics: [],
+    luminance_statistics: null,
+    deconvolution: null,
+    preview_url: '/p',
+    original_preview_url: '/o',
+    fits_url: null,
+  },
+  error: null,
+};
+
+describe('applyStackStretch polling', () => {
+  it('polls 202 answers, reporting their progress, until the result is ready', async () => {
+    let calls = 0;
+    server.use(
+      http.post(`/api/db/test/stack-previews/${jobId}/0/stretch`, () => {
+        calls += 1;
+        if (calls < 3) {
+          return HttpResponse.json(
+            {
+              success: true,
+              data: {
+                pending: true,
+                stage: 'RC-Astro StarXTerminator',
+                fraction: calls * 0.25,
+              },
+              error: null,
+            },
+            { status: 202 }
+          );
+        }
+        return HttpResponse.json(ready);
+      })
+    );
+
+    const seen: StackStretchPendingProgress[] = [];
+    const preview = await apiClient.applyStackStretch(
+      'test',
+      jobId,
+      0,
+      { model: { type: 'identity' }, color_strategy: 'linked' },
+      { onProgress: (progress) => seen.push(progress), pollIntervalMs: 5 }
+    );
+
+    expect(calls).toBe(3);
+    expect(seen.map((progress) => progress.fraction)).toEqual([0.25, 0.5]);
+    expect(seen[0].stage).toBe('RC-Astro StarXTerminator');
+    expect(preview.stretch_id).toBe('b'.repeat(64));
+  });
+
+  it('surfaces a failed poll as an error', async () => {
+    server.use(
+      http.post(`/api/db/test/stack-previews/${jobId}/0/stretch`, () =>
+        HttpResponse.json(
+          { success: false, data: null, error: 'sxt: not licensed' },
+          { status: 400 }
+        )
+      )
+    );
+    await expect(
+      apiClient.applyStackStretch(
+        'test',
+        jobId,
+        0,
+        { model: { type: 'identity' }, color_strategy: 'linked' },
+        { pollIntervalMs: 5 }
+      )
+    ).rejects.toThrow(/not licensed/);
+  });
+});

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -1044,19 +1044,34 @@ export const apiClient = {
     groupIndex: number,
     request: StackViewProcessingRequest
   ): Promise<StackStretchPreview> => {
-    try {
-      const apiInstance = await getApi();
-      const { data } = await apiInstance.post<ApiResponse<StackStretchPreview>>(
-        dbPath(
-          dbId,
-          `/stack-previews/${encodeURIComponent(jobId)}/${groupIndex}/stretch`
-        ),
-        request
-      );
-      if (!data.data) throw new Error(data.error || 'Failed to apply stack stretch');
-      return normalizeStretchPreview(data.data);
-    } catch (cause) {
-      throw stackStretchError(cause, 'Failed to apply stack stretch');
+    // A long chain (RC-Astro tools take minutes) answers 202 and computes
+    // detached; re-sending the identical request polls it and finally
+    // returns the cached result. The cap is generous: a CPU-only
+    // StarXTerminator pass on a large stack legitimately takes a while.
+    const deadline = Date.now() + 60 * 60 * 1000;
+    for (;;) {
+      try {
+        const apiInstance = await getApi();
+        const response = await apiInstance.post<ApiResponse<StackStretchPreview>>(
+          dbPath(
+            dbId,
+            `/stack-previews/${encodeURIComponent(jobId)}/${groupIndex}/stretch`
+          ),
+          request
+        );
+        if (response.status !== 202) {
+          if (!response.data.data) {
+            throw new Error(response.data.error || 'Failed to apply stack stretch');
+          }
+          return normalizeStretchPreview(response.data.data);
+        }
+      } catch (cause) {
+        throw stackStretchError(cause, 'Failed to apply stack stretch');
+      }
+      if (Date.now() > deadline) {
+        throw new Error('Stack processing is still running; try again later');
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5000));
     }
   },
 

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -76,6 +76,7 @@ import type {
   StackViewProcessingRequest,
   AstrometryCapabilities,
   RcAstroCapabilities,
+  StackStretchPendingProgress,
   AstrometryValidationReport,
   CatalogInstallPreset,
   CatalogInstallStatus,
@@ -1042,17 +1043,26 @@ export const apiClient = {
     dbId: string,
     jobId: string,
     groupIndex: number,
-    request: StackViewProcessingRequest
+    request: StackViewProcessingRequest,
+    options?: {
+      /** Live progress from a detached run's 202 polls. */
+      onProgress?: (progress: StackStretchPendingProgress) => void;
+      /** Poll interval override, for tests. */
+      pollIntervalMs?: number;
+    }
   ): Promise<StackStretchPreview> => {
     // A long chain (RC-Astro tools take minutes) answers 202 and computes
-    // detached; re-sending the identical request polls it and finally
-    // returns the cached result. The cap is generous: a CPU-only
-    // StarXTerminator pass on a large stack legitimately takes a while.
+    // detached; re-sending the identical request polls it — each poll
+    // carrying the run's live progress — and finally returns the cached
+    // result. The cap is generous: a CPU-only StarXTerminator pass on a
+    // large stack legitimately takes a while.
     const deadline = Date.now() + 60 * 60 * 1000;
     for (;;) {
       try {
         const apiInstance = await getApi();
-        const response = await apiInstance.post<ApiResponse<StackStretchPreview>>(
+        const response = await apiInstance.post<
+          ApiResponse<StackStretchPreview | StackStretchPendingProgress>
+        >(
           dbPath(
             dbId,
             `/stack-previews/${encodeURIComponent(jobId)}/${groupIndex}/stretch`
@@ -1060,18 +1070,21 @@ export const apiClient = {
           request
         );
         if (response.status !== 202) {
-          if (!response.data.data) {
+          const data = response.data.data as StackStretchPreview | null;
+          if (!data) {
             throw new Error(response.data.error || 'Failed to apply stack stretch');
           }
-          return normalizeStretchPreview(response.data.data);
+          return normalizeStretchPreview(data);
         }
+        const pending = response.data.data as StackStretchPendingProgress | null;
+        if (pending && options?.onProgress) options.onProgress(pending);
       } catch (cause) {
         throw stackStretchError(cause, 'Failed to apply stack stretch');
       }
       if (Date.now() > deadline) {
         throw new Error('Stack processing is still running; try again later');
       }
-      await new Promise((resolve) => setTimeout(resolve, 5000));
+      await new Promise((resolve) => setTimeout(resolve, options?.pollIntervalMs ?? 5000));
     }
   },
 

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -75,6 +75,7 @@ import type {
   StackStretchPreview,
   StackViewProcessingRequest,
   AstrometryCapabilities,
+  RcAstroCapabilities,
   AstrometryValidationReport,
   CatalogInstallPreset,
   CatalogInstallStatus,
@@ -288,6 +289,13 @@ export const apiClient = {
       '/astrometry/capabilities'
     );
     if (!data.data) throw new Error(data.error || 'Failed to inspect Seiza catalogs');
+    return data.data;
+  },
+
+  getRcAstroCapabilities: async (): Promise<RcAstroCapabilities> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<RcAstroCapabilities>>('/tools/rc-astro');
+    if (!data.data) throw new Error(data.error || 'Failed to probe RC-Astro tools');
     return data.data;
   },
 

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -762,6 +762,15 @@ export interface StackRcAstroResult {
   has_stars: boolean;
 }
 
+/** A 202 poll answer while a detached processing run computes. */
+export interface StackStretchPendingProgress {
+  pending: true;
+  /** The tool currently running, e.g. "RC-Astro StarXTerminator". */
+  stage?: string;
+  /** The chain's overall fraction complete in 0..1. */
+  fraction?: number;
+}
+
 export interface StackDeconvolutionConfig {
   psf_fwhm_pixels: number;
   iterations: number;

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -700,6 +700,66 @@ export interface StackStretchRequest {
 
 export interface StackViewProcessingRequest extends StackStretchRequest {
   deconvolution?: StackDeconvolutionConfig | null;
+  rc_astro?: RcAstroProcessing | null;
+}
+
+/** One RC-Astro schema parameter's type, default, and range. */
+export type ExternalParameterKind =
+  | { type: 'float'; default: number; min: number; max: number }
+  | { type: 'bool'; default: boolean }
+  | { type: 'int'; default: number; min: number; max: number };
+
+export interface ExternalToolParameter {
+  name: string;
+  /** The CLI flag; null marks a GUI-only parameter that cannot be set. */
+  flag: string | null;
+  label: string;
+  description: string;
+  kind: ExternalParameterKind;
+}
+
+/** One RC-Astro tool's live contract, read from `rc-astro <tool> --json`. */
+export interface ExternalToolSchema {
+  schema_version: number;
+  cli_version: string;
+  key: string;
+  name: string;
+  ml_version: number | null;
+  licensed: boolean;
+  license_message: string | null;
+  parameters: ExternalToolParameter[];
+}
+
+export interface RcAstroCapabilities {
+  available: boolean;
+  executable?: string;
+  tools: ExternalToolSchema[];
+  error?: string;
+}
+
+export type RcAstroParameterValue = number | boolean;
+
+export interface RcAstroStep {
+  tool: string;
+  parameters: Record<string, RcAstroParameterValue>;
+}
+
+export interface RcAstroProcessing {
+  steps: RcAstroStep[];
+}
+
+export interface RcAstroStepResult {
+  tool: string;
+  name: string;
+  ml_version: number | null;
+  device?: string;
+  warnings: string[];
+}
+
+export interface StackRcAstroResult {
+  cli_version: string;
+  steps: RcAstroStepResult[];
+  has_stars: boolean;
 }
 
 export interface StackDeconvolutionConfig {
@@ -744,9 +804,15 @@ export interface StackStretchPreview {
   channel_statistics: Array<StackStretchStatistics | null>;
   luminance_statistics: StackStretchStatistics | null;
   deconvolution: StackDeconvolutionResult | null;
+  rc_astro?: StackRcAstroResult | null;
+  rc_astro_id?: string | null;
   preview_url: string;
   original_preview_url: string;
   fits_url: string | null;
+  /** Present when star removal kept a stars image. */
+  stars_preview_url?: string | null;
+  stars_original_preview_url?: string | null;
+  stars_fits_url?: string | null;
 }
 
 export type StackColorRole = 'luminance' | 'red' | 'green' | 'blue' | 'ha' | 'oiii' | 'sii';

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -297,6 +297,10 @@ export default function StackPreviewPanel({
   const [watchedJobIds, setWatchedJobIds] = useState<string[]>([]);
   const [inspector, setInspector] = useState<StackArtifact | null>(null);
   const [stretches, setStretches] = useState<Record<string, StackStretchPreview>>({});
+  // Which channels currently show the stars image instead of the starless
+  // one, keyed like `stretches`. Only meaningful while star removal is
+  // applied to that channel.
+  const [starsView, setStarsView] = useState<Record<string, boolean>>({});
 
   const currentChannels = useMemo(() => {
     const channels = new Map<string, ChannelInput>();
@@ -924,13 +928,38 @@ export default function StackPreviewPanel({
                     {artifact && (
                       <div className="stack-preview-image">
                         <img
-                          src={appliedStretch?.preview_url ?? apiClient.getStackPreviewUrl(
-                            dbId, artifact.jobId, artifact.group.index, artifact.artifactRevision
-                          )}
+                          src={(stretchKey && starsView[stretchKey] && appliedStretch?.stars_preview_url)
+                            || appliedStretch?.preview_url
+                            || apiClient.getStackPreviewUrl(
+                              dbId, artifact.jobId, artifact.group.index, artifact.artifactRevision
+                            )}
                           alt={`${targetName} ${filterName} stack preview`}
                         />
                         {isSkyOriented(artifact.group.sky_orientation) && (
                           <span className="stack-preview-orientation">N ↑ · E ←</span>
+                        )}
+                        {stretchKey && appliedStretch?.stars_preview_url && (
+                          <div className="stack-preview-stars-toggle" role="group" aria-label="Star removal view">
+                            <button
+                              type="button"
+                              className={starsView[stretchKey] ? '' : 'is-active'}
+                              onClick={() => setStarsView((current) => ({ ...current, [stretchKey]: false }))}
+                            >
+                              Starless
+                            </button>
+                            <button
+                              type="button"
+                              className={starsView[stretchKey] ? 'is-active' : ''}
+                              onClick={() => setStarsView((current) => ({ ...current, [stretchKey]: true }))}
+                            >
+                              Stars
+                            </button>
+                            {appliedStretch.stars_fits_url && (
+                              <a href={appliedStretch.stars_fits_url} download title="Download the stars linear FITS">
+                                Stars FITS
+                              </a>
+                            )}
+                          </div>
                         )}
                       </div>
                     )}

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -971,8 +971,8 @@ export default function StackPreviewPanel({
                         channels={artifact.group.output_channels === 3 ? 3 : 1}
                         disabled={!canCompute || running}
                         applied={appliedStretch}
-                        apply={(request) => apiClient.applyStackStretch(
-                          dbId, artifact.jobId, artifact.group.index, request
+                        apply={(request, onProgress) => apiClient.applyStackStretch(
+                          dbId, artifact.jobId, artifact.group.index, request, { onProgress }
                         )}
                         onApplied={(preview) => setStretches((currentStretches) => ({
                           ...currentStretches,

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -421,6 +421,7 @@ export default function StackPreviewPanel({
     setWatchedJobIds([]);
     setInspector(null);
     setStretches({});
+    setStarsView({});
     setFrameOrder('capture');
     resetStart();
     resetStop();
@@ -977,11 +978,20 @@ export default function StackPreviewPanel({
                           ...currentStretches,
                           [stretchKey]: preview,
                         }))}
-                        onRevert={() => setStretches((currentStretches) => {
-                          const next = { ...currentStretches };
-                          delete next[stretchKey];
-                          return next;
-                        })}
+                        onRevert={() => {
+                          setStretches((currentStretches) => {
+                            const next = { ...currentStretches };
+                            delete next[stretchKey];
+                            return next;
+                          });
+                          // The next star removal starts on the starless
+                          // view, not wherever this one was left.
+                          setStarsView((current) => {
+                            const next = { ...current };
+                            delete next[stretchKey];
+                            return next;
+                          });
+                        }}
                       />
                     )}
                     {!artifact && groupBusy && (

--- a/static/src/components/StackRcAstroControls.tsx
+++ b/static/src/components/StackRcAstroControls.tsx
@@ -34,7 +34,22 @@ export default function StackRcAstroControls({
     retry: false,
   });
 
-  if (!capabilities.data?.available) return null;
+  // No install renders nothing; an install whose probe failed says so, so
+  // a broken setup is distinguishable from an absent one.
+  if (!capabilities.data?.available) {
+    if (capabilities.data?.error) {
+      return (
+        <section className="stack-rc-astro-controls" aria-label={`${label} RC-Astro tools`}>
+          <header>
+            <strong>RC-Astro tools</strong>
+            <span>unavailable</span>
+          </header>
+          <p>{capabilities.data.error}</p>
+        </section>
+      );
+    }
+    return null;
+  }
   const tools = capabilities.data.tools;
 
   const stepFor = (tool: string) => config?.steps.find((step) => step.tool === tool);

--- a/static/src/components/StackRcAstroControls.tsx
+++ b/static/src/components/StackRcAstroControls.tsx
@@ -1,0 +1,194 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import type {
+  ExternalToolParameter,
+  ExternalToolSchema,
+  RcAstroProcessing,
+  RcAstroParameterValue,
+  StackRcAstroResult,
+} from '../api/types';
+
+/**
+ * RC-Astro tool chain controls (BlurXTerminator, NoiseXTerminator,
+ * StarXTerminator), rendered from each tool's live schema so the knobs stay
+ * correct across CLI upgrades. Nothing renders when the CLI is not
+ * installed on the server.
+ */
+export default function StackRcAstroControls({
+  label,
+  config,
+  result,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  config: RcAstroProcessing | null | undefined;
+  result?: StackRcAstroResult;
+  disabled: boolean;
+  onChange: (config: RcAstroProcessing | null) => void;
+}) {
+  const capabilities = useQuery({
+    queryKey: ['rc-astro-capabilities'],
+    queryFn: apiClient.getRcAstroCapabilities,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  if (!capabilities.data?.available) return null;
+  const tools = capabilities.data.tools;
+
+  const stepFor = (tool: string) => config?.steps.find((step) => step.tool === tool);
+
+  const setStep = (tool: string, parameters: Record<string, RcAstroParameterValue> | null) => {
+    const others = config?.steps.filter((step) => step.tool !== tool) ?? [];
+    const steps = parameters === null ? others : [...others, { tool, parameters }];
+    onChange(steps.length === 0 ? null : { steps });
+  };
+
+  return (
+    <section className="stack-rc-astro-controls" aria-label={`${label} RC-Astro tools`}>
+      <header>
+        <strong>RC-Astro tools</strong>
+        <span>
+          {config?.steps.length
+            ? `${config.steps.length} step(s) · linear, before stretch`
+            : 'Off'}
+        </span>
+      </header>
+      <p>
+        Runs the server&apos;s licensed RC-Astro tools on the linear stack.
+        Star removal keeps both images, so starless and stars stretch on
+        their own.
+      </p>
+      {tools.map((schema) => (
+        <ToolSection
+          key={schema.key}
+          schema={schema}
+          parameters={stepFor(schema.key)?.parameters}
+          disabled={disabled || !schema.licensed}
+          onToggle={(enabled) =>
+            setStep(schema.key, enabled ? defaultParameters(schema) : null)
+          }
+          onParameter={(name, value) => {
+            const current = stepFor(schema.key)?.parameters ?? defaultParameters(schema);
+            setStep(schema.key, { ...current, [name]: value });
+          }}
+        />
+      ))}
+      {result && (
+        <div className="stack-rc-astro-diagnostics">
+          {result.steps.map((step) => (
+            <span key={step.tool}>
+              {step.name}
+              {step.device ? ` · ${step.device}` : ''}
+              {step.warnings.map((warning) => (
+                <small key={warning}>{warning}</small>
+              ))}
+            </span>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** What a freshly enabled tool asks for: star removal keeps the stars. */
+function defaultParameters(schema: ExternalToolSchema): Record<string, RcAstroParameterValue> {
+  if (schema.key === 'sxt') {
+    const stars = schema.parameters.find(
+      (parameter) => parameter.name === 'stars' || parameter.name === 'difference'
+    );
+    if (stars?.flag) return { [stars.name]: true };
+  }
+  return {};
+}
+
+function ToolSection({
+  schema,
+  parameters,
+  disabled,
+  onToggle,
+  onParameter,
+}: {
+  schema: ExternalToolSchema;
+  parameters: Record<string, RcAstroParameterValue> | undefined;
+  disabled: boolean;
+  onToggle: (enabled: boolean) => void;
+  onParameter: (name: string, value: RcAstroParameterValue) => void;
+}) {
+  const enabled = parameters !== undefined;
+  return (
+    <div className="stack-rc-astro-tool">
+      <label>
+        <input
+          type="checkbox"
+          checked={enabled}
+          disabled={disabled}
+          onChange={(event) => onToggle(event.target.checked)}
+          aria-label={schema.name}
+        />
+        <strong>{schema.name}</strong>
+        {!schema.licensed && <small>not licensed</small>}
+      </label>
+      {enabled && (
+        <div className="stack-rc-astro-fields">
+          {schema.parameters
+            .filter((parameter) => parameter.flag !== null)
+            .map((parameter) => (
+              <ParameterField
+                key={parameter.name}
+                parameter={parameter}
+                value={parameters[parameter.name]}
+                disabled={disabled}
+                onChange={(value) => onParameter(parameter.name, value)}
+              />
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ParameterField({
+  parameter,
+  value,
+  disabled,
+  onChange,
+}: {
+  parameter: ExternalToolParameter;
+  value: RcAstroParameterValue | undefined;
+  disabled: boolean;
+  onChange: (value: RcAstroParameterValue) => void;
+}) {
+  const { kind } = parameter;
+  if (kind.type === 'bool') {
+    return (
+      <label className="stack-stretch-field stack-rc-astro-switch" title={parameter.description}>
+        <input
+          type="checkbox"
+          checked={typeof value === 'boolean' ? value : kind.default}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.checked)}
+          aria-label={parameter.label}
+        />
+        <span>{parameter.label}</span>
+      </label>
+    );
+  }
+  const numeric = typeof value === 'number' ? value : kind.default;
+  return (
+    <label className="stack-stretch-field" title={parameter.description}>
+      <span>{parameter.label}</span>
+      <input
+        type="number"
+        aria-label={parameter.label}
+        value={Number.isFinite(numeric) ? numeric : ''}
+        min={kind.min}
+        max={kind.max}
+        step={kind.type === 'int' ? 1 : 0.05}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.valueAsNumber)}
+      />
+    </label>
+  );
+}

--- a/static/src/components/StackStretchControls.tsx
+++ b/static/src/components/StackStretchControls.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { StackStretchPreview, StackViewProcessingRequest } from '../api/types';
 import StackStretchStageEditor from './StackStretchStageEditor';
 import StackDeconvolutionControls from './StackDeconvolutionControls';
+import StackRcAstroControls from './StackRcAstroControls';
 import ProcessingSetupsBar from './ProcessingSetupsBar';
 import { builtinViewSetups } from './processingSetups';
 import { validateDeconvolution } from './stackDeconvolution';
@@ -33,13 +34,13 @@ export default function StackStretchControls({
 }: StackStretchControlsProps) {
   const initialType = displayReferred ? 'identity' : 'auto-mtf';
   const [request, setRequest] = useState<StackViewProcessingRequest>(() =>
-    ({ ...defaultStretchRequest(initialType), deconvolution: null })
+    ({ ...defaultStretchRequest(initialType), deconvolution: null, rc_astro: null })
   );
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const revert = () => {
-    setRequest({ ...defaultStretchRequest(initialType), deconvolution: null });
+    setRequest({ ...defaultStretchRequest(initialType), deconvolution: null, rc_astro: null });
     setError(null);
     onRevert();
   };
@@ -70,7 +71,7 @@ export default function StackStretchControls({
       <summary>
         <span>View processing</span>
         <small>{applied
-          ? `${applied.deconvolution ? `${applied.deconvolution.config.psf_fwhm_pixels}px deconv · ` : ''}${stretchModelLabels[applied.config.model.type]} applied`
+          ? `${applied.deconvolution ? `${applied.deconvolution.config.psf_fwhm_pixels}px deconv · ` : ''}${applied.rc_astro ? `RC-Astro ×${applied.rc_astro.steps.length} · ` : ''}${stretchModelLabels[applied.config.model.type]} applied`
           : 'Deconvolution off · default stretch'}</small>
       </summary>
       <div className="stack-stretch-body">
@@ -82,6 +83,7 @@ export default function StackStretchControls({
           onApply={(settings) => {
             setRequest({
               deconvolution: null,
+              rc_astro: null,
               ...(settings as StackViewProcessingRequest),
             });
             setError(null);
@@ -95,6 +97,16 @@ export default function StackStretchControls({
           onChange={(deconvolution) => setRequest((current) => ({
             ...current,
             deconvolution,
+          }))}
+        />
+        <StackRcAstroControls
+          label={label}
+          config={request.rc_astro}
+          result={applied?.rc_astro ?? undefined}
+          disabled={disabled || pending || displayReferred}
+          onChange={(rc_astro) => setRequest((current) => ({
+            ...current,
+            rc_astro,
           }))}
         />
         <StackStretchStageEditor

--- a/static/src/components/StackStretchControls.tsx
+++ b/static/src/components/StackStretchControls.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
-import type { StackStretchPreview, StackViewProcessingRequest } from '../api/types';
+import type {
+  StackStretchPendingProgress,
+  StackStretchPreview,
+  StackViewProcessingRequest,
+} from '../api/types';
 import StackStretchStageEditor from './StackStretchStageEditor';
 import StackDeconvolutionControls from './StackDeconvolutionControls';
 import StackRcAstroControls from './StackRcAstroControls';
@@ -17,7 +21,10 @@ interface StackStretchControlsProps {
   displayReferred?: boolean;
   disabled?: boolean;
   applied?: StackStretchPreview;
-  apply: (request: StackViewProcessingRequest) => Promise<StackStretchPreview>;
+  apply: (
+    request: StackViewProcessingRequest,
+    onProgress?: (progress: StackStretchPendingProgress) => void
+  ) => Promise<StackStretchPreview>;
   onApplied: (preview: StackStretchPreview) => void;
   onRevert: () => void;
 }
@@ -37,6 +44,8 @@ export default function StackStretchControls({
     ({ ...defaultStretchRequest(initialType), deconvolution: null, rc_astro: null })
   );
   const [pending, setPending] = useState(false);
+  const [pendingProgress, setPendingProgress] =
+    useState<StackStretchPendingProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const revert = () => {
@@ -66,13 +75,15 @@ export default function StackStretchControls({
       return;
     }
     setPending(true);
+    setPendingProgress(null);
     setError(null);
     try {
-      onApplied(await apply(request));
+      onApplied(await apply(request, setPendingProgress));
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : 'Stretch rendering failed');
     } finally {
       setPending(false);
+      setPendingProgress(null);
     }
   };
 
@@ -143,7 +154,15 @@ export default function StackStretchControls({
         {error && <div className="stack-stretch-error" role="alert">{error}</div>}
         <div className="stack-stretch-actions">
           <button type="button" disabled={disabled || pending} onClick={submit}>
-            {pending ? 'Applying…' : 'Apply processing'}
+            {pending
+              ? pendingProgress?.fraction !== undefined
+                ? `Applying… ${Math.round(pendingProgress.fraction * 100)}%${
+                    pendingProgress.stage
+                      ? ` · ${pendingProgress.stage.replace('RC-Astro ', '')}`
+                      : ''
+                  }`
+                : 'Applying…'
+              : 'Apply processing'}
           </button>
           <button type="button" disabled={disabled || pending || !applied} onClick={revert}>
             Revert processing

--- a/static/src/components/StackStretchControls.tsx
+++ b/static/src/components/StackStretchControls.tsx
@@ -55,6 +55,16 @@ export default function StackStretchControls({
       setError(deconvolutionError);
       return;
     }
+    // A cleared number field reads as NaN and would serialize as null.
+    const badRcAstro = request.rc_astro?.steps.some((step) =>
+      Object.values(step.parameters).some(
+        (value) => typeof value === 'number' && !Number.isFinite(value)
+      )
+    );
+    if (badRcAstro) {
+      setError('Enter a finite value for every RC-Astro parameter');
+      return;
+    }
     setPending(true);
     setError(null);
     try {

--- a/static/src/components/__tests__/StackRcAstroControls.test.tsx
+++ b/static/src/components/__tests__/StackRcAstroControls.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import StackRcAstroControls from '../StackRcAstroControls';
+import type { RcAstroProcessing } from '../../api/types';
+
+function ok(data: unknown) {
+  return HttpResponse.json({ success: true, data, error: null });
+}
+
+function wrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const capabilities = {
+  available: true,
+  executable: '/usr/local/bin/rc-astro',
+  tools: [
+    {
+      schema_version: 6,
+      cli_version: '2.6.6',
+      key: 'bxt',
+      name: 'RC-Astro BlurXTerminator',
+      ml_version: 4,
+      licensed: true,
+      license_message: 'Permanently licensed',
+      parameters: [
+        {
+          name: 'ss',
+          flag: '--ss',
+          label: 'Sharpen Stars',
+          description: 'Amount of stellar sharpening',
+          kind: { type: 'float', default: 0.5, min: 0, max: 0.7 },
+        },
+      ],
+    },
+    {
+      schema_version: 6,
+      cli_version: '2.6.6',
+      key: 'sxt',
+      name: 'RC-Astro StarXTerminator',
+      ml_version: 11,
+      licensed: true,
+      license_message: 'Permanently licensed',
+      parameters: [
+        {
+          name: 'stars',
+          flag: '--stars',
+          label: 'Generate Star Image',
+          description: 'Also write a stars-only image',
+          kind: { type: 'bool', default: false },
+        },
+        {
+          name: 'unscreen',
+          flag: '--unscreen',
+          label: 'Unscreen Stars',
+          description: 'Unscreen stars',
+          kind: { type: 'bool', default: false },
+        },
+        {
+          name: 'csep',
+          flag: null,
+          label: 'Color Separation',
+          description: 'GUI only',
+          kind: { type: 'bool', default: false },
+        },
+      ],
+    },
+  ],
+};
+
+describe('StackRcAstroControls', () => {
+  it('renders nothing when rc-astro is not installed', async () => {
+    server.use(http.get('/api/tools/rc-astro', () => ok({ available: false, tools: [] })));
+    const { container } = render(
+      <StackRcAstroControls label="Sh2 157 R" config={null} disabled={false} onChange={() => {}} />,
+      { wrapper: wrapper() }
+    );
+    await waitFor(() =>
+      expect(container.querySelector('.stack-rc-astro-controls')).toBeNull()
+    );
+  });
+
+  it('builds controls from the schema and keeps the stars image by default', async () => {
+    server.use(http.get('/api/tools/rc-astro', () => ok(capabilities)));
+    const onChange = vi.fn();
+    render(
+      <StackRcAstroControls label="Sh2 157 R" config={null} disabled={false} onChange={onChange} />,
+      { wrapper: wrapper() }
+    );
+
+    const sxt = await screen.findByRole('checkbox', { name: 'RC-Astro StarXTerminator' });
+    fireEvent.click(sxt);
+    // Enabling star removal keeps the stars image so both halves can be
+    // stretched independently.
+    expect(onChange).toHaveBeenCalledWith({
+      steps: [{ tool: 'sxt', parameters: { stars: true } }],
+    } satisfies RcAstroProcessing);
+  });
+
+  it('shows flagged parameters only, seeded from schema defaults', async () => {
+    server.use(http.get('/api/tools/rc-astro', () => ok(capabilities)));
+    const config: RcAstroProcessing = {
+      steps: [{ tool: 'sxt', parameters: { stars: true } }],
+    };
+    render(
+      <StackRcAstroControls label="Sh2 157 R" config={config} disabled={false} onChange={() => {}} />,
+      { wrapper: wrapper() }
+    );
+
+    expect(await screen.findByRole('checkbox', { name: 'Generate Star Image' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Unscreen Stars' })).not.toBeChecked();
+    // A parameter with no CLI flag cannot be set and is not offered.
+    expect(screen.queryByText('Color Separation')).toBeNull();
+  });
+
+  it('threads a float edit through onChange', async () => {
+    server.use(http.get('/api/tools/rc-astro', () => ok(capabilities)));
+    const onChange = vi.fn();
+    const config: RcAstroProcessing = { steps: [{ tool: 'bxt', parameters: {} }] };
+    render(
+      <StackRcAstroControls label="Sh2 157 R" config={config} disabled={false} onChange={onChange} />,
+      { wrapper: wrapper() }
+    );
+
+    const field = await screen.findByRole('spinbutton', { name: 'Sharpen Stars' });
+    expect(field).toHaveValue(0.5);
+    fireEvent.change(field, { target: { value: '0.3' } });
+    expect(onChange).toHaveBeenCalledWith({
+      steps: [{ tool: 'bxt', parameters: { ss: 0.3 } }],
+    } satisfies RcAstroProcessing);
+  });
+});


### PR DESCRIPTION
## What this adds

With RC-Astro's standalone `rc-astro` CLI installed and licensed on the server, **View processing** on a mono stack card offers **BlurXTerminator**, **NoiseXTerminator**, and **StarXTerminator** on the linear data — after deconvolution, before the stretch.

- **Schema-driven controls.** The UI renders its knobs from each tool's live `--json` contract (via `GET /api/tools/rc-astro`), because flag names change between CLI builds (`--stars` vs `--difference`, `--nsr` vs `--nsd`). Nothing renders when the CLI isn't installed; an unlicensed product shows as such and stays disabled.
- **Star removal as stacked outputs.** SXT keeps both halves: the starless image becomes the processed linear source and the stars image is stored beside it. Each gets its own stretch on its own normalization (the stars image is mostly empty sky with bright peaks — borrowing the starless normalization would crush it), a **Starless / Stars** switch on the card, and a stars FITS download — so the nebulosity can be stretched hard and the stars screened back later.
- **Deconvolution-style caching.** A new `stack-previews/rc-astro/<id>/` tier, content-addressed by the settings **plus each tool's CLI and neural-network model versions** — a tool upgrade rebuilds instead of serving stale output. The integration artifact is never modified; "Revert processing" restores the original. The stretch id folds the rc-astro id in, mirroring how deconvolution participates.
- Runs execute under the existing stack-preview permit + interactive-job guard, in `spawn_blocking`. `PSF_GUARD_RC_ASTRO` names the executable for service units with a minimal PATH.

Depends on `seiza_stacking::external` (theatrus/seiza#167): the schema/argv/event-stream driver lives there, including the unit-scale normalization the tools' [0,1] clamp requires (verified against rc-astro 2.6.6 on a real 6248×4176 frame — starless background 476–890 ADU, stars 95.6 % zero peaking near saturation).

## Status

**Draft: blocked on the seiza-stacking 0.11.5 release.** The pin is already 0.11.5; once published I'll refresh the lockfile and mark ready.

## Checks run locally (against a path-patched seiza)

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (744 passed; new: chain validation, order-independent cache identity, version tracking, and a fake-rc-astro end-to-end proving the second apply is a cache hit)
- `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (323 passed; 4 new component tests: schema-driven rendering, stars-kept default, GUI-only param exclusion, float edit threading), `npm run build`
- Docs: STACKING_PREVIEWS.md section + deliberate-limits update, release note.
- Not yet validated: a live server round trip (supergateway has no rc-astro install yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)