### PR TITLE
Show Forget night only for a checkbox-selected night

### DIFF
--- a/static/src/components/CalibrationLibraryDialog.tsx
+++ b/static/src/components/CalibrationLibraryDialog.tsx
@@ -481,7 +481,10 @@ export default function CalibrationLibraryDialog({
                                 {VALIDITY_LABELS[shared]}
                               </span>
                             )}
-                            {canManage && (
+                            {/* Destructive, so it only appears once the
+                                night's checkbox says the user means this
+                                group. */}
+                            {canManage && selectedGroups.has(group.key) && (
                               <button
                                 className="remove-button"
                                 onClick={() => handleForgetNight(section, group)}

--- a/static/src/components/__tests__/CalibrationLibraryDialog.validity.test.tsx
+++ b/static/src/components/__tests__/CalibrationLibraryDialog.validity.test.tsx
@@ -149,10 +149,12 @@ describe('calibration validity marking', () => {
     expect(await screen.findByText('flat-a.fits')).toBeInTheDocument();
     expect(screen.queryByText('dark-a.fits')).toBeNull();
 
-    // Forgetting a night names only that section's frames.
+    // Forget night is destructive: it only appears once a night's checkbox
+    // is selected, and names only that section's frames.
+    expect(screen.queryByRole('button', { name: 'Forget night' })).toBeNull();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Darks Night of 2026-06-01' }));
     const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
-    const forgetButtons = screen.getAllByRole('button', { name: 'Forget night' });
-    fireEvent.click(forgetButtons[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Forget night' }));
     await waitFor(() => expect(received).toEqual({ frame_uuids: ['dark-a'] }));
     confirm.mockRestore();
   });


### PR DESCRIPTION
Destructive actions should follow an explicit selection: the per-night **Forget night** button now renders only once that night's checkbox is checked, instead of sitting on every collapsed row. Test updated to assert the button is absent before selection and acts on the selected section's frames.

Checks: `npx tsc --noEmit`, `npm run lint`, dialog tests (4 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)