### PR TITLE
Fence calibration frames around an optical change

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -78,6 +78,24 @@ session (within a day of each other — dust moves between sessions). The
 nearest cluster with enough frames builds the master, so a stray single flat
 near the lights cannot orphan a complete session from a week earlier.
 
+### Validity boundaries
+
+Nearest-in-time is the right default, but it cannot know about a dust
+cleaning, a re-spaced imaging train, or any other change that makes older
+calibration wrong for newer lights. When nights lack their own frames, mark
+the boundary yourself: in the **Calibration library**, frames are grouped by
+imaging night — select a night (or several) and mark those frames usable
+**only for lights after them** (a set shot right after the change) or **only
+for lights before them** (the final set shot before it). Marked frames carry
+a badge, and matching never selects them across their boundary, in either
+direction, for any kind. Marking the same selection **in both directions
+again** clears the boundary. A light captured exactly at the boundary
+instant matches either way, and a frame with no recorded capture time
+cannot be judged and keeps matching — the same rule as any unrecorded
+setting. Marks survive folder re-scans, sync to other catalogs with the
+rest of the library, and immediately change which masters the next stack
+selects.
+
 A stack group whose lights need different master sets — a multi-night
 target with per-night flats, or a library large enough that the selection
 horizon moves — partitions into calibration sessions. Each light calibrates

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -141,6 +141,16 @@
   integration artifact is never modified. See [stack
   previews](https://github.com/theatrus/psf-guard/blob/main/docs/STACKING_PREVIEWS.md).
 
+- Calibration frames can now be fenced around an optical change. The
+  Calibration library groups frames by imaging night; select a night or a
+  range of nights and mark those frames usable only for lights captured
+  after them (a set shot right after a dust cleaning or train change) or
+  only before them (the final set shot before it). Matching never selects a
+  marked frame across its boundary for any kind, marked frames carry a
+  badge, marks survive folder re-scans and library sync, and marking the
+  selection "in both directions again" clears the fence. See [calibration
+  libraries](https://github.com/theatrus/psf-guard/blob/main/docs/CALIBRATION_LIBRARY.md).
+
 ## Changed
 
 - A dark now suits a light when their exposures agree to a tenth of a percent

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -4324,13 +4324,23 @@ mod tests {
         assert!(selects(&conn, &newer_light));
 
         assert_eq!(
-            set_frames_validity(&conn, std::slice::from_ref(&uuid), Some(ValidDirection::Forward)).unwrap(),
+            set_frames_validity(
+                &conn,
+                std::slice::from_ref(&uuid),
+                Some(ValidDirection::Forward)
+            )
+            .unwrap(),
             1
         );
         assert!(!selects(&conn, &older_light), "forward excludes the past");
         assert!(selects(&conn, &newer_light));
 
-        set_frames_validity(&conn, std::slice::from_ref(&uuid), Some(ValidDirection::Backward)).unwrap();
+        set_frames_validity(
+            &conn,
+            std::slice::from_ref(&uuid),
+            Some(ValidDirection::Backward),
+        )
+        .unwrap();
         assert!(selects(&conn, &older_light));
         assert!(
             !selects(&conn, &newer_light),

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -23,7 +23,11 @@ use std::time::UNIX_EPOCH;
 /// 1: the original calibration library.
 /// 2: `psf_guard_calibration_frame.rotation`, so a flat only matches a light
 ///    shot at the same rotator angle.
-pub const CALIBRATION_SCHEMA_VERSION: i64 = 3;
+/// 4: `psf_guard_calibration_frame.valid_direction`, so a frame can be
+///    marked usable only for lights captured after it (a set shot after an
+///    optics change or cleaning) or only before it. NULL keeps the old
+///    behavior: usable in both directions.
+pub const CALIBRATION_SCHEMA_VERSION: i64 = 4;
 // 2: flat masters suppress defective pixels spatially after integration.
 /// Version 3: masters preserve sensor, optics, exposure and capture-time
 /// metadata (seiza-stacking 0.11.1). Masters written before that carry no
@@ -63,6 +67,38 @@ impl CalibrationKind {
     }
 }
 
+/// Which lights a calibration frame may serve, relative to its own capture
+/// time. Marked by the user around an optical change — a dust cleaning, a
+/// re-spaced imaging train — so a frame is never matched to imaging done on
+/// the other side of that change when nights lack their own calibration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidDirection {
+    /// Only lights captured at or after this frame.
+    Forward,
+    /// Only lights captured at or before this frame.
+    Backward,
+}
+
+impl ValidDirection {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Forward => "forward",
+            Self::Backward => "backward",
+        }
+    }
+
+    fn from_db(value: Option<String>) -> Option<Self> {
+        match value.as_deref() {
+            Some("forward") => Some(Self::Forward),
+            Some("backward") => Some(Self::Backward),
+            // Unknown text from a newer build reads as unrestricted rather
+            // than failing the row: the old behavior, safely.
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CalibrationFrame {
     pub id: i64,
@@ -89,6 +125,8 @@ pub struct CalibrationFrame {
     pub focal_length_mm: Option<f64>,
     /// Rotator angle in degrees at capture, when the rig recorded one.
     pub rotation: Option<f64>,
+    /// User-set validity boundary; absent means both directions.
+    pub valid_direction: Option<ValidDirection>,
     /// Set after the current file (or a basename-remapped file) has been
     /// checked against this catalog row's hard settings.
     pub source_verified: bool,
@@ -167,6 +205,8 @@ pub struct CalibrationFrameSummary {
     pub camera_temp: Option<f64>,
     pub filter: Option<String>,
     pub focal_length_mm: Option<f64>,
+    /// User-set validity boundary; absent means both directions.
+    pub valid_direction: Option<ValidDirection>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -346,6 +386,10 @@ const MIGRATIONS: &[Migration] = &[
         to_version: 3,
         apply: backfill_flat_rotation,
     },
+    Migration {
+        to_version: 4,
+        apply: add_valid_direction_column,
+    },
 ];
 
 /// Columns selected by the calibration matching and master-building paths.
@@ -378,7 +422,19 @@ const READABLE_FRAME_COLUMNS: &[&str] = &[
     "filter_name",
     "focal_length_mm",
     "rotation",
+    "valid_direction",
 ];
+
+fn add_valid_direction_column(conn: &Connection) -> Result<bool> {
+    // NULL means "no boundary": the frame keeps matching in both time
+    // directions, exactly as every frame did before the column existed.
+    add_column_if_missing(
+        conn,
+        "psf_guard_calibration_frame",
+        "valid_direction",
+        "TEXT",
+    )
+}
 
 fn add_rotation_column(conn: &Connection) -> Result<bool> {
     // NULL means "not recorded", which the matcher treats as compatible, so
@@ -661,6 +717,7 @@ pub fn ensure_schema(conn: &Connection) -> Result<()> {
             filter_name        TEXT,
             focal_length_mm    REAL,
             rotation           REAL,
+            valid_direction    TEXT,
             file_size          INTEGER,
             file_mtime_ns      TEXT,
             added_at           INTEGER NOT NULL,
@@ -910,17 +967,27 @@ pub fn library_details(conn: &Connection) -> Result<CalibrationLibraryDetails> {
             frames: Vec::new(),
         });
     }
-    let mut statement = conn.prepare(
+    // The listing tolerates a catalog that could not be upgraded: an absent
+    // column reads as NULL rather than failing the whole dialog.
+    let has_validity = table_column_names(conn, "psf_guard_calibration_frame")?
+        .iter()
+        .any(|name| name.eq_ignore_ascii_case("valid_direction"));
+    let validity_column = if has_validity {
+        "valid_direction"
+    } else {
+        "NULL AS valid_direction"
+    };
+    let mut statement = conn.prepare(&format!(
         r#"
         SELECT id, frame_uuid, rig_uuid, kind, source_path, source_fingerprint,
                captured_at, telescope, camera, width, height, channels,
                binning_x, binning_y, gain, offset, readout_mode, bayer_pattern,
                exposure_s, camera_temp, filter_name, focal_length_mm,
-               NULL AS rotation
+               NULL AS rotation, {validity_column}
         FROM psf_guard_calibration_frame
         ORDER BY kind, captured_at DESC, source_path COLLATE NOCASE
-        "#,
-    )?;
+        "#
+    ))?;
     let frames = statement
         .query_map([], row_to_frame)?
         .map(|row| {
@@ -946,10 +1013,48 @@ pub fn library_details(conn: &Connection) -> Result<CalibrationLibraryDetails> {
                 camera_temp: frame.camera_temp,
                 filter: frame.filter,
                 focal_length_mm: frame.focal_length_mm,
+                valid_direction: frame.valid_direction,
             })
         })
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(CalibrationLibraryDetails { summary, frames })
+}
+
+/// Mark frames with a validity boundary (or clear one with `None`). Returns
+/// how many rows changed. A catalog that could not be upgraded to carry the
+/// column reports zero rather than failing.
+pub fn set_frames_validity(
+    conn: &Connection,
+    frame_uuids: &[String],
+    direction: Option<ValidDirection>,
+) -> Result<usize> {
+    if frame_uuids.is_empty() || !schema_exists(conn) {
+        return Ok(0);
+    }
+    let has_validity = table_column_names(conn, "psf_guard_calibration_frame")?
+        .iter()
+        .any(|name| name.eq_ignore_ascii_case("valid_direction"));
+    if !has_validity {
+        anyhow::bail!(
+            "this catalog has not been upgraded to record calibration validity; \
+             open it with write access once and retry"
+        );
+    }
+    let mut changed = 0usize;
+    let mut statement = conn.prepare(
+        "UPDATE psf_guard_calibration_frame
+         SET valid_direction = ?1, updated_at = ?2
+         WHERE frame_uuid = ?3",
+    )?;
+    let now = chrono::Utc::now().timestamp();
+    for frame_uuid in frame_uuids {
+        changed += statement.execute(rusqlite::params![
+            direction.map(ValidDirection::as_str),
+            now,
+            frame_uuid
+        ])?;
+    }
+    Ok(changed)
 }
 
 pub fn forget_frame(conn: &mut Connection, frame_uuid: &str) -> Result<CalibrationMutationOutcome> {
@@ -1208,7 +1313,8 @@ pub fn select_for_light(conn: &Connection, light: &FrameMeta) -> Result<Calibrat
         SELECT id, frame_uuid, rig_uuid, kind, source_path, source_fingerprint,
                captured_at, telescope, camera, width, height, channels,
                binning_x, binning_y, gain, offset, readout_mode, bayer_pattern,
-               exposure_s, camera_temp, filter_name, focal_length_mm, rotation
+               exposure_s, camera_temp, filter_name, focal_length_mm, rotation,
+               valid_direction
         FROM psf_guard_calibration_frame
         ORDER BY captured_at DESC, id DESC
         "#,
@@ -1218,6 +1324,12 @@ pub fn select_for_light(conn: &Connection, light: &FrameMeta) -> Result<Calibrat
         .collect::<rusqlite::Result<Vec<_>>>()?;
     let mut selected = CalibrationSelection::default();
     for candidate in frames {
+        // A frame marked usable only forward or backward of its capture —
+        // shot around an optics change or cleaning — never serves a light
+        // on the other side of that boundary.
+        if !validity_admits(&candidate, light.timestamp) {
+            continue;
+        }
         if !sensor_matches(light, &candidate) {
             continue;
         }
@@ -1245,7 +1357,11 @@ pub fn select_for_light(conn: &Connection, light: &FrameMeta) -> Result<Calibrat
     sort_candidates(&mut selected.flat, light.timestamp);
     if let Some(flat) = selected.flat.first() {
         for candidate in query_kind(conn, CalibrationKind::DarkFlat)? {
-            if frame_pair_matches(flat, &candidate)
+            // Dark-flats pair with the flat, but the boundary is judged
+            // against the light: the mark protects the imaging on the
+            // other side of the change.
+            if validity_admits(&candidate, light.timestamp)
+                && frame_pair_matches(flat, &candidate)
                 && exposure_matches(flat.exposure_s, candidate.exposure_s)
                 && temperature_matches(flat.camera_temp, candidate.camera_temp)
             {
@@ -3098,7 +3214,8 @@ fn query_kind(conn: &Connection, kind: CalibrationKind) -> Result<Vec<Calibratio
         SELECT id, frame_uuid, rig_uuid, kind, source_path, source_fingerprint,
                captured_at, telescope, camera, width, height, channels,
                binning_x, binning_y, gain, offset, readout_mode, bayer_pattern,
-               exposure_s, camera_temp, filter_name, focal_length_mm, rotation
+               exposure_s, camera_temp, filter_name, focal_length_mm, rotation,
+               valid_direction
         FROM psf_guard_calibration_frame WHERE kind = ?1
         ORDER BY captured_at DESC, id DESC
         "#,
@@ -3141,8 +3258,26 @@ fn row_to_frame(row: &rusqlite::Row<'_>) -> rusqlite::Result<CalibrationFrame> {
         filter: row.get(20)?,
         focal_length_mm: row.get(21)?,
         rotation: row.get(22)?,
+        valid_direction: ValidDirection::from_db(row.get(23)?),
         source_verified: false,
     })
+}
+
+/// Whether a candidate's validity boundary admits this light. A frame or
+/// light with no recorded time cannot be judged and matches, the same way
+/// an unrecorded angle matches any angle.
+fn validity_admits(candidate: &CalibrationFrame, light_timestamp: Option<i64>) -> bool {
+    let (Some(direction), Some(light), Some(frame)) = (
+        candidate.valid_direction,
+        light_timestamp,
+        candidate.captured_at,
+    ) else {
+        return true;
+    };
+    match direction {
+        ValidDirection::Forward => light >= frame,
+        ValidDirection::Backward => light <= frame,
+    }
 }
 
 pub fn export_destinations(
@@ -3489,8 +3624,11 @@ mod tests {
         // An older build added the column from its own write path without
         // recording a version, so the step must survive being run over it.
         let conn = version_one_catalog();
-        conn.execute_batch("ALTER TABLE psf_guard_calibration_frame ADD COLUMN rotation REAL;")
-            .unwrap();
+        conn.execute_batch(
+            "ALTER TABLE psf_guard_calibration_frame ADD COLUMN rotation REAL;
+             ALTER TABLE psf_guard_calibration_frame ADD COLUMN valid_direction TEXT;",
+        )
+        .unwrap();
         assert!(
             schema_supports_current_reads(&conn),
             "the physical shape is readable even while its version lags"
@@ -3581,8 +3719,11 @@ mod tests {
         // the version row would report no calibration for a catalog that is
         // perfectly readable, including where it cannot be upgraded at all.
         let conn = version_one_catalog();
-        conn.execute_batch("ALTER TABLE psf_guard_calibration_frame ADD COLUMN rotation REAL;")
-            .unwrap();
+        conn.execute_batch(
+            "ALTER TABLE psf_guard_calibration_frame ADD COLUMN rotation REAL;
+             ALTER TABLE psf_guard_calibration_frame ADD COLUMN valid_direction TEXT;",
+        )
+        .unwrap();
         assert!(
             schema_supports_current_reads(&conn),
             "the columns are all there"
@@ -3618,8 +3759,11 @@ mod tests {
         let conn = version_one_catalog();
         // A newer build would have run every step this one knows about, so the
         // columns are there; it simply also knows steps this build does not.
-        conn.execute_batch("ALTER TABLE psf_guard_calibration_frame ADD COLUMN rotation REAL;")
-            .unwrap();
+        conn.execute_batch(
+            "ALTER TABLE psf_guard_calibration_frame ADD COLUMN rotation REAL;
+             ALTER TABLE psf_guard_calibration_frame ADD COLUMN valid_direction TEXT;",
+        )
+        .unwrap();
         conn.execute(
             "UPDATE psf_guard_calibration_schema SET version = ?1 WHERE singleton = 1",
             [CALIBRATION_SCHEMA_VERSION + 1],
@@ -3922,6 +4066,7 @@ mod tests {
             filter: Some(filter.into()),
             focal_length_mm: Some(2350.0),
             rotation: Some(101.99),
+            valid_direction: None,
             source_verified: false,
         };
         // Nearest-first, as selection delivers them: the R set, with the one
@@ -3977,6 +4122,7 @@ mod tests {
             filter: Some(filter.into()),
             focal_length_mm: Some(2350.0),
             rotation: Some(101.99),
+            valid_direction: None,
             source_verified: false,
         };
         let frames = vec![bias(0, "R"), bias(1, "OIII"), bias(2, "L")];
@@ -4013,6 +4159,7 @@ mod tests {
             filter: None,
             focal_length_mm: Some(2350.0),
             rotation: None,
+            valid_direction: None,
             source_verified: false,
         };
         let frames = vec![
@@ -4056,6 +4203,7 @@ mod tests {
             filter: Some("Ha".into()),
             focal_length_mm: None,
             rotation,
+            valid_direction: None,
             source_verified: false,
         };
         // Five flats at 30° and two strays at 120°: the master takes only
@@ -4097,6 +4245,7 @@ mod tests {
             filter: None,
             focal_length_mm: None,
             rotation: None,
+            valid_direction: None,
             source_verified: false,
         };
         assert!(!sensor_matches(&light, &candidate));
@@ -4137,6 +4286,130 @@ mod tests {
         let details = library_details(&conn).unwrap();
         assert_eq!(details.frames.len(), 1);
         assert_eq!(details.frames[0].kind, CalibrationKind::Dark);
+    }
+
+    #[test]
+    fn a_validity_boundary_is_never_crossed() {
+        // A dark shot after a sensor cleaning must never serve a light from
+        // before it once marked forward, and the reverse for backward. Both
+        // directions return when the mark is cleared.
+        let temp = tempfile::tempdir().unwrap();
+        let dark_path = temp.path().join("dark.fits");
+        std::fs::write(&dark_path, b"dark").unwrap();
+        let mut dark = frame(dark_path.to_str().unwrap(), "DARK");
+        dark.timestamp = Some(1_000);
+
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            import_calibration_frames(&tx, &[dark], Some("profile")).unwrap();
+            tx.commit().unwrap();
+        }
+        let uuid: String = conn
+            .query_row(
+                "SELECT frame_uuid FROM psf_guard_calibration_frame",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let mut older_light = frame("/light.fits", "LIGHT");
+        older_light.timestamp = Some(900);
+        let mut newer_light = frame("/light.fits", "LIGHT");
+        newer_light.timestamp = Some(1_100);
+
+        let selects = |conn: &Connection, light: &FrameMeta| {
+            select_for_light(conn, light).unwrap().dark.len() == 1
+        };
+        assert!(selects(&conn, &older_light));
+        assert!(selects(&conn, &newer_light));
+
+        assert_eq!(
+            set_frames_validity(&conn, std::slice::from_ref(&uuid), Some(ValidDirection::Forward)).unwrap(),
+            1
+        );
+        assert!(!selects(&conn, &older_light), "forward excludes the past");
+        assert!(selects(&conn, &newer_light));
+
+        set_frames_validity(&conn, std::slice::from_ref(&uuid), Some(ValidDirection::Backward)).unwrap();
+        assert!(selects(&conn, &older_light));
+        assert!(
+            !selects(&conn, &newer_light),
+            "backward excludes the future"
+        );
+
+        // A light captured exactly at the boundary is admitted either way.
+        let mut boundary_light = frame("/light.fits", "LIGHT");
+        boundary_light.timestamp = Some(1_000);
+        assert!(selects(&conn, &boundary_light));
+
+        set_frames_validity(&conn, std::slice::from_ref(&uuid), None).unwrap();
+        assert!(selects(&conn, &older_light));
+        assert!(selects(&conn, &newer_light));
+
+        // The listing carries the mark for the UI.
+        set_frames_validity(&conn, &[uuid], Some(ValidDirection::Forward)).unwrap();
+        let details = library_details(&conn).unwrap();
+        assert_eq!(
+            details.frames[0].valid_direction,
+            Some(ValidDirection::Forward)
+        );
+    }
+
+    #[test]
+    fn a_reimport_does_not_clear_a_validity_mark() {
+        // Re-scanning a folder updates a row's header-derived columns; the
+        // user's mark is not header-derived and must survive.
+        let temp = tempfile::tempdir().unwrap();
+        let dark_path = temp.path().join("dark.fits");
+        std::fs::write(&dark_path, b"dark").unwrap();
+        let mut dark = frame(dark_path.to_str().unwrap(), "DARK");
+        dark.timestamp = Some(1_000);
+
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            import_calibration_frames(&tx, &[dark.clone()], Some("profile")).unwrap();
+            tx.commit().unwrap();
+        }
+        let uuid: String = conn
+            .query_row(
+                "SELECT frame_uuid FROM psf_guard_calibration_frame",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        set_frames_validity(&conn, &[uuid], Some(ValidDirection::Backward)).unwrap();
+
+        // A changed file takes the upsert's update path.
+        std::fs::write(&dark_path, b"dark v2 with more bytes").unwrap();
+        dark.timestamp = Some(1_001);
+        {
+            let tx = conn.transaction().unwrap();
+            let outcome = import_calibration_frames(&tx, &[dark], Some("profile")).unwrap();
+            assert_eq!(outcome.updated, 1);
+            tx.commit().unwrap();
+        }
+        let details = library_details(&conn).unwrap();
+        assert_eq!(
+            details.frames[0].valid_direction,
+            Some(ValidDirection::Backward)
+        );
+    }
+
+    #[test]
+    fn marking_validity_needs_an_upgraded_catalog() {
+        let conn = version_one_catalog();
+        let error = set_frames_validity(&conn, &["x".to_string()], None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("has not been upgraded"), "{error}");
+
+        migrate_existing(&conn).unwrap();
+        // Upgraded, an unknown frame is simply zero rows changed.
+        assert_eq!(
+            set_frames_validity(&conn, &["x".to_string()], None).unwrap(),
+            0
+        );
     }
 
     #[test]
@@ -4219,6 +4492,7 @@ mod tests {
             filter: Some("Ha".into()),
             focal_length_mm: None,
             rotation: None,
+            valid_direction: None,
             source_verified: false,
         };
         let day = 24 * 60 * 60;

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -136,6 +136,50 @@ pub async fn forget_calibration_frame(
     Ok(Json(ApiResponse::success(outcome)))
 }
 
+#[derive(Debug, serde::Deserialize)]
+pub struct SetCalibrationValidityRequest {
+    pub frame_uuids: Vec<String>,
+    /// "forward", "backward", or "both" (which clears the mark).
+    pub direction: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct SetCalibrationValidityResponse {
+    pub updated: usize,
+}
+
+/// PUT /api/db/{db}/calibrations/frames/validity — mark frames as usable
+/// only for lights after them, only before them, or both again.
+pub async fn set_calibration_validity(
+    State(_state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Json(request): Json<SetCalibrationValidityRequest>,
+) -> Result<Json<ApiResponse<SetCalibrationValidityResponse>>, AppError> {
+    let direction = match request.direction.as_str() {
+        "both" => None,
+        "forward" => Some(crate::calibration::ValidDirection::Forward),
+        "backward" => Some(crate::calibration::ValidDirection::Backward),
+        other => {
+            return Err(AppError::BadRequest(format!(
+                "direction must be both, forward, or backward, not {other:?}"
+            )));
+        }
+    };
+    if request.frame_uuids.is_empty() {
+        return Err(AppError::BadRequest("no frames named".into()));
+    }
+    let conn = ctx.db();
+    let conn = conn.lock().map_err(AppError::db)?;
+    let updated = crate::calibration::set_frames_validity(&conn, &request.frame_uuids, direction)
+        .map_err(|error| AppError::BadRequest(error.to_string()))?;
+    if updated == 0 {
+        return Err(AppError::NotFound);
+    }
+    Ok(Json(ApiResponse::success(SetCalibrationValidityResponse {
+        updated,
+    })))
+}
+
 pub async fn clear_calibration_masters(
     State(state): State<Arc<AppState>>,
     ctx: DbContext,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -367,6 +367,10 @@ async fn run_server_internal(
             delete(handlers::forget_calibration_frame),
         )
         .route(
+            "/calibrations/frames/validity",
+            put(handlers::set_calibration_validity),
+        )
+        .route(
             "/calibrations/masters",
             delete(handlers::clear_calibration_masters),
         )

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -630,6 +630,20 @@ export const apiClient = {
     return data.data;
   },
 
+  setCalibrationValidity: async (
+    dbId: string,
+    frameUuids: string[],
+    direction: 'both' | 'forward' | 'backward'
+  ): Promise<{ updated: number }> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.put<ApiResponse<{ updated: number }>>(
+      dbPath(dbId, '/calibrations/frames/validity'),
+      { frame_uuids: frameUuids, direction }
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to mark calibration validity');
+    return data.data;
+  },
+
   forgetCalibrationFrame: async (
     dbId: string,
     frameUuid: string

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1464,7 +1464,14 @@ export interface CalibrationFrameSummary {
   camera_temp?: number | null;
   filter?: string | null;
   focal_length_mm?: number | null;
+  /**
+   * User-set validity boundary: `forward` serves only lights captured at or
+   * after this frame, `backward` only at or before. Absent means both.
+   */
+  valid_direction?: CalibrationValidDirection | null;
 }
+
+export type CalibrationValidDirection = 'forward' | 'backward';
 
 export interface CalibrationLibraryDetails {
   summary: CalibrationLibrarySummary;

--- a/static/src/components/CalibrationLibraryDialog.tsx
+++ b/static/src/components/CalibrationLibraryDialog.tsx
@@ -27,6 +27,32 @@ function formatDate(timestamp?: number | null): string {
   return new Date(timestamp * 1000).toLocaleString();
 }
 
+/**
+ * The imaging night a capture belongs to: twelve hours back, then the date,
+ * so frames from one session share a group across local midnight — the same
+ * rule the server's calibration report uses.
+ */
+function nightKey(timestamp?: number | null): string {
+  if (timestamp === undefined || timestamp === null) return 'unknown';
+  return new Date((timestamp - 12 * 3600) * 1000).toISOString().slice(0, 10);
+}
+
+function nightLabel(key: string): string {
+  return key === 'unknown' ? 'Date unknown' : `Night of ${key}`;
+}
+
+const VALIDITY_LABELS: Record<'forward' | 'backward', string> = {
+  forward: '▸ after only',
+  backward: '◂ before only',
+};
+
+const VALIDITY_TITLES: Record<'forward' | 'backward', string> = {
+  forward:
+    'Marked usable only for lights captured after this frame — shot after an optics change or cleaning.',
+  backward:
+    'Marked usable only for lights captured before this frame — shot before an optics change or cleaning.',
+};
+
 function formatSettings(frame: CalibrationFrameSummary): string {
   const values = [
     frame.width && frame.height ? `${frame.width}×${frame.height}` : null,
@@ -80,6 +106,16 @@ export default function CalibrationLibraryDialog({
     mutationFn: () => apiClient.clearCalibrationMasters(dbId),
     onSuccess: refresh,
   });
+  const [selectedNights, setSelectedNights] = useState<Set<string>>(new Set());
+  const [markDirection, setMarkDirection] = useState<'both' | 'forward' | 'backward'>('forward');
+  const markValidity = useMutation({
+    mutationFn: (input: { frameUuids: string[]; direction: 'both' | 'forward' | 'backward' }) =>
+      apiClient.setCalibrationValidity(dbId, input.frameUuids, input.direction),
+    onSuccess: () => {
+      setSelectedNights(new Set());
+      refresh();
+    },
+  });
 
   const frames = useMemo(
     () =>
@@ -91,8 +127,42 @@ export default function CalibrationLibraryDialog({
       ),
     [details.data?.frames, kind, missingOnly, rig]
   );
-  useEffect(() => setVisibleCount(100), [kind, missingOnly, rig]);
+  useEffect(() => {
+    setVisibleCount(100);
+    setSelectedNights(new Set());
+  }, [kind, missingOnly, rig]);
   const visibleFrames = frames.slice(0, visibleCount);
+
+  // Grouped display: one section per imaging night, newest first, so a
+  // day's frames — or a range of days — can be selected together and
+  // marked around an optics change or cleaning.
+  const nightGroups = useMemo(() => {
+    const groups = new Map<string, CalibrationFrameSummary[]>();
+    for (const frame of visibleFrames) {
+      const key = nightKey(frame.captured_at);
+      const bucket = groups.get(key);
+      if (bucket) bucket.push(frame);
+      else groups.set(key, [frame]);
+    }
+    return [...groups.entries()].sort(([left], [right]) => {
+      if (left === 'unknown') return 1;
+      if (right === 'unknown') return -1;
+      return right.localeCompare(left);
+    });
+  }, [visibleFrames]);
+
+  const toggleNight = (night: string) => {
+    setSelectedNights((current) => {
+      const next = new Set(current);
+      if (next.has(night)) next.delete(night);
+      else next.add(night);
+      return next;
+    });
+  };
+  const selectedFrames = useMemo(
+    () => visibleFrames.filter((frame) => selectedNights.has(nightKey(frame.captured_at))),
+    [visibleFrames, selectedNights]
+  );
 
   const handleForget = (frame: CalibrationFrameSummary) => {
     if (
@@ -209,9 +279,47 @@ export default function CalibrationLibraryDialog({
             entries, or clear generated masters.
           </div>
         )}
-        {(forget.error || clearMasters.error) && (
+        {canManage && selectedNights.size > 0 && (
+          <div className="calibration-validity-bar">
+            <span>
+              {selectedFrames.length} frame{selectedFrames.length === 1 ? '' : 's'} across{' '}
+              {selectedNights.size} night{selectedNights.size === 1 ? '' : 's'} — usable
+            </span>
+            <select
+              value={markDirection}
+              aria-label="Validity direction"
+              onChange={(event) =>
+                setMarkDirection(event.target.value as 'both' | 'forward' | 'backward')
+              }
+            >
+              <option value="forward">only for lights after them (after a change)</option>
+              <option value="backward">only for lights before them (before a change)</option>
+              <option value="both">in both directions again</option>
+            </select>
+            <button
+              className="save-button"
+              disabled={markValidity.isPending || selectedFrames.length === 0}
+              onClick={() =>
+                markValidity.mutate({
+                  frameUuids: selectedFrames.map((frame) => frame.frame_uuid),
+                  direction: markDirection,
+                })
+              }
+            >
+              {markValidity.isPending ? 'Marking…' : 'Mark'}
+            </button>
+            <button
+              className="browse-button"
+              onClick={() => setSelectedNights(new Set())}
+              disabled={markValidity.isPending}
+            >
+              Clear selection
+            </button>
+          </div>
+        )}
+        {(forget.error || clearMasters.error || markValidity.error) && (
           <div className="calibration-library-error">
-            {forget.error?.message || clearMasters.error?.message}
+            {forget.error?.message || clearMasters.error?.message || markValidity.error?.message}
           </div>
         )}
 
@@ -240,50 +348,78 @@ export default function CalibrationLibraryDialog({
                   {canManage && <th aria-label="Actions" />}
                 </tr>
               </thead>
-              <tbody>
-                {visibleFrames.map((frame) => (
-                  <tr key={frame.frame_uuid} className={frame.source_exists ? '' : 'missing'}>
-                    <td>
-                      <span className={`calibration-kind calibration-kind-${frame.kind}`}>
-                        {KIND_LABELS[frame.kind]}
-                      </span>
+              {nightGroups.map(([night, nightFrames]) => (
+                <tbody key={night} className="calibration-night-group">
+                  <tr className="calibration-night-row">
+                    <td colSpan={canManage ? 5 : 4}>
+                      <label>
+                        {canManage && (
+                          <input
+                            type="checkbox"
+                            checked={selectedNights.has(night)}
+                            onChange={() => toggleNight(night)}
+                            aria-label={`Select ${nightLabel(night)}`}
+                          />
+                        )}
+                        <strong>{nightLabel(night)}</strong>
+                        <span>
+                          {nightFrames.length} frame{nightFrames.length === 1 ? '' : 's'}
+                        </span>
+                      </label>
                     </td>
-                    <td>
-                      <strong>{fileName(frame.source_path)}</strong>
-                      <small className="calibration-frame-path" title={frame.source_path}>
-                        {frame.source_path}
-                      </small>
-                      <small>{formatDate(frame.captured_at)}</small>
-                    </td>
-                    <td>
-                      <span>{formatSettings(frame)}</span>
-                      {frame.camera && <small>{frame.camera}</small>}
-                    </td>
-                    <td>
-                      <span
-                        className={
-                          frame.source_exists
-                            ? 'calibration-source-ready'
-                            : 'calibration-source-missing'
-                        }
-                      >
-                        {frame.source_exists ? '✓ Available' : '⚠ Missing'}
-                      </span>
-                    </td>
-                    {canManage && (
-                      <td>
-                        <button
-                          className="remove-button"
-                          onClick={() => handleForget(frame)}
-                          disabled={forget.isPending}
-                        >
-                          Forget
-                        </button>
-                      </td>
-                    )}
                   </tr>
-                ))}
-              </tbody>
+                  {nightFrames.map((frame) => (
+                    <tr key={frame.frame_uuid} className={frame.source_exists ? '' : 'missing'}>
+                      <td>
+                        <span className={`calibration-kind calibration-kind-${frame.kind}`}>
+                          {KIND_LABELS[frame.kind]}
+                        </span>
+                      </td>
+                      <td>
+                        <strong>{fileName(frame.source_path)}</strong>
+                        <small className="calibration-frame-path" title={frame.source_path}>
+                          {frame.source_path}
+                        </small>
+                        <small>{formatDate(frame.captured_at)}</small>
+                      </td>
+                      <td>
+                        <span>{formatSettings(frame)}</span>
+                        {frame.camera && <small>{frame.camera}</small>}
+                      </td>
+                      <td>
+                        <span
+                          className={
+                            frame.source_exists
+                              ? 'calibration-source-ready'
+                              : 'calibration-source-missing'
+                          }
+                        >
+                          {frame.source_exists ? '✓ Available' : '⚠ Missing'}
+                        </span>
+                        {frame.valid_direction && (
+                          <span
+                            className={`calibration-validity calibration-validity-${frame.valid_direction}`}
+                            title={VALIDITY_TITLES[frame.valid_direction]}
+                          >
+                            {VALIDITY_LABELS[frame.valid_direction]}
+                          </span>
+                        )}
+                      </td>
+                      {canManage && (
+                        <td>
+                          <button
+                            className="remove-button"
+                            onClick={() => handleForget(frame)}
+                            disabled={forget.isPending}
+                          >
+                            Forget
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              ))}
             </table>
           )}
           {frames.length > 0 && (

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -1221,6 +1221,66 @@
   background: color-mix(in srgb, var(--color-error) 6%, transparent);
 }
 
+/* One section per imaging night; the header row selects the whole night. */
+.tauri-settings .calibration-night-row td {
+  padding: 7px 10px;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border-secondary);
+}
+
+.tauri-settings .calibration-night-row label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.tauri-settings .calibration-night-row strong {
+  display: inline;
+  font-size: 12px;
+}
+
+.tauri-settings .calibration-night-row span {
+  display: inline;
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
+/* The marking bar shown while nights are selected. */
+.tauri-settings .calibration-validity-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 10px;
+  padding: 8px 12px;
+  border: 1px solid var(--color-primary-alpha-30);
+  border-radius: 6px;
+  background: var(--color-primary-alpha-10);
+  font-size: 12px;
+}
+
+.tauri-settings .calibration-validity-bar select {
+  padding: 4px 8px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: 5px;
+  background: var(--color-bg-input);
+  color: var(--color-text-primary);
+  font-size: 12px;
+}
+
+/* Validity badge on a marked frame. */
+.tauri-settings .calibration-validity {
+  display: inline-block;
+  margin-top: 3px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--color-warning-alpha-20, rgb(234 179 8 / 18%));
+  color: var(--color-warning, #eab308);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
 .tauri-settings .calibration-frame-table td strong,
 .tauri-settings .calibration-frame-table td span,
 .tauri-settings .calibration-frame-table td small {

--- a/static/src/components/__tests__/CalibrationLibraryDialog.validity.test.tsx
+++ b/static/src/components/__tests__/CalibrationLibraryDialog.validity.test.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server } from '../../test/msw-server';
+import CalibrationLibraryDialog from '../CalibrationLibraryDialog';
+
+function wrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+// Two flats one night, one flat two nights later — around a dust cleaning.
+// 2026-06-01 20:00 UTC and 2026-06-03 20:00 UTC.
+const earlyNight = Math.floor(Date.UTC(2026, 5, 1, 20) / 1000);
+const lateNight = Math.floor(Date.UTC(2026, 5, 3, 20) / 1000);
+
+function flat(uuid: string, capturedAt: number, validDirection: string | null = null) {
+  return {
+    frame_uuid: uuid,
+    rig_uuid: 'rig-1',
+    kind: 'flat',
+    source_path: `/calibration/${uuid}.fits`,
+    source_exists: true,
+    captured_at: capturedAt,
+    camera: 'Camera',
+    exposure_s: 3,
+    valid_direction: validDirection,
+  };
+}
+
+const summary = {
+  schema_version: 4,
+  frame_count: 3,
+  master_count: 0,
+  rigs: [
+    { rig_uuid: 'rig-1', name: 'Rig', frame_count: 3, bias: 0, dark: 0, dark_flat: 0, flat: 3 },
+  ],
+};
+
+function serveLibrary(frames: unknown[]) {
+  server.use(
+    http.get('/api/db/demo/calibrations/details', () =>
+      HttpResponse.json({ success: true, data: { summary, frames }, error: null })
+    ),
+    http.get('/api/db/demo/calibrations', () =>
+      HttpResponse.json({ success: true, data: summary, error: null })
+    )
+  );
+}
+
+describe('calibration validity marking', () => {
+  it('groups frames by imaging night and marks a selected night forward', async () => {
+    serveLibrary([
+      flat('old-a', earlyNight),
+      flat('old-b', earlyNight + 600),
+      flat('new-a', lateNight),
+    ]);
+    let received: unknown = null;
+    server.use(
+      http.put('/api/db/demo/calibrations/frames/validity', async ({ request }) => {
+        received = await request.json();
+        return HttpResponse.json({ success: true, data: { updated: 2 }, error: null });
+      })
+    );
+
+    render(
+      <CalibrationLibraryDialog dbId="demo" dbName="Demo" canManage onClose={() => {}} />,
+      { wrapper: wrapper() }
+    );
+
+    // One group per night, newest first.
+    expect(await screen.findByText('Night of 2026-06-03')).toBeInTheDocument();
+    expect(screen.getByText('Night of 2026-06-01')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Night of 2026-06-01' }));
+    expect(screen.getByText(/2 frames across 1 night/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Validity direction'), {
+      target: { value: 'backward' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Mark' }));
+
+    await waitFor(() =>
+      expect(received).toEqual({
+        frame_uuids: ['old-a', 'old-b'],
+        direction: 'backward',
+      })
+    );
+  });
+
+  it('shows the validity badge on marked frames', async () => {
+    serveLibrary([
+      flat('old-a', earlyNight, 'backward'),
+      flat('new-a', lateNight, 'forward'),
+    ]);
+    render(
+      <CalibrationLibraryDialog dbId="demo" dbName="Demo" canManage onClose={() => {}} />,
+      { wrapper: wrapper() }
+    );
+    expect(await screen.findByText('◂ before only')).toBeInTheDocument();
+    expect(screen.getByText('▸ after only')).toBeInTheDocument();
+  });
+
+  it('offers no selection to a read-only viewer', async () => {
+    serveLibrary([flat('old-a', earlyNight)]);
+    render(
+      <CalibrationLibraryDialog dbId="demo" dbName="Demo" canManage={false} onClose={() => {}} />,
+      { wrapper: wrapper() }
+    );
+    expect(await screen.findByText('Night of 2026-06-01')).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: /Select Night/ })).toBeNull();
+  });
+});


### PR DESCRIPTION
## What this adds

Nearest-in-time calibration matching cannot know about a dust cleaning or an imaging-train change. When nights lack their own calibration frames, this lets the user mark the boundary:

- **Grouped display**: the Calibration library now groups frames by imaging night (the server's night rule — twelve hours back, then the date), newest first. Night header rows carry a checkbox, so a day's frames — or a range of nights — select together.
- **Directional marks**: with nights selected, a marking bar offers **only for lights after them** (a set shot right after the change), **only for lights before them** (the final set shot before it), or **both directions again** (clears the mark). Marked frames show a badge with a tooltip explaining the direction.
- **Enforcement**: `select_for_light` gates every candidate — dark-flats judged against the light, like the rest — so a marked frame is never selected across its boundary for any kind, in matching, masters, exports, the project calibration report, and the stack pipeline alike. A light exactly at the boundary matches either way; a frame or light with no recorded time keeps matching, the same rule as any unrecorded setting.

## Mechanics

- Calibration schema **v4**: nullable `valid_direction` column, added by the upgrade-on-open ladder (idempotent, add-only). Un-upgraded catalogs read marks as absent and refuse marking with a clear message; the ladder's existing drift/race/newer-build tests all still pass with the new rung.
- Marks **survive folder re-scans** (the import upsert never touches the column) and **sync** with the rest of the library (column-intersection sync carries it once both sides upgrade).
- **Caches invalidate for free**: selection fingerprints hash the selected frame set, so a mark that changes selection shifts every dependent stack/plan/master identity.
- `PUT /api/db/{db}/calibrations/frames/validity` (write-gated like every non-GET) marks or clears by frame uuid.

Also in this branch: docs — a **Validity boundaries** section in CALIBRATION_LIBRARY.md and the release note.

## Checks run locally

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (824 passed; new: boundary-never-crossed in both directions with the exact-boundary case, re-scan survival, un-upgraded-catalog refusal, plus the three hand-crafted-shape migration tests updated for v4)
- `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (331 passed; new: night grouping + marking PUT payload, badge rendering, read-only viewers get no selection), `npm run build`
- Playwright not run locally; relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)