### PR TITLE
Collapse the calibration library by night and split the long-lived kinds

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -84,7 +84,13 @@ Nearest-in-time is the right default, but it cannot know about a dust
 cleaning, a re-spaced imaging train, or any other change that makes older
 calibration wrong for newer lights. When nights lack their own frames, mark
 the boundary yourself: in the **Calibration library**, frames are grouped by
-imaging night — select a night (or several) and mark those frames usable
+imaging night, collapsed to one row per night until expanded, with flats
+(and their dark-flats) in one section and darks and bias in their own —
+those batches stay valid far longer than flats and should not interleave
+with per-night flat groups. Each night row can also **Forget night**,
+removing that section's records for the night (and dependent masters) in
+one step without touching the FITS files. Select a night (or several) and
+mark those frames usable
 **only for lights after them** (a set shot right after the change) or **only
 for lights before them** (the final set shot before it). Marked frames carry
 a badge, and matching never selects them across their boundary, in either

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -142,7 +142,11 @@
   previews](https://github.com/theatrus/psf-guard/blob/main/docs/STACKING_PREVIEWS.md).
 
 - Calibration frames can now be fenced around an optical change. The
-  Calibration library groups frames by imaging night; select a night or a
+  Calibration library groups frames by imaging night — collapsed to one
+  row per night until expanded, with flats (and their dark-flats) in one
+  section and the longer-lived darks and bias in their own, and a **Forget
+  night** action that removes a night's records for one section in a
+  single step; select a night or a
   range of nights and mark those frames usable only for lights captured
   after them (a set shot right after a dust cleaning or train change) or
   only before them (the final set shot before it). Matching never selects a

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -1058,19 +1058,32 @@ pub fn set_frames_validity(
 }
 
 pub fn forget_frame(conn: &mut Connection, frame_uuid: &str) -> Result<CalibrationMutationOutcome> {
-    if !schema_exists(conn) {
+    forget_frames(conn, std::slice::from_ref(&frame_uuid.to_string()))
+}
+
+/// Remove several catalog records in one transaction — a whole night of a
+/// kind at once — with the same transitive master invalidation a single
+/// forget performs. The FITS files are never touched.
+pub fn forget_frames(
+    conn: &mut Connection,
+    frame_uuids: &[String],
+) -> Result<CalibrationMutationOutcome> {
+    if frame_uuids.is_empty() || !schema_exists(conn) {
         return Ok(CalibrationMutationOutcome::default());
     }
     let transaction = conn.transaction()?;
-    let frame_exists = transaction
-        .query_row(
-            "SELECT 1 FROM psf_guard_calibration_frame WHERE frame_uuid = ?1",
-            [frame_uuid],
-            |_| Ok(()),
-        )
-        .optional()?
-        .is_some();
-    if !frame_exists {
+    let uuid_set = frame_uuids
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::HashSet<_>>();
+    let any_exists = {
+        let mut statement = transaction
+            .prepare("SELECT 1 FROM psf_guard_calibration_frame WHERE frame_uuid = ?1")?;
+        frame_uuids
+            .iter()
+            .any(|uuid| statement.exists([uuid]).unwrap_or(false))
+    };
+    if !any_exists {
         return Ok(CalibrationMutationOutcome::default());
     }
 
@@ -1111,7 +1124,12 @@ pub fn forget_frame(conn: &mut Connection, frame_uuid: &str) -> Result<Calibrati
         .collect::<Result<Vec<_>>>()?;
     let mut invalid = links
         .iter()
-        .filter(|master| master.sources.iter().any(|source| source == frame_uuid))
+        .filter(|master| {
+            master
+                .sources
+                .iter()
+                .any(|source| uuid_set.contains(source.as_str()))
+        })
         .map(|master| master.uuid.clone())
         .collect::<std::collections::HashSet<_>>();
     loop {
@@ -1136,10 +1154,14 @@ pub fn forget_frame(conn: &mut Connection, frame_uuid: &str) -> Result<Calibrati
             [master_uuid],
         )?;
     }
-    let frames_removed = transaction.execute(
-        "DELETE FROM psf_guard_calibration_frame WHERE frame_uuid = ?1",
-        [frame_uuid],
-    )?;
+    let mut frames_removed = 0usize;
+    {
+        let mut statement =
+            transaction.prepare("DELETE FROM psf_guard_calibration_frame WHERE frame_uuid = ?1")?;
+        for frame_uuid in frame_uuids {
+            frames_removed += statement.execute([frame_uuid])?;
+        }
+    }
     transaction.commit()?;
     Ok(CalibrationMutationOutcome {
         frames_removed,
@@ -4362,6 +4384,48 @@ mod tests {
         assert_eq!(
             details.frames[0].valid_direction,
             Some(ValidDirection::Forward)
+        );
+    }
+
+    #[test]
+    fn forgetting_a_whole_night_removes_every_named_frame_at_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut meta = Vec::new();
+        for index in 0..3 {
+            let path = temp.path().join(format!("dark-{index}.fits"));
+            std::fs::write(&path, format!("dark {index}")).unwrap();
+            let mut dark = frame(path.to_str().unwrap(), "DARK");
+            dark.timestamp = Some(1_000 + index);
+            meta.push(dark);
+        }
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            import_calibration_frames(&tx, &meta, Some("profile")).unwrap();
+            tx.commit().unwrap();
+        }
+        let uuids: Vec<String> = conn
+            .prepare("SELECT frame_uuid FROM psf_guard_calibration_frame")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(uuids.len(), 3);
+
+        // Unknown ids remove nothing rather than failing the batch.
+        let outcome = forget_frames(
+            &mut conn,
+            &["missing".to_string(), uuids[0].clone(), uuids[1].clone()],
+        )
+        .unwrap();
+        assert_eq!(outcome.frames_removed, 2);
+        assert_eq!(library_summary(&conn).unwrap().frame_count, 1);
+
+        assert_eq!(
+            forget_frames(&mut conn, &[]).unwrap().frames_removed,
+            0,
+            "an empty batch is a no-op"
         );
     }
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -137,6 +137,31 @@ pub async fn forget_calibration_frame(
 }
 
 #[derive(Debug, serde::Deserialize)]
+pub struct ForgetCalibrationFramesRequest {
+    pub frame_uuids: Vec<String>,
+}
+
+/// DELETE /api/db/{db}/calibrations/frames — forget several catalog records
+/// (a whole night of a kind) in one transaction. Files are never touched.
+pub async fn forget_calibration_frames(
+    State(_state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Json(request): Json<ForgetCalibrationFramesRequest>,
+) -> Result<Json<ApiResponse<crate::calibration::CalibrationMutationOutcome>>, AppError> {
+    if request.frame_uuids.is_empty() {
+        return Err(AppError::BadRequest("no frames named".into()));
+    }
+    let conn = ctx.db();
+    let mut conn = conn.lock().map_err(AppError::db)?;
+    let outcome =
+        crate::calibration::forget_frames(&mut conn, &request.frame_uuids).map_err(AppError::db)?;
+    if outcome.frames_removed == 0 {
+        return Err(AppError::NotFound);
+    }
+    Ok(Json(ApiResponse::success(outcome)))
+}
+
+#[derive(Debug, serde::Deserialize)]
 pub struct SetCalibrationValidityRequest {
     pub frame_uuids: Vec<String>,
     /// "forward", "backward", or "both" (which clears the mark).

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -371,6 +371,10 @@ async fn run_server_internal(
             put(handlers::set_calibration_validity),
         )
         .route(
+            "/calibrations/frames",
+            delete(handlers::forget_calibration_frames),
+        )
+        .route(
             "/calibrations/masters",
             delete(handlers::clear_calibration_masters),
         )

--- a/static/e2e/data-transfer.spec.ts
+++ b/static/e2e/data-transfer.spec.ts
@@ -219,6 +219,10 @@ test('settings shows calibration coverage for each database rig', async ({ page 
 
   const library = page.getByRole('dialog', { name: 'Calibration library' });
   await expect(library).toBeVisible();
+  // Night groups start collapsed: expand the flat's (no capture date) and
+  // the dark's before asserting their rows.
+  await library.getByRole('button', { name: /Date unknown/ }).click();
+  await library.getByRole('button', { name: /Night of/ }).click();
   await expect(library.getByText('dark-300s.fits', { exact: true })).toBeVisible();
   await expect(library.getByText('flat-ha.fits', { exact: true })).toBeVisible();
   await expect(library.getByText('⚠ Missing')).toBeVisible();

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -644,6 +644,19 @@ export const apiClient = {
     return data.data;
   },
 
+  forgetCalibrationFrames: async (
+    dbId: string,
+    frameUuids: string[]
+  ): Promise<CalibrationMutationOutcome> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.delete<ApiResponse<CalibrationMutationOutcome>>(
+      dbPath(dbId, '/calibrations/frames'),
+      { data: { frame_uuids: frameUuids } }
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to forget calibration frames');
+    return data.data;
+  },
+
   forgetCalibrationFrame: async (
     dbId: string,
     frameUuid: string

--- a/static/src/components/CalibrationLibraryDialog.tsx
+++ b/static/src/components/CalibrationLibraryDialog.tsx
@@ -41,6 +41,49 @@ function nightLabel(key: string): string {
   return key === 'unknown' ? 'Date unknown' : `Night of ${key}`;
 }
 
+/**
+ * Darks and bias live in their own sections: they stay valid far longer
+ * than flats, so their long-lived batches must not interleave with the
+ * per-night flat groups. Dark-flats belong with the flats they pair with.
+ */
+type LibrarySection = 'flats' | 'darks' | 'bias';
+
+const SECTION_LABELS: Record<LibrarySection, string> = {
+  flats: 'Flats',
+  darks: 'Darks',
+  bias: 'Bias',
+};
+
+const SECTION_ORDER: LibrarySection[] = ['flats', 'darks', 'bias'];
+
+function sectionOf(kind: CalibrationFrameSummary['kind']): LibrarySection {
+  if (kind === 'flat' || kind === 'dark_flat') return 'flats';
+  return kind === 'dark' ? 'darks' : 'bias';
+}
+
+interface NightGroup {
+  key: string;
+  night: string;
+  frames: CalibrationFrameSummary[];
+}
+
+function kindBreakdown(frames: CalibrationFrameSummary[]): string {
+  const counts = new Map<CalibrationFrameSummary['kind'], number>();
+  for (const frame of frames) {
+    counts.set(frame.kind, (counts.get(frame.kind) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([kind, count]) => `${count} ${KIND_LABELS[kind].toLowerCase()}`)
+    .join(' · ');
+}
+
+/** The group's shared mark, when every frame agrees on one. */
+function groupValidity(frames: CalibrationFrameSummary[]): 'forward' | 'backward' | null {
+  const first = frames[0]?.valid_direction ?? null;
+  if (!first) return null;
+  return frames.every((frame) => frame.valid_direction === first) ? first : null;
+}
+
 const VALIDITY_LABELS: Record<'forward' | 'backward', string> = {
   forward: '▸ after only',
   backward: '◂ before only',
@@ -83,7 +126,6 @@ export default function CalibrationLibraryDialog({
   const [kind, setKind] = useState<'all' | CalibrationFrameSummary['kind']>('all');
   const [rig, setRig] = useState('all');
   const [missingOnly, setMissingOnly] = useState(false);
-  const [visibleCount, setVisibleCount] = useState(100);
   const details = useQuery({
     queryKey: ['db', dbId, 'calibrations', 'details'],
     queryFn: () => apiClient.getCalibrationLibraryDetails(dbId),
@@ -102,17 +144,22 @@ export default function CalibrationLibraryDialog({
     mutationFn: (frameUuid: string) => apiClient.forgetCalibrationFrame(dbId, frameUuid),
     onSuccess: refresh,
   });
+  const forgetNight = useMutation({
+    mutationFn: (frameUuids: string[]) => apiClient.forgetCalibrationFrames(dbId, frameUuids),
+    onSuccess: refresh,
+  });
   const clearMasters = useMutation({
     mutationFn: () => apiClient.clearCalibrationMasters(dbId),
     onSuccess: refresh,
   });
-  const [selectedNights, setSelectedNights] = useState<Set<string>>(new Set());
+  const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [markDirection, setMarkDirection] = useState<'both' | 'forward' | 'backward'>('forward');
   const markValidity = useMutation({
     mutationFn: (input: { frameUuids: string[]; direction: 'both' | 'forward' | 'backward' }) =>
       apiClient.setCalibrationValidity(dbId, input.frameUuids, input.direction),
     onSuccess: () => {
-      setSelectedNights(new Set());
+      setSelectedGroups(new Set());
       refresh();
     },
   });
@@ -128,40 +175,61 @@ export default function CalibrationLibraryDialog({
     [details.data?.frames, kind, missingOnly, rig]
   );
   useEffect(() => {
-    setVisibleCount(100);
-    setSelectedNights(new Set());
+    setSelectedGroups(new Set());
   }, [kind, missingOnly, rig]);
-  const visibleFrames = frames.slice(0, visibleCount);
 
-  // Grouped display: one section per imaging night, newest first, so a
-  // day's frames — or a range of days — can be selected together and
-  // marked around an optics change or cleaning.
-  const nightGroups = useMemo(() => {
-    const groups = new Map<string, CalibrationFrameSummary[]>();
-    for (const frame of visibleFrames) {
-      const key = nightKey(frame.captured_at);
-      const bucket = groups.get(key);
-      if (bucket) bucket.push(frame);
-      else groups.set(key, [frame]);
+  // Grouped display, collapsed first: flats (with their dark-flats) get one
+  // group per imaging night; darks and bias sit in their own sections since
+  // their batches stay valid far longer. Groups render as header rows only
+  // until expanded, so a large library stays a short list of nights.
+  const sections = useMemo(() => {
+    const built = new Map<LibrarySection, Map<string, NightGroup>>();
+    for (const frame of frames) {
+      const section = sectionOf(frame.kind);
+      const night = nightKey(frame.captured_at);
+      const key = `${section}:${night}`;
+      const groups = built.get(section) ?? new Map<string, NightGroup>();
+      const group = groups.get(key) ?? { key, night, frames: [] };
+      group.frames.push(frame);
+      groups.set(key, group);
+      built.set(section, groups);
     }
-    return [...groups.entries()].sort(([left], [right]) => {
-      if (left === 'unknown') return 1;
-      if (right === 'unknown') return -1;
-      return right.localeCompare(left);
+    return SECTION_ORDER.flatMap((section) => {
+      const groups = built.get(section);
+      if (!groups) return [];
+      const ordered = [...groups.values()].sort((left, right) => {
+        if (left.night === 'unknown') return 1;
+        if (right.night === 'unknown') return -1;
+        return right.night.localeCompare(left.night);
+      });
+      return [{ section, groups: ordered }];
     });
-  }, [visibleFrames]);
+  }, [frames]);
 
-  const toggleNight = (night: string) => {
-    setSelectedNights((current) => {
+  const toggleSelected = (key: string) => {
+    setSelectedGroups((current) => {
       const next = new Set(current);
-      if (next.has(night)) next.delete(night);
-      else next.add(night);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+  const toggleExpanded = (key: string) => {
+    setExpandedGroups((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       return next;
     });
   };
   const selectedFrames = useMemo(
-    () => visibleFrames.filter((frame) => selectedNights.has(nightKey(frame.captured_at))),
-    [visibleFrames, selectedNights]
+    () =>
+      sections.flatMap(({ groups }) =>
+        groups
+          .filter((group) => selectedGroups.has(group.key))
+          .flatMap((group) => group.frames)
+      ),
+    [sections, selectedGroups]
   );
 
   const handleForget = (frame: CalibrationFrameSummary) => {
@@ -171,6 +239,16 @@ export default function CalibrationLibraryDialog({
       )
     ) {
       forget.mutate(frame.frame_uuid);
+    }
+  };
+
+  const handleForgetNight = (section: LibrarySection, group: NightGroup) => {
+    if (
+      window.confirm(
+        `Forget every ${SECTION_LABELS[section].toLowerCase()} frame from ${nightLabel(group.night)} (${group.frames.length} record${group.frames.length === 1 ? '' : 's'})? PSF Guard removes the catalog records and dependent masters. The FITS files will not be deleted.`
+      )
+    ) {
+      forgetNight.mutate(group.frames.map((frame) => frame.frame_uuid));
     }
   };
 
@@ -279,11 +357,11 @@ export default function CalibrationLibraryDialog({
             entries, or clear generated masters.
           </div>
         )}
-        {canManage && selectedNights.size > 0 && (
+        {canManage && selectedGroups.size > 0 && (
           <div className="calibration-validity-bar">
             <span>
               {selectedFrames.length} frame{selectedFrames.length === 1 ? '' : 's'} across{' '}
-              {selectedNights.size} night{selectedNights.size === 1 ? '' : 's'} — usable
+              {selectedGroups.size} group{selectedGroups.size === 1 ? '' : 's'} — usable
             </span>
             <select
               value={markDirection}
@@ -310,16 +388,19 @@ export default function CalibrationLibraryDialog({
             </button>
             <button
               className="browse-button"
-              onClick={() => setSelectedNights(new Set())}
+              onClick={() => setSelectedGroups(new Set())}
               disabled={markValidity.isPending}
             >
               Clear selection
             </button>
           </div>
         )}
-        {(forget.error || clearMasters.error || markValidity.error) && (
+        {(forget.error || forgetNight.error || clearMasters.error || markValidity.error) && (
           <div className="calibration-library-error">
-            {forget.error?.message || clearMasters.error?.message || markValidity.error?.message}
+            {forget.error?.message ||
+              forgetNight.error?.message ||
+              clearMasters.error?.message ||
+              markValidity.error?.message}
           </div>
         )}
 
@@ -348,27 +429,71 @@ export default function CalibrationLibraryDialog({
                   {canManage && <th aria-label="Actions" />}
                 </tr>
               </thead>
-              {nightGroups.map(([night, nightFrames]) => (
-                <tbody key={night} className="calibration-night-group">
-                  <tr className="calibration-night-row">
+              {sections.map(({ section, groups }) => (
+                <tbody key={section} className="calibration-section-group">
+                  <tr className="calibration-section-row">
                     <td colSpan={canManage ? 5 : 4}>
-                      <label>
-                        {canManage && (
-                          <input
-                            type="checkbox"
-                            checked={selectedNights.has(night)}
-                            onChange={() => toggleNight(night)}
-                            aria-label={`Select ${nightLabel(night)}`}
-                          />
-                        )}
-                        <strong>{nightLabel(night)}</strong>
-                        <span>
-                          {nightFrames.length} frame{nightFrames.length === 1 ? '' : 's'}
-                        </span>
-                      </label>
+                      <strong>{SECTION_LABELS[section]}</strong>
+                      <span>
+                        {groups.reduce((sum, group) => sum + group.frames.length, 0)} frame
+                        {groups.reduce((sum, group) => sum + group.frames.length, 0) === 1
+                          ? ''
+                          : 's'}{' '}
+                        · {groups.length} night{groups.length === 1 ? '' : 's'}
+                      </span>
                     </td>
                   </tr>
-                  {nightFrames.map((frame) => (
+                  {groups.map((group) => {
+                    const expanded = expandedGroups.has(group.key);
+                    const shared = groupValidity(group.frames);
+                    return [
+                      <tr key={group.key} className="calibration-night-row">
+                        <td colSpan={canManage ? 5 : 4}>
+                          <div className="calibration-night-controls">
+                            {canManage && (
+                              <input
+                                type="checkbox"
+                                checked={selectedGroups.has(group.key)}
+                                onChange={() => toggleSelected(group.key)}
+                                aria-label={`Select ${SECTION_LABELS[section]} ${nightLabel(group.night)}`}
+                              />
+                            )}
+                            <button
+                              type="button"
+                              className="calibration-night-toggle"
+                              aria-expanded={expanded}
+                              onClick={() => toggleExpanded(group.key)}
+                            >
+                              <span
+                                className={`expand-toggle ${expanded ? 'expanded' : ''}`}
+                                aria-hidden="true"
+                              >
+                                ▶
+                              </span>
+                              <strong>{nightLabel(group.night)}</strong>
+                              <span>{kindBreakdown(group.frames)}</span>
+                            </button>
+                            {shared && (
+                              <span
+                                className={`calibration-validity calibration-validity-${shared}`}
+                                title={VALIDITY_TITLES[shared]}
+                              >
+                                {VALIDITY_LABELS[shared]}
+                              </span>
+                            )}
+                            {canManage && (
+                              <button
+                                className="remove-button"
+                                onClick={() => handleForgetNight(section, group)}
+                                disabled={forgetNight.isPending}
+                              >
+                                Forget night
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>,
+                      ...(expanded ? group.frames : []).map((frame) => (
                     <tr key={frame.frame_uuid} className={frame.source_exists ? '' : 'missing'}>
                       <td>
                         <span className={`calibration-kind calibration-kind-${frame.kind}`}>
@@ -417,7 +542,9 @@ export default function CalibrationLibraryDialog({
                         </td>
                       )}
                     </tr>
-                  ))}
+                      )),
+                    ];
+                  })}
                 </tbody>
               ))}
             </table>
@@ -425,16 +552,10 @@ export default function CalibrationLibraryDialog({
           {frames.length > 0 && (
             <div className="calibration-library-footer">
               <span>
-                Showing {visibleFrames.length} of {frames.length} matching frames
+                {frames.length} matching frame{frames.length === 1 ? '' : 's'} in{' '}
+                {sections.reduce((sum, { groups }) => sum + groups.length, 0)} night group
+                {sections.reduce((sum, { groups }) => sum + groups.length, 0) === 1 ? '' : 's'}
               </span>
-              {visibleFrames.length < frames.length && (
-                <button
-                  className="browse-button"
-                  onClick={() => setVisibleCount((count) => count + 100)}
-                >
-                  Show 100 more
-                </button>
-              )}
             </div>
           )}
         </div>

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -1221,29 +1221,77 @@
   background: color-mix(in srgb, var(--color-error) 6%, transparent);
 }
 
-/* One section per imaging night; the header row selects the whole night. */
+/* Kind sections (Flats / Darks / Bias), each holding collapsed night
+   groups. Darks and bias stay valid far longer than flats, so their
+   batches never interleave with the per-night flat groups. */
+.tauri-settings .calibration-section-row td {
+  padding: 9px 10px 5px;
+  border-bottom: 0;
+}
+
+.tauri-settings .calibration-section-row strong {
+  display: inline;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.tauri-settings .calibration-section-row span {
+  display: inline;
+  margin-left: 8px;
+  color: var(--color-text-hint);
+  font-size: 10px;
+}
+
+/* One collapsed row per imaging night; the header selects, expands, or
+   forgets the whole night. */
 .tauri-settings .calibration-night-row td {
-  padding: 7px 10px;
+  padding: 6px 10px;
   background: var(--color-bg-secondary);
   border-bottom: 1px solid var(--color-border-secondary);
 }
 
-.tauri-settings .calibration-night-row label {
+.tauri-settings .calibration-night-controls {
   display: flex;
   align-items: center;
   gap: 8px;
-  cursor: pointer;
 }
 
-.tauri-settings .calibration-night-row strong {
+.tauri-settings .calibration-night-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 2px 0;
+  background: none;
+  border: 0;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.tauri-settings .calibration-night-toggle strong {
   display: inline;
   font-size: 12px;
 }
 
-.tauri-settings .calibration-night-row span {
+.tauri-settings .calibration-night-toggle span:not(.expand-toggle) {
   display: inline;
   color: var(--color-text-muted);
   font-size: 11px;
+}
+
+.tauri-settings .calibration-night-toggle .expand-toggle {
+  display: inline-block;
+  color: var(--color-text-muted);
+  font-size: 9px;
+  transition: transform 0.15s;
+}
+
+.tauri-settings .calibration-night-toggle .expand-toggle.expanded {
+  transform: rotate(90deg);
 }
 
 /* The marking bar shown while nights are selected. */

--- a/static/src/components/__tests__/CalibrationLibraryDialog.validity.test.tsx
+++ b/static/src/components/__tests__/CalibrationLibraryDialog.validity.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { server } from '../../test/msw-server';
 import CalibrationLibraryDialog from '../CalibrationLibraryDialog';
 
@@ -78,8 +78,8 @@ describe('calibration validity marking', () => {
     expect(await screen.findByText('Night of 2026-06-03')).toBeInTheDocument();
     expect(screen.getByText('Night of 2026-06-01')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Night of 2026-06-01' }));
-    expect(screen.getByText(/2 frames across 1 night/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Flats Night of 2026-06-01' }));
+    expect(screen.getByText(/2 frames across 1 group/)).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Validity direction'), {
       target: { value: 'backward' },
@@ -107,6 +107,56 @@ describe('calibration validity marking', () => {
     expect(screen.getByText('▸ after only')).toBeInTheDocument();
   });
 
+  it('starts collapsed, separates darks from flats, and forgets a whole night', async () => {
+    serveLibrary([
+      flat('flat-a', earlyNight),
+      { ...flat('dark-a', earlyNight), kind: 'dark' },
+      { ...flat('bias-a', earlyNight), kind: 'bias' },
+    ]);
+    let received: unknown = null;
+    server.use(
+      http.delete('/api/db/demo/calibrations/frames', async ({ request }) => {
+        received = await request.json();
+        return HttpResponse.json({
+          success: true,
+          data: { frames_removed: 1, masters_removed: 0 },
+          error: null,
+        });
+      })
+    );
+
+    const { container } = render(
+      <CalibrationLibraryDialog dbId="demo" dbName="Demo" canManage onClose={() => {}} />,
+      { wrapper: wrapper() }
+    );
+
+    // Darks and bias sit in their own sections beside the flat nights: the
+    // same night appears once per section, not merged.
+    expect(await screen.findByText('Flats')).toBeInTheDocument();
+    const sectionRows = container.querySelectorAll('.calibration-section-row');
+    expect([...sectionRows].map((row) => row.querySelector('strong')?.textContent)).toEqual([
+      'Flats',
+      'Darks',
+      'Bias',
+    ]);
+    expect(screen.getAllByText('Night of 2026-06-01')).toHaveLength(3);
+
+    // Collapsed first: no frame rows until a group is expanded.
+    expect(screen.queryByText('flat-a.fits')).toBeNull();
+    expect(screen.queryByText('dark-a.fits')).toBeNull();
+    const toggles = screen.getAllByRole('button', { name: /Night of 2026-06-01/ });
+    fireEvent.click(toggles[0]);
+    expect(await screen.findByText('flat-a.fits')).toBeInTheDocument();
+    expect(screen.queryByText('dark-a.fits')).toBeNull();
+
+    // Forgetting a night names only that section's frames.
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const forgetButtons = screen.getAllByRole('button', { name: 'Forget night' });
+    fireEvent.click(forgetButtons[1]);
+    await waitFor(() => expect(received).toEqual({ frame_uuids: ['dark-a'] }));
+    confirm.mockRestore();
+  });
+
   it('offers no selection to a read-only viewer', async () => {
     serveLibrary([flat('old-a', earlyNight)]);
     render(
@@ -114,6 +164,6 @@ describe('calibration validity marking', () => {
       { wrapper: wrapper() }
     );
     expect(await screen.findByText('Night of 2026-06-01')).toBeInTheDocument();
-    expect(screen.queryByRole('checkbox', { name: /Select Night/ })).toBeNull();
+    expect(screen.queryByRole('checkbox', { name: /Select Flats/ })).toBeNull();
   });
 });

--- a/static/src/components/__tests__/CalibrationLibrarySummary.test.tsx
+++ b/static/src/components/__tests__/CalibrationLibrarySummary.test.tsx
@@ -110,6 +110,10 @@ describe('CalibrationLibrarySummary', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Manage' }));
 
     expect(await screen.findByRole('dialog', { name: 'Calibration library' })).toBeInTheDocument();
+    // Groups start collapsed: the night header is visible, its rows are not.
+    const nightToggle = await screen.findByRole('button', { name: /Date unknown/ });
+    expect(screen.queryByText('dark-300s.fits')).toBeNull();
+    fireEvent.click(nightToggle);
     expect(await screen.findByText('dark-300s.fits')).toBeInTheDocument();
     expect(screen.getByText(/3000×2000 · 1×1 bin · gain 100/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Forget' })).toBeInTheDocument();


### PR DESCRIPTION
Follow-ups to the validity-fence work (#383), per review of the grouped display:

- **Collapsed first**: night groups render as one header row each — chevron, kind breakdown, and the group's shared validity badge — expanding on click. The flat 100-row pagination is gone; a large library is now a short list of nights, and the footer reports totals.
- **Long-lived kinds separated**: flats (and the dark-flats that pair with them) keep per-night groups in a **Flats** section; **Darks** and **Bias** get their own sections, since those batches stay valid far longer than flats and should not interleave with flat nights. Selection keys are section-scoped, so marking a flat night never touches the same night's darks.
- **Forget night**: each night row can remove that section's records for the night in one transaction — `forget_frames` generalizes the single forget with identical transitive master invalidation (a removed bias still cascades through dependent dark and flat masters), served as `DELETE /api/db/{db}/calibrations/frames` with the uuids in the body. FITS files are never touched, and unknown uuids in a batch skip rather than failing it.

## Checks run locally

- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` (825 passed; new: bulk forget removes every named frame, skips unknown ids, no-ops on empty)
- `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (332 passed; new: collapsed-by-default with expansion, section separation with per-section Forget-night payload; existing validity and summary tests updated for the collapsed display)
- Playwright not run locally; relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)