### PR TITLE
Release v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,13 +9,3 @@
 ## Changed
 
 ## Fixed
-
-- Changing one RC-Astro step no longer recomputes the whole chain. Each step
-  caches under its own identity, so turning NoiseXTerminator on after a
-  BlurXTerminator run — or retuning a later step — reuses every artifact
-  before the change.
-- Every view now works on a phone screen. The image detail view stacks the
-  image above its info panel instead of squeezing the image to nothing, the
-  comparison view keeps its Swap and Unmark buttons reachable, headers and
-  overview project cards wrap instead of truncating, and keyboard cheat
-  sheets stay out of the way on touch screens.

--- a/docs/releases/v0.9.1.md
+++ b/docs/releases/v0.9.1.md
@@ -1,0 +1,16 @@
+# v0.9.1
+
+PSF Guard 0.9.1 makes every view work on a phone screen and stops RC-Astro
+processing from recomputing the whole chain when one step changes.
+
+## Fixed
+
+- Changing one RC-Astro step no longer recomputes the whole chain. Each step
+  caches under its own identity, so turning NoiseXTerminator on after a
+  BlurXTerminator run — or retuning a later step — reuses every artifact
+  before the change.
+- Every view now works on a phone screen. The image detail view stacks the
+  image above its info panel instead of squeezing the image to nothing, the
+  comparison view keeps its Swap and Unmark buttons reachable, headers and
+  overview project cards wrap instead of truncating, and keyboard cheat
+  sheets stay out of the way on touch screens.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -7,7 +7,7 @@
 %global debug_package %{nil}
 
 Name:           psf-guard
-Version:        0.9.0
+Version:        0.9.1
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -90,6 +90,10 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Fri Aug 29 2026 Yann Ramin <github@theatr.us> - 0.9.1-1
+- Every view lays out for phone screens
+- RC-Astro steps cache one by one, so changing a later step reuses earlier work
+
 * Fri Aug 29 2026 Yann Ramin <github@theatr.us> - 0.9.0-1
 - Run RC-Astro BlurXTerminator, NoiseXTerminator, and StarXTerminator on stack previews
 - Star removal keeps starless and stars as separate stacked outputs

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
Patch release: the two fixes merged since v0.9.0.

- Every view lays out for phone screens (#387).
- RC-Astro steps cache under their own identities, so changing a later step reuses the work before it (#388).

Version bumped in Cargo.toml, Cargo.lock, tauri.conf.json, and packaging/rpm/psf-guard.spec (with a changelog entry). `docs/releases/unreleased.md` became `v0.9.1.md` with a banner-ready opening sentence, and a fresh skeleton starts the next cycle.

## Checks run locally

- `cargo fmt -- --check` — clean
- `node scripts/check-release-version.mjs v0.9.1` — prints 0.9.1
- `cargo clippy --locked --all-targets --all-features -- -D warnings` — clean
- `cargo test --locked` — all 22 test binaries green
- `cargo build --release --locked --bin psf-guard-cli` — `psf-guard 0.9.1`
- `npm ci` / `npm run lint` / `npx vitest run` (332 passed) / `npm run build` / `npm run test:release` (14 pass, 0 fail)
- `git diff --check` — clean
- Stale-version search: only spec history and node engine ranges mention 0.9.0.

No Tauri bundle built locally: no app, updater, packaging, or signing code changed since v0.9.0 built clean on all three platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv