### PR TITLE
Lay out every view for phone screens

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,3 +9,9 @@
 ## Changed
 
 ## Fixed
+
+- Every view now works on a phone screen. The image detail view stacks the
+  image above its info panel instead of squeezing the image to nothing, the
+  comparison view keeps its Swap and Unmark buttons reachable, headers and
+  overview project cards wrap instead of truncating, and keyboard cheat
+  sheets stay out of the way on touch screens.

--- a/static/e2e/mobile-layout.spec.ts
+++ b/static/e2e/mobile-layout.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  registerFixtureDb,
+  resetDatabases,
+  waitForCacheReady,
+} from './helpers';
+
+// A common phone: iPhone 14 / Pixel-class logical viewport.
+const PHONE = { width: 390, height: 844 };
+test.use({ viewport: PHONE, isMobile: true, hasTouch: true });
+
+let dbId: string;
+
+test.beforeEach(async ({ request }) => {
+  await resetDatabases(request);
+  const entry = await registerFixtureDb(request, {
+    name: 'Imaging Rig e2e',
+    slug: 'imaging-rig-e2e',
+  });
+  dbId = entry.id;
+  await waitForCacheReady(request, dbId);
+});
+
+/**
+ * The one mobile invariant every view must hold: the page body never scrolls
+ * sideways. Wide content (tables, strips, canvases) must scroll inside its
+ * own container instead. On failure, name the widest offenders so the fix
+ * starts from the right selector.
+ *
+ * Also writes a full-page screenshot per view — into the test output dir,
+ * and into PSF_GUARD_E2E_SHOT_DIR when set — so a human can review the
+ * layout, which no width assertion can do alone.
+ */
+async function expectPhoneFit(page: Page, testInfo: TestInfo, name: string) {
+  // Let late-arriving previews and fonts settle before measuring.
+  await page.waitForLoadState('networkidle').catch(() => {});
+
+  const shot = await page.screenshot({ fullPage: true });
+  await testInfo.attach(`${name}.png`, { body: shot, contentType: 'image/png' });
+  const shotDir = process.env.PSF_GUARD_E2E_SHOT_DIR;
+  if (shotDir) {
+    fs.mkdirSync(shotDir, { recursive: true });
+    fs.writeFileSync(path.join(shotDir, `${name}.png`), shot);
+  }
+
+  const layout = await page.evaluate(() => {
+    const limit = window.innerWidth + 1;
+    const offenders: string[] = [];
+    for (const el of Array.from(document.querySelectorAll<HTMLElement>('*'))) {
+      const rect = el.getBoundingClientRect();
+      if ((rect.right > limit || rect.left < -1) && rect.width > 24) {
+        const cls = typeof el.className === 'string' ? el.className : '';
+        offenders.push(
+          `<${el.tagName.toLowerCase()} class="${cls.split(' ').slice(0, 2).join(' ')}"> ` +
+            `left=${Math.round(rect.left)} right=${Math.round(rect.right)}`
+        );
+        if (offenders.length >= 10) break;
+      }
+    }
+    return {
+      scrollWidth: document.documentElement.scrollWidth,
+      innerWidth: window.innerWidth,
+      offenders,
+    };
+  });
+
+  expect(
+    layout.scrollWidth,
+    `${name} scrolls sideways (${layout.scrollWidth}px page in a ` +
+      `${layout.innerWidth}px viewport). Widest elements:\n` +
+      layout.offenders.join('\n')
+  ).toBeLessThanOrEqual(layout.innerWidth + 1);
+}
+
+test('overview fits a phone', async ({ page }, testInfo) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Earlier work' })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expectPhoneFit(page, testInfo, 'overview');
+  // Scroll the main content column, not the header the pointer starts over.
+  await page.mouse.move(195, 500);
+  await page.mouse.wheel(0, 8000);
+  await expectPhoneFit(page, testInfo, 'overview-bottom');
+});
+
+test('image grid fits a phone', async ({ page }, testInfo) => {
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+  const firstCard = page.locator('.image-card').first();
+  await expect(firstCard).toBeVisible({ timeout: 15_000 });
+  await expectPhoneFit(page, testInfo, 'grid');
+  await firstCard.scrollIntoViewIfNeeded();
+  await expectPhoneFit(page, testInfo, 'grid-cards');
+});
+
+test('grid statistics fit a phone', async ({ page }, testInfo) => {
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+  await expect(page.locator('.image-card').first()).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByRole('button', { name: 'Stats' }).click();
+  const stats = page.locator('.stats-dashboard');
+  await expect(stats).toBeVisible();
+  await stats.scrollIntoViewIfNeeded();
+  await expectPhoneFit(page, testInfo, 'grid-stats');
+});
+
+test('export dialog fits a phone', async ({ page }, testInfo) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Earlier work' })).toBeVisible({
+    timeout: 15_000,
+  });
+  const exportButton = page.getByRole('button', { name: /Export/ }).first();
+  await exportButton.scrollIntoViewIfNeeded();
+  await exportButton.click();
+  await expect(page.locator('.export-dialog')).toBeVisible();
+  await expectPhoneFit(page, testInfo, 'export-dialog');
+});
+
+test('project picker opens usable on a phone', async ({ page }, testInfo) => {
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+  await expect(page.locator('.image-card').first()).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByRole('button', { name: /Project \/ target:/ }).click();
+  await expect(
+    page.getByPlaceholder('Type to find a project or target')
+  ).toBeVisible();
+  await expectPhoneFit(page, testInfo, 'project-picker');
+});
+
+test('image detail fits a phone', async ({ page }, testInfo) => {
+  await page.goto(`/#/detail/1?db=${encodeURIComponent(dbId)}&project=1`);
+  await expect(page.getByRole('img', { name: 'Alpha M44 - B' })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expectPhoneFit(page, testInfo, 'detail');
+  await page
+    .locator('.detail-info')
+    .evaluate((el) => el.scrollTo(0, el.scrollHeight));
+  await expectPhoneFit(page, testInfo, 'detail-info-end');
+});
+
+test('comparison fits a phone', async ({ page }, testInfo) => {
+  await page.goto(
+    `/#/compare/1/2?db=${encodeURIComponent(dbId)}&project=1`
+  );
+  await expect(page.locator('.comparison-container')).toBeVisible({
+    timeout: 15_000,
+  });
+  await expectPhoneFit(page, testInfo, 'compare');
+});
+
+test('sequence view fits a phone', async ({ page }, testInfo) => {
+  await page.goto(`/#/sequence?db=${encodeURIComponent(dbId)}&project=1`);
+  await expect(page.locator('.sequence-view')).toBeVisible({ timeout: 15_000 });
+  await expectPhoneFit(page, testInfo, 'sequence');
+});
+
+test('settings modal fits a phone', async ({ page }, testInfo) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Earlier work' })).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await expect(page.locator('.tauri-settings').first()).toBeVisible();
+  await expectPhoneFit(page, testInfo, 'settings');
+});
+
+test('help overlay fits a phone', async ({ page }, testInfo) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'Earlier work' })).toBeVisible({
+    timeout: 15_000,
+  });
+  // A phone has no keyboard; the Help button is the mobile path.
+  await page.getByRole('button', { name: 'Help' }).click();
+  await expect(page.getByText('Keyboard Shortcuts').first()).toBeVisible();
+  await expectPhoneFit(page, testInfo, 'help');
+});

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -1632,6 +1632,62 @@
   background: var(--color-bg-surface);
 }
 
+/* Phone layout: the desktop row (image beside a 360px info panel) leaves the
+   image no width at all on a narrow screen. Stack instead: image pinned on
+   top, info scrolling under it. The header wraps and the status banner drops
+   its absolute centering so it cannot sit on the title. */
+@media (max-width: 760px) {
+  .detail-header {
+    flex-wrap: wrap;
+    gap: 0.4rem 0.6rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .detail-header h2 {
+    font-size: 1.05rem;
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .detail-header .status-banner {
+    position: static;
+    transform: none;
+    order: 1;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    min-width: 0;
+  }
+
+  .detail-header .close-button {
+    order: 2;
+  }
+
+  .detail-content {
+    flex-direction: column;
+  }
+
+  .detail-image {
+    flex: none;
+    height: 46vh;
+    min-height: 220px;
+    padding: 0.5rem;
+  }
+
+  .detail-info {
+    width: auto;
+    flex: 1;
+    padding: 0.85rem;
+  }
+
+  /* Keyboard cheat sheet: those keys do not exist on a touch screen. */
+  .detail-shortcuts {
+    display: none;
+  }
+}
+
 .detail-astrometry-overlay {
   position: absolute;
   top: 0;
@@ -2742,6 +2798,56 @@
   color: var(--color-text-muted);
   font-size: 0.85rem;
   font-family: monospace;
+}
+
+/* Phone layout: wrap the header so Swap stays reachable, tighten the panel
+   gutters, and drop the keyboard-shortcut bar — those keys do not exist on a
+   touch screen and the bar costs a full row of image height. */
+@media (max-width: 760px) {
+  .comparison-header {
+    flex-wrap: wrap;
+    gap: 0.4rem 0.75rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  /* Row one: title and close. Row two: the controls, full width. */
+  .comparison-header h2 {
+    font-size: 1.05rem;
+    flex: 1;
+  }
+
+  .comparison-header .close-button {
+    order: 1;
+  }
+
+  .comparison-controls {
+    order: 2;
+    flex-basis: 100%;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.9rem;
+  }
+
+  .comparison-content {
+    gap: 0.5rem;
+    padding: 0.5rem;
+  }
+
+  .comparison-shortcuts {
+    display: none;
+  }
+
+  .panel-actions {
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.5rem;
+  }
+
+  .panel-actions .action-button {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 0.45rem 0.5rem;
+    font-size: 0.82rem;
+  }
 }
 
 /* Statistics Dashboard */
@@ -6351,6 +6457,24 @@
 
   .selection-preset-control select {
     width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  /* One control per row: side by side, the threshold slider and its value
+     run off the panel edge. */
+  .sequence-review-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .threshold-control {
+    justify-content: space-between;
+  }
+
+  .threshold-control input[type="range"] {
+    flex: 1;
+    width: auto;
+    min-width: 0;
   }
 }
 

--- a/static/src/components/Overview.css
+++ b/static/src/components/Overview.css
@@ -1168,6 +1168,19 @@
 
   .project-open-main {
     width: calc(100% + 12px);
+    flex-wrap: wrap;
+    row-gap: 4px;
+  }
+
+  /* Full-width title row; badges and the open label wrap under it instead
+     of squeezing the name down to an ellipsis. */
+  .project-open-main .project-title {
+    flex: 1 1 100%;
+    white-space: normal;
+  }
+
+  .project-open-main .project-open-label {
+    margin-left: 0;
   }
 
   .project-header-actions {


### PR DESCRIPTION
## What

Makes every view usable on a phone (390px-class viewport), verified view by view with screenshots.

- **Image detail**: the info panel is a fixed 360px column, so at phone width the image collapsed to zero width. The view now stacks: image pinned on top, info scrolling below. The header wraps, so the status chip no longer overlaps the title.
- **Comparison**: the header wraps (the Swap button was clipped off-screen) and the per-panel action row wraps (the Unmark button was clipped). The keyboard-shortcut bar is hidden at phone width — those keys do not exist on a touch screen, and the bar cost a full row of image height.
- **Detail keyboard cheat sheet**: hidden at phone width for the same reason.
- **Overview project cards**: the project name gets a full row instead of truncating to two letters beside the open button.
- **Sequence controls**: the score-threshold row gets one control per row at narrow width, so the slider and its value stay inside the panel.

## Verification

New `static/e2e/mobile-layout.spec.ts` drives ten views at a 390x844 mobile viewport — overview (top and bottom), grid (controls and cards), grid stats, export dialog, project picker, detail (top and info end), comparison, sequence, settings modal, and help overlay. Each check screenshots the view (attached to the test report, and to `PSF_GUARD_E2E_SHOT_DIR` when set) and fails if the page scrolls sideways, naming the widest offending elements.

Screenshots were reviewed by eye each round; the layout fixes above are the issues that pass found.

## Checks run locally

- `npm run lint` — clean
- `npx vitest run` — 332 passed
- `npm run build` — clean
- `npx playwright test` — 103 passed (full suite, including the 10 new mobile checks)
- `git diff --check` — clean

No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv