### PR TITLE
Harden remote sync and catalog-aware image intake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,11 @@ reflink-copy = "0.1.30"
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_System_SystemInformation"] }
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_SystemInformation",
+] }
 
 [dev-dependencies]
 filetime = "0.2"
@@ -125,4 +129,3 @@ overflow-checks = false
 
 [build-dependencies]
 tauri-build = { version = "2.6.2", features = [] }
-

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ token_file = "/run/secrets/psf-guard-key"    # or token = "..."
 [[remote_upload]]
 database = "telescope"
 image_dir = "/data/incoming"
+placement = "target_tree"                       # optional; default is "flat"
 token_file = "/run/secrets/psf-guard-key"
 ```
 

--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -361,6 +361,9 @@ server filesystem paths. A headless deployment therefore takes both grants from
 naming a registry slug and a key (inline, or `token_file` for systemd
 credentials and Docker secrets).
 
+An upload block may set `placement = "target_tree"` to use the target and frame
+type layout. Omitting it keeps the compatibility `flat` layout.
+
 They apply to the in-memory database list at startup and are never written back
 to the registry, so the config file stays the whole account of what a
 deployment allows and rotating a key is a restart. A database has one key,
@@ -428,11 +431,34 @@ image=@capture.fits
 ```
 
 The database settings select one of that database's registered image roots as
-the receive directory. The server requires the URL slug and echoed database ID
-to agree, authenticates with the selected database's salted token hash, streams
-at most 512 MiB to a sibling temporary file, verifies SHA-256 and the frame
-headers, and publishes without overwriting an existing basename. The filename
-must carry a frame extension: `.fits`, `.fit`, `.fts`, or `.xisf`.
+the receive directory and a placement policy. **Receive directory** keeps the
+compatibility layout with every upload at that root. **Target and frame type**
+uses PSF Guard's standard tree: `<target>/LIGHT/<filter>` for lights,
+`<target>/FLAT/<filter>` for flats, and top-level `BIAS`, `DARK`, or `DARKFLAT`
+folders for the other calibration kinds. A light with no resolvable catalog
+target or `OBJECT` header uses the importer's `Unknown Target`; a flat with no
+`OBJECT` uses `Unsorted`. All segments come from catalog rows or verified
+headers and are sanitized by the server. The upload client never supplies a
+path.
+
+For light frames, PSF Guard records the accepted local path and SHA-256 against
+the acquired-image identity in a PSF Guard-owned table. Identical retries keep
+using that registered file even if Target Scheduler later changes `FileName`,
+the target is renamed, the parent tree is deleted, or the selected receive root
+or layout changes. A database without acquired-image GUIDs also records a
+capture-row fingerprint so reuse of an integer row ID cannot inherit an old
+upload. Calibration uploads have separate provenance keyed by frame UUID with
+the accepted path and SHA-256. A missing calibration file is restored only
+when the retry matches that digest; different bytes return `409 Conflict`
+rather than silently reusing its UUID. Older flat uploads are discovered
+across the database's registered image roots and backfilled on their next
+retry.
+
+The server requires the URL slug and echoed database ID to agree,
+authenticates with the selected database's salted token hash, streams at most
+512 MiB to a sibling temporary file, verifies SHA-256 and the frame headers,
+and publishes without overwriting an existing basename. The filename must
+carry a frame extension: `.fits`, `.fit`, `.fts`, or `.xisf`.
 
 For a light, the normal one-frame importer resolves an existing target by
 object name or coordinates and reuses its exposure plan. If no target matches,
@@ -442,12 +468,24 @@ never creates a Target Scheduler `acquiredimage` row. This path therefore works
 with an existing Target Scheduler catalog and with a fresh PSF Guard catalog
 whose user never installed Target Scheduler.
 
+When scheduler sync creates the light row before its file arrives, capture
+time and filter normally establish the association. If either header is
+missing, the unique basename must also resolve by `OBJECT` or coordinates to
+that row's target. A supplied time, filter, object, or coordinate that resolves
+elsewhere remains a conflict.
+
 Identical retries are idempotent. The response returns the resolved database,
 frame kind, and either the project, target, and image IDs for a light or the
 calibration frame and rig UUIDs. If scheduler sync registered a unique light
 row first, the upload attaches the file to that row without importing a
 duplicate. An ambiguous registered basename or an existing receive file with
 different content returns `409 Conflict`.
+
+Before publish, PSF Guard creates only server-derived directories below a
+registered image root, rejects symlinks and Windows junctions in the parent
+tree, and canonicalizes the parent again immediately before writing. Cleanup
+after a failed import repeats the containment check and removes only the file
+whose SHA-256 matches the upload.
 
 ### Files copied after scheduler sync
 

--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -361,8 +361,20 @@ server filesystem paths. A headless deployment therefore takes both grants from
 naming a registry slug and a key (inline, or `token_file` for systemd
 credentials and Docker secrets).
 
-An upload block may set `placement = "target_tree"` to use the target and frame
-type layout. Omitting it keeps the compatibility `flat` layout.
+An upload block may set `placement = "target_tree"` and a validated
+`directory_template` such as `%YEAR%/%TARGET%/%NIGHT%/%TYPE%`. The basename is
+always appended by the server; clients cannot select a path. Available tokens
+are `%PROJECT%`, `%TARGET%`, `%DATE%`, `%NIGHT%`, `%YEAR%`, `%TYPE%`, `%FILTER%`,
+`%TELESCOPE%`, `%CAMERA%`, `%EXPOSURE%`, and `%GAIN%`. `%NIGHT%` follows N.I.N.A.'s
+observing-night convention: `DATE-LOC` minus 12 hours. Omitting placement keeps
+the compatibility `flat` layout.
+
+The desktop Settings flow scans catalog-linked files below the selected receive
+root when `target_tree` is saved. It persists a uniquely dominant pattern and
+shows how many catalog files supported it. Empty or mixed catalogs keep the
+selected preset, so placement never requires a filesystem scan during an image
+upload. Headless servers have no Settings scanner and use their explicit
+`directory_template` (or the legacy target/type/filter default).
 
 They apply to the in-memory database list at startup and are never written back
 to the registry, so the config file stays the whole account of what a

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,9 +6,9 @@
 
 ## Added
 
-- Remote image receivers can optionally organize uploaded lights and flats by
-  target, frame type, and filter while keeping the existing flat layout as the
-  default.
+- Remote image receivers can match an existing catalog folder tree or use a
+  preset/custom target, date, frame type, filter, camera, and exposure layout,
+  while keeping the existing flat layout as the default.
 
 ## Changed
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,20 @@
 
 ## Added
 
+- Remote image receivers can optionally organize uploaded lights and flats by
+  target, frame type, and filter while keeping the existing flat layout as the
+  default.
+
 ## Changed
 
 ## Fixed
+
+- Remote scheduler sync and export now wait for transient SQLite locks instead
+  of failing immediately while N.I.N.A. or another server task is using the
+  catalog.
+- Remote uploads now retain a durable path and content identity, restore
+  missing files on an identical retry, and avoid attaching same-named frames
+  to the wrong scheduler target.
+- Replacing an uploaded image now invalidates its rendered, quality,
+  astrometry, and satellite evidence, including star and HFR values PSF Guard
+  previously wrote back, without scanning the full cache tree.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -5,6 +5,7 @@
 # Rust release binaries carry no DWARF here (the release profile sets no
 # debug), so there is nothing for find-debuginfo to harvest.
 %global debug_package %{nil}
+%global rustflags_debuginfo 0
 
 Name:           psf-guard
 Version:        0.9.1
@@ -56,7 +57,9 @@ tar -xf %{SOURCE1}
 # build.rs not to invoke npm. Crates resolve from ./vendor, so build offline.
 export PSF_GUARD_SKIP_FRONTEND_BUILD=1
 export CARGO_NET_OFFLINE=true
-cargo build --release --locked
+# Build only the binary shipped by this package and cap concurrent rustc jobs
+# to keep linking within memory limits on standard RPM builders.
+cargo build --release --locked --bin psf-guard --jobs 1
 
 %install
 install -Dpm0755 target/release/%{name} %{buildroot}%{_bindir}/%{name}

--- a/src/commands/import/headers.rs
+++ b/src/commands/import/headers.rs
@@ -28,6 +28,9 @@ pub struct FrameMeta {
     pub timestamp: Option<i64>,
     /// DATE-OBS original text, for the metadata JSON.
     pub date_obs: Option<String>,
+    /// DATE-LOC original text. N.I.N.A. directory templates use this local
+    /// value for observing-night (`DATEMINUS12`) folders.
+    pub date_local: Option<String>,
     pub exposure_s: Option<f64>,
     pub gain: Option<i64>,
     pub offset: Option<i64>,
@@ -143,6 +146,7 @@ pub fn read_frame_meta_named(path: &Path, declared: &Path) -> FrameMeta {
     meta.object = text(&["OBJECT"]);
     meta.filter = text(&["FILTER", "FILTERNAME"]);
     meta.date_obs = text(&["DATE-OBS", "DATE-LOC"]);
+    meta.date_local = text(&["DATE-LOC"]);
     meta.timestamp = meta.date_obs.as_deref().and_then(parse_fits_datetime);
     meta.exposure_s = f64_of(&["EXPTIME", "EXPOSURE"]).filter(|v| *v > 0.0);
     meta.gain = i64_of(&["GAIN"]);

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -530,9 +530,26 @@ pub(crate) fn resolve_existing_target_name(
     frame: &FrameMeta,
     radius_deg: f64,
 ) -> Result<Option<String>> {
+    Ok(resolve_existing_target_identity(conn, frame, radius_deg)?.map(|identity| identity.0))
+}
+
+/// Resolve the target and its owning project together. Directory templates
+/// need both values from the same coordinate-aware match when mosaic panels or
+/// separate projects reuse a target name.
+pub(crate) fn resolve_existing_target_identity(
+    conn: &Connection,
+    frame: &FrameMeta,
+    radius_deg: f64,
+) -> Result<Option<(String, String)>> {
     let targets = load_existing_targets(conn)?;
-    Ok(match_existing_target(frame, &targets, radius_deg)
-        .map(|(index, _)| targets[index].name.clone()))
+    Ok(
+        match_existing_target(frame, &targets, radius_deg).map(|(index, _)| {
+            (
+                targets[index].name.clone(),
+                targets[index].project_name.clone(),
+            )
+        }),
+    )
 }
 
 /// Insert frames into an EXISTING target: reuse (or create) the profile's

--- a/src/commands/import/mod.rs
+++ b/src/commands/import/mod.rs
@@ -522,6 +522,19 @@ fn match_existing_target(
         .map(|(i, _)| (i, "coordinates"))
 }
 
+/// Resolve the target name the ordinary importer would attach one light to.
+/// Remote upload placement uses this before publishing the file so its
+/// server-owned directory layout agrees with the later catalog import.
+pub(crate) fn resolve_existing_target_name(
+    conn: &Connection,
+    frame: &FrameMeta,
+    radius_deg: f64,
+) -> Result<Option<String>> {
+    let targets = load_existing_targets(conn)?;
+    Ok(match_existing_target(frame, &targets, radius_deg)
+        .map(|(index, _)| targets[index].name.clone()))
+}
+
 /// Insert frames into an EXISTING target: reuse (or create) the profile's
 /// exposure template, reuse a matching exposure plan on the target (bumping
 /// its acquired count) or add one, and land the images under the target's

--- a/src/commands/sync/remote.rs
+++ b/src/commands/sync/remote.rs
@@ -16,6 +16,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::server::database_context::open_scheduler_connection_with_flags;
 use crate::server::remote_sync::SyncOperation;
 use crate::sync_client::{local_bundle, materialize, SyncClient};
 
@@ -126,8 +127,9 @@ async fn pull_from(
     materialize(&bundle, &staged_path, &options.local_path)
         .context("staging the peer's bundle as a scheduler database")?;
 
-    let source = Connection::open_with_flags(&staged_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .context("opening the staged bundle")?;
+    let source =
+        open_scheduler_connection_with_flags(&staged_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .context("opening the staged bundle")?;
     let destination = open_local(&options.local_path, options.dry_run)?;
     require_pull_capable(&source).context("the peer's catalog")?;
     require_pull_capable(&destination).context("the local database")?;
@@ -190,13 +192,15 @@ async fn push_to(
 /// merge engine runs the same statements inside a transaction it rolls back —
 /// better to fail here than halfway through.
 fn open_local(path: &Path, dry_run: bool) -> Result<Connection> {
-    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE).with_context(|| {
-        format!(
-            "opening the local database {} for {}",
-            path.display(),
-            if dry_run { "a dry run" } else { "writing" }
-        )
-    })
+    open_scheduler_connection_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE).with_context(
+        || {
+            format!(
+                "opening the local database {} for {}",
+                path.display(),
+                if dry_run { "a dry run" } else { "writing" }
+            )
+        },
+    )
 }
 
 fn pull_summary(summary: &crate::commands::sync::PullSummary) -> BTreeMap<String, i64> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,10 @@ pub struct RemoteUploadConfig {
     /// Layout below `image_dir`. Omitted keeps the compatibility flat layout.
     #[serde(default)]
     pub placement: crate::db_registry::RemoteImageUploadPlacement,
+    /// Server-owned directory template for `target_tree` placement. A
+    /// headless server cannot use the Settings scanner, so this is explicit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub directory_template: Option<String>,
     /// Bearer token, in the clear. Prefer `token_file`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
@@ -152,6 +156,24 @@ pub fn apply_remote_access(
         access.enabled = true;
         access.image_dir = config.image_dir.clone();
         access.placement = config.placement;
+        if let Some(template) = config.directory_template.as_deref() {
+            crate::server::remote_upload_layout::validate_directory_template(template)
+                .with_context(|| {
+                    format!(
+                        "remote upload directory template for database '{}'",
+                        config.database
+                    )
+                })?;
+            let template = template.trim().replace('\\', "/");
+            access.directory_layout = Some(crate::db_registry::RemoteImageUploadDirectoryLayout {
+                template: template.clone(),
+                fallback_template: template,
+                source: crate::db_registry::RemoteImageUploadTemplateSource::Preset,
+                samples: 0,
+            });
+        } else {
+            access.directory_layout = None;
+        }
         note(&mut opened, &config.database, "image upload");
     }
     Ok(opened
@@ -1205,6 +1227,15 @@ directory = "./cache"
         let directory = tempfile::tempdir().unwrap();
         let image_dir = directory.path().join("incoming");
         let mut entries = vec![entry("telescope")];
+        entries[0].remote_image_upload = Some(crate::db_registry::RemoteImageUploadConfig {
+            directory_layout: Some(crate::db_registry::RemoteImageUploadDirectoryLayout {
+                template: "%YEAR%/%TARGET%/%NIGHT%/%TYPE%".into(),
+                fallback_template: "%TARGET%/%DATE%/%TYPE%".into(),
+                source: crate::db_registry::RemoteImageUploadTemplateSource::Catalog,
+                samples: 12,
+            }),
+            ..Default::default()
+        });
 
         let opened = apply_remote_access(
             &mut entries,
@@ -1217,6 +1248,7 @@ directory = "./cache"
                 database: "telescope".into(),
                 image_dir: image_dir.to_string_lossy().into_owned(),
                 placement: crate::db_registry::RemoteImageUploadPlacement::TargetTree,
+                directory_template: None,
                 token: Some(TOKEN.into()),
                 token_file: None,
             }],
@@ -1231,6 +1263,10 @@ directory = "./cache"
         assert_eq!(
             access.placement,
             crate::db_registry::RemoteImageUploadPlacement::TargetTree
+        );
+        assert!(
+            access.directory_layout.is_none(),
+            "omitting a headless template keeps the legacy target/type/filter layout"
         );
         assert!(access.token_matches(TOKEN));
         // The receive directory is made ready at startup, not on the first
@@ -1254,6 +1290,7 @@ directory = "./cache"
                 database: "telescope".into(),
                 image_dir: directory.path().to_string_lossy().into_owned(),
                 placement: crate::db_registry::RemoteImageUploadPlacement::Flat,
+                directory_template: None,
                 token: Some("a-different-token-long-enough".into()),
                 token_file: None,
             }],

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,9 @@ pub struct RemoteUploadConfig {
     pub database: String,
     /// Directory the received frames are written to. Created if absent.
     pub image_dir: String,
+    /// Layout below `image_dir`. Omitted keeps the compatibility flat layout.
+    #[serde(default)]
+    pub placement: crate::db_registry::RemoteImageUploadPlacement,
     /// Bearer token, in the clear. Prefer `token_file`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
@@ -148,6 +151,7 @@ pub fn apply_remote_access(
         let access = open(entries, &config.database, &token, &mut keyed)?;
         access.enabled = true;
         access.image_dir = config.image_dir.clone();
+        access.placement = config.placement;
         note(&mut opened, &config.database, "image upload");
     }
     Ok(opened
@@ -1212,6 +1216,7 @@ directory = "./cache"
             &[RemoteUploadConfig {
                 database: "telescope".into(),
                 image_dir: image_dir.to_string_lossy().into_owned(),
+                placement: crate::db_registry::RemoteImageUploadPlacement::TargetTree,
                 token: Some(TOKEN.into()),
                 token_file: None,
             }],
@@ -1223,6 +1228,10 @@ directory = "./cache"
         assert!(access.sync_enabled);
         assert!(access.enabled);
         assert_eq!(access.image_dir, image_dir.to_string_lossy());
+        assert_eq!(
+            access.placement,
+            crate::db_registry::RemoteImageUploadPlacement::TargetTree
+        );
         assert!(access.token_matches(TOKEN));
         // The receive directory is made ready at startup, not on the first
         // upload, so a bad path fails while the operator is still watching.
@@ -1244,6 +1253,7 @@ directory = "./cache"
             &[RemoteUploadConfig {
                 database: "telescope".into(),
                 image_dir: directory.path().to_string_lossy().into_owned(),
+                placement: crate::db_registry::RemoteImageUploadPlacement::Flat,
                 token: Some("a-different-token-long-enough".into()),
                 token_file: None,
             }],
@@ -1252,5 +1262,25 @@ directory = "./cache"
         .to_string();
 
         assert!(error.contains("one key"), "{error}");
+    }
+
+    #[test]
+    fn remote_upload_config_defaults_to_the_flat_layout() {
+        let config: Config = toml_edit::de::from_str(&format!(
+            r#"
+            [server]
+            [cache]
+            [[remote_upload]]
+            database = "telescope"
+            image_dir = "incoming"
+            token = "{TOKEN}"
+            "#
+        ))
+        .unwrap();
+
+        assert_eq!(
+            config.remote_upload[0].placement,
+            crate::db_registry::RemoteImageUploadPlacement::Flat
+        );
     }
 }

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -80,6 +80,37 @@ pub enum RemoteImageUploadPlacement {
     TargetTree,
 }
 
+pub const DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE: &str = "%TARGET%/%TYPE%/%FILTER%";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteImageUploadTemplateSource {
+    #[default]
+    Preset,
+    Catalog,
+}
+
+/// A validated server-owned directory layout below the configured receive
+/// root. The client still supplies only the image basename.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteImageUploadDirectoryLayout {
+    /// Effective template rendered for new uploads.
+    pub template: String,
+    /// Operator-selected template retained when catalog detection succeeds, so
+    /// an empty or ambiguous later scan does not silently change the fallback.
+    #[serde(default = "default_remote_upload_directory_template")]
+    pub fallback_template: String,
+    #[serde(default)]
+    pub source: RemoteImageUploadTemplateSource,
+    /// Catalog files which supported a detected layout. Zero for a preset.
+    #[serde(default)]
+    pub samples: usize,
+}
+
+fn default_remote_upload_directory_template() -> String {
+    DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE.to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct RemoteImageUploadConfig {
     #[serde(default)]
@@ -104,11 +135,29 @@ pub struct RemoteImageUploadConfig {
     /// only a basename; it can never choose a directory or relative path.
     #[serde(default)]
     pub placement: RemoteImageUploadPlacement,
+    /// Persisted preset or catalog-derived template for `TargetTree`.
+    /// Missing in older registries means the original target/type/filter tree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub directory_layout: Option<RemoteImageUploadDirectoryLayout>,
 }
 
 impl RemoteImageUploadConfig {
     pub const MIN_TOKEN_LENGTH: usize = 24;
     pub const MAX_TOKEN_LENGTH: usize = 256;
+
+    pub fn directory_template(&self) -> &str {
+        self.directory_layout
+            .as_ref()
+            .map(|layout| layout.template.as_str())
+            .unwrap_or(DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE)
+    }
+
+    pub fn fallback_directory_template(&self) -> &str {
+        self.directory_layout
+            .as_ref()
+            .map(|layout| layout.fallback_template.as_str())
+            .unwrap_or(DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE)
+    }
 
     pub fn set_token(&mut self, token: &str) -> Result<()> {
         if token.len() < Self::MIN_TOKEN_LENGTH || token.len() > Self::MAX_TOKEN_LENGTH {

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -67,6 +67,19 @@ pub struct RemoteClient {
     pub paired_at: i64,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteImageUploadPlacement {
+    /// Keep every received frame directly below the selected image root.
+    /// This is the compatibility default for registries written before
+    /// target-aware placement existed.
+    #[default]
+    Flat,
+    /// Group lights and flats by target, with the frame type and filter below
+    /// it. Other calibration kinds use their own top-level frame-type folder.
+    TargetTree,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct RemoteImageUploadConfig {
     #[serde(default)]
@@ -87,6 +100,10 @@ pub struct RemoteImageUploadConfig {
     /// sync protocol existed does not silently gain merge and apply rights.
     #[serde(default)]
     pub sync_enabled: bool,
+    /// Server-derived layout below `image_dir`. The client still supplies
+    /// only a basename; it can never choose a directory or relative path.
+    #[serde(default)]
+    pub placement: RemoteImageUploadPlacement,
 }
 
 impl RemoteImageUploadConfig {
@@ -841,6 +858,7 @@ mod tests {
         let mut config = RemoteImageUploadConfig {
             enabled: true,
             image_dir: images.to_string_lossy().into_owned(),
+            placement: RemoteImageUploadPlacement::TargetTree,
             ..Default::default()
         };
         config.set_token(token).unwrap();
@@ -874,6 +892,24 @@ mod tests {
             .as_ref()
             .unwrap()
             .token_matches(token));
+        assert_eq!(
+            loaded.databases[0]
+                .remote_image_upload
+                .as_ref()
+                .unwrap()
+                .placement,
+            RemoteImageUploadPlacement::TargetTree
+        );
+    }
+
+    #[test]
+    fn remote_upload_without_placement_keeps_the_flat_compatibility_layout() {
+        let config: RemoteImageUploadConfig = serde_json::from_value(serde_json::json!({
+            "enabled": false,
+            "image_dir": ""
+        }))
+        .unwrap();
+        assert_eq!(config.placement, RemoteImageUploadPlacement::Flat);
     }
 
     #[test]

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -418,6 +418,13 @@ pub struct RemoteImageUploadSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image_directory: Option<String>,
     pub placement: crate::db_registry::RemoteImageUploadPlacement,
+    /// Operator-selected fallback below the receive directory.
+    pub directory_template: String,
+    /// Effective catalog-derived template, when detection found one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog_directory_template: Option<String>,
+    pub directory_template_source: crate::db_registry::RemoteImageUploadTemplateSource,
+    pub directory_template_samples: usize,
     pub token_configured: bool,
     pub sync_enabled: bool,
     /// Paired clients, for the Settings list and per-client revocation.
@@ -449,6 +456,14 @@ pub struct RemoteImageUploadUpdate {
     /// Optional so older management clients leave the stored layout alone.
     #[serde(default)]
     pub placement: Option<crate::db_registry::RemoteImageUploadPlacement>,
+    /// Fallback used when the selected receive root has no unambiguous
+    /// catalog layout. Catalog detection can replace it while saving.
+    #[serde(default)]
+    pub directory_template: Option<String>,
+    /// Request a fresh catalog/tree match even when the layout settings did
+    /// not otherwise change.
+    #[serde(default)]
+    pub rescan_directory_layout: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -417,6 +417,7 @@ pub struct RemoteImageUploadSummary {
     pub enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image_directory: Option<String>,
+    pub placement: crate::db_registry::RemoteImageUploadPlacement,
     pub token_configured: bool,
     pub sync_enabled: bool,
     /// Paired clients, for the Settings list and per-client revocation.
@@ -445,6 +446,9 @@ pub struct RemoteImageUploadUpdate {
     /// or the reverse. Absent means "leave the stored setting alone".
     #[serde(default)]
     pub sync_enabled: Option<bool>,
+    /// Optional so older management clients leave the stored layout alone.
+    #[serde(default)]
+    pub placement: Option<crate::db_registry::RemoteImageUploadPlacement>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -45,6 +45,7 @@ fn db_read_only_flags() -> OpenFlags {
 /// Sized to cover the worst observed single-query duration. (External writers
 /// like N.I.N.A. on a network share get the same courtesy.)
 pub(crate) const SCHEDULER_BUSY_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_REMOTE_IMAGE_VERIFICATIONS: usize = 4096;
 const MAX_REMOTE_FILE_VERIFICATIONS: usize = 4096;
 
 /// Apply the server's lock-wait policy to a scheduler database connection.
@@ -440,6 +441,8 @@ pub(crate) struct RemoteImageFileIdentity {
     file_index: Option<u64>,
     #[cfg(windows)]
     creation_time: u64,
+    #[cfg(windows)]
+    change_time: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -459,7 +462,7 @@ pub(crate) fn remote_image_file_identity(path: &Path) -> Option<RemoteImageFileI
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt as _;
     #[cfg(windows)]
-    let (volume_serial_number, file_index) = windows_file_id(path)?;
+    let (volume_serial_number, file_index, change_time) = windows_file_identity(path)?;
     Some(RemoteImageFileIdentity {
         canonical_path: std::fs::canonicalize(path).ok()?,
         len: metadata.len(),
@@ -481,27 +484,46 @@ pub(crate) fn remote_image_file_identity(path: &Path) -> Option<RemoteImageFileI
             use std::os::windows::fs::MetadataExt as _;
             metadata.creation_time()
         },
+        #[cfg(windows)]
+        change_time,
     })
 }
 
 #[cfg(windows)]
-fn windows_file_id(path: &Path) -> Option<(u32, u64)> {
+fn windows_file_identity(path: &Path) -> Option<(u32, u64, i64)> {
     use std::os::windows::io::AsRawHandle as _;
     use windows_sys::Win32::Foundation::HANDLE;
     use windows_sys::Win32::Storage::FileSystem::{
-        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+        FileBasicInfo, GetFileInformationByHandle, GetFileInformationByHandleEx,
+        BY_HANDLE_FILE_INFORMATION, FILE_BASIC_INFO,
     };
 
     let file = std::fs::File::open(path).ok()?;
+    let handle = file.as_raw_handle() as HANDLE;
     let mut information = unsafe { std::mem::zeroed::<BY_HANDLE_FILE_INFORMATION>() };
-    let success =
-        unsafe { GetFileInformationByHandle(file.as_raw_handle() as HANDLE, &mut information) };
+    let success = unsafe { GetFileInformationByHandle(handle, &mut information) };
     if success == 0 {
         return None;
     }
     let file_index =
         (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow);
-    Some((information.dwVolumeSerialNumber, file_index))
+    let mut basic_information = FILE_BASIC_INFO::default();
+    let basic_success = unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileBasicInfo,
+            std::ptr::addr_of_mut!(basic_information).cast::<std::ffi::c_void>(),
+            std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    };
+    if basic_success == 0 {
+        return None;
+    }
+    Some((
+        information.dwVolumeSerialNumber,
+        file_index,
+        basic_information.ChangeTime,
+    ))
 }
 
 fn arrival_source_fingerprint(path: &Path) -> Option<ArrivalSourceFingerprint> {
@@ -1037,18 +1059,29 @@ impl DatabaseContext {
         expected_sha256: &str,
     ) {
         let expected_sha256 = expected_sha256.to_ascii_lowercase();
-        let previous = lock_recover(&self.remote_image_verifications).insert(
+        let mut image_verifications = lock_recover(&self.remote_image_verifications);
+        let evicted = if !image_verifications.contains_key(&image_id)
+            && image_verifications.len() >= MAX_REMOTE_IMAGE_VERIFICATIONS
+            && let Some(image_to_evict) = image_verifications.keys().next().copied()
+        {
+            image_verifications.remove(&image_to_evict)
+        } else {
+            None
+        };
+        let previous = image_verifications.insert(
             image_id,
             RemoteImageVerification {
                 identity: identity.clone(),
                 expected_sha256: expected_sha256.clone(),
             },
         );
+        drop(image_verifications);
+
         let mut file_verifications = lock_recover(&self.remote_file_verifications);
-        if let Some(previous) = previous {
+        for stale in [evicted, previous].into_iter().flatten() {
             file_verifications.remove(&RemoteImageVerificationKey {
-                identity: previous.identity,
-                expected_sha256: previous.expected_sha256.to_ascii_lowercase(),
+                identity: stale.identity,
+                expected_sha256: stale.expected_sha256,
             });
         }
         if file_verifications.len() >= MAX_REMOTE_FILE_VERIFICATIONS
@@ -2414,5 +2447,85 @@ mod tests {
         );
         let after = remote_image_file_identity(&path).unwrap();
         assert_ne!(before, after);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn remote_file_identity_changes_for_in_place_write_with_preserved_mtime() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("mapped.fits");
+        std::fs::write(&path, b"original").unwrap();
+        let original_metadata = std::fs::metadata(&path).unwrap();
+        let original_mtime = filetime::FileTime::from_last_modification_time(&original_metadata);
+        let before = remote_image_file_identity(&path).unwrap();
+
+        std::thread::sleep(Duration::from_millis(20));
+        std::fs::write(&path, b"replaced").unwrap();
+        filetime::set_file_mtime(&path, original_mtime).unwrap();
+
+        let after_metadata = std::fs::metadata(&path).unwrap();
+        assert_eq!(
+            filetime::FileTime::from_last_modification_time(&after_metadata),
+            original_mtime
+        );
+        let after = remote_image_file_identity(&path).unwrap();
+        assert_eq!(before.file_index, after.file_index);
+        assert_eq!(before.creation_time, after.creation_time);
+        assert_ne!(before.change_time, after.change_time);
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn remote_image_verifications_are_bounded() {
+        let context = DatabaseContext::new_for_test(Connection::open_in_memory().unwrap());
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("mapped.fits");
+        std::fs::write(&path, b"fixture").unwrap();
+        let identity = remote_image_file_identity(&path).unwrap();
+
+        for image_id in 0..=MAX_REMOTE_IMAGE_VERIFICATIONS {
+            let mut image_identity = identity.clone();
+            image_identity.len = image_id as u64;
+            context.record_remote_image_verification(
+                image_id as i32,
+                image_identity,
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            );
+        }
+
+        let newest_image_id = MAX_REMOTE_IMAGE_VERIFICATIONS as i32;
+        let stale_key = {
+            let verifications = lock_recover(&context.remote_image_verifications);
+            assert_eq!(verifications.len(), MAX_REMOTE_IMAGE_VERIFICATIONS);
+            let newest = verifications.get(&newest_image_id).unwrap();
+            let file_verifications = lock_recover(&context.remote_file_verifications);
+            assert_eq!(file_verifications.len(), MAX_REMOTE_FILE_VERIFICATIONS);
+            assert!(verifications.values().all(|verification| {
+                file_verifications.contains(&RemoteImageVerificationKey {
+                    identity: verification.identity.clone(),
+                    expected_sha256: verification.expected_sha256.clone(),
+                })
+            }));
+            RemoteImageVerificationKey {
+                identity: newest.identity.clone(),
+                expected_sha256: newest.expected_sha256.clone(),
+            }
+        };
+
+        let mut replacement_identity = identity;
+        replacement_identity.len = (MAX_REMOTE_IMAGE_VERIFICATIONS + 1) as u64;
+        let replacement_sha = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        context.record_remote_image_verification(
+            newest_image_id,
+            replacement_identity.clone(),
+            replacement_sha,
+        );
+
+        let file_verifications = lock_recover(&context.remote_file_verifications);
+        assert!(!file_verifications.contains(&stale_key));
+        assert!(file_verifications.contains(&RemoteImageVerificationKey {
+            identity: replacement_identity,
+            expected_sha256: replacement_sha.to_string(),
+        }));
     }
 }

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -17,7 +17,7 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, RwLock, Weak};
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex as TokioMutex;
 
@@ -44,11 +44,38 @@ fn db_read_only_flags() -> OpenFlags {
 /// out the current refresh statement and wins the gap between statements.
 /// Sized to cover the worst observed single-query duration. (External writers
 /// like N.I.N.A. on a network share get the same courtesy.)
-const DB_BUSY_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const SCHEDULER_BUSY_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_REMOTE_FILE_VERIFICATIONS: usize = 4096;
 
-/// The one way to open a scheduler DB connection in the server: flags above +
-/// busy timeout. Every open site (initial, both reopen paths, the refresh
-/// connection) must go through here so none silently loses the busy handler.
+/// Apply the server's lock-wait policy to a scheduler database connection.
+///
+/// Most connections come from [`open_scheduler_connection`]. Short-lived
+/// connections that need different flags, such as the read-only source and
+/// writable destination used by scheduler sync, must call this immediately
+/// after opening so they do not fail instantly on ordinary SQLite contention.
+pub(crate) fn configure_scheduler_busy_timeout(conn: &Connection) -> rusqlite::Result<()> {
+    conn.busy_timeout(SCHEDULER_BUSY_TIMEOUT)
+}
+
+/// Open a scheduler connection with caller-selected access flags and the
+/// server's shared lock-wait policy.
+///
+/// Use this for short-lived catalog connections that cannot use
+/// [`open_scheduler_connection`], which chooses writable access with a
+/// read-only fallback and runs PSF Guard schema upgrades.
+pub(crate) fn open_scheduler_connection_with_flags(
+    path: impl AsRef<Path>,
+    flags: OpenFlags,
+) -> rusqlite::Result<Connection> {
+    let conn = Connection::open_with_flags(path, flags)?;
+    configure_scheduler_busy_timeout(&conn)?;
+    Ok(conn)
+}
+
+/// The usual way to open a scheduler DB connection in the server: flags above
+/// plus the shared busy timeout. Every long-lived open site (initial, both
+/// reopen paths, the refresh connection) must go through here so none silently
+/// loses the busy handler.
 pub(crate) fn open_scheduler_connection(path: &str) -> rusqlite::Result<Connection> {
     let conn = match Connection::open_with_flags(path, db_open_flags()) {
         Ok(conn) => conn,
@@ -68,7 +95,7 @@ pub(crate) fn open_scheduler_connection(path: &str) -> rusqlite::Result<Connecti
             }
         }
     };
-    conn.busy_timeout(DB_BUSY_TIMEOUT)?;
+    configure_scheduler_busy_timeout(&conn)?;
     upgrade_psf_guard_tables(&conn, path);
     Ok(conn)
 }
@@ -238,6 +265,62 @@ fn error_is_corruption(err: &anyhow::Error) -> bool {
     })
 }
 
+/// Whether an operation exhausted SQLite's configured lock wait.
+///
+/// Database helpers add context before returning errors, so inspect the full
+/// chain rather than only the outermost cause. This classification belongs at
+/// the HTTP boundary: busy/locked is an operational database failure, not bad
+/// client input.
+pub(crate) fn error_is_sqlite_contention(err: &anyhow::Error) -> bool {
+    use rusqlite::ffi::ErrorCode;
+
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<rusqlite::Error>(),
+            Some(rusqlite::Error::SqliteFailure(sqlite, _))
+                if matches!(sqlite.code, ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+        )
+    })
+}
+
+/// Whether an anyhow chain contains a SQLite engine failure. Callers use
+/// this to keep filesystem, I/O, corruption, and lock failures from being
+/// reported as malformed HTTP input while still classifying their own
+/// preflight validation errors separately.
+pub(crate) fn error_has_sqlite_failure(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<rusqlite::Error>().is_some())
+}
+
+/// SQLite failures caused by the running host rather than invalid row data.
+/// Constraint/type/schema failures are deliberately excluded because remote
+/// bundle materialization uses those to reject malformed client input.
+pub(crate) fn error_is_sqlite_operational_failure(err: &anyhow::Error) -> bool {
+    use rusqlite::ffi::ErrorCode;
+
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<rusqlite::Error>(),
+            Some(rusqlite::Error::SqliteFailure(sqlite, _))
+                if matches!(
+                    sqlite.code,
+                    ErrorCode::DatabaseBusy
+                        | ErrorCode::DatabaseLocked
+                        | ErrorCode::PermissionDenied
+                        | ErrorCode::OutOfMemory
+                        | ErrorCode::ReadOnly
+                        | ErrorCode::OperationInterrupted
+                        | ErrorCode::SystemIoFailure
+                        | ErrorCode::DatabaseCorrupt
+                        | ErrorCode::DiskFull
+                        | ErrorCode::CannotOpen
+                        | ErrorCode::FileLockingProtocolFailed
+                        | ErrorCode::NotADatabase
+                )
+        )
+    })
+}
+
 /// All per-database state for the running server.
 pub struct DatabaseContext {
     /// Canonical id used in URLs and on disk. URL-safe slug, e.g. `imaging-rig`
@@ -279,6 +362,19 @@ pub struct DatabaseContext {
     /// bounded, nonblocking probe schedule; expired entries remain as strict
     /// identity markers until displaced by the bounded-cap policy.
     delayed_remote_images: Arc<Mutex<HashMap<i32, DelayedRemoteImage>>>,
+    /// Content checks for files accepted through remote-upload provenance.
+    /// The first resolver call hashes the file; later calls only compare its
+    /// canonical path, size, modification time, and expected upload digest.
+    remote_image_verifications: Arc<Mutex<HashMap<i32, RemoteImageVerification>>>,
+    /// File-level index of the same completed checks. This lets two scheduler
+    /// rows mapped to one file reuse the result without scanning every image.
+    remote_file_verifications: Arc<Mutex<HashSet<RemoteImageVerificationKey>>>,
+    /// Rendezvous locks for cold mapped-image content checks. Keys include the
+    /// observed file identity and accepted digest so concurrent resolvers for
+    /// the same large file share one hash, even if different scheduler rows
+    /// refer to it. Weak values keep completed keys from accumulating.
+    remote_image_verification_locks:
+        Arc<Mutex<HashMap<RemoteImageVerificationKey, Weak<Mutex<()>>>>>,
     /// Serializes cold directory-tree builds so N concurrent requests on an
     /// empty cache share one filesystem scan instead of starting N.
     tree_build_lock: Arc<Mutex<()>>,
@@ -323,6 +419,89 @@ struct ArrivalSourceFingerprint {
     canonical_path: PathBuf,
     len: u64,
     modified: Option<std::time::SystemTime>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RemoteImageFileIdentity {
+    canonical_path: PathBuf,
+    len: u64,
+    modified: Option<std::time::SystemTime>,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+    #[cfg(windows)]
+    volume_serial_number: Option<u32>,
+    #[cfg(windows)]
+    file_index: Option<u64>,
+    #[cfg(windows)]
+    creation_time: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RemoteImageVerification {
+    identity: RemoteImageFileIdentity,
+    expected_sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RemoteImageVerificationKey {
+    identity: RemoteImageFileIdentity,
+    expected_sha256: String,
+}
+
+pub(crate) fn remote_image_file_identity(path: &Path) -> Option<RemoteImageFileIdentity> {
+    let metadata = std::fs::metadata(path).ok()?;
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt as _;
+    #[cfg(windows)]
+    let (volume_serial_number, file_index) = windows_file_id(path)?;
+    Some(RemoteImageFileIdentity {
+        canonical_path: std::fs::canonicalize(path).ok()?,
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+        #[cfg(unix)]
+        device: metadata.dev(),
+        #[cfg(unix)]
+        inode: metadata.ino(),
+        #[cfg(unix)]
+        changed_seconds: metadata.ctime(),
+        #[cfg(unix)]
+        changed_nanoseconds: metadata.ctime_nsec(),
+        #[cfg(windows)]
+        volume_serial_number: Some(volume_serial_number),
+        #[cfg(windows)]
+        file_index: Some(file_index),
+        #[cfg(windows)]
+        creation_time: {
+            use std::os::windows::fs::MetadataExt as _;
+            metadata.creation_time()
+        },
+    })
+}
+
+#[cfg(windows)]
+fn windows_file_id(path: &Path) -> Option<(u32, u64)> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+
+    let file = std::fs::File::open(path).ok()?;
+    let mut information = unsafe { std::mem::zeroed::<BY_HANDLE_FILE_INFORMATION>() };
+    let success =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle() as HANDLE, &mut information) };
+    if success == 0 {
+        return None;
+    }
+    let file_index =
+        (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow);
+    Some((information.dwVolumeSerialNumber, file_index))
 }
 
 fn arrival_source_fingerprint(path: &Path) -> Option<ArrivalSourceFingerprint> {
@@ -505,6 +684,9 @@ impl DatabaseContext {
             directory_tree_additions: Arc::new(RwLock::new(HashSet::new())),
             file_check_additions: Arc::new(RwLock::new(HashMap::new())),
             delayed_remote_images: Arc::new(Mutex::new(HashMap::new())),
+            remote_image_verifications: Arc::new(Mutex::new(HashMap::new())),
+            remote_file_verifications: Arc::new(Mutex::new(HashSet::new())),
+            remote_image_verification_locks: Arc::new(Mutex::new(HashMap::new())),
             tree_build_lock: Arc::new(Mutex::new(())),
             tree_rebuild_inflight: Arc::new(AtomicBool::new(false)),
             refresh_mutex: Arc::new(TokioMutex::new(())),
@@ -601,6 +783,8 @@ impl DatabaseContext {
             Ok(new_conn) => {
                 *lock_recover(&self.db_connection) = new_conn;
                 *lock_recover(&self.db_fingerprint) = Some(new_fp);
+                lock_recover(&self.remote_image_verifications).clear();
+                lock_recover(&self.remote_file_verifications).clear();
                 tracing::info!(
                     "🔁 Database file for db={} was replaced on disk ({}); reopened connection",
                     self.id,
@@ -628,6 +812,8 @@ impl DatabaseContext {
             Ok(new_conn) => {
                 *lock_recover(&self.db_connection) = new_conn;
                 *lock_recover(&self.db_fingerprint) = fingerprint_path(&self.database_path);
+                lock_recover(&self.remote_image_verifications).clear();
+                lock_recover(&self.remote_file_verifications).clear();
                 tracing::info!(
                     "🔁 Reopened connection for db={} after a corruption-class error",
                     self.id
@@ -797,6 +983,87 @@ impl DatabaseContext {
         let mut cache = self.directory_tree_cache.write().unwrap();
         *cache = None;
         tracing::info!("🗑️  Directory tree cache cleared for db={}", self.id);
+    }
+
+    pub(crate) fn remote_image_verification_is_current(
+        &self,
+        image_id: i32,
+        identity: &RemoteImageFileIdentity,
+        expected_sha256: &str,
+    ) -> bool {
+        lock_recover(&self.remote_image_verifications)
+            .get(&image_id)
+            .is_some_and(|verification| {
+                verification.identity == *identity
+                    && verification.expected_sha256 == expected_sha256
+            })
+    }
+
+    pub(crate) fn remote_image_verification_is_known(
+        &self,
+        identity: &RemoteImageFileIdentity,
+        expected_sha256: &str,
+    ) -> bool {
+        lock_recover(&self.remote_file_verifications).contains(&RemoteImageVerificationKey {
+            identity: identity.clone(),
+            expected_sha256: expected_sha256.to_ascii_lowercase(),
+        })
+    }
+
+    pub(crate) fn remote_image_verification_lock(
+        &self,
+        identity: &RemoteImageFileIdentity,
+        expected_sha256: &str,
+    ) -> Arc<Mutex<()>> {
+        let key = RemoteImageVerificationKey {
+            identity: identity.clone(),
+            expected_sha256: expected_sha256.to_ascii_lowercase(),
+        };
+        let mut locks = lock_recover(&self.remote_image_verification_locks);
+        if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(key, Arc::downgrade(&lock));
+        lock
+    }
+
+    pub(crate) fn record_remote_image_verification(
+        &self,
+        image_id: i32,
+        identity: RemoteImageFileIdentity,
+        expected_sha256: &str,
+    ) {
+        let expected_sha256 = expected_sha256.to_ascii_lowercase();
+        let previous = lock_recover(&self.remote_image_verifications).insert(
+            image_id,
+            RemoteImageVerification {
+                identity: identity.clone(),
+                expected_sha256: expected_sha256.clone(),
+            },
+        );
+        let mut file_verifications = lock_recover(&self.remote_file_verifications);
+        if let Some(previous) = previous {
+            file_verifications.remove(&RemoteImageVerificationKey {
+                identity: previous.identity,
+                expected_sha256: previous.expected_sha256.to_ascii_lowercase(),
+            });
+        }
+        if file_verifications.len() >= MAX_REMOTE_FILE_VERIFICATIONS
+            && let Some(entry_to_evict) = file_verifications.iter().next().cloned()
+        {
+            file_verifications.remove(&entry_to_evict);
+        }
+        file_verifications.insert(RemoteImageVerificationKey {
+            identity,
+            expected_sha256,
+        });
+    }
+
+    pub(crate) fn clear_remote_image_verification(&self, image_id: i32) {
+        lock_recover(&self.remote_image_verifications).remove(&image_id);
     }
 
     pub fn get_directory_tree_stats(&self) -> Option<crate::directory_tree::DirectoryTreeStats> {
@@ -1528,6 +1795,9 @@ impl DatabaseContext {
             directory_tree_additions: Arc::new(RwLock::new(HashSet::new())),
             file_check_additions: Arc::new(RwLock::new(HashMap::new())),
             delayed_remote_images: Arc::new(Mutex::new(HashMap::new())),
+            remote_image_verifications: Arc::new(Mutex::new(HashMap::new())),
+            remote_file_verifications: Arc::new(Mutex::new(HashSet::new())),
+            remote_image_verification_locks: Arc::new(Mutex::new(HashMap::new())),
             tree_build_lock: Arc::new(Mutex::new(())),
             tree_rebuild_inflight: Arc::new(AtomicBool::new(false)),
             refresh_mutex: Arc::new(TokioMutex::new(())),
@@ -1563,6 +1833,9 @@ impl Clone for DatabaseContext {
             directory_tree_additions: self.directory_tree_additions.clone(),
             file_check_additions: self.file_check_additions.clone(),
             delayed_remote_images: self.delayed_remote_images.clone(),
+            remote_image_verifications: self.remote_image_verifications.clone(),
+            remote_file_verifications: self.remote_file_verifications.clone(),
+            remote_image_verification_locks: self.remote_image_verification_locks.clone(),
             tree_build_lock: self.tree_build_lock.clone(),
             tree_rebuild_inflight: self.tree_rebuild_inflight.clone(),
             refresh_mutex: self.refresh_mutex.clone(),
@@ -1637,6 +1910,21 @@ mod tests {
                     (300, 1, 30, 3000, 'L', 0, 'not json', NULL, 'default');",
         )
         .unwrap();
+    }
+
+    #[test]
+    fn scheduler_connection_with_flags_uses_busy_timeout() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("scheduler.sqlite");
+        drop(Connection::open(&path).unwrap());
+
+        for flags in [db_read_only_flags(), db_open_flags()] {
+            let connection = open_scheduler_connection_with_flags(&path, flags).unwrap();
+            let timeout_ms: i64 = connection
+                .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(timeout_ms, 60_000);
+        }
     }
 
     #[test]
@@ -2054,8 +2342,8 @@ mod tests {
     #[test]
     fn corruption_errors_are_classified() {
         use rusqlite::ffi::{
-            Error as FfiError, SQLITE_BUSY, SQLITE_CORRUPT, SQLITE_IOERR, SQLITE_NOTADB,
-            SQLITE_SCHEMA,
+            Error as FfiError, SQLITE_BUSY, SQLITE_CORRUPT, SQLITE_IOERR, SQLITE_LOCKED,
+            SQLITE_NOTADB, SQLITE_SCHEMA,
         };
 
         let corrupt = rusqlite::Error::SqliteFailure(
@@ -2072,7 +2360,7 @@ mod tests {
 
         // Transient / benign codes must NOT be treated as a file swap, or a
         // passing hiccup would needlessly reopen the connection.
-        for transient in [SQLITE_BUSY, SQLITE_IOERR, SQLITE_SCHEMA] {
+        for transient in [SQLITE_BUSY, SQLITE_LOCKED, SQLITE_IOERR, SQLITE_SCHEMA] {
             let e = rusqlite::Error::SqliteFailure(FfiError::new(transient), None);
             assert!(
                 !is_corruption_error(&e),
@@ -2086,5 +2374,45 @@ mod tests {
         assert!(!error_is_corruption(&anyhow::anyhow!(
             "some unrelated failure"
         )));
+    }
+
+    #[test]
+    fn sqlite_contention_is_classified_through_context() {
+        use rusqlite::ffi::{Error as FfiError, SQLITE_BUSY, SQLITE_LOCKED};
+
+        for code in [SQLITE_BUSY, SQLITE_LOCKED] {
+            let contention = rusqlite::Error::SqliteFailure(FfiError::new(code), None);
+            let wrapped = anyhow::Error::new(contention)
+                .context("querying scheduler rows")
+                .context("creating remote export");
+            assert!(error_is_sqlite_contention(&wrapped));
+        }
+        assert!(!error_is_sqlite_contention(&anyhow::anyhow!(
+            "validation failed"
+        )));
+    }
+
+    #[test]
+    fn remote_file_identity_changes_for_same_size_preserved_mtime_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("mapped.fits");
+        let replacement = directory.path().join("replacement.fits");
+        std::fs::write(&path, b"original").unwrap();
+        let original_metadata = std::fs::metadata(&path).unwrap();
+        let original_mtime = filetime::FileTime::from_last_modification_time(&original_metadata);
+        let before = remote_image_file_identity(&path).unwrap();
+
+        std::fs::write(&replacement, b"replaced").unwrap();
+        filetime::set_file_mtime(&replacement, original_mtime).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        std::fs::rename(&replacement, &path).unwrap();
+
+        let after_metadata = std::fs::metadata(&path).unwrap();
+        assert_eq!(
+            filetime::FileTime::from_last_modification_time(&after_metadata),
+            original_mtime
+        );
+        let after = remote_image_file_identity(&path).unwrap();
+        assert_ne!(before, after);
     }
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -567,12 +567,27 @@ fn remote_image_upload_summary(
     ctx: &crate::server::database_context::DatabaseContext,
 ) -> RemoteImageUploadSummary {
     let config = ctx.remote_image_upload.as_ref();
+    let directory_layout = config.and_then(|config| config.directory_layout.as_ref());
     RemoteImageUploadSummary {
         enabled: ctx.remote_image_upload_dir.is_some(),
         image_directory: config
             .map(|config| config.image_dir.clone())
             .filter(|directory| !directory.is_empty()),
         placement: config.map(|config| config.placement).unwrap_or_default(),
+        directory_template: config
+            .map(|config| config.fallback_directory_template().to_string())
+            .unwrap_or_else(|| {
+                crate::db_registry::DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE.to_string()
+            }),
+        catalog_directory_template: directory_layout
+            .filter(|layout| {
+                layout.source == crate::db_registry::RemoteImageUploadTemplateSource::Catalog
+            })
+            .map(|layout| layout.template.clone()),
+        directory_template_source: directory_layout
+            .map(|layout| layout.source)
+            .unwrap_or_default(),
+        directory_template_samples: directory_layout.map(|layout| layout.samples).unwrap_or(0),
         token_configured: config.is_some_and(|config| config.token_is_configured()),
         sync_enabled: config.is_some_and(|config| config.sync_enabled),
         clients: config
@@ -1405,9 +1420,7 @@ pub async fn update_database_route(
     let mut reg = DbRegistry::load_or_init(&registry_path)
         .map_err(|e| AppError::InternalError(format!("loading registry: {}", e)))?;
 
-    if reg.find(&db_id).is_none() {
-        return Err(AppError::NotFound);
-    }
+    let previous_entry = reg.find(&db_id).cloned().ok_or(AppError::NotFound)?;
 
     reg.update(
         &db_id,
@@ -1429,6 +1442,94 @@ pub async fn update_database_route(
                 "registry update lost the entry".into(),
             ))?;
         apply_remote_image_upload_update(entry, update)?;
+    }
+    let updated_entry = reg.find(&new_id).ok_or(AppError::InternalError(
+        "registry update lost the entry".into(),
+    ))?;
+    let remote_layout_scan = updated_entry
+        .remote_image_upload
+        .as_ref()
+        .filter(|config| {
+            config.enabled
+                && config.placement == crate::db_registry::RemoteImageUploadPlacement::TargetTree
+                && remote_image_layout_needs_scan(
+                    &previous_entry,
+                    updated_entry,
+                    req.remote_image_upload.as_ref(),
+                )
+        })
+        .map(|config| {
+            config
+                .validated_image_dir(&updated_entry.image_dirs)
+                .map(|receive_root| (updated_entry.db_path.clone(), receive_root))
+                .map_err(|error| AppError::BadRequest(error.to_string()))
+        })
+        .transpose()?;
+    if let Some((database_path, receive_root)) = remote_layout_scan {
+        let detected = tokio::task::spawn_blocking(move || {
+            crate::server::remote_upload_layout::detect_catalog_directory_layout(
+                &database_path,
+                &receive_root,
+            )
+        })
+        .await
+        .map_err(|error| {
+            AppError::InternalError(format!("remote upload layout scan failed: {error}"))
+        })?;
+        match detected {
+            Ok(Some(detected)) => {
+                let entry = reg
+                    .databases
+                    .iter_mut()
+                    .find(|entry| entry.id == new_id)
+                    .ok_or(AppError::InternalError(
+                        "registry update lost the entry".into(),
+                    ))?;
+                let config = entry
+                    .remote_image_upload
+                    .as_mut()
+                    .expect("layout scanning requires remote upload configuration");
+                config.directory_layout =
+                    Some(crate::db_registry::RemoteImageUploadDirectoryLayout {
+                        template: detected.template,
+                        fallback_template: config.fallback_directory_template().to_string(),
+                        source: crate::db_registry::RemoteImageUploadTemplateSource::Catalog,
+                        samples: detected.samples,
+                    });
+            }
+            Ok(None) => {
+                let entry = reg
+                    .databases
+                    .iter_mut()
+                    .find(|entry| entry.id == new_id)
+                    .ok_or(AppError::InternalError(
+                        "registry update lost the entry".into(),
+                    ))?;
+                let config = entry
+                    .remote_image_upload
+                    .as_mut()
+                    .expect("layout scanning requires remote upload configuration");
+                reset_catalog_directory_layout(config);
+            }
+            Err(error) => {
+                let entry = reg
+                    .databases
+                    .iter_mut()
+                    .find(|entry| entry.id == new_id)
+                    .ok_or(AppError::InternalError(
+                        "registry update lost the entry".into(),
+                    ))?;
+                let config = entry
+                    .remote_image_upload
+                    .as_mut()
+                    .expect("layout scanning requires remote upload configuration");
+                reset_catalog_directory_layout(config);
+                tracing::warn!(
+                    database = %new_id,
+                    "Could not detect remote upload catalog layout; using preset: {error:#}"
+                );
+            }
+        }
     }
     if let Some(export_dir) = req.export_dir.as_ref() {
         let entry = reg
@@ -1528,8 +1629,25 @@ fn apply_remote_image_upload_update(
     if let Some(sync_enabled) = update.sync_enabled {
         config.sync_enabled = sync_enabled;
     }
+    let target_tree_was_selected = update.placement.is_some_and(|placement| {
+        placement == crate::db_registry::RemoteImageUploadPlacement::TargetTree
+            && config.placement != crate::db_registry::RemoteImageUploadPlacement::TargetTree
+    });
     if let Some(placement) = update.placement {
         config.placement = placement;
+    }
+    if let Some(template) = update.directory_template.as_deref() {
+        crate::server::remote_upload_layout::validate_directory_template(template)
+            .map_err(|error| AppError::BadRequest(error.to_string()))?;
+        let template = template.trim().replace('\\', "/");
+        if target_tree_was_selected || template != config.fallback_directory_template() {
+            config.directory_layout = Some(crate::db_registry::RemoteImageUploadDirectoryLayout {
+                template: template.clone(),
+                fallback_template: template,
+                source: crate::db_registry::RemoteImageUploadTemplateSource::Preset,
+                samples: 0,
+            });
+        }
     }
     if config.sync_enabled && !config.token_is_configured() {
         return Err(AppError::BadRequest(
@@ -1543,6 +1661,125 @@ fn apply_remote_image_upload_update(
     }
     entry.remote_image_upload = Some(config);
     Ok(())
+}
+
+fn remote_image_layout_needs_scan(
+    previous: &crate::db_registry::DbEntry,
+    updated: &crate::db_registry::DbEntry,
+    request: Option<&RemoteImageUploadUpdate>,
+) -> bool {
+    if request.is_some_and(|request| request.rescan_directory_layout) {
+        return true;
+    }
+    let previous_config = previous.remote_image_upload.as_ref();
+    let updated_config = updated.remote_image_upload.as_ref();
+    previous.db_path != updated.db_path
+        || previous.image_dirs != updated.image_dirs
+        || previous_config.map(|config| config.enabled)
+            != updated_config.map(|config| config.enabled)
+        || previous_config.map(|config| config.image_dir.trim())
+            != updated_config.map(|config| config.image_dir.trim())
+        || previous_config.map(|config| config.placement)
+            != updated_config.map(|config| config.placement)
+        || previous_config.map(|config| config.fallback_directory_template())
+            != updated_config.map(|config| config.fallback_directory_template())
+}
+
+fn reset_catalog_directory_layout(config: &mut crate::db_registry::RemoteImageUploadConfig) {
+    if config.directory_layout.as_ref().is_some_and(|layout| {
+        layout.source == crate::db_registry::RemoteImageUploadTemplateSource::Catalog
+    }) {
+        let fallback = config.fallback_directory_template().to_string();
+        config.directory_layout = Some(crate::db_registry::RemoteImageUploadDirectoryLayout {
+            template: fallback.clone(),
+            fallback_template: fallback,
+            source: crate::db_registry::RemoteImageUploadTemplateSource::Preset,
+            samples: 0,
+        });
+    }
+}
+
+#[cfg(test)]
+mod remote_image_layout_settings_tests {
+    use super::*;
+
+    fn legacy_target_tree_entry() -> crate::db_registry::DbEntry {
+        crate::db_registry::DbEntry {
+            id: "catalog".into(),
+            name: "Catalog".into(),
+            db_path: "catalog.sqlite".into(),
+            image_dirs: vec!["images".into()],
+            reject_archive: None,
+            remote_image_upload: Some(crate::db_registry::RemoteImageUploadConfig {
+                placement: crate::db_registry::RemoteImageUploadPlacement::TargetTree,
+                ..Default::default()
+            }),
+            export_dir: None,
+        }
+    }
+
+    fn update() -> RemoteImageUploadUpdate {
+        RemoteImageUploadUpdate {
+            enabled: false,
+            image_directory: None,
+            token: None,
+            sync_enabled: None,
+            placement: Some(crate::db_registry::RemoteImageUploadPlacement::TargetTree),
+            directory_template: None,
+            rescan_directory_layout: false,
+        }
+    }
+
+    #[test]
+    fn unrelated_save_preserves_legacy_layout_and_skips_the_tree_scan() {
+        let previous = legacy_target_tree_entry();
+        let mut updated = previous.clone();
+        apply_remote_image_upload_update(&mut updated, &update()).unwrap();
+
+        assert!(updated
+            .remote_image_upload
+            .as_ref()
+            .unwrap()
+            .directory_layout
+            .is_none());
+        assert!(!remote_image_layout_needs_scan(
+            &previous,
+            &updated,
+            Some(&update())
+        ));
+
+        let mut rescan = update();
+        rescan.rescan_directory_layout = true;
+        assert!(remote_image_layout_needs_scan(
+            &previous,
+            &updated,
+            Some(&rescan)
+        ));
+    }
+
+    #[test]
+    fn a_failed_or_empty_scan_returns_a_catalog_layout_to_its_preset() {
+        let mut config = crate::db_registry::RemoteImageUploadConfig {
+            directory_layout: Some(crate::db_registry::RemoteImageUploadDirectoryLayout {
+                template: "%YEAR%/%TARGET%/%NIGHT%/%TYPE%".into(),
+                fallback_template: "%TARGET%/%DATE%/%TYPE%".into(),
+                source: crate::db_registry::RemoteImageUploadTemplateSource::Catalog,
+                samples: 42,
+            }),
+            ..Default::default()
+        };
+
+        reset_catalog_directory_layout(&mut config);
+
+        let layout = config.directory_layout.unwrap();
+        assert_eq!(layout.template, "%TARGET%/%DATE%/%TYPE%");
+        assert_eq!(layout.fallback_template, "%TARGET%/%DATE%/%TYPE%");
+        assert_eq!(
+            layout.source,
+            crate::db_registry::RemoteImageUploadTemplateSource::Preset
+        );
+        assert_eq!(layout.samples, 0);
+    }
 }
 
 /// `DELETE /api/databases/{db_id}` — drop the registered database. Returns

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1,8 +1,9 @@
+use anyhow::Context as _;
 use axum::{
     extract::{Extension, Path, Query, State},
     http::{
-        header::{CACHE_CONTROL, CONTENT_TYPE},
-        StatusCode,
+        header::{CACHE_CONTROL, CONTENT_TYPE, ETAG, IF_NONE_MATCH},
+        HeaderMap, HeaderValue, StatusCode,
     },
     response::{IntoResponse, Response},
     Json,
@@ -11,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fmt::Write as _;
+use std::io::Read as _;
 use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 use tokio::fs::File;
@@ -19,7 +21,10 @@ use tokio::io::AsyncReadExt;
 use crate::db::Database;
 use crate::models::{GradingStatus, OverallDesiredStats, ProjectDesiredStats};
 use crate::server::api::*;
-use crate::server::database_context::DatabaseContext;
+use crate::server::database_context::{
+    error_has_sqlite_failure, error_is_sqlite_contention, open_scheduler_connection_with_flags,
+    remote_image_file_identity, DatabaseContext,
+};
 use crate::server::extract::DbContext;
 use crate::server::state::AppState;
 
@@ -296,7 +301,7 @@ pub async fn get_image_astrometry(
     ctx: DbContext,
     Path((_db_id, image_id)): Path<(String, i32)>,
 ) -> Result<Json<ApiResponse<crate::astrometry::AstrometryAnalysis>>, AppError> {
-    let (fits_path, expected_target) = resolve_astrometry_input(&ctx, image_id)?;
+    let (fits_path, expected_target) = resolve_astrometry_input(&ctx.0, image_id).await?;
     let cache_dir = ctx.cache_dir_path.clone();
     let astrometry = Arc::clone(&state.astrometry);
     let guard = state.begin_interactive_job();
@@ -321,7 +326,7 @@ pub async fn solve_image_astrometry(
     Path((_db_id, image_id)): Path<(String, i32)>,
 ) -> Result<Json<ApiResponse<crate::astrometry::AstrometryAnalysis>>, AppError> {
     let _solve_guard = ctx.astrometry_solve_mutex.lock().await;
-    let (fits_path, expected_target) = resolve_astrometry_input(&ctx, image_id)?;
+    let (fits_path, expected_target) = resolve_astrometry_input(&ctx.0, image_id).await?;
     let cache_dir = ctx.cache_dir_path.clone();
     let astrometry = Arc::clone(&state.astrometry);
     let guard = state.begin_interactive_job();
@@ -360,7 +365,7 @@ pub async fn get_image_satellites(
     ctx: DbContext,
     Path((_db_id, image_id)): Path<(String, i32)>,
 ) -> Result<Json<ApiResponse<crate::satellites::SatelliteAnalysisStatus>>, AppError> {
-    let (fits_path, expected_target) = resolve_astrometry_input(&ctx, image_id)?;
+    let (fits_path, expected_target) = resolve_astrometry_input(&ctx.0, image_id).await?;
     let cache_dir = ctx.cache_dir_path.clone();
     let astrometry = Arc::clone(&state.astrometry);
     let guard = state.begin_interactive_job();
@@ -395,7 +400,7 @@ pub async fn predict_image_satellites(
     ctx: DbContext,
     Path((_db_id, image_id)): Path<(String, i32)>,
 ) -> Result<Json<ApiResponse<crate::satellites::SatelliteAnalysis>>, AppError> {
-    let (fits_path, expected_target) = resolve_astrometry_input(&ctx, image_id)?;
+    let (fits_path, expected_target) = resolve_astrometry_input(&ctx.0, image_id).await?;
     let cache_dir = ctx.cache_dir_path.clone();
     let astrometry = Arc::clone(&state.astrometry);
     let guard = state.begin_interactive_job();
@@ -466,8 +471,8 @@ pub async fn predict_image_satellites(
     Ok(Json(ApiResponse::success(prediction)))
 }
 
-fn resolve_astrometry_input(
-    ctx: &DatabaseContext,
+async fn resolve_astrometry_input(
+    ctx: &Arc<DatabaseContext>,
     image_id: i32,
 ) -> Result<(PathBuf, Option<(f64, f64)>), AppError> {
     let (image, file_only, target_name) = resolve_image_meta(ctx, image_id)?;
@@ -478,7 +483,7 @@ fn resolve_astrometry_input(
             .map_err(AppError::db)?
             .expected_for_grading()
     };
-    let fits_path = find_fits_file(ctx, &image, &target_name, &file_only)?;
+    let fits_path = find_fits_file_async(ctx, &image, &target_name, &file_only).await?;
     Ok((fits_path, expected_target))
 }
 
@@ -567,6 +572,7 @@ fn remote_image_upload_summary(
         image_directory: config
             .map(|config| config.image_dir.clone())
             .filter(|directory| !directory.is_empty()),
+        placement: config.map(|config| config.placement).unwrap_or_default(),
         token_configured: config.is_some_and(|config| config.token_is_configured()),
         sync_enabled: config.is_some_and(|config| config.sync_enabled),
         clients: config
@@ -686,6 +692,155 @@ fn grade_label(status: i32) -> &'static str {
     }
 }
 
+fn open_scheduler_sync_connections(
+    source_path: &FsPath,
+    destination_path: &FsPath,
+) -> anyhow::Result<(rusqlite::Connection, rusqlite::Connection)> {
+    use rusqlite::OpenFlags;
+
+    let source =
+        open_scheduler_connection_with_flags(source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .with_context(|| {
+                format!(
+                    "opening source scheduler database {}",
+                    source_path.display()
+                )
+            })?;
+    let destination =
+        open_scheduler_connection_with_flags(destination_path, OpenFlags::SQLITE_OPEN_READ_WRITE)
+            .with_context(|| {
+            format!(
+                "opening destination scheduler database {}",
+                destination_path.display()
+            )
+        })?;
+
+    Ok((source, destination))
+}
+
+fn classify_scheduler_sync_failure(
+    error: &anyhow::Error,
+    source_path: &str,
+    destination_path: &str,
+) -> AppError {
+    if error.downcast_ref::<StaleSyncPreview>().is_some() {
+        return AppError::Conflict(
+            "This preview is stale because the destination database changed. Preview again.".into(),
+        );
+    }
+
+    let message = format!(
+        "syncing source scheduler database {source_path} into destination scheduler database {destination_path}: {error:#}"
+    );
+    if error_is_sqlite_contention(error) {
+        AppError::DatabaseError(format!(
+            "{message}; a scheduler database remained busy or locked after the lock wait expired"
+        ))
+    } else if error_has_sqlite_failure(error) {
+        AppError::DatabaseError(message)
+    } else {
+        AppError::BadRequest(message)
+    }
+}
+
+fn classify_sync_snapshot_failure(error: anyhow::Error, source_path: &str) -> AppError {
+    let message =
+        format!("creating a scheduler sync snapshot from source database {source_path}: {error:#}");
+    let contention = if error_is_sqlite_contention(&error)
+        || crate::server::sync_preview::error_is_sync_snapshot_contention(&error)
+    {
+        "; the source scheduler database remained busy or locked after the lock wait expired"
+    } else {
+        ""
+    };
+    // The peer path comes from the server's registry and the snapshot path is
+    // server-owned. Open, backup, mkdir, and rename failures are operational;
+    // none are malformed request data.
+    AppError::DatabaseError(format!("{message}{contention}"))
+}
+
+#[cfg(test)]
+mod scheduler_sync_error_tests {
+    use super::*;
+    use rusqlite::ffi::{Error as FfiError, SQLITE_BUSY, SQLITE_LOCKED};
+
+    #[test]
+    fn sync_database_failures_keep_both_catalog_paths() {
+        for code in [SQLITE_BUSY, SQLITE_LOCKED] {
+            let error =
+                anyhow::Error::new(rusqlite::Error::SqliteFailure(FfiError::new(code), None))
+                    .context("applying scheduler rows")
+                    .context("sync operation");
+
+            match classify_scheduler_sync_failure(
+                &error,
+                "source-scheduler.sqlite",
+                "destination-scheduler.sqlite",
+            ) {
+                AppError::DatabaseError(message) => {
+                    assert!(message.contains("source-scheduler.sqlite"));
+                    assert!(message.contains("destination-scheduler.sqlite"));
+                    assert!(message.contains("busy or locked"));
+                }
+                other => panic!("contention was misclassified: {other:?}"),
+            }
+        }
+
+        match classify_scheduler_sync_failure(
+            &anyhow::anyhow!("disk read failed"),
+            "source-scheduler.sqlite",
+            "destination-scheduler.sqlite",
+        ) {
+            AppError::BadRequest(message) => {
+                assert!(message.contains("source-scheduler.sqlite"));
+                assert!(message.contains("destination-scheduler.sqlite"));
+                assert!(message.contains("disk read failed"));
+            }
+            other => panic!("non-contention sync failure was misclassified: {other:?}"),
+        }
+
+        let io_error = anyhow::Error::new(rusqlite::Error::SqliteFailure(
+            FfiError::new(rusqlite::ffi::SQLITE_IOERR),
+            Some("disk read failed".into()),
+        ));
+        assert!(matches!(
+            classify_scheduler_sync_failure(&io_error, "source.sqlite", "destination.sqlite"),
+            AppError::DatabaseError(_)
+        ));
+    }
+
+    #[test]
+    fn stale_sync_preview_remains_a_conflict() {
+        let error = anyhow::Error::new(StaleSyncPreview).context("applying preview");
+        let app_error = classify_scheduler_sync_failure(&error, "source.sqlite", "dest.sqlite");
+        assert!(matches!(&app_error, AppError::Conflict(_)));
+        assert_eq!(app_error.into_response().status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn exhausted_snapshot_wait_is_an_operational_database_failure() {
+        let error = anyhow::Error::new(crate::server::sync_preview::SyncSnapshotContention {
+            message: "source remained busy".into(),
+        });
+        match classify_sync_snapshot_failure(error, "source.sqlite") {
+            AppError::DatabaseError(message) => {
+                assert!(message.contains("source.sqlite"));
+                assert!(message.contains("busy or locked"));
+            }
+            other => panic!("snapshot contention was misclassified: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snapshot_filesystem_failures_are_operational() {
+        let error = anyhow::anyhow!("renaming server-owned snapshot failed: access denied");
+        assert!(matches!(
+            classify_sync_snapshot_failure(error, "source.sqlite"),
+            AppError::DatabaseError(_)
+        ));
+    }
+}
+
 pub(crate) async fn execute_scheduler_sync_paths(
     state: &Arc<AppState>,
     source_path: PathBuf,
@@ -700,7 +855,7 @@ pub(crate) async fn execute_scheduler_sync_paths(
         sync_planning_in_transaction, sync_pull, sync_pull_in_transaction, PlanningOptions,
         PullOptions, SyncGradesOptions,
     };
-    use rusqlite::{Connection, OpenFlags, Transaction, TransactionBehavior};
+    use rusqlite::{Transaction, TransactionBehavior};
 
     let fingerprint_queries = crate::server::sync_preview::fingerprint_queries(&req);
     let kind = req.kind;
@@ -719,6 +874,8 @@ pub(crate) async fn execute_scheduler_sync_paths(
     let reviewed_only = req.reviewed_only;
     let with_image_data = req.with_image_data.unwrap_or(true);
     let destination_id_for_cache = destination_id.clone();
+    let source_path_for_error = source_path.display().to_string();
+    let destination_path_for_error = destination_path.display().to_string();
 
     let response = tokio::task::spawn_blocking(
         move || -> anyhow::Result<(
@@ -735,10 +892,8 @@ pub(crate) async fn execute_scheduler_sync_paths(
                 "The two configured entries point to the same database file."
             );
 
-            let source =
-                Connection::open_with_flags(&source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-            let destination =
-                Connection::open_with_flags(&destination_path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
+            let (source, destination) =
+                open_scheduler_sync_connections(&source_path, &destination_path)?;
 
             let run = |transaction: Option<&Transaction<'_>>| -> anyhow::Result<(
                 SchedulerSyncResponse,
@@ -919,14 +1074,11 @@ pub(crate) async fn execute_scheduler_sync_paths(
     .await
     .map_err(|error| AppError::InternalError(format!("scheduler sync task failed: {error}")))?
     .map_err(|error| {
-        if error.downcast_ref::<StaleSyncPreview>().is_some() {
-            AppError::Conflict(
-                "This preview is stale because the destination database changed. Preview again."
-                    .into(),
-            )
-        } else {
-            AppError::BadRequest(format!("{error:#}"))
-        }
+        classify_scheduler_sync_failure(
+            &error,
+            &source_path_for_error,
+            &destination_path_for_error,
+        )
     })?;
 
     let (response, fingerprint, changed_images) = response;
@@ -983,10 +1135,16 @@ pub async fn preview_sync_database_route(
 ) -> Result<Json<ApiResponse<SchedulerSyncPreviewResponse>>, AppError> {
     request.dry_run = true;
     let (source_path, _destination_path) = sync_endpoint_paths(&state, &db_id, &request)?;
-    let source_snapshot_file = state
-        .sync_previews
-        .create_source_snapshot(&source_path)
-        .map_err(|error| AppError::BadRequest(format!("{error:#}")))?;
+    let source_path_for_error = source_path.display().to_string();
+    let snapshot_state = state.clone();
+    let source_snapshot_file = tokio::task::spawn_blocking(move || {
+        snapshot_state
+            .sync_previews
+            .create_source_snapshot(&source_path)
+    })
+    .await
+    .map_err(|error| AppError::InternalError(format!("sync snapshot task failed: {error}")))?
+    .map_err(|error| classify_sync_snapshot_failure(error, &source_path_for_error))?;
     let source_snapshot_path = state
         .sync_previews
         .source_snapshot_path_for_file(&source_snapshot_file)
@@ -1370,6 +1528,9 @@ fn apply_remote_image_upload_update(
     if let Some(sync_enabled) = update.sync_enabled {
         config.sync_enabled = sync_enabled;
     }
+    if let Some(placement) = update.placement {
+        config.placement = placement;
+    }
     if config.sync_enabled && !config.token_is_configured() {
         return Err(AppError::BadRequest(
             "generate a remote API key before enabling remote scheduler sync".into(),
@@ -1439,7 +1600,7 @@ pub async fn export_archive_route(
     // (same rule as the import job and the background file-check refresh).
     let plan_ctx = ctx.0.clone();
     let plan = tokio::task::spawn_blocking(move || {
-        let conn = rusqlite::Connection::open_with_flags(
+        let conn = open_scheduler_connection_with_flags(
             &plan_ctx.database_path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
         )
@@ -1574,7 +1735,7 @@ pub async fn export_local_route(
     // request-connection mutex through a directory walk).
     let plan_ctx = ctx.0.clone();
     let summary = tokio::task::spawn_blocking(move || {
-        let conn = rusqlite::Connection::open_with_flags(
+        let conn = open_scheduler_connection_with_flags(
             &plan_ctx.database_path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
         )
@@ -1667,7 +1828,7 @@ pub async fn start_server_export_route(
     let job_store = store.clone();
     tokio::task::spawn_blocking(move || {
         let run = || -> anyhow::Result<()> {
-            let conn = rusqlite::Connection::open_with_flags(
+            let conn = open_scheduler_connection_with_flags(
                 &job_ctx.database_path,
                 rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
             )
@@ -1748,7 +1909,7 @@ pub async fn get_project_calibration_report(
         .map_err(|error| AppError::InternalError(format!("indexing image folders: {error}")))?;
     let database_path = ctx.database_path.clone();
     let report = tokio::task::spawn_blocking(move || {
-        let conn = rusqlite::Connection::open_with_flags(
+        let conn = open_scheduler_connection_with_flags(
             &database_path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
         )
@@ -2253,7 +2414,7 @@ fn run_import_blocking(
         .collect();
 
     job::set_stage(&ctx.import_job, "importing");
-    let mut conn = rusqlite::Connection::open_with_flags(
+    let mut conn = open_scheduler_connection_with_flags(
         &ctx.database_path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_URI,
     )
@@ -2327,18 +2488,31 @@ async fn run_quality_scan_for_target(
 /// Write scan-measured star count and HFR into `acquiredimage.metadata` for
 /// frames that imported without them, so an imported catalog carries the same
 /// star metadata a N.I.N.A. catalog does. `pending` is `(image id, filename,
-/// metadata JSON as read)`. The patch fills only missing keys — a measured
+/// metadata JSON as read, mapped source revision)`. The patch fills only missing keys — a measured
 /// N.I.N.A. value is never overwritten — and a row that changed since it was
 /// read is left alone.
-fn fill_missing_star_metadata(ctx: &DatabaseContext, pending: &[(i32, String, String)]) -> usize {
+fn fill_missing_star_metadata(
+    ctx: &DatabaseContext,
+    pending: &[(i32, String, String, Option<String>)],
+) -> usize {
     use crate::server::spatial_scan as scan;
 
-    let patches: Vec<(i32, &String, String)> = pending
+    let patches: Vec<(i32, &String, String, Option<String>)> = pending
         .iter()
-        .filter_map(|(image_id, filename, metadata)| {
-            let entry = scan::valid_quality_entry(&ctx.spatial_metrics, *image_id, filename)?;
-            scan::star_metrics_metadata_patch(metadata, entry.star_count, entry.avg_hfr)
-                .map(|updated| (*image_id, metadata, updated))
+        .filter_map(|(image_id, filename, metadata, mapped_source_revision)| {
+            let entry = scan::valid_quality_entry_for_source(
+                &ctx.spatial_metrics,
+                *image_id,
+                filename,
+                mapped_source_revision.as_deref(),
+            )?;
+            scan::star_metrics_metadata_patch(
+                metadata,
+                entry.star_count,
+                entry.avg_hfr,
+                entry.source_revision.as_deref(),
+            )
+            .map(|updated| (*image_id, metadata, updated, mapped_source_revision.clone()))
         })
         .collect();
     if patches.is_empty() {
@@ -2347,24 +2521,75 @@ fn fill_missing_star_metadata(ctx: &DatabaseContext, pending: &[(i32, String, St
 
     // A dedicated connection: this runs on a blocking scan thread and must
     // not tie up the shared request connection.
-    let conn = match crate::server::database_context::open_scheduler_connection(&ctx.database_path)
+    let mut conn =
+        match crate::server::database_context::open_scheduler_connection(&ctx.database_path) {
+            Ok(conn) => conn,
+            Err(e) => {
+                tracing::warn!("📐 Star-metadata fill skipped for db={}: {}", ctx.id, e);
+                return 0;
+            }
+        };
+    // Reserve the writer before re-reading upload provenance. This makes the
+    // source check and metadata CAS one serializable operation with a remote
+    // upload's mapping update and stale-metadata cleanup.
+    let transaction = match conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
     {
-        Ok(conn) => conn,
+        Ok(transaction) => transaction,
         Err(e) => {
             tracing::warn!("📐 Star-metadata fill skipped for db={}: {}", ctx.id, e);
             return 0;
         }
     };
-    let db = Database::new(&conn);
-    let mut filled = 0usize;
-    for (image_id, expected, updated) in &patches {
-        match db.update_image_metadata_if_unchanged(*image_id, expected, updated) {
-            Ok(true) => filled += 1,
-            Ok(false) => {} // concurrent writer wins; skip quietly
-            Err(e) => {
-                tracing::warn!("📐 Star-metadata fill failed for image {}: {}", image_id, e)
+    let image_ids = patches
+        .iter()
+        .map(|(image_id, _, _, _)| *image_id)
+        .collect::<Vec<_>>();
+    let images = match Database::new(&transaction).get_images_by_ids(&image_ids) {
+        Ok(images) => images,
+        Err(e) => {
+            tracing::warn!("📐 Star-metadata fill skipped for db={}: {}", ctx.id, e);
+            return 0;
+        }
+    };
+    let mapped_sources = match crate::server::remote_upload::mapped_light_sources(
+        &transaction,
+        &ctx.image_dir_paths,
+        images.iter(),
+    ) {
+        Ok(sources) => sources,
+        Err(e) => {
+            tracing::warn!(
+                "📐 Star-metadata provenance check skipped for db={}: {:?}",
+                ctx.id,
+                e
+            );
+            return 0;
+        }
+    };
+    let filled = {
+        let db = Database::new(&transaction);
+        let mut filled = 0usize;
+        for (image_id, expected, updated, expected_mapped_source) in &patches {
+            if mapped_sources.quality_revision(*image_id) != expected_mapped_source.as_deref() {
+                continue;
+            }
+            match db.update_image_metadata_if_unchanged(*image_id, expected, updated) {
+                Ok(true) => filled += 1,
+                Ok(false) => {} // concurrent writer wins; skip quietly
+                Err(e) => {
+                    tracing::warn!("📐 Star-metadata fill failed for image {}: {}", image_id, e)
+                }
             }
         }
+        filled
+    };
+    if let Err(e) = transaction.commit() {
+        tracing::warn!(
+            "📐 Star-metadata fill commit failed for db={}: {}",
+            ctx.id,
+            e
+        );
+        return 0;
     }
     if filled > 0 {
         tracing::info!(
@@ -2949,24 +3174,29 @@ pub async fn get_image(
 
     // Try to resolve the filesystem path for the FITS file
     let delayed_probe = ctx.delayed_file_probe(image.id);
-    let resolved_fits_path = metadata["FileName"].as_str().and_then(|filename| {
-        let file_only = filename.split(&['\\', '/'][..]).next_back()?;
+    let resolved_fits_path = if let Some(filename) = metadata["FileName"].as_str() {
+        let file_only = filename.split(&['\\', '/'][..]).next_back();
         if delayed_probe == crate::server::database_context::DelayedFileProbe::Wait {
-            return None;
-        }
-        let resolved = if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe
-        {
-            find_fits_file_cached(&ctx, &image, &target_name, file_only)
+            None
+        } else if let Some(file_only) = file_only {
+            let resolved =
+                if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe {
+                    find_fits_file_cached_async(&ctx.0, &image, &target_name, file_only).await
+                } else {
+                    find_fits_file_async(&ctx.0, &image, &target_name, file_only).await
+                };
+            // Detail metadata remains usable for a missing or ambiguous
+            // source; preview generation-status carries the terminal message.
+            resolved.ok().filter(|path| {
+                delayed_probe != crate::server::database_context::DelayedFileProbe::Probe
+                    || ctx.delayed_source_is_stable(image.id, path)
+            })
         } else {
-            find_fits_file(&ctx, &image, &target_name, file_only)
-        };
-        // Detail metadata remains usable for a missing or ambiguous source;
-        // preview generation-status carries the specific terminal message.
-        resolved.ok().filter(|path| {
-            delayed_probe != crate::server::database_context::DelayedFileProbe::Probe
-                || ctx.delayed_source_is_stable(image.id, path)
-        })
-    });
+            None
+        }
+    } else {
+        None
+    };
 
     let filesystem_path_string = resolved_fits_path
         .as_ref()
@@ -3255,11 +3485,10 @@ pub(crate) fn preview_cache_key(
     midtone: f64,
     shadow: f64,
     color: bool,
+    mapping_revision: Option<&str>,
 ) -> String {
-    // The colour marker only appears when colour was asked for, so every
-    // greyscale preview already on disk keeps its key and stays valid.
-    format!(
-        "{}_{}_{}_{}_{}_{}_{}_{}_{}_{}{}",
+    let mut key = format!(
+        "{}_{}_{}_{}_{}_{}_{}_{}_{}_{}",
         image.id,
         image.project_id,
         image.target_id,
@@ -3270,8 +3499,15 @@ pub(crate) fn preview_cache_key(
         (midtone * 10000.0) as i32,
         (shadow * 10000.0) as i32,
         image_file_identity_cache_token(image),
-        if color { "_color" } else { "" },
-    )
+    );
+    if let Some(revision) = mapping_revision {
+        let _ = write!(&mut key, "_mapping_{revision}");
+    }
+    // The colour marker remains last, so existing unmapped keys do not move.
+    if color {
+        key.push_str("_color");
+    }
+    key
 }
 
 fn image_file_identity_cache_token(image: &crate::models::AcquiredImage) -> String {
@@ -3344,10 +3580,11 @@ pub(crate) fn annotated_cache_key(
     file_only: &str,
     size: &str,
     max_stars: usize,
+    mapping_revision: Option<&str>,
 ) -> String {
     // v3: stars now carry HFR labels (v2: telescope-class presets), so
     // earlier renders are stale.
-    format!(
+    let mut key = format!(
         "annotated_v4_{}_{}_{}_{}_{}_{}_{}_{}",
         image.id,
         image.project_id,
@@ -3357,7 +3594,37 @@ pub(crate) fn annotated_cache_key(
         size,
         max_stars,
         image_file_identity_cache_token(image),
-    )
+    );
+    if let Some(revision) = mapping_revision {
+        let _ = write!(&mut key, "_mapping_{revision}");
+    }
+    key
+}
+
+/// The durable upload mapping is part of rendered-artifact identity. A worker
+/// that started before a remap keeps writing its old key, while new requests
+/// immediately address the new mapping's key.
+pub(crate) fn rendered_artifact_mapping_revision(
+    ctx: &DatabaseContext,
+    image: &crate::models::AcquiredImage,
+) -> Result<Option<String>, AppError> {
+    use crate::server::remote_upload::{resolve_mapped_light_file, MappedLightFile};
+
+    let mapping = {
+        let connection = ctx.db();
+        let connection = connection.lock().map_err(AppError::db)?;
+        resolve_mapped_light_file(&connection, &ctx.image_dir_paths, image)?
+    };
+    match mapping {
+        MappedLightFile::Absent => Ok(None),
+        MappedLightFile::Invalid => Err(AppError::Conflict(
+            "remote image provenance no longer matches this scheduler row".into(),
+        )),
+        MappedLightFile::Missing { artifact_revision }
+        | MappedLightFile::Ready {
+            artifact_revision, ..
+        } => Ok(Some(artifact_revision)),
+    }
 }
 
 /// Resolve the on-disk cache path for a preview/annotated artifact, creating
@@ -3381,22 +3648,66 @@ fn artifact_cache_path(
 
 /// Serve a cached image, labelled as whatever it was written as rather than as
 /// whatever the setting says now.
-async fn serve_cached_png(cache_path: &std::path::Path) -> Result<Response, AppError> {
-    let buffer = tokio::fs::read(cache_path)
+async fn serve_cached_png(
+    cache_path: &std::path::Path,
+    request_headers: &HeaderMap,
+) -> Result<Response, AppError> {
+    let metadata = tokio::fs::metadata(cache_path)
         .await
         .map_err(|_| AppError::InternalError("Failed to read cache".to_string()))?;
-    Ok((
-        StatusCode::OK,
-        [
-            (
+    let mut etag_hash = Sha256::new();
+    etag_hash.update(cache_path.to_string_lossy().as_bytes());
+    etag_hash.update(metadata.len().to_le_bytes());
+    if let Ok(modified) = metadata.modified()
+        && let Ok(elapsed) = modified.duration_since(std::time::UNIX_EPOCH)
+    {
+        etag_hash.update(elapsed.as_secs().to_le_bytes());
+        etag_hash.update(elapsed.subsec_nanos().to_le_bytes());
+    }
+    let digest = etag_hash.finalize();
+    let mut etag = String::with_capacity(26);
+    etag.push('"');
+    for byte in digest.iter().take(12) {
+        let _ = write!(&mut etag, "{byte:02x}");
+    }
+    etag.push('"');
+    let not_modified = request_headers
+        .get(IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|values| {
+            values.split(',').any(|value| {
+                let value = value.trim();
+                value == etag || value.strip_prefix("W/") == Some(etag.as_str())
+            })
+        });
+
+    let mut response = if not_modified {
+        StatusCode::NOT_MODIFIED.into_response()
+    } else {
+        let buffer = tokio::fs::read(cache_path)
+            .await
+            .map_err(|_| AppError::InternalError("Failed to read cache".to_string()))?;
+        (
+            StatusCode::OK,
+            [(
                 CONTENT_TYPE,
                 crate::preview_format::PreviewFormat::of_path(cache_path).content_type(),
-            ),
-            (CACHE_CONTROL, "max-age=86400"),
-        ],
-        buffer,
-    )
-        .into_response())
+            )],
+            buffer,
+        )
+            .into_response()
+    };
+    // The URL names a scheduler row, not the current upload mapping. Require
+    // revalidation, then let unchanged artifacts complete with a bodyless 304.
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+    response.headers_mut().insert(
+        ETAG,
+        HeaderValue::from_str(&etag)
+            .map_err(|_| AppError::InternalError("Invalid cache ETag".to_string()))?,
+    );
+    Ok(response)
 }
 
 async fn write_cache_atomic(path: &FsPath, contents: &[u8]) -> std::io::Result<()> {
@@ -3471,6 +3782,7 @@ pub async fn get_image_preview(
     ctx: DbContext,
     Path((_db_id, image_id)): Path<(String, i32)>,
     Query(options): Query<PreviewOptions>,
+    headers: HeaderMap,
 ) -> Result<Response, AppError> {
     let size = options.size.as_deref().unwrap_or("screen");
     let stretch = options.stretch.unwrap_or(true);
@@ -3481,14 +3793,24 @@ pub async fn get_image_preview(
         .unwrap_or_else(|| state.preview_color_default());
 
     let (image, file_only, target_name) = resolve_image_meta(&ctx, image_id)?;
-    let cache_key = preview_cache_key(&image, &file_only, size, stretch, midtone, shadow, color);
+    let mapping_revision = rendered_artifact_mapping_revision(&ctx, &image)?;
+    let cache_key = preview_cache_key(
+        &image,
+        &file_only,
+        size,
+        stretch,
+        midtone,
+        shadow,
+        color,
+        mapping_revision.as_deref(),
+    );
     let cache_path = artifact_cache_path(&ctx, "previews", &cache_key, state.preview_encoding())?;
 
     let delayed_probe = ctx.delayed_file_probe(image.id);
     if delayed_probe == crate::server::database_context::DelayedFileProbe::NotPending
         && cache_path.exists()
     {
-        return serve_cached_png(&cache_path).await;
+        return serve_cached_png(&cache_path, &headers).await;
     }
 
     // Miss: resolve the source (404 if truly missing), hand generation to the
@@ -3497,9 +3819,9 @@ pub async fn get_image_preview(
         return Ok(generating_response());
     }
     let source = if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe {
-        find_fits_file_cached(&ctx, &image, &target_name, &file_only)
+        find_fits_file_cached_async(&ctx.0, &image, &target_name, &file_only).await
     } else {
-        find_fits_file(&ctx, &image, &target_name, &file_only)
+        find_fits_file_async(&ctx.0, &image, &target_name, &file_only).await
     };
     let fits_path = match source {
         Ok(path) => path,
@@ -3517,7 +3839,7 @@ pub async fn get_image_preview(
         && tracked_cache_matches_source(&state, &cache_path, &fits_path)?
     {
         if ctx.complete_delayed_file_probe(image.id, &fits_path) {
-            return serve_cached_png(&cache_path).await;
+            return serve_cached_png(&cache_path, &headers).await;
         }
         return Ok(generating_response());
     }
@@ -3548,6 +3870,51 @@ pub fn find_fits_file(
         FileResolutionPolicy::Ordinary
     };
     find_fits_file_inner(ctx, image, target_name, filename, policy, true, None)
+}
+
+/// Resolve a source on Tokio's blocking pool. A durable remote-upload mapping
+/// can require one full-file SHA-256 on a cold process, which must not run on
+/// an async request worker.
+pub(crate) async fn find_fits_file_async(
+    ctx: &Arc<DatabaseContext>,
+    image: &crate::models::AcquiredImage,
+    target_name: &str,
+    filename: &str,
+) -> Result<std::path::PathBuf, AppError> {
+    find_fits_file_on_blocking_pool(ctx, image, target_name, filename, false).await
+}
+
+async fn find_fits_file_cached_async(
+    ctx: &Arc<DatabaseContext>,
+    image: &crate::models::AcquiredImage,
+    target_name: &str,
+    filename: &str,
+) -> Result<std::path::PathBuf, AppError> {
+    find_fits_file_on_blocking_pool(ctx, image, target_name, filename, true).await
+}
+
+async fn find_fits_file_on_blocking_pool(
+    ctx: &Arc<DatabaseContext>,
+    image: &crate::models::AcquiredImage,
+    target_name: &str,
+    filename: &str,
+    cached_only: bool,
+) -> Result<std::path::PathBuf, AppError> {
+    let ctx = Arc::clone(ctx);
+    let image = image.clone();
+    let target_name = target_name.to_string();
+    let filename = filename.to_string();
+    tokio::task::spawn_blocking(move || {
+        if cached_only {
+            find_fits_file_cached(&ctx, &image, &target_name, &filename)
+        } else {
+            find_fits_file(&ctx, &image, &target_name, &filename)
+        }
+    })
+    .await
+    .map_err(|error| {
+        AppError::InternalError(format!("FITS source resolution task failed: {error}"))
+    })?
 }
 
 /// A delayed remote row needs stronger identity proof than an ordinary local
@@ -3618,6 +3985,16 @@ fn find_fits_file_inner(
     let canonical_roots = shared_canonical_roots
         .or(owned_canonical_roots.as_deref())
         .unwrap_or_default();
+
+    if let Some(path) = resolve_mapped_remote_image(ctx, image, canonical_roots)? {
+        tracing::debug!(
+            image_id = image.id,
+            path = %path.display(),
+            "Resolved image through durable remote-upload provenance"
+        );
+        ctx.record_resolved_image_file(image, &path);
+        return Ok(path);
+    }
 
     // Date-based layouts are a fast path, not a prerequisite. A remote sync
     // can legitimately carry no acquireddate while retaining the original
@@ -3748,6 +4125,127 @@ fn find_fits_file_inner(
         filename
     );
     Err(AppError::NotFound)
+}
+
+fn resolve_mapped_remote_image(
+    ctx: &DatabaseContext,
+    image: &crate::models::AcquiredImage,
+    canonical_roots: &[PathBuf],
+) -> Result<Option<PathBuf>, AppError> {
+    resolve_mapped_remote_image_with(ctx, image, canonical_roots, mapped_file_sha256)
+}
+
+fn resolve_mapped_remote_image_with(
+    ctx: &DatabaseContext,
+    image: &crate::models::AcquiredImage,
+    canonical_roots: &[PathBuf],
+    hash_file: impl FnOnce(&FsPath) -> Result<String, AppError>,
+) -> Result<Option<PathBuf>, AppError> {
+    use crate::server::remote_upload::{resolve_mapped_light_file, MappedLightFile};
+
+    let mapping = {
+        let connection = ctx.db();
+        let connection = connection.lock().map_err(AppError::db)?;
+        resolve_mapped_light_file(&connection, canonical_roots, image)?
+    };
+    let MappedLightFile::Ready {
+        path,
+        sha256: expected_sha256,
+        ..
+    } = mapping
+    else {
+        return match mapping {
+            MappedLightFile::Absent => Ok(None),
+            MappedLightFile::Invalid => Err(AppError::Conflict(
+                "remote image provenance no longer matches this scheduler row".into(),
+            )),
+            MappedLightFile::Missing { .. } => Err(AppError::NotFound),
+            MappedLightFile::Ready { .. } => unreachable!(),
+        };
+    };
+
+    let observed_identity = remote_image_file_identity(&path).ok_or(AppError::NotFound)?;
+    if ctx.remote_image_verification_is_current(image.id, &observed_identity, &expected_sha256) {
+        return Ok(Some(path));
+    }
+
+    let verification_lock =
+        ctx.remote_image_verification_lock(&observed_identity, &expected_sha256);
+    let _verification_guard = verification_lock
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // A concurrent resolver may have completed while this one waited. Re-stat
+    // before trusting its result so a replace cannot move this request onto a
+    // lock keyed for different bytes.
+    let before = remote_image_file_identity(&path).ok_or(AppError::NotFound)?;
+    if before != observed_identity {
+        ctx.clear_remote_image_verification(image.id);
+        return Err(AppError::Conflict(format!(
+            "mapped remote image {} changed while its upload identity was being verified",
+            path.display()
+        )));
+    }
+    if ctx.remote_image_verification_is_current(image.id, &before, &expected_sha256) {
+        return Ok(Some(path));
+    }
+    if ctx.remote_image_verification_is_known(&before, &expected_sha256) {
+        ctx.record_remote_image_verification(image.id, before, &expected_sha256);
+        return Ok(Some(path));
+    }
+
+    let actual_sha256 = hash_file(&path)?;
+    let after = remote_image_file_identity(&path).ok_or(AppError::NotFound)?;
+    if before != after {
+        ctx.clear_remote_image_verification(image.id);
+        return Err(AppError::Conflict(format!(
+            "mapped remote image {} changed while its upload identity was being verified",
+            path.display()
+        )));
+    }
+    if !actual_sha256.eq_ignore_ascii_case(&expected_sha256) {
+        ctx.clear_remote_image_verification(image.id);
+        return Err(AppError::Conflict(format!(
+            "mapped remote image {} no longer matches the content accepted during upload",
+            path.display()
+        )));
+    }
+
+    ctx.record_remote_image_verification(image.id, after, &expected_sha256);
+    Ok(Some(path))
+}
+
+fn mapped_file_sha256(path: &FsPath) -> Result<String, AppError> {
+    let mut file = std::fs::File::open(path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            AppError::NotFound
+        } else {
+            AppError::InternalError(format!(
+                "opening mapped remote image {}: {error}",
+                path.display()
+            ))
+        }
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|error| {
+            AppError::InternalError(format!(
+                "reading mapped remote image {}: {error}",
+                path.display()
+            ))
+        })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let digest = hasher.finalize();
+    let mut encoded = String::with_capacity(64);
+    for byte in digest {
+        let _ = write!(&mut encoded, "{byte:02x}");
+    }
+    Ok(encoded)
 }
 
 const CAPTURE_IDENTITY_TIME_TOLERANCE_SECS: u64 = 2;
@@ -3998,7 +4496,7 @@ pub async fn get_image_stars(
         (image, file_only, target_name)
     };
 
-    let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
+    let fits_path = find_fits_file_async(&ctx.0, &image, &target_name, &file_only).await?;
     let source_token = source_file_cache_token(&fits_path)
         .ok_or_else(|| AppError::Conflict("Source file is not ready".to_string()))?;
 
@@ -4123,28 +4621,36 @@ pub async fn get_annotated_image(
     ctx: DbContext,
     Path((_db_id, image_id)): Path<(String, i32)>,
     Query(options): Query<PreviewOptions>,
+    headers: HeaderMap,
 ) -> Result<Response, AppError> {
     let size = options.size.as_deref().unwrap_or("screen");
     let max_stars = options.max_stars.unwrap_or(1000) as usize;
 
     let (image, file_only, target_name) = resolve_image_meta(&ctx, image_id)?;
-    let cache_key = annotated_cache_key(&image, &file_only, size, max_stars);
+    let mapping_revision = rendered_artifact_mapping_revision(&ctx, &image)?;
+    let cache_key = annotated_cache_key(
+        &image,
+        &file_only,
+        size,
+        max_stars,
+        mapping_revision.as_deref(),
+    );
     let cache_path = artifact_cache_path(&ctx, "annotated", &cache_key, state.preview_encoding())?;
 
     let delayed_probe = ctx.delayed_file_probe(image.id);
     if delayed_probe == crate::server::database_context::DelayedFileProbe::NotPending
         && cache_path.exists()
     {
-        return serve_cached_png(&cache_path).await;
+        return serve_cached_png(&cache_path, &headers).await;
     }
 
     if delayed_probe == crate::server::database_context::DelayedFileProbe::Wait {
         return Ok(generating_response());
     }
     let source = if delayed_probe == crate::server::database_context::DelayedFileProbe::Probe {
-        find_fits_file_cached(&ctx, &image, &target_name, &file_only)
+        find_fits_file_cached_async(&ctx.0, &image, &target_name, &file_only).await
     } else {
-        find_fits_file(&ctx, &image, &target_name, &file_only)
+        find_fits_file_async(&ctx.0, &image, &target_name, &file_only).await
     };
     let fits_path = match source {
         Ok(path) => path,
@@ -4162,7 +4668,7 @@ pub async fn get_annotated_image(
         && tracked_cache_matches_source(&state, &cache_path, &fits_path)?
     {
         if ctx.complete_delayed_file_probe(image.id, &fits_path) {
-            return serve_cached_png(&cache_path).await;
+            return serve_cached_png(&cache_path, &headers).await;
         }
         return Ok(generating_response());
     }
@@ -4215,6 +4721,12 @@ pub struct GenerationStatusBatch {
 
 const MAX_DELAYED_FILE_PROBES_PER_STATUS_BATCH: usize = 8;
 
+struct GenerationStatusLookup<'a> {
+    images: &'a HashMap<i32, crate::models::AcquiredImage>,
+    target_names: &'a HashMap<i32, String>,
+    mapped_sources: &'a crate::server::remote_upload::MappedLightSources,
+}
+
 fn consume_delayed_batch_probe(
     probes: &HashMap<i32, crate::server::database_context::DelayedFileProbe>,
     image_id: i32,
@@ -4251,9 +4763,10 @@ pub async fn post_generation_status(
     // per-tile "error"; only an id genuinely absent from the results is
     // terminal.
     let ids: Vec<i32> = req.requests.iter().map(|r| r.image_id).collect();
-    let (images_by_id, target_names): (
+    let (images_by_id, target_names, mapped_sources): (
         HashMap<i32, crate::models::AcquiredImage>,
         HashMap<i32, String>,
+        crate::server::remote_upload::MappedLightSources,
     ) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
@@ -4261,9 +4774,15 @@ pub async fn post_generation_status(
         let images = db.get_images_by_ids(&ids).map_err(AppError::db)?;
         let target_ids: Vec<i32> = images.iter().map(|i| i.target_id).collect();
         let targets = db.get_targets_by_ids(&target_ids).map_err(AppError::db)?;
+        let mapped_sources = crate::server::remote_upload::mapped_light_sources(
+            &conn,
+            &ctx.image_dir_paths,
+            images.iter(),
+        )?;
         (
             images.into_iter().map(|i| (i.id, i)).collect(),
             targets.into_iter().map(|t| (t.id, t.name)).collect(),
+            mapped_sources,
         )
     };
 
@@ -4274,6 +4793,11 @@ pub async fn post_generation_status(
     let statuses = tokio::task::spawn_blocking(move || {
         let mut canonical_roots = None;
         let mut consumed_probe_ids = std::collections::HashSet::new();
+        let lookup = GenerationStatusLookup {
+            images: &images_by_id,
+            target_names: &target_names,
+            mapped_sources: &mapped_sources,
+        };
         requests
             .iter()
             .map(|item| {
@@ -4286,8 +4810,7 @@ pub async fn post_generation_status(
                     &state,
                     &ctx,
                     item,
-                    &images_by_id,
-                    &target_names,
+                    &lookup,
                     delayed_probe,
                     &mut canonical_roots,
                 )
@@ -4313,8 +4836,7 @@ fn status_for_item(
     state: &Arc<AppState>,
     ctx: &DatabaseContext,
     item: &GenStatusItem,
-    images_by_id: &HashMap<i32, crate::models::AcquiredImage>,
-    target_names: &HashMap<i32, String>,
+    lookup: &GenerationStatusLookup<'_>,
     delayed_probe: crate::server::database_context::DelayedFileProbe,
     canonical_roots: &mut Option<Vec<PathBuf>>,
 ) -> crate::server::preview_queue::GenerationStatus {
@@ -4333,21 +4855,34 @@ fn status_for_item(
     let encoding = state.preview_encoding();
     let color_default = state.preview_color_default();
 
-    let Some(image) = images_by_id.get(&item.image_id) else {
+    let Some(image) = lookup.images.get(&item.image_id) else {
         return err("image not found");
     };
-    let Some(target_name) = target_names.get(&image.target_id) else {
+    let Some(target_name) = lookup.target_names.get(&image.target_id) else {
         return err("target not found");
     };
     let Some(file_only) = filename_from_metadata(&image.metadata) else {
         return err("no filename in metadata");
     };
+    if lookup.mapped_sources.is_invalid(image.id) {
+        return err("remote image provenance is invalid");
+    }
+    let mapping_revision = lookup
+        .mapped_sources
+        .get(&image.id)
+        .and_then(|source| source.revision.strip_prefix("mapping:").map(str::to_owned));
 
     let size = item.size.clone().unwrap_or_else(|| "screen".to_string());
     let (cache_path, kind) = match item.kind.as_deref() {
         Some("annotated") => {
             let max_stars = item.max_stars.unwrap_or(1000) as usize;
-            let key = annotated_cache_key(image, &file_only, &size, max_stars);
+            let key = annotated_cache_key(
+                image,
+                &file_only,
+                &size,
+                max_stars,
+                mapping_revision.as_deref(),
+            );
             match artifact_cache_path(ctx, "annotated", &key, encoding) {
                 Ok(p) => (
                     p,
@@ -4364,7 +4899,16 @@ fn status_for_item(
             let midtone = item.midtone.unwrap_or(0.2);
             let shadow = item.shadow.unwrap_or(-2.8);
             let color = item.color.unwrap_or(color_default);
-            let key = preview_cache_key(image, &file_only, &size, stretch, midtone, shadow, color);
+            let key = preview_cache_key(
+                image,
+                &file_only,
+                &size,
+                stretch,
+                midtone,
+                shadow,
+                color,
+                mapping_revision.as_deref(),
+            );
             match artifact_cache_path(ctx, "previews", &key, encoding) {
                 Ok(p) => (
                     p,
@@ -4522,7 +5066,7 @@ pub async fn get_psf_visualization(
 
     let psf_type: PSFType = psf_type_str.parse().unwrap_or(PSFType::Moffat4);
 
-    let fits_path = find_fits_file(&ctx, &image, &target_name, &file_only)?;
+    let fits_path = find_fits_file_async(&ctx.0, &image, &target_name, &file_only).await?;
     let source_token = source_file_cache_token(&fits_path)
         .ok_or_else(|| AppError::Conflict("Source file is not ready".to_string()))?;
 
@@ -4927,7 +5471,7 @@ pub async fn analyze_sequence(
     // Fetch images from the requested target, project, or database. Wider
     // scopes still score each target/filter group independently and only read
     // evidence already stored in metadata or caches.
-    let (images_data, expected_by_image) = {
+    let (images_data, expected_by_image, mapped_sources) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
@@ -4983,7 +5527,12 @@ pub async fn analyze_sequence(
             images_data.push(image);
         }
 
-        (images_data, expected_by_image)
+        let mapped_sources = crate::server::remote_upload::mapped_light_sources(
+            &conn,
+            &ctx.image_dir_paths,
+            images_data.iter().map(|(image, _, _)| image),
+        )?;
+        (images_data, expected_by_image, mapped_sources)
     };
 
     if images_data.is_empty() {
@@ -5044,13 +5593,22 @@ pub async fn analyze_sequence(
         for (img, _project_name, target_name) in &images_data {
             let mut metrics =
                 extract_metrics_from_metadata(img.id, &img.metadata, img.acquired_date);
-            merge_spatial_metrics(&mut metrics, &spatial_store, &img.metadata);
+            let mapped_source = mapped_sources.get(&img.id);
+            let mapped_source_revision = mapped_sources.quality_revision(img.id);
+            merge_spatial_metrics(
+                &mut metrics,
+                &spatial_store,
+                &img.metadata,
+                mapped_source_revision,
+            );
             merge_astrometry_metrics(
                 &mut metrics,
                 &astrometry_cache_dir,
                 &img.metadata,
                 &astrometry_evidence,
                 expected_by_image.get(&img.id).copied().flatten(),
+                mapped_source.map(|source| source.path.as_path()),
+                mapped_sources.is_invalid(img.id),
             );
             // Key on the normalized filter so case or whitespace variants of
             // one physical filter form ONE comparison cohort; the raw name
@@ -5066,7 +5624,12 @@ pub async fn analyze_sequence(
             entries_by_group
                 .entry(group.clone())
                 .or_default()
-                .push(stored_entry_for(&spatial_store, img.id, &img.metadata));
+                .push(stored_entry_for(
+                    &spatial_store,
+                    img.id,
+                    &img.metadata,
+                    mapped_source_revision,
+                ));
             by_group.entry(group).or_default().push(metrics);
         }
 
@@ -5139,7 +5702,7 @@ pub async fn get_image_quality(
     };
 
     // Get the target image and its context from database
-    let (target_image, all_filter_images, target_name, expected_by_image) = {
+    let (target_image, all_filter_images, target_name, expected_by_image, mapped_sources) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
@@ -5178,7 +5741,19 @@ pub async fn get_image_quality(
             .collect::<Result<std::collections::HashMap<_, _>, _>>()
             .map_err(AppError::db)?;
 
-        (target_image, filter_images, target_name, expected_by_image)
+        let mapped_sources = crate::server::remote_upload::mapped_light_sources(
+            &conn,
+            &ctx.image_dir_paths,
+            filter_images.iter().map(|(image, _, _)| image),
+        )?;
+
+        (
+            target_image,
+            filter_images,
+            target_name,
+            expected_by_image,
+            mapped_sources,
+        )
     };
 
     if all_filter_images.is_empty() {
@@ -5213,15 +5788,29 @@ pub async fn get_image_quality(
         let mut entries = Vec::with_capacity(all_filter_images.len());
         for (img, _, _) in &all_filter_images {
             let mut m = extract_metrics_from_metadata(img.id, &img.metadata, img.acquired_date);
-            merge_spatial_metrics(&mut m, &spatial_store, &img.metadata);
+            let mapped_source = mapped_sources.get(&img.id);
+            let mapped_source_revision = mapped_sources.quality_revision(img.id);
+            merge_spatial_metrics(
+                &mut m,
+                &spatial_store,
+                &img.metadata,
+                mapped_source_revision,
+            );
             merge_astrometry_metrics(
                 &mut m,
                 &astrometry_cache_dir,
                 &img.metadata,
                 &astrometry_evidence,
                 expected_by_image.get(&img.id).copied().flatten(),
+                mapped_source.map(|source| source.path.as_path()),
+                mapped_sources.is_invalid(img.id),
             );
-            entries.push(stored_entry_for(&spatial_store, img.id, &img.metadata));
+            entries.push(stored_entry_for(
+                &spatial_store,
+                img.id,
+                &img.metadata,
+                mapped_source_revision,
+            ));
             metrics.push(m);
         }
         merge_photometric_signals(&mut metrics, &entries, session_gap_minutes);
@@ -5282,9 +5871,15 @@ pub(crate) fn stored_entry_for(
     store: &crate::server::spatial_scan::SharedSpatialStore,
     image_id: i32,
     metadata_json: &str,
+    mapped_source_revision: Option<&str>,
 ) -> Option<crate::server::spatial_scan::StoredSpatialMetrics> {
     let file_only = filename_from_metadata(metadata_json)?;
-    crate::server::spatial_scan::valid_quality_entry(store, image_id, &file_only)
+    crate::server::spatial_scan::valid_quality_entry_for_source(
+        store,
+        image_id,
+        &file_only,
+        mapped_source_revision,
+    )
 }
 
 /// Run the cross-frame photometric pass (transparency, localized extinction,
@@ -5403,13 +5998,17 @@ pub(crate) fn merge_spatial_metrics(
     metrics: &mut crate::sequence_analysis::ImageMetrics,
     store: &crate::server::spatial_scan::SharedSpatialStore,
     metadata_json: &str,
+    mapped_source_revision: Option<&str>,
 ) {
     let Some(file_only) = filename_from_metadata(metadata_json) else {
         return;
     };
-    if let Some(entry) =
-        crate::server::spatial_scan::valid_entry(store, metrics.image_id, &file_only)
-    {
+    if let Some(entry) = crate::server::spatial_scan::valid_entry_for_source(
+        store,
+        metrics.image_id,
+        &file_only,
+        mapped_source_revision,
+    ) {
         if entry.detector == crate::server::spatial_scan::QUALITY_DETECTOR
             && entry.detector_version == crate::server::spatial_scan::QUALITY_DETECTOR_VERSION
         {
@@ -5434,7 +6033,12 @@ pub(crate) fn merge_astrometry_metrics(
     metadata_json: &str,
     evidence: &crate::astrometry::AstrometryEvidenceCache,
     expected_target: Option<(f64, f64)>,
+    mapped_source_path: Option<&std::path::Path>,
+    mapped_source_invalid: bool,
 ) {
+    if mapped_source_invalid {
+        return;
+    }
     let Some(file_only) = filename_from_metadata(metadata_json) else {
         return;
     };
@@ -5442,10 +6046,11 @@ pub(crate) fn merge_astrometry_metrics(
     else {
         return;
     };
-    let cached_file = std::path::Path::new(&analysis.source_fingerprint.canonical_path)
-        .file_name()
-        .and_then(|name| name.to_str());
-    if cached_file != Some(file_only.as_str()) {
+    if !cached_pixel_source_matches(
+        &analysis.source_fingerprint.canonical_path,
+        &file_only,
+        mapped_source_path,
+    ) {
         return;
     }
     metrics.astrometry = crate::sequence_analysis::astrometry_metrics_from_analysis(&analysis);
@@ -5453,6 +6058,55 @@ pub(crate) fn merge_astrometry_metrics(
         crate::satellites::persisted_analysis(cache_dir, metrics.image_id, &analysis)
             .as_ref()
             .map(crate::sequence_analysis::SatelliteFrameMetrics::from);
+}
+
+fn cached_pixel_source_matches(
+    cached_path: &str,
+    filename: &str,
+    mapped_source_path: Option<&std::path::Path>,
+) -> bool {
+    let cached_path = std::path::Path::new(cached_path);
+    if let Some(mapped_source_path) = mapped_source_path {
+        #[cfg(windows)]
+        {
+            return dunce::simplified(cached_path)
+                .to_string_lossy()
+                .eq_ignore_ascii_case(&dunce::simplified(mapped_source_path).to_string_lossy());
+        }
+        #[cfg(not(windows))]
+        {
+            return cached_path == mapped_source_path;
+        }
+    }
+    cached_path.file_name().and_then(|name| name.to_str()) == Some(filename)
+}
+
+#[cfg(test)]
+mod cached_pixel_source_tests {
+    use super::cached_pixel_source_matches;
+
+    #[test]
+    fn mapped_evidence_requires_the_exact_registered_source_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let current = directory.path().join("current").join("frame.fits");
+        let old = directory.path().join("old").join("frame.fits");
+
+        assert!(cached_pixel_source_matches(
+            &current.to_string_lossy(),
+            "frame.fits",
+            Some(&current)
+        ));
+        assert!(!cached_pixel_source_matches(
+            &old.to_string_lossy(),
+            "frame.fits",
+            Some(&current)
+        ));
+        assert!(cached_pixel_source_matches(
+            &old.to_string_lossy(),
+            "frame.fits",
+            None
+        ));
+    }
 }
 
 /// POST /api/db/{db_id}/analysis/spatial-scan
@@ -5495,7 +6149,7 @@ async fn start_spatial_scan_with_priority(
     // Collect this target's images together with schema-adaptive intended
     // framing. Unsupported coordinate epochs are deliberately omitted from
     // absolute grading, though the solver may still use FITS hints.
-    let candidates = {
+    let (candidates, mapped_sources) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
@@ -5528,7 +6182,12 @@ async fn start_spatial_scan_with_priority(
                 .map_err(AppError::db)?;
             candidates.push((img, target_name.clone(), expected));
         }
-        candidates
+        let mapped_sources = crate::server::remote_upload::mapped_light_sources(
+            &conn,
+            &ctx.image_dir_paths,
+            candidates.iter().map(|(image, _, _)| image),
+        )?;
+        (candidates, mapped_sources)
     };
 
     // Keep the union of spatial, astrometry, and satellite work. One side may
@@ -5538,7 +6197,7 @@ async fn start_spatial_scan_with_priority(
     // once the scan has measurements, they are written back to the DB —
     // unless the caller opted out of metadata writes.
     let fill_metadata = req.fill_metadata.unwrap_or(true);
-    let mut star_fill: Vec<(i32, String, String)> = Vec::new();
+    let mut star_fill: Vec<(i32, String, String, Option<String>)> = Vec::new();
     let mut skipped_cached = 0usize;
     let force_spatial = req.force || req.force_spatial;
     let force_astrometry = req.force || req.force_astrometry;
@@ -5549,10 +6208,21 @@ async fn start_spatial_scan_with_priority(
         };
         if fill_metadata && crate::server::spatial_scan::metadata_lacks_star_metrics(&img.metadata)
         {
-            star_fill.push((img.id, file_only.clone(), img.metadata.clone()));
+            star_fill.push((
+                img.id,
+                file_only.clone(),
+                img.metadata.clone(),
+                mapped_sources.quality_revision(img.id).map(str::to_owned),
+            ));
         }
         let spatial_cached = !force_spatial
-            && scan::valid_quality_entry(&ctx.spatial_metrics, img.id, &file_only).is_some();
+            && scan::valid_quality_entry_for_source(
+                &ctx.spatial_metrics,
+                img.id,
+                &file_only,
+                mapped_sources.quality_revision(img.id),
+            )
+            .is_some();
         if spatial_cached {
             skipped_cached += 1;
         }
@@ -5566,10 +6236,14 @@ async fn start_spatial_scan_with_priority(
             })
             .flatten()
             .filter(|analysis| {
-                std::path::Path::new(&analysis.source_fingerprint.canonical_path)
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    == Some(file_only.as_str())
+                !mapped_sources.is_invalid(img.id)
+                    && cached_pixel_source_matches(
+                        &analysis.source_fingerprint.canonical_path,
+                        &file_only,
+                        mapped_sources
+                            .get(&img.id)
+                            .map(|source| source.path.as_path()),
+                    )
             });
         let astrometry_cached = cached_astrometry.is_some();
         let satellite_cached = !include_satellites
@@ -5664,12 +6338,38 @@ async fn start_spatial_scan_with_priority(
                 need_satellite,
             ) in &work
             {
-                match find_fits_file(&ctx_arc, img, target_name, file_only) {
-                    Ok(path) => items.push((
+                let source_generation = crate::server::spatial_scan::source_generation(
+                    &ctx_arc.spatial_metrics,
+                    img.id,
+                );
+                let resolved =
+                    find_fits_file(&ctx_arc, img, target_name, file_only).and_then(|path| {
+                        let source_revision = rendered_artifact_mapping_revision(&ctx_arc, img)?
+                            .map(|revision| format!("mapping:{revision}"))
+                            .or_else(|| {
+                                source_file_cache_token(&path)
+                                    .map(|revision| format!("file:{revision}"))
+                            });
+                        if source_generation
+                            != crate::server::spatial_scan::source_generation(
+                                &ctx_arc.spatial_metrics,
+                                img.id,
+                            )
+                        {
+                            return Err(AppError::Conflict(
+                                "image source changed while preparing the quality scan".into(),
+                            ));
+                        }
+                        Ok((path, source_revision))
+                    });
+                match resolved {
+                    Ok((path, source_revision)) => items.push((
                         crate::server::spatial_scan::ScanWorkItem {
                             image_id: img.id,
                             filename: file_only.clone(),
                             fits_path: path,
+                            source_generation,
+                            source_revision,
                         },
                         *expected,
                         *need_spatial,
@@ -6142,7 +6842,7 @@ mod delayed_ready_tests {
                 artifact_cache_path(
                     &ctx,
                     "annotated",
-                    &annotated_cache_key(&image, "arrived.fits", "screen", 1000),
+                    &annotated_cache_key(&image, "arrived.fits", "screen", 1000, None),
                     state.preview_encoding(),
                 )
                 .unwrap()
@@ -6158,6 +6858,7 @@ mod delayed_ready_tests {
                         0.2,
                         -2.8,
                         state.preview_color_default(),
+                        None,
                     ),
                     state.preview_encoding(),
                 )
@@ -6174,6 +6875,12 @@ mod delayed_ready_tests {
                 MAX_DELAYED_FILE_PROBES_PER_STATUS_BATCH,
             )[&IMAGE_ID];
             let mut canonical_roots = None;
+            let mapped_sources = crate::server::remote_upload::MappedLightSources::default();
+            let lookup = GenerationStatusLookup {
+                images: &images,
+                target_names: &targets,
+                mapped_sources: &mapped_sources,
+            };
             let status = status_for_item(
                 &state,
                 &ctx,
@@ -6187,8 +6894,7 @@ mod delayed_ready_tests {
                     max_stars: None,
                     color: None,
                 },
-                &images,
-                &targets,
+                &lookup,
                 delayed_probe,
                 &mut canonical_roots,
             );
@@ -6213,6 +6919,7 @@ mod delayed_ready_tests {
                     DbContext(Arc::clone(&ctx)),
                     Path(("test".into(), IMAGE_ID)),
                     Query(options),
+                    HeaderMap::new(),
                 )
                 .await
                 .unwrap()
@@ -6222,6 +6929,7 @@ mod delayed_ready_tests {
                     DbContext(Arc::clone(&ctx)),
                     Path(("test".into(), IMAGE_ID)),
                     Query(options),
+                    HeaderMap::new(),
                 )
                 .await
                 .unwrap()
@@ -6251,7 +6959,7 @@ mod delayed_ready_tests {
 mod preview_cache_key_tests {
     use super::{
         annotated_cache_key, image_file_identity_cache_token, preview_cache_key,
-        psf_multi_cache_key, star_detection_cache_key,
+        psf_multi_cache_key, serve_cached_png, star_detection_cache_key,
     };
     use crate::models::AcquiredImage;
 
@@ -6274,8 +6982,8 @@ mod preview_cache_key_tests {
     fn colour_and_greyscale_are_different_artifacts() {
         // They are rendered differently, so serving one for the other shows
         // the wrong pixels rather than a stale copy of the right ones.
-        let mono = preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, false);
-        let color = preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, true);
+        let mono = preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, false, None);
+        let color = preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, true, None);
         assert_ne!(mono, color);
         assert!(color.ends_with("_color"), "{color}");
     }
@@ -6285,7 +6993,7 @@ mod preview_cache_key_tests {
         // Previews already on disk were written before colour existed. The
         // marker only appears on the colour variant so those stay valid.
         assert!(
-            !preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, false)
+            !preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, false, None,)
                 .contains("color"),
         );
     }
@@ -6309,13 +7017,68 @@ mod preview_cache_key_tests {
                 crate::server::PREGENERATE_MIDTONE,
                 crate::server::PREGENERATE_SHADOW,
                 color,
+                None,
             );
             // What `get_image_preview` computes for a caller taking every
             // default on a server configured that way.
             let requested =
-                preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, color);
+                preview_cache_key(&image(), "one.fits", "screen", true, 0.2, -2.8, color, None);
             assert_eq!(warmed, requested);
         }
+    }
+
+    #[test]
+    fn remote_mapping_changes_move_inflight_jobs_to_a_new_artifact() {
+        let first_preview = preview_cache_key(
+            &image(),
+            "one.fits",
+            "screen",
+            true,
+            0.2,
+            -2.8,
+            false,
+            Some("mapping-a"),
+        );
+        let remapped_preview = preview_cache_key(
+            &image(),
+            "one.fits",
+            "screen",
+            true,
+            0.2,
+            -2.8,
+            false,
+            Some("mapping-b"),
+        );
+        let first_annotated =
+            annotated_cache_key(&image(), "one.fits", "screen", 1000, Some("mapping-a"));
+        let remapped_annotated =
+            annotated_cache_key(&image(), "one.fits", "screen", 1000, Some("mapping-b"));
+
+        assert_ne!(first_preview, remapped_preview);
+        assert_ne!(first_annotated, remapped_annotated);
+        assert!(first_preview.contains("_mapping_mapping-a"));
+        assert!(remapped_preview.contains("_mapping_mapping-b"));
+    }
+
+    #[tokio::test]
+    async fn rendered_artifacts_require_browser_revalidation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("preview.png");
+        tokio::fs::write(&path, b"cached pixels").await.unwrap();
+
+        let response = serve_cached_png(&path, &axum::http::HeaderMap::new())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers()[axum::http::header::CACHE_CONTROL],
+            "no-cache"
+        );
+        let etag = response.headers()[axum::http::header::ETAG].clone();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(axum::http::header::IF_NONE_MATCH, etag);
+        let response = serve_cached_png(&path, &headers).await.unwrap();
+        assert_eq!(response.status(), axum::http::StatusCode::NOT_MODIFIED);
     }
 
     #[test]
@@ -6332,12 +7095,12 @@ mod preview_cache_key_tests {
             image_file_identity_cache_token(&moved)
         );
         assert_ne!(
-            preview_cache_key(&first, "one.fits", "screen", true, 0.2, -2.8, false),
-            preview_cache_key(&moved, "one.fits", "screen", true, 0.2, -2.8, false)
+            preview_cache_key(&first, "one.fits", "screen", true, 0.2, -2.8, false, None,),
+            preview_cache_key(&moved, "one.fits", "screen", true, 0.2, -2.8, false, None,)
         );
         assert_ne!(
-            annotated_cache_key(&first, "one.fits", "screen", 1000),
-            annotated_cache_key(&moved, "one.fits", "screen", 1000)
+            annotated_cache_key(&first, "one.fits", "screen", 1000, None),
+            annotated_cache_key(&moved, "one.fits", "screen", 1000, None)
         );
         assert_ne!(
             star_detection_cache_key(&first, "one.fits", "source-a"),
@@ -6353,13 +7116,16 @@ mod preview_cache_key_tests {
 #[cfg(test)]
 mod file_resolution_tests {
     use super::{
-        find_fits_file, find_fits_file_cached, metadata_suffix_candidates, AppError,
+        canonical_image_roots, fill_missing_star_metadata, find_fits_file, find_fits_file_cached,
+        mapped_file_sha256, metadata_suffix_candidates, resolve_mapped_remote_image_with, AppError,
         DatabaseContext,
     };
     use crate::commands::sync::ChangedAcquiredImage;
     use crate::models::AcquiredImage;
     use std::io::Write;
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
     use std::time::Duration;
 
     const CAPTURE_TIME: i64 = 1_784_869_200;
@@ -6439,6 +7205,311 @@ mod file_resolution_tests {
         let mut file = std::fs::File::create(path).unwrap();
         file.write_all(&header).unwrap();
         file.write_all(&[0u8; 2880]).unwrap();
+    }
+
+    #[test]
+    fn remapped_upload_cannot_commit_stale_star_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+        let metadata = serde_json::json!({ "FileName": "remote/repeated.fits" }).to_string();
+        let old_path = image_root.join("old/repeated.fits");
+        let new_path = image_root.join("new/repeated.fits");
+
+        let old_revision = {
+            let connection = ctx.db();
+            let connection = connection.lock().unwrap();
+            connection
+                .execute_batch(
+                    "INSERT INTO project (Id, profileId, name, isMosaic, flatsHandling, guid)
+                         VALUES (7, 'profile', 'Project', 0, 0, 'project-guid');
+                     INSERT INTO target (Id, name, active, epochcode, projectId, guid)
+                         VALUES (3, 'Target', 1, 0, 7, 'target-guid');
+                     CREATE TABLE psf_guard_remote_image_file (
+                         acquiredimage_id INTEGER PRIMARY KEY,
+                         acquiredimage_guid TEXT,
+                         acquiredimage_identity TEXT,
+                         source_path TEXT NOT NULL,
+                         source_sha256 TEXT NOT NULL,
+                         updated_at INTEGER NOT NULL
+                     );",
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO acquiredimage
+                        (Id, projectId, targetId, acquireddate, filtername, gradingStatus,
+                         metadata, profileId, guid)
+                     VALUES (42, 7, 3, ?1, 'Ha', 0, ?2, 'profile', 'image-guid')",
+                    rusqlite::params![CAPTURE_TIME, metadata],
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO psf_guard_remote_image_file
+                        (acquiredimage_id, acquiredimage_guid, acquiredimage_identity,
+                         source_path, source_sha256, updated_at)
+                     VALUES (42, 'image-guid', NULL, ?1, 'old-sha', 1)",
+                    [old_path.to_string_lossy().as_ref()],
+                )
+                .unwrap();
+            let images = crate::db::Database::new(&connection)
+                .get_images_by_ids(&[42])
+                .unwrap();
+            crate::server::remote_upload::mapped_light_sources(
+                &connection,
+                &ctx.image_dir_paths,
+                images.iter(),
+            )
+            .unwrap()
+            .quality_revision(42)
+            .unwrap()
+            .to_string()
+        };
+
+        ctx.spatial_metrics.write().unwrap().metrics.insert(
+            42,
+            crate::server::spatial_scan::StoredSpatialMetrics {
+                image_id: 42,
+                filename: "repeated.fits".into(),
+                source_revision: Some(old_revision.clone()),
+                detector: crate::server::spatial_scan::QUALITY_DETECTOR.into(),
+                detector_version: crate::server::spatial_scan::QUALITY_DETECTOR_VERSION,
+                star_count: 123,
+                avg_hfr: 2.4,
+                dead_cell_fraction: None,
+                star_uniformity: None,
+                bg_cell_spread: 0.0,
+                bg_cell_max_dev: 0.0,
+                median_adu: 1000.0,
+                computed_at: 0,
+                catalog: Default::default(),
+                star_cell_counts: vec![1.0],
+                star_dead_cells: vec![false],
+                bg_cell_medians: vec![1000.0],
+                grid_cols: 1,
+                grid_rows: 1,
+                width: 10,
+                height: 10,
+                exposure_s: Some(300.0),
+                bg_glow_max: 0.0,
+                bg_glow_cells: vec![false],
+            },
+        );
+        let pending = vec![(
+            42,
+            "repeated.fits".to_string(),
+            metadata.clone(),
+            Some(old_revision),
+        )];
+
+        assert_eq!(fill_missing_star_metadata(&ctx, &pending), 1);
+        {
+            let connection = ctx.db();
+            let connection = connection.lock().unwrap();
+            connection
+                .execute(
+                    "UPDATE acquiredimage SET metadata = ?1 WHERE Id = 42",
+                    [&metadata],
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "UPDATE psf_guard_remote_image_file
+                     SET source_path = ?1, source_sha256 = 'new-sha', updated_at = 2
+                     WHERE acquiredimage_id = 42",
+                    [new_path.to_string_lossy().as_ref()],
+                )
+                .unwrap();
+        }
+
+        assert_eq!(fill_missing_star_metadata(&ctx, &pending), 0);
+        let stored: String = {
+            let connection = ctx.db();
+            let connection = connection.lock().unwrap();
+            connection
+                .query_row(
+                    "SELECT metadata FROM acquiredimage WHERE Id = 42",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap()
+        };
+        assert_eq!(stored, metadata);
+    }
+
+    #[test]
+    fn durable_upload_mapping_wins_after_restart_and_rejects_changed_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        let (ctx, image_root) = context(&temp);
+        let database_path = PathBuf::from(&ctx.database_path);
+        let mapped = image_root.join("M 31/LIGHT/Ha/repeated.fits");
+        let duplicate = image_root.join("M 42/LIGHT/Ha/repeated.fits");
+        std::fs::create_dir_all(mapped.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(duplicate.parent().unwrap()).unwrap();
+        std::fs::write(&mapped, b"mapped upload without identity headers").unwrap();
+        std::fs::write(&duplicate, b"different file with the same basename").unwrap();
+        let sha256 = mapped_file_sha256(&mapped).unwrap();
+        let mapped_path = std::fs::canonicalize(&mapped)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let metadata = serde_json::json!({ "FileName": r"C:\remote\repeated.fits" });
+
+        {
+            let connection = ctx.db();
+            let connection = connection.lock().unwrap();
+            connection
+                .execute_batch(
+                    "INSERT INTO project (Id, profileId, name, isMosaic, flatsHandling, guid)
+                         VALUES (7, 'profile', 'Project', 0, 0, 'project-guid');
+                     INSERT INTO target (Id, name, active, epochcode, projectId, guid)
+                         VALUES (3, 'M 31', 1, 0, 7, 'target-guid');
+                     CREATE TABLE psf_guard_remote_image_file (
+                         acquiredimage_id INTEGER PRIMARY KEY,
+                         acquiredimage_guid TEXT,
+                         acquiredimage_identity TEXT,
+                         source_path TEXT NOT NULL,
+                         source_sha256 TEXT NOT NULL,
+                         updated_at INTEGER NOT NULL
+                     );",
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO acquiredimage
+                        (Id, projectId, targetId, acquireddate, filtername, gradingStatus,
+                         metadata, profileId, guid)
+                     VALUES (42, 7, 3, NULL, '', 0, ?1, 'profile', 'image-guid')",
+                    [metadata.to_string()],
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO psf_guard_remote_image_file
+                        (acquiredimage_id, acquiredimage_guid, acquiredimage_identity,
+                         source_path, source_sha256, updated_at)
+                     VALUES (42, 'image-guid', NULL, ?1, ?2, 1)",
+                    rusqlite::params![mapped_path, sha256],
+                )
+                .unwrap();
+        }
+        drop(ctx);
+
+        let restarted = Arc::new(
+            DatabaseContext::new(
+                "test".into(),
+                "Test".into(),
+                database_path.to_string_lossy().into_owned(),
+                vec![image_root.to_string_lossy().into_owned()],
+                None,
+                None,
+                temp.path()
+                    .join("cache-restarted")
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+            .unwrap(),
+        );
+        let mut scheduler_image = image(r"C:\remote\repeated.fits", "");
+        scheduler_image.acquired_date = None;
+        scheduler_image.metadata = metadata.to_string();
+        scheduler_image.guid = Some("image-guid".into());
+
+        let worker_count = 4;
+        let start = Arc::new(Barrier::new(worker_count));
+        let hash_calls = Arc::new(AtomicUsize::new(0));
+        let canonical_roots = Arc::new(canonical_image_roots(&restarted));
+        let workers: Vec<_> = (0..worker_count)
+            .map(|_| {
+                let restarted = Arc::clone(&restarted);
+                let scheduler_image = scheduler_image.clone();
+                let start = Arc::clone(&start);
+                let hash_calls = Arc::clone(&hash_calls);
+                let canonical_roots = Arc::clone(&canonical_roots);
+                std::thread::spawn(move || {
+                    start.wait();
+                    resolve_mapped_remote_image_with(
+                        &restarted,
+                        &scheduler_image,
+                        canonical_roots.as_slice(),
+                        |path| {
+                            hash_calls.fetch_add(1, Ordering::SeqCst);
+                            std::thread::sleep(Duration::from_millis(50));
+                            mapped_file_sha256(path)
+                        },
+                    )
+                    .unwrap()
+                    .unwrap()
+                })
+            })
+            .collect();
+        for worker in workers {
+            assert_eq!(
+                worker.join().unwrap(),
+                dunce::canonicalize(&mapped).unwrap()
+            );
+        }
+        assert_eq!(
+            hash_calls.load(Ordering::SeqCst),
+            1,
+            "concurrent cold resolvers share one full-file hash"
+        );
+
+        assert_eq!(
+            find_fits_file(&restarted, &scheduler_image, "M 31", "repeated.fits").unwrap(),
+            dunce::canonicalize(&mapped).unwrap()
+        );
+        assert_eq!(
+            find_fits_file(&restarted, &scheduler_image, "M 31", "repeated.fits").unwrap(),
+            dunce::canonicalize(&mapped).unwrap(),
+            "the verified mapping remains a cheap cache hit"
+        );
+
+        std::fs::write(&mapped, b"mapped upload was changed after verification").unwrap();
+        match find_fits_file(&restarted, &scheduler_image, "M 31", "repeated.fits") {
+            Err(AppError::Conflict(message)) => {
+                assert!(message.contains("no longer matches"), "{message}");
+            }
+            other => panic!("changed mapped bytes were not refused: {other:?}"),
+        }
+
+        std::fs::write(&mapped, b"mapped upload without identity headers").unwrap();
+        {
+            let connection = restarted.db();
+            connection
+                .lock()
+                .unwrap()
+                .execute(
+                    "UPDATE acquiredimage SET guid = 'replacement-guid' WHERE Id = 42",
+                    [],
+                )
+                .unwrap();
+        }
+        scheduler_image.guid = Some("replacement-guid".into());
+        match find_fits_file(&restarted, &scheduler_image, "M 31", "repeated.fits") {
+            Err(AppError::Conflict(message)) => {
+                assert!(
+                    message.contains("provenance no longer matches"),
+                    "{message}"
+                );
+            }
+            other => panic!("stale provenance allowed basename fallback: {other:?}"),
+        }
+        let mapping_count: i64 = {
+            let connection = restarted.db();
+            let connection = connection.lock().unwrap();
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM psf_guard_remote_image_file WHERE acquiredimage_id = 42",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap()
+        };
+        assert_eq!(
+            mapping_count, 1,
+            "read-side resolution preserves provenance"
+        );
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -18,6 +18,7 @@ pub mod quality_backfill;
 pub mod remote_audit;
 pub mod remote_sync;
 pub mod remote_upload;
+pub mod remote_upload_layout;
 pub mod scheduler;
 pub mod slug;
 pub mod spatial_scan;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1084,6 +1084,14 @@ async fn pregenerate_preview(
             .next()
             .ok_or_else(|| anyhow::anyhow!("Image not found: {}", image_id))?
     };
+    let mapping_revision =
+        handlers::rendered_artifact_mapping_revision(ctx, &image_data).map_err(|error| {
+            anyhow::anyhow!(
+                "Resolving rendered-artifact mapping for image {} failed: {:?}",
+                image_id,
+                error
+            )
+        })?;
 
     // The same key the request path builds. This used to be a second
     // `format!` kept in step by a comment, which is how pre-generation came to
@@ -1099,6 +1107,7 @@ async fn pregenerate_preview(
         // Warm whichever rendition this server serves by default, so the
         // warmed artifact is the one the viewer will ask for.
         state.preview_color_default(),
+        mapping_revision.as_deref(),
     );
 
     let cache_manager = CacheManager::new(std::path::PathBuf::from(&ctx.cache_dir));
@@ -1123,19 +1132,18 @@ async fn pregenerate_preview(
     tracing::debug!("🎨 Pre-generating {} preview for image {}", size, image_id);
 
     // Find FITS file using existing function
-    let fits_path =
-        handlers::find_fits_file(ctx, &image_data, target_name, file_only).map_err(|error| {
-            match error {
-                handlers::AppError::Conflict(message) => anyhow::anyhow!(message),
-                handlers::AppError::NotFound => {
-                    anyhow::anyhow!("FITS file not found for image {}", image_id)
-                }
-                other => anyhow::anyhow!(
-                    "Source resolution failed for image {}: {:?}",
-                    image_id,
-                    other
-                ),
+    let fits_path = handlers::find_fits_file_async(ctx, &image_data, target_name, file_only)
+        .await
+        .map_err(|error| match error {
+            handlers::AppError::Conflict(message) => anyhow::anyhow!(message),
+            handlers::AppError::NotFound => {
+                anyhow::anyhow!("FITS file not found for image {}", image_id)
             }
+            other => anyhow::anyhow!(
+                "Source resolution failed for image {}: {:?}",
+                image_id,
+                other
+            ),
         })?;
 
     // Determine target dimensions
@@ -1193,11 +1201,25 @@ async fn pregenerate_annotated(
             .next()
             .ok_or_else(|| anyhow::anyhow!("Image not found: {}", image_id))?
     };
+    let mapping_revision =
+        handlers::rendered_artifact_mapping_revision(ctx, &image_data).map_err(|error| {
+            anyhow::anyhow!(
+                "Resolving rendered-artifact mapping for image {} failed: {:?}",
+                image_id,
+                error
+            )
+        })?;
 
     // Create cache key matching the on-demand annotated format for consistency
     let size = "screen"; // Pre-generation uses screen size for annotated images
     let max_stars = 1000; // Pre-generation uses default max_stars
-    let cache_key = handlers::annotated_cache_key(&image_data, file_only, size, max_stars);
+    let cache_key = handlers::annotated_cache_key(
+        &image_data,
+        file_only,
+        size,
+        max_stars,
+        mapping_revision.as_deref(),
+    );
 
     let cache_manager = CacheManager::new(std::path::PathBuf::from(&ctx.cache_dir));
     cache_manager.ensure_category_dir("annotated")?;
@@ -1220,19 +1242,18 @@ async fn pregenerate_annotated(
     tracing::debug!("🎨 Pre-generating annotated image for image {}", image_id);
 
     // Find FITS file
-    let fits_path =
-        handlers::find_fits_file(ctx, &image_data, target_name, file_only).map_err(|error| {
-            match error {
-                handlers::AppError::Conflict(message) => anyhow::anyhow!(message),
-                handlers::AppError::NotFound => {
-                    anyhow::anyhow!("FITS file not found for image {}", image_id)
-                }
-                other => anyhow::anyhow!(
-                    "Source resolution failed for image {}: {:?}",
-                    image_id,
-                    other
-                ),
+    let fits_path = handlers::find_fits_file_async(ctx, &image_data, target_name, file_only)
+        .await
+        .map_err(|error| match error {
+            handlers::AppError::Conflict(message) => anyhow::anyhow!(message),
+            handlers::AppError::NotFound => {
+                anyhow::anyhow!("FITS file not found for image {}", image_id)
             }
+            other => anyhow::anyhow!(
+                "Source resolution failed for image {}: {:?}",
+                image_id,
+                other
+            ),
         })?;
 
     // Generate atomically via the shared queue helper — consistent sizing with

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -12,6 +12,7 @@
 //! would mean pinning a canonical JSON encoding, so reordering one struct
 //! field would reject every plugin already in the field.
 
+use anyhow::Context as _;
 use axum::{
     extract::{Path, State},
     http::{header::AUTHORIZATION, HeaderMap, StatusCode},
@@ -39,7 +40,10 @@ use crate::server::{
         ApiRefreshStatus, ApiResponse, SchedulerSyncKind, SchedulerSyncRequest,
         SchedulerSyncResponse, SchedulerSyncTableCounts,
     },
-    database_context::DatabaseContext,
+    database_context::{
+        error_has_sqlite_failure, error_is_sqlite_contention, error_is_sqlite_operational_failure,
+        open_scheduler_connection_with_flags, DatabaseContext,
+    },
     handlers::{execute_scheduler_sync_paths, AppError, SyncGuardMode},
     remote_audit::{AuditAction, AuditOutcome, AuditRecord},
     state::AppState,
@@ -585,7 +589,10 @@ async fn create_preview_inner(
     .map_err(|error| AppError::InternalError(format!("bundle task failed: {error}")))?
     {
         state.sync_previews.remove_source_snapshot(&snapshot_file);
-        return Err(refuse(format!("invalid catalog bundle: {error:#}")));
+        let (outcome, app_error) = classify_materialize_failure(&error);
+        let detail = detail_of(&app_error);
+        audit(outcome, Some(&detail), None, BTreeMap::new());
+        return Err(app_error);
     }
     let materialize_duration = started.elapsed();
     tracing::info!(
@@ -890,6 +897,7 @@ pub async fn create_export(
     require_protocol(request.protocol_version)?;
     require_catalog(&catalog, &request.catalog_id)?;
     let database_path = PathBuf::from(&catalog.database_path);
+    let database_path_for_error = database_path.clone();
     let catalog_id = catalog.id.clone();
     let operation = request.operation;
     let reviewed_only = request.reviewed_only;
@@ -921,9 +929,10 @@ pub async fn create_export(
     {
         Ok(bundle) => bundle,
         Err(error) => {
-            let message = format!("creating export: {error:#}");
-            audit(AuditOutcome::Failed, Some(&message), BTreeMap::new());
-            return Err(AppError::BadRequest(message));
+            let (outcome, app_error) = classify_export_failure(&database_path_for_error, &error);
+            let detail = detail_of(&app_error);
+            audit(outcome, Some(&detail), BTreeMap::new());
+            return Err(app_error);
         }
     };
     let summary = bundle
@@ -1129,18 +1138,110 @@ pub(crate) fn materialize_bundle(
             // engine to read, so borrow the destination's own DDL. One
             // connection serves every miss.
             if template.is_none() {
-                template = Some(Connection::open_with_flags(
-                    template_path,
-                    OpenFlags::SQLITE_OPEN_READ_ONLY,
-                )?);
+                template = Some(
+                    open_scheduler_connection_with_flags(
+                        template_path,
+                        OpenFlags::SQLITE_OPEN_READ_ONLY,
+                    )
+                    .with_context(|| LiveDestinationCatalogAccess {
+                        path: template_path.to_path_buf(),
+                        table: (*table_name).to_string(),
+                    })?,
+                );
             }
             let template = template.as_ref().expect("template connection is open");
-            create_empty_table_from_template(&transaction, template, table_name)?;
+            create_empty_table_from_template(&transaction, template, table_name).with_context(
+                || LiveDestinationCatalogAccess {
+                    path: template_path.to_path_buf(),
+                    table: (*table_name).to_string(),
+                },
+            )?;
         }
     }
     transaction.pragma_update(None, "user_version", bundle.source.schema_version)?;
     transaction.commit()?;
     Ok(())
+}
+
+#[derive(Debug)]
+struct LiveDestinationCatalogAccess {
+    path: PathBuf,
+    table: String,
+}
+
+impl std::fmt::Display for LiveDestinationCatalogAccess {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "reading omitted table {} from live destination scheduler database {}",
+            self.table,
+            self.path.display()
+        )
+    }
+}
+
+impl std::error::Error for LiveDestinationCatalogAccess {}
+
+fn error_has_live_destination_catalog_access(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<LiveDestinationCatalogAccess>()
+        .is_some()
+}
+
+fn classify_materialize_failure(error: &anyhow::Error) -> (AuditOutcome, AppError) {
+    if error_has_live_destination_catalog_access(error) {
+        let contention = if error_is_sqlite_contention(error) {
+            " because it remained busy or locked after the lock wait expired"
+        } else {
+            ""
+        };
+        (
+            AuditOutcome::Failed,
+            AppError::DatabaseError(format!(
+                "preparing remote sync could not access the live destination catalog{contention}: {error:#}"
+            )),
+        )
+    } else if error_is_sqlite_operational_failure(error) {
+        (
+            AuditOutcome::Failed,
+            AppError::DatabaseError(format!(
+                "preparing remote sync failed while writing its server-side snapshot: {error:#}"
+            )),
+        )
+    } else {
+        (
+            AuditOutcome::Refused,
+            AppError::BadRequest(format!("invalid catalog bundle: {error:#}")),
+        )
+    }
+}
+
+fn classify_export_failure(
+    database_path: &FsPath,
+    error: &anyhow::Error,
+) -> (AuditOutcome, AppError) {
+    if error_is_sqlite_contention(error) {
+        (
+            AuditOutcome::Failed,
+            AppError::DatabaseError(format!(
+                "creating remote sync export from scheduler database {} failed because it remained busy or locked after the lock wait expired: {error:#}",
+                database_path.display()
+            )),
+        )
+    } else if error_has_sqlite_failure(error) {
+        (
+            AuditOutcome::Failed,
+            AppError::DatabaseError(format!(
+                "creating remote sync export from scheduler database {} failed: {error:#}",
+                database_path.display()
+            )),
+        )
+    } else {
+        (
+            AuditOutcome::Failed,
+            AppError::BadRequest(format!("creating export: {error:#}")),
+        )
+    }
 }
 
 fn create_bundle_table(
@@ -1255,7 +1356,8 @@ pub(crate) fn export_bundle(
     reviewed_only: bool,
     include_thumbnails: bool,
 ) -> anyhow::Result<CatalogBundle> {
-    let connection = Connection::open_with_flags(database_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let connection =
+        open_scheduler_connection_with_flags(database_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
     let schema_version: i64 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     anyhow::ensure!(
         schema_version >= 22,
@@ -1698,6 +1800,145 @@ mod tests {
         assert_eq!(tables, 0, "rollback left tables in the snapshot");
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_file(&template);
+    }
+
+    #[test]
+    fn destination_catalog_locks_are_operational_materialize_failures() {
+        use rusqlite::ffi::{Error as FfiError, SQLITE_BUSY, SQLITE_LOCKED};
+
+        for code in [SQLITE_BUSY, SQLITE_LOCKED] {
+            let error = anyhow::Error::new(rusqlite::Error::SqliteFailure(
+                FfiError::new(code),
+                Some("catalog is in use".to_string()),
+            ))
+            .context(LiveDestinationCatalogAccess {
+                path: PathBuf::from("locked-scheduler.sqlite"),
+                table: "imagedata".to_string(),
+            });
+
+            let (outcome, app_error) = classify_materialize_failure(&error);
+            assert_eq!(outcome, AuditOutcome::Failed);
+            match app_error {
+                AppError::DatabaseError(message) => {
+                    assert!(message.contains("live destination catalog"));
+                    assert!(message.contains("busy or locked"));
+                    assert!(message.contains("locked-scheduler.sqlite"));
+                    assert!(message.contains("imagedata"));
+                }
+                other => panic!("destination lock was misclassified: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn every_live_destination_access_failure_is_operational() {
+        let error = anyhow::anyhow!("template schema could not be read")
+            .context(LiveDestinationCatalogAccess {
+                path: PathBuf::from("destination-scheduler.sqlite"),
+                table: "exposureplan".to_string(),
+            })
+            .context("materializing bundle");
+
+        let (outcome, app_error) = classify_materialize_failure(&error);
+
+        assert_eq!(outcome, AuditOutcome::Failed);
+        match app_error {
+            AppError::DatabaseError(message) => {
+                assert!(message.contains("live destination catalog"));
+                assert!(message.contains("destination-scheduler.sqlite"));
+                assert!(message.contains("exposureplan"));
+                assert!(message.contains("template schema could not be read"));
+            }
+            other => panic!("destination access was misclassified: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_bundle_materialization_remains_a_refusal() {
+        let error = anyhow::anyhow!("duplicate primary key in acquiredimage");
+
+        let (outcome, app_error) = classify_materialize_failure(&error);
+
+        assert_eq!(outcome, AuditOutcome::Refused);
+        match app_error {
+            AppError::BadRequest(message) => {
+                assert!(message.contains("invalid catalog bundle"));
+                assert!(message.contains("duplicate primary key"));
+            }
+            other => panic!("invalid bundle was misclassified: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn materialize_disk_failures_are_operational() {
+        for code in [
+            rusqlite::ffi::SQLITE_FULL,
+            rusqlite::ffi::SQLITE_CORRUPT,
+            rusqlite::ffi::SQLITE_NOTADB,
+        ] {
+            let error = anyhow::Error::new(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(code),
+                Some("server snapshot failed".into()),
+            ));
+
+            let (outcome, app_error) = classify_materialize_failure(&error);
+
+            assert_eq!(outcome, AuditOutcome::Failed);
+            assert!(matches!(app_error, AppError::DatabaseError(_)));
+        }
+    }
+
+    #[test]
+    fn export_contention_is_a_database_failure() {
+        use rusqlite::ffi::{Error as FfiError, SQLITE_BUSY, SQLITE_LOCKED};
+
+        for code in [SQLITE_BUSY, SQLITE_LOCKED] {
+            let error =
+                anyhow::Error::new(rusqlite::Error::SqliteFailure(FfiError::new(code), None))
+                    .context("reading acquiredimage")
+                    .context("building catalog bundle");
+
+            let (outcome, app_error) =
+                classify_export_failure(FsPath::new("scheduler.sqlite"), &error);
+            assert_eq!(outcome, AuditOutcome::Failed);
+            match app_error {
+                AppError::DatabaseError(message) => {
+                    assert!(message.contains("scheduler.sqlite"));
+                    assert!(message.contains("busy or locked"));
+                    assert!(message.contains("reading acquiredimage"));
+                }
+                other => panic!("export contention was misclassified: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn export_validation_failures_remain_bad_requests() {
+        let error = anyhow::anyhow!("database schema version 21 is older than required version 22");
+
+        let (outcome, app_error) = classify_export_failure(FsPath::new("scheduler.sqlite"), &error);
+
+        assert_eq!(outcome, AuditOutcome::Failed);
+        match app_error {
+            AppError::BadRequest(message) => {
+                assert!(message.contains("creating export"));
+                assert!(message.contains("older than required"));
+            }
+            other => panic!("export validation was misclassified: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn export_io_failures_are_operational_database_errors() {
+        let error = anyhow::Error::new(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_IOERR),
+            Some("disk read failed".into()),
+        ));
+
+        let (outcome, app_error) = classify_export_failure(FsPath::new("scheduler.sqlite"), &error);
+
+        assert_eq!(outcome, AuditOutcome::Failed);
+        assert!(matches!(app_error, AppError::DatabaseError(_)));
     }
 
     #[test]

--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -161,7 +161,11 @@ pub async fn upload_image(
     })?;
     let database_path = ctx.database_path.clone();
     let database_id = ctx.id.clone();
-    let placement = config.placement;
+    let directory_layout = UploadDirectoryLayout {
+        placement: config.placement,
+        template: config.directory_template().to_string(),
+        explicit: config.directory_layout.is_some(),
+    };
     let registered_roots = ctx.image_dir_paths.clone();
     let response_sha256 = sha256.clone();
     let response_filename = filename.clone();
@@ -171,7 +175,7 @@ pub async fn upload_image(
             &database_path,
             &upload_dir,
             &registered_roots,
-            placement,
+            &directory_layout,
             temporary,
             frame,
             filename,
@@ -218,13 +222,19 @@ struct PublishedRemoteImage {
     light_mapping_changed: bool,
 }
 
+struct UploadDirectoryLayout {
+    placement: RemoteImageUploadPlacement,
+    template: String,
+    explicit: bool,
+}
+
 #[allow(clippy::too_many_arguments)]
 fn publish_and_import(
     database_id: &str,
     database_path: &str,
     upload_dir: &Path,
     registered_roots: &[PathBuf],
-    placement: RemoteImageUploadPlacement,
+    directory_layout: &UploadDirectoryLayout,
     temporary: tempfile::NamedTempFile,
     mut frame: import::headers::FrameMeta,
     filename: String,
@@ -266,7 +276,7 @@ fn publish_and_import(
                         registered_roots,
                         &filename,
                         &sha256,
-                        placement == RemoteImageUploadPlacement::Flat,
+                        directory_layout.placement == RemoteImageUploadPlacement::Flat,
                     )?
                 }
             }
@@ -278,7 +288,7 @@ fn publish_and_import(
             &filename,
             &sha256,
             kind,
-            placement,
+            directory_layout.placement,
         )?,
     };
     let destination = if let Some(registered) = registered_destination {
@@ -292,7 +302,7 @@ fn publish_and_import(
                 .as_ref()
                 .map(|existing| &existing.resolution),
             &filename,
-            placement,
+            directory_layout,
         )?;
         upload_dir.join(relative)
     };
@@ -546,52 +556,184 @@ fn upload_relative_destination(
     calibration_kind: Option<CalibrationKind>,
     existing_resolution: Option<&RemoteImageResolution>,
     filename: &str,
-    placement: RemoteImageUploadPlacement,
+    directory_layout: &UploadDirectoryLayout,
 ) -> Result<PathBuf, AppError> {
-    if placement == RemoteImageUploadPlacement::Flat {
+    if directory_layout.placement == RemoteImageUploadPlacement::Flat {
         return Ok(PathBuf::from(filename));
     }
-
-    let filter = upload_directory_component(frame.filter.as_deref().unwrap_or("NONE"), "NONE");
-    let relative = match calibration_kind {
-        None => {
-            let resolved_target = if let Some(resolution) = existing_resolution {
-                Some(resolution.target_name.clone())
-            } else {
-                import::resolve_existing_target_name(
-                    connection,
-                    frame,
-                    import::DEFAULT_MATCH_RADIUS_DEG,
-                )
-                .map_err(|error| {
-                    AppError::DatabaseError(format!("resolving the upload target: {error:#}"))
-                })?
+    if !directory_layout.explicit {
+        let filter = upload_directory_component(frame.filter.as_deref().unwrap_or("NONE"), "NONE");
+        match calibration_kind {
+            Some(CalibrationKind::Flat) => {
+                let target = upload_directory_component(
+                    frame.object.as_deref().unwrap_or("Unsorted"),
+                    "Unsorted",
+                );
+                return Ok(PathBuf::from(target)
+                    .join("FLAT")
+                    .join(filter)
+                    .join(filename));
             }
-            .or_else(|| frame.object.clone())
-            .unwrap_or_else(|| "Unknown Target".to_string());
-            PathBuf::from(upload_directory_component(
-                &resolved_target,
-                "Unknown Target",
-            ))
-            .join("LIGHT")
-            .join(filter)
-            .join(filename)
+            Some(CalibrationKind::Bias) => return Ok(PathBuf::from("BIAS").join(filename)),
+            Some(CalibrationKind::Dark) => return Ok(PathBuf::from("DARK").join(filename)),
+            Some(CalibrationKind::DarkFlat) => {
+                return Ok(PathBuf::from("DARKFLAT").join(filename));
+            }
+            None => {}
         }
-        Some(CalibrationKind::Flat) => {
-            let target = upload_directory_component(
-                frame.object.as_deref().unwrap_or("Unsorted"),
-                "Unsorted",
-            );
-            PathBuf::from(target)
-                .join("FLAT")
-                .join(filter)
-                .join(filename)
-        }
-        Some(CalibrationKind::Bias) => PathBuf::from("BIAS").join(filename),
-        Some(CalibrationKind::Dark) => PathBuf::from("DARK").join(filename),
-        Some(CalibrationKind::DarkFlat) => PathBuf::from("DARKFLAT").join(filename),
+    }
+
+    crate::server::remote_upload_layout::validate_directory_template(&directory_layout.template)
+        .map_err(|error| {
+            AppError::InternalError(format!("invalid configured remote upload layout: {error}"))
+        })?;
+    let (target, project) =
+        upload_directory_identity(connection, frame, calibration_kind, existing_resolution)?;
+    let frame_type = match calibration_kind {
+        None => "LIGHT",
+        Some(CalibrationKind::Flat) => "FLAT",
+        Some(CalibrationKind::Bias) => "BIAS",
+        Some(CalibrationKind::Dark) => "DARK",
+        Some(CalibrationKind::DarkFlat) => "DARKFLAT",
     };
+    let (capture_date, observing_night) = upload_capture_dates(frame);
+    let exposure = frame
+        .exposure_s
+        .map(format_upload_exposure)
+        .unwrap_or_else(|| "UNKNOWN".to_string());
+    let gain = frame
+        .gain
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "UNKNOWN".to_string());
+    let capture_year = observing_night
+        .split_once('-')
+        .map(|(year, _)| year)
+        .filter(|year| year.len() == 4 && year.bytes().all(|byte| byte.is_ascii_digit()))
+        .unwrap_or("Unknown Year");
+    let replacements = [
+        ("%TARGET%", target.as_str(), "Unknown Target"),
+        ("%PROJECT%", project.as_str(), "Unknown Project"),
+        ("%DATE%", capture_date.as_str(), "Unknown Date"),
+        ("%NIGHT%", observing_night.as_str(), "Unknown Date"),
+        ("%YEAR%", capture_year, "Unknown Year"),
+        ("%TYPE%", frame_type, "LIGHT"),
+        (
+            "%FILTER%",
+            frame.filter.as_deref().unwrap_or("NONE"),
+            "NONE",
+        ),
+        (
+            "%TELESCOPE%",
+            frame.telescope.as_deref().unwrap_or("Unknown Telescope"),
+            "Unknown Telescope",
+        ),
+        (
+            "%CAMERA%",
+            frame.camera.as_deref().unwrap_or("Unknown Camera"),
+            "Unknown Camera",
+        ),
+        ("%EXPOSURE%", exposure.as_str(), "UNKNOWN"),
+        ("%GAIN%", gain.as_str(), "UNKNOWN"),
+    ];
+    let mut relative = PathBuf::new();
+    for component in directory_layout.template.split(['/', '\\']) {
+        let rendered = render_upload_template_component(component, &replacements);
+        relative.push(upload_directory_component(&rendered, "Unsorted"));
+    }
+    relative.push(filename);
     Ok(relative)
+}
+
+fn render_upload_template_component(
+    component: &str,
+    replacements: &[(&str, &str, &str)],
+) -> String {
+    let mut rendered = String::with_capacity(component.len());
+    let mut remaining = component;
+    while let Some(start) = remaining.find('%') {
+        rendered.push_str(&remaining[..start]);
+        let token_start = &remaining[start..];
+        let end = token_start[1..]
+            .find('%')
+            .map(|offset| offset + 2)
+            .expect("validated remote upload templates contain complete tokens");
+        let token = &token_start[..end];
+        let (_, value, fallback) = replacements
+            .iter()
+            .find(|(candidate, _, _)| *candidate == token)
+            .expect("validated remote upload templates contain known tokens");
+        rendered.push_str(&upload_directory_component(value, fallback));
+        remaining = &token_start[end..];
+    }
+    rendered.push_str(remaining);
+    rendered
+}
+
+fn upload_directory_identity(
+    connection: &rusqlite::Connection,
+    frame: &import::headers::FrameMeta,
+    calibration_kind: Option<CalibrationKind>,
+    existing_resolution: Option<&RemoteImageResolution>,
+) -> Result<(String, String), AppError> {
+    if let Some(resolution) = existing_resolution {
+        return Ok((
+            resolution.target_name.clone(),
+            resolution.project_name.clone(),
+        ));
+    }
+    if calibration_kind.is_some() {
+        let target = frame
+            .object
+            .clone()
+            .unwrap_or_else(|| match calibration_kind {
+                Some(CalibrationKind::Flat) => "Unsorted".to_string(),
+                _ => "Calibration".to_string(),
+            });
+        return Ok((target.clone(), target));
+    }
+
+    if let Some(identity) = import::resolve_existing_target_identity(
+        connection,
+        frame,
+        import::DEFAULT_MATCH_RADIUS_DEG,
+    )
+    .map_err(|error| AppError::DatabaseError(format!("resolving the upload target: {error:#}")))?
+    {
+        return Ok(identity);
+    }
+    let target = frame
+        .object
+        .clone()
+        .unwrap_or_else(|| "Unknown Target".to_string());
+    Ok((target.clone(), target))
+}
+
+fn upload_capture_dates(frame: &import::headers::FrameMeta) -> (String, String) {
+    let local = frame.date_local.as_deref().or(frame.date_obs.as_deref());
+    let timestamp = local
+        .and_then(import::headers::parse_fits_datetime)
+        .or(frame.timestamp);
+    let Some(timestamp) =
+        timestamp.and_then(|value| chrono::DateTime::<chrono::Utc>::from_timestamp(value, 0))
+    else {
+        return ("Unknown Date".to_string(), "Unknown Date".to_string());
+    };
+    let date = timestamp.format("%Y-%m-%d").to_string();
+    let night = (timestamp - chrono::Duration::hours(12))
+        .format("%Y-%m-%d")
+        .to_string();
+    (date, night)
+}
+
+fn format_upload_exposure(value: f64) -> String {
+    let mut formatted = format!("{value:.3}");
+    while formatted.ends_with('0') {
+        formatted.pop();
+    }
+    if formatted.ends_with('.') {
+        formatted.pop();
+    }
+    formatted
 }
 
 /// Create and canonicalize the server-derived parent before publishing. This
@@ -794,7 +936,7 @@ fn metadata_is_link(metadata: &std::fs::Metadata) -> bool {
     false
 }
 
-fn upload_directory_component(value: &str, fallback: &str) -> String {
+pub(super) fn upload_directory_component(value: &str, fallback: &str) -> String {
     let value = if value.trim().is_empty() {
         fallback
     } else {
@@ -2143,5 +2285,108 @@ mod tests {
             &outcome,
         )
         .unwrap());
+    }
+
+    #[test]
+    fn nina_local_date_drives_observing_night_folders() {
+        let frame = import::headers::FrameMeta {
+            date_obs: Some("2026-08-31T11:30:00Z".into()),
+            date_local: Some("2026-08-31T04:30:00".into()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            upload_capture_dates(&frame),
+            ("2026-08-31".into(), "2026-08-30".into())
+        );
+    }
+
+    #[test]
+    fn catalog_template_renders_server_owned_components() {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        let frame = import::headers::FrameMeta {
+            object: Some("M 31".into()),
+            filter: Some("Ha".into()),
+            date_local: Some("2026-08-31T04:30:00".into()),
+            exposure_s: Some(300.0),
+            gain: Some(100),
+            ..Default::default()
+        };
+        let resolution = RemoteImageResolution {
+            image_id: 1,
+            project_id: 2,
+            project_name: "Andromeda project".into(),
+            target_id: 3,
+            target_name: "M 31".into(),
+        };
+
+        let path = upload_relative_destination(
+            &connection,
+            &frame,
+            None,
+            Some(&resolution),
+            "frame.fits",
+            &UploadDirectoryLayout {
+                placement: RemoteImageUploadPlacement::TargetTree,
+                template: "%YEAR%/%PROJECT%/%TARGET%/%NIGHT%/%TYPE%/%FILTER%/%EXPOSURE%s_G%GAIN%"
+                    .into(),
+                explicit: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            path,
+            PathBuf::from("2026")
+                .join("Andromeda project")
+                .join("M 31")
+                .join("2026-08-30")
+                .join("LIGHT")
+                .join("Ha")
+                .join("300s_G100")
+                .join("frame.fits")
+        );
+    }
+
+    #[test]
+    fn project_token_uses_the_same_coordinate_aware_target_match() {
+        let temp = tempfile::tempdir().unwrap();
+        let database_path = temp.path().join("scheduler.sqlite");
+        crate::ts_schema::create_fresh_db(&database_path).unwrap();
+        let connection = rusqlite::Connection::open(database_path).unwrap();
+        connection
+            .execute_batch(
+                "INSERT INTO project (Id, profileId, name, isMosaic, flatsHandling, guid)
+                     VALUES (1, 'profile', 'Far project', 0, 0, 'project-far');
+                 INSERT INTO project (Id, profileId, name, isMosaic, flatsHandling, guid)
+                     VALUES (2, 'profile', 'Near project', 0, 0, 'project-near');
+                 INSERT INTO target (Id, name, active, ra, dec, epochcode, projectId, guid)
+                     VALUES (1, 'Shared target', 1, 1.0, 20.0, 0, 1, 'target-far');
+                 INSERT INTO target (Id, name, active, ra, dec, epochcode, projectId, guid)
+                     VALUES (2, 'Shared target', 1, 2.0, 20.0, 0, 2, 'target-near');",
+            )
+            .unwrap();
+        let frame = import::headers::FrameMeta {
+            object: Some("Shared target".into()),
+            ra_deg: Some(30.0),
+            dec_deg: Some(20.0),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            upload_directory_identity(&connection, &frame, None, None).unwrap(),
+            ("Shared target".into(), "Near project".into())
+        );
+    }
+
+    #[test]
+    fn token_shaped_metadata_is_not_rendered_twice() {
+        let replacements = [
+            ("%TARGET%", "%TYPE%", "Unknown Target"),
+            ("%TYPE%", "LIGHT", "LIGHT"),
+        ];
+        assert_eq!(
+            render_upload_template_component("%TARGET%_%TYPE%", &replacements),
+            "%TYPE%_LIGHT"
+        );
     }
 }

--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -20,9 +20,11 @@ use tokio::io::AsyncWriteExt;
 
 use crate::calibration::{self, CalibrationKind};
 use crate::commands::import::{self, ImportOptions, ImportOutcome};
+use crate::db_registry::RemoteImageUploadPlacement;
 use crate::server::api::{
     ApiResponse, RemoteCalibrationResolution, RemoteImageResolution, RemoteImageUploadResponse,
 };
+use crate::server::database_context::open_scheduler_connection_with_flags;
 use crate::server::extract::DbContext;
 use crate::server::handlers::AppError;
 
@@ -31,6 +33,8 @@ pub const MAX_MULTIPART_BYTES: usize = MAX_IMAGE_BYTES as usize + 1024 * 1024;
 
 const DATABASE_ID_HEADER: &str = "x-psf-guard-database-id";
 const CONTENT_SHA256_HEADER: &str = "x-content-sha256";
+const MAX_UPLOAD_DIRECTORY_COMPONENT_BYTES: usize = 120;
+const CAPTURE_IDENTITY_TIME_TOLERANCE_SECS: u64 = 2;
 
 pub async fn upload_image(
     ctx: DbContext,
@@ -157,14 +161,17 @@ pub async fn upload_image(
     })?;
     let database_path = ctx.database_path.clone();
     let database_id = ctx.id.clone();
-    let destination = upload_dir.join(&filename);
+    let placement = config.placement;
+    let registered_roots = ctx.image_dir_paths.clone();
     let response_sha256 = sha256.clone();
     let response_filename = filename.clone();
-    let result = tokio::task::spawn_blocking(move || {
+    let published = tokio::task::spawn_blocking(move || {
         publish_and_import(
             &database_id,
             &database_path,
-            destination,
+            &upload_dir,
+            &registered_roots,
+            placement,
             temporary,
             frame,
             filename,
@@ -176,6 +183,23 @@ pub async fn upload_image(
     .await
     .map_err(|error| AppError::InternalError(format!("image import task failed: {error}")))??;
 
+    if published.light_mapping_changed
+        && let Some(resolution) = published.response.resolution.as_ref()
+        && let Ok(image_id) = i32::try_from(resolution.image_id)
+    {
+        ctx.clear_remote_image_verification(image_id);
+        if crate::server::spatial_scan::invalidate_image_source(
+            &ctx.spatial_metrics,
+            &ctx.cache_dir_path,
+            image_id,
+        ) {
+            tracing::info!(
+                db = %ctx.id,
+                image_id,
+                "Invalidated pixel-quality evidence after recording remote image provenance"
+            );
+        }
+    }
     ctx.clear_directory_tree_cache();
     ctx.file_check_cache.write().unwrap().clear();
     let _ = ctx.ensure_cache_available();
@@ -186,36 +210,99 @@ pub async fn upload_image(
         bytes,
         response_sha256
     );
-    Ok(Json(ApiResponse::success(result)))
+    Ok(Json(ApiResponse::success(published.response)))
+}
+
+struct PublishedRemoteImage {
+    response: RemoteImageUploadResponse,
+    light_mapping_changed: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
 fn publish_and_import(
     database_id: &str,
     database_path: &str,
-    destination: PathBuf,
+    upload_dir: &Path,
+    registered_roots: &[PathBuf],
+    placement: RemoteImageUploadPlacement,
     temporary: tempfile::NamedTempFile,
     mut frame: import::headers::FrameMeta,
     filename: String,
     bytes: u64,
     sha256: String,
     calibration_kind: Option<CalibrationKind>,
-) -> Result<RemoteImageUploadResponse, AppError> {
-    let mut connection = rusqlite::Connection::open_with_flags(
+) -> Result<PublishedRemoteImage, AppError> {
+    let mut connection = open_scheduler_connection_with_flags(
         database_path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_URI,
     )
     .map_err(AppError::db)?;
+    ensure_remote_upload_provenance_schema(&connection)?;
 
-    let existing_resolution = find_resolution(&connection, &filename)?;
+    let existing_resolution =
+        find_resolution(&connection, registered_roots, &filename, &sha256, &frame)?;
     if existing_resolution.is_some() && calibration_kind.is_some() {
         return Err(AppError::Conflict(format!(
             "{filename} is already registered as a light in this database"
         )));
     }
 
+    // Retries follow the path already registered in this catalog before they
+    // derive a path from today's target name or placement setting. That keeps
+    // a rename or Flat/TargetTree toggle from publishing the same frame twice.
+    let registered_destination = match calibration_kind {
+        None => match existing_resolution.as_ref() {
+            Some(existing) => {
+                if let Some(path) =
+                    find_mapped_remote_image_file(&connection, registered_roots, existing, &sha256)?
+                {
+                    Some(path)
+                } else if let Some(path) =
+                    registered_receive_file(registered_roots, &existing.registered_path)
+                {
+                    Some(path)
+                } else {
+                    find_legacy_flat_upload(
+                        registered_roots,
+                        &filename,
+                        &sha256,
+                        placement == RemoteImageUploadPlacement::Flat,
+                    )?
+                }
+            }
+            None => None,
+        },
+        Some(kind) => find_registered_calibration_file(
+            &connection,
+            registered_roots,
+            &filename,
+            &sha256,
+            kind,
+            placement,
+        )?,
+    };
+    let destination = if let Some(registered) = registered_destination {
+        registered
+    } else {
+        let relative = upload_relative_destination(
+            &connection,
+            &frame,
+            calibration_kind,
+            existing_resolution
+                .as_ref()
+                .map(|existing| &existing.resolution),
+            &filename,
+            placement,
+        )?;
+        upload_dir.join(relative)
+    };
+    let (destination_root, destination) =
+        prepare_registered_upload_destination(upload_dir, registered_roots, &destination)?;
+    validate_publish_destination(&destination_root, &destination)?;
+
     let already_present = if destination.is_file() {
         let existing_sha256 = sha256_file(&destination)?;
+        validate_publish_destination(&destination_root, &destination)?;
         if !constant_time_eq(existing_sha256.as_bytes(), sha256.as_bytes()) {
             return Err(AppError::Conflict(format!(
                 "{filename} already exists in the receive directory with different content"
@@ -223,28 +310,34 @@ fn publish_and_import(
         }
         true
     } else {
-        match temporary.persist_noclobber(&destination) {
-            Ok(_) => false,
-            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
-                let existing_sha256 = sha256_file(&destination)?;
-                if !constant_time_eq(existing_sha256.as_bytes(), sha256.as_bytes()) {
-                    return Err(AppError::Conflict(format!(
-                        "{filename} appeared concurrently with different content"
-                    )));
-                }
-                true
-            }
-            Err(error) => {
-                return Err(AppError::InternalError(format!(
-                    "publishing uploaded image {}: {}",
-                    destination.display(),
-                    error.error
-                )));
-            }
-        }
+        persist_uploaded_file(
+            temporary,
+            &destination_root,
+            &destination,
+            &filename,
+            &sha256,
+        )?
     };
 
-    let outcome = if calibration_kind.is_none() && existing_resolution.is_some() {
+    // N.I.N.A. may commit the scheduler row after the initial lookup but
+    // before these bytes finish publishing. Recheck at that boundary so the
+    // ordinary import does not race a row that has just appeared.
+    let resolution_after_publish = if calibration_kind.is_none() && existing_resolution.is_none() {
+        match find_resolution(&connection, registered_roots, &filename, &sha256, &frame) {
+            Ok(resolution) => resolution,
+            Err(error) => {
+                if !already_present && matches!(&error, AppError::Conflict(_)) {
+                    cleanup_published_file(&destination_root, &destination, &sha256);
+                }
+                return Err(error);
+            }
+        }
+    } else {
+        None
+    };
+    let outcome = if calibration_kind.is_none()
+        && (existing_resolution.is_some() || resolution_after_publish.is_some())
+    {
         ImportOutcome {
             scanned: 1,
             skipped_existing: 1,
@@ -252,34 +345,59 @@ fn publish_and_import(
         }
     } else {
         frame.path = destination.clone();
-        match import::import_frames(&mut connection, vec![frame], &ImportOptions::default()) {
-            Ok(outcome)
-                if (calibration_kind.is_none() && outcome.imported == 1)
-                    || (calibration_kind.is_some()
-                        && outcome.calibration.imported
-                            + outcome.calibration.updated
-                            + outcome.calibration.skipped_existing
-                            == 1) =>
-            {
-                outcome
-            }
+        match import::import_frames(
+            &mut connection,
+            vec![frame.clone()],
+            &ImportOptions::default(),
+        ) {
             Ok(outcome) => {
-                if !already_present {
-                    let _ = std::fs::remove_file(&destination);
+                let accepted = if calibration_kind.is_none() {
+                    match light_import_outcome_is_accepted(
+                        &connection,
+                        registered_roots,
+                        &filename,
+                        &sha256,
+                        &frame,
+                        &outcome,
+                    ) {
+                        Ok(accepted) => accepted,
+                        Err(error) => {
+                            // A database/IO failure is indeterminate: keep the
+                            // already verified bytes so a retry can finish the
+                            // mapping. Only a proven identity mismatch makes
+                            // this publish unsafe to retain.
+                            if !already_present && matches!(&error, AppError::Conflict(_)) {
+                                cleanup_published_file(&destination_root, &destination, &sha256);
+                            }
+                            return Err(error);
+                        }
+                    }
+                } else {
+                    outcome.calibration.imported
+                        + outcome.calibration.updated
+                        + outcome.calibration.skipped_existing
+                        == 1
+                };
+                if accepted {
+                    outcome
+                } else {
+                    if !already_present {
+                        cleanup_published_file(&destination_root, &destination, &sha256);
+                    }
+                    return Err(AppError::BadRequest(format!(
+                        "uploaded image was not imported (unreadable={}, non_light={}, duplicate={}, calibration_imported={}, calibration_updated={}, calibration_duplicate={})",
+                        outcome.unreadable,
+                        outcome.non_light,
+                        outcome.skipped_existing,
+                        outcome.calibration.imported,
+                        outcome.calibration.updated,
+                        outcome.calibration.skipped_existing,
+                    )));
                 }
-                return Err(AppError::BadRequest(format!(
-                    "uploaded image was not imported (unreadable={}, non_light={}, duplicate={}, calibration_imported={}, calibration_updated={}, calibration_duplicate={})",
-                    outcome.unreadable,
-                    outcome.non_light,
-                    outcome.skipped_existing,
-                    outcome.calibration.imported,
-                    outcome.calibration.updated,
-                    outcome.calibration.skipped_existing,
-                )));
             }
             Err(error) => {
                 if !already_present {
-                    let _ = std::fs::remove_file(&destination);
+                    cleanup_published_file(&destination_root, &destination, &sha256);
                 }
                 return Err(AppError::DatabaseError(format!(
                     "importing uploaded image: {error:#}"
@@ -288,12 +406,23 @@ fn publish_and_import(
         }
     };
 
-    let (frame_kind, resolution, calibration) = match calibration_kind {
+    let (frame_kind, resolution, calibration, light_mapping_changed) = match calibration_kind {
         None => {
-            let resolution = find_resolution(&connection, &filename)?.ok_or_else(|| {
-                AppError::InternalError("uploaded light was imported but cannot be resolved".into())
-            })?;
-            ("light".to_string(), Some(resolution), None)
+            let resolution =
+                find_resolution(&connection, registered_roots, &filename, &sha256, &frame)?
+                    .ok_or_else(|| {
+                        AppError::InternalError(
+                            "uploaded light was imported but cannot be resolved".into(),
+                        )
+                    })?;
+            let mapping_changed =
+                record_remote_image_file(&connection, &resolution, &destination, &sha256)?;
+            (
+                "light".to_string(),
+                Some(resolution.resolution),
+                None,
+                mapping_changed,
+            )
         }
         Some(kind) => {
             let calibration = find_calibration_resolution(&connection, &destination, kind)?
@@ -302,20 +431,404 @@ fn publish_and_import(
                         "uploaded calibration frame was imported but cannot be resolved".into(),
                     )
                 })?;
-            (kind.as_str().to_string(), None, Some(calibration))
+            record_remote_calibration_file(&connection, &calibration, &destination, &sha256)?;
+            (kind.as_str().to_string(), None, Some(calibration), false)
         }
     };
-    Ok(RemoteImageUploadResponse {
-        database_id: database_id.to_string(),
-        filename,
-        bytes,
-        sha256,
-        already_present,
-        frame_kind,
-        resolution,
-        calibration,
-        import: outcome,
+    Ok(PublishedRemoteImage {
+        response: RemoteImageUploadResponse {
+            database_id: database_id.to_string(),
+            filename,
+            bytes,
+            sha256,
+            already_present,
+            frame_kind,
+            resolution,
+            calibration,
+            import: outcome,
+        },
+        light_mapping_changed,
     })
+}
+
+fn persist_uploaded_file(
+    temporary: tempfile::NamedTempFile,
+    destination_root: &Path,
+    destination: &Path,
+    filename: &str,
+    expected_sha256: &str,
+) -> Result<bool, AppError> {
+    validate_publish_destination(destination_root, destination)?;
+    match temporary.persist_noclobber(destination) {
+        Ok(_) => Ok(false),
+        Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            validate_concurrent_upload(destination_root, destination, filename, expected_sha256)
+        }
+        Err(error) if error.error.kind() == std::io::ErrorKind::CrossesDevices => {
+            // A retry can follow durable provenance back to another registered
+            // image root, including a different Windows volume. Copy into a
+            // temporary sibling there, sync it, then use the same atomic
+            // no-clobber publish within that filesystem.
+            let source = error.file;
+            let parent = destination.parent().ok_or_else(|| {
+                AppError::InternalError("remote upload destination has no parent".into())
+            })?;
+            validate_publish_destination(destination_root, destination)?;
+            let mut sibling = tempfile::NamedTempFile::new_in(parent).map_err(|copy_error| {
+                AppError::InternalError(format!(
+                    "creating upload temporary file beside {}: {copy_error}",
+                    destination.display()
+                ))
+            })?;
+            let mut input = source.reopen().map_err(|copy_error| {
+                AppError::InternalError(format!(
+                    "reopening the received upload for {}: {copy_error}",
+                    destination.display()
+                ))
+            })?;
+            std::io::copy(&mut input, sibling.as_file_mut()).map_err(|copy_error| {
+                AppError::InternalError(format!(
+                    "copying the received upload beside {}: {copy_error}",
+                    destination.display()
+                ))
+            })?;
+            sibling.as_file().sync_all().map_err(|copy_error| {
+                AppError::InternalError(format!(
+                    "syncing the received upload beside {}: {copy_error}",
+                    destination.display()
+                ))
+            })?;
+            validate_publish_destination(destination_root, destination)?;
+            match sibling.persist_noclobber(destination) {
+                Ok(_) => Ok(false),
+                Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    validate_concurrent_upload(
+                        destination_root,
+                        destination,
+                        filename,
+                        expected_sha256,
+                    )
+                }
+                Err(error) => Err(AppError::InternalError(format!(
+                    "publishing uploaded image {}: {}",
+                    destination.display(),
+                    error.error
+                ))),
+            }
+        }
+        Err(error) => Err(AppError::InternalError(format!(
+            "publishing uploaded image {}: {}",
+            destination.display(),
+            error.error
+        ))),
+    }
+}
+
+fn validate_concurrent_upload(
+    destination_root: &Path,
+    destination: &Path,
+    filename: &str,
+    expected_sha256: &str,
+) -> Result<bool, AppError> {
+    validate_publish_destination(destination_root, destination)?;
+    let existing_sha256 = sha256_file(destination)?;
+    if !constant_time_eq(existing_sha256.as_bytes(), expected_sha256.as_bytes()) {
+        return Err(AppError::Conflict(format!(
+            "{filename} appeared concurrently with different content"
+        )));
+    }
+    Ok(true)
+}
+
+fn upload_relative_destination(
+    connection: &rusqlite::Connection,
+    frame: &import::headers::FrameMeta,
+    calibration_kind: Option<CalibrationKind>,
+    existing_resolution: Option<&RemoteImageResolution>,
+    filename: &str,
+    placement: RemoteImageUploadPlacement,
+) -> Result<PathBuf, AppError> {
+    if placement == RemoteImageUploadPlacement::Flat {
+        return Ok(PathBuf::from(filename));
+    }
+
+    let filter = upload_directory_component(frame.filter.as_deref().unwrap_or("NONE"), "NONE");
+    let relative = match calibration_kind {
+        None => {
+            let resolved_target = if let Some(resolution) = existing_resolution {
+                Some(resolution.target_name.clone())
+            } else {
+                import::resolve_existing_target_name(
+                    connection,
+                    frame,
+                    import::DEFAULT_MATCH_RADIUS_DEG,
+                )
+                .map_err(|error| {
+                    AppError::DatabaseError(format!("resolving the upload target: {error:#}"))
+                })?
+            }
+            .or_else(|| frame.object.clone())
+            .unwrap_or_else(|| "Unknown Target".to_string());
+            PathBuf::from(upload_directory_component(
+                &resolved_target,
+                "Unknown Target",
+            ))
+            .join("LIGHT")
+            .join(filter)
+            .join(filename)
+        }
+        Some(CalibrationKind::Flat) => {
+            let target = upload_directory_component(
+                frame.object.as_deref().unwrap_or("Unsorted"),
+                "Unsorted",
+            );
+            PathBuf::from(target)
+                .join("FLAT")
+                .join(filter)
+                .join(filename)
+        }
+        Some(CalibrationKind::Bias) => PathBuf::from("BIAS").join(filename),
+        Some(CalibrationKind::Dark) => PathBuf::from("DARK").join(filename),
+        Some(CalibrationKind::DarkFlat) => PathBuf::from("DARKFLAT").join(filename),
+    };
+    Ok(relative)
+}
+
+/// Create and canonicalize the server-derived parent before publishing. This
+/// also refuses a pre-existing symlink that would redirect a target folder
+/// outside the configured receive root.
+fn prepare_upload_destination(upload_dir: &Path, relative: &Path) -> Result<PathBuf, AppError> {
+    let parent = relative.parent().unwrap_or_else(|| Path::new(""));
+    let canonical_root = dunce::canonicalize(upload_dir).map_err(|error| {
+        AppError::InternalError(format!(
+            "resolving remote upload directory {}: {error}",
+            upload_dir.display()
+        ))
+    })?;
+    let mut canonical_parent = canonical_root.clone();
+    for component in parent.components() {
+        let std::path::Component::Normal(segment) = component else {
+            return Err(AppError::InternalError(
+                "server-derived remote upload path was not relative".into(),
+            ));
+        };
+        let next = canonical_parent.join(segment);
+        match std::fs::symlink_metadata(&next) {
+            Ok(metadata) if metadata_is_link(&metadata) => {
+                return Err(AppError::Conflict(
+                    "remote upload target directory cannot contain symbolic links".into(),
+                ));
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                return Err(AppError::Conflict(format!(
+                    "remote upload target path is not a directory: {}",
+                    next.display()
+                )));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                std::fs::create_dir(&next).map_err(|error| {
+                    AppError::InternalError(format!(
+                        "creating remote upload directory {}: {error}",
+                        next.display()
+                    ))
+                })?;
+            }
+            Err(error) => {
+                return Err(AppError::InternalError(format!(
+                    "checking remote upload directory {}: {error}",
+                    next.display()
+                )));
+            }
+        }
+        canonical_parent = dunce::canonicalize(&next).map_err(|error| {
+            AppError::InternalError(format!(
+                "resolving remote upload directory {}: {error}",
+                next.display()
+            ))
+        })?;
+        if !canonical_parent.starts_with(&canonical_root) {
+            return Err(AppError::Conflict(
+                "remote upload target directory resolves outside the configured image root".into(),
+            ));
+        }
+    }
+    Ok(canonical_parent.join(
+        relative
+            .file_name()
+            .expect("a server-derived upload path always has a filename"),
+    ))
+}
+
+/// Resolve a destination below one of the database's registered roots and
+/// create its parent tree without following a symlink or Windows reparse
+/// point. Stored provenance paths may name parents that no longer exist.
+fn prepare_registered_upload_destination(
+    upload_dir: &Path,
+    registered_roots: &[PathBuf],
+    destination: &Path,
+) -> Result<(PathBuf, PathBuf), AppError> {
+    let mut roots = registered_roots.to_vec();
+    if !roots.iter().any(|root| root == upload_dir) {
+        roots.push(upload_dir.to_path_buf());
+    }
+
+    for root in roots {
+        let Ok(canonical_root) = dunce::canonicalize(&root) else {
+            continue;
+        };
+        let relative = destination
+            .strip_prefix(&canonical_root)
+            .or_else(|_| destination.strip_prefix(&root));
+        let Ok(relative) = relative else {
+            continue;
+        };
+        if relative.as_os_str().is_empty()
+            || relative
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        {
+            continue;
+        }
+        let prepared = prepare_upload_destination(&canonical_root, relative)?;
+        return Ok((canonical_root, prepared));
+    }
+
+    Err(AppError::Conflict(format!(
+        "remote upload destination is outside the database's registered image roots: {}",
+        destination.display()
+    )))
+}
+
+/// Recheck containment immediately before hashing or publishing. The earlier
+/// preparation makes directories, while this pass narrows the window in which
+/// another process could replace one with a redirecting filesystem object.
+fn validate_publish_destination(root: &Path, destination: &Path) -> Result<(), AppError> {
+    let canonical_root = dunce::canonicalize(root).map_err(|error| {
+        AppError::InternalError(format!(
+            "resolving remote upload root {}: {error}",
+            root.display()
+        ))
+    })?;
+    let relative = destination.strip_prefix(&canonical_root).map_err(|_| {
+        AppError::Conflict("remote upload destination left its registered image root".into())
+    })?;
+    let parent = relative.parent().unwrap_or_else(|| Path::new(""));
+    let mut current = canonical_root.clone();
+    for component in parent.components() {
+        let std::path::Component::Normal(segment) = component else {
+            return Err(AppError::Conflict(
+                "remote upload destination is not a safe relative path".into(),
+            ));
+        };
+        current.push(segment);
+        let metadata = std::fs::symlink_metadata(&current).map_err(|error| {
+            AppError::InternalError(format!(
+                "checking remote upload directory {}: {error}",
+                current.display()
+            ))
+        })?;
+        if metadata_is_link(&metadata) {
+            return Err(AppError::Conflict(
+                "remote upload target directory cannot contain symbolic links or junctions".into(),
+            ));
+        }
+        if !metadata.is_dir() {
+            return Err(AppError::Conflict(format!(
+                "remote upload target path is not a directory: {}",
+                current.display()
+            )));
+        }
+    }
+    let canonical_parent = dunce::canonicalize(destination.parent().unwrap_or(&canonical_root))
+        .map_err(|error| {
+            AppError::InternalError(format!(
+                "resolving remote upload parent {}: {error}",
+                destination.parent().unwrap_or(&canonical_root).display()
+            ))
+        })?;
+    if !canonical_parent.starts_with(&canonical_root) {
+        return Err(AppError::Conflict(
+            "remote upload target directory resolves outside its registered image root".into(),
+        ));
+    }
+    if let Ok(metadata) = std::fs::symlink_metadata(destination) {
+        if metadata_is_link(&metadata) {
+            return Err(AppError::Conflict(
+                "remote upload destination cannot be a symbolic link or junction".into(),
+            ));
+        }
+        if !metadata.is_file() {
+            return Err(AppError::Conflict(format!(
+                "remote upload destination is not a file: {}",
+                destination.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn cleanup_published_file(root: &Path, destination: &Path, expected_sha256: &str) {
+    if validate_publish_destination(root, destination).is_err() || !destination.is_file() {
+        return;
+    }
+    let Ok(actual_sha256) = sha256_file(destination) else {
+        return;
+    };
+    if constant_time_eq(actual_sha256.as_bytes(), expected_sha256.as_bytes()) {
+        let _ = std::fs::remove_file(destination);
+    }
+}
+
+fn metadata_is_link(metadata: &std::fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0400;
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+    #[cfg(not(windows))]
+    false
+}
+
+fn upload_directory_component(value: &str, fallback: &str) -> String {
+    let value = if value.trim().is_empty() {
+        fallback
+    } else {
+        value
+    };
+    let mut cleaned = crate::commands::export::sanitize_component(value);
+    if cleaned.len() > MAX_UPLOAD_DIRECTORY_COMPONENT_BYTES {
+        let mut end = MAX_UPLOAD_DIRECTORY_COMPONENT_BYTES;
+        while !cleaned.is_char_boundary(end) {
+            end -= 1;
+        }
+        cleaned.truncate(end);
+    }
+    cleaned = cleaned.trim().trim_end_matches(['.', ' ']).to_string();
+    if cleaned.is_empty() {
+        cleaned = fallback.to_string();
+    }
+    if is_windows_reserved_component(&cleaned) {
+        cleaned.insert(0, '_');
+    }
+    cleaned
+}
+
+fn is_windows_reserved_component(value: &str) -> bool {
+    let stem = value
+        .split('.')
+        .next()
+        .unwrap_or(value)
+        .to_ascii_uppercase();
+    matches!(stem.as_str(), "CON" | "PRN" | "AUX" | "NUL" | "CLOCK$")
+        || stem
+            .strip_prefix("COM")
+            .or_else(|| stem.strip_prefix("LPT"))
+            .is_some_and(|suffix| suffix.len() == 1 && matches!(suffix.as_bytes()[0], b'1'..=b'9'))
 }
 
 fn find_calibration_resolution(
@@ -347,67 +860,1068 @@ fn find_calibration_resolution(
         .map_err(AppError::db)
 }
 
-fn find_resolution(
+fn find_registered_calibration_file(
     connection: &rusqlite::Connection,
+    registered_roots: &[PathBuf],
     filename: &str,
-) -> Result<Option<RemoteImageResolution>, AppError> {
+    expected_sha256: &str,
+    kind: CalibrationKind,
+    placement: RemoteImageUploadPlacement,
+) -> Result<Option<PathBuf>, AppError> {
+    if !calibration::schema_exists(connection) {
+        return Ok(None);
+    }
     let mut statement = connection
         .prepare(
-            "SELECT ai.Id, ai.metadata, p.Id, p.name, t.Id, t.name
-             FROM acquiredimage ai
-             JOIN project p ON p.Id = ai.projectId
-             JOIN target t ON t.Id = ai.targetId
-             WHERE ai.metadata LIKE ?1 ESCAPE '!'
-             ORDER BY ai.Id",
+            "SELECT frame_uuid, source_path
+             FROM psf_guard_calibration_frame
+             WHERE kind = ?1
+             ORDER BY id",
         )
         .map_err(AppError::db)?;
-    let pattern = format!("%{}%", escape_like(filename));
     let rows = statement
-        .query_map([pattern], |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, i64>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, i64>(4)?,
-                row.get::<_, String>(5)?,
-            ))
+        .query_map([kind.as_str()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })
+        .map_err(AppError::db)?
+        .collect::<rusqlite::Result<Vec<_>>>()
         .map_err(AppError::db)?;
-
+    drop(statement);
     let mut matches = Vec::new();
-    for row in rows {
-        let (image_id, metadata, project_id, project_name, target_id, target_name) =
-            row.map_err(AppError::db)?;
-        let registered_filename = serde_json::from_str::<serde_json::Value>(&metadata)
-            .ok()
-            .and_then(|value| {
-                value
-                    .get("FileName")
-                    .and_then(|value| value.as_str())
-                    .map(str::to_string)
-            })
-            .and_then(|path| path.rsplit(['/', '\\']).next().map(str::to_string));
-        if registered_filename
-            .as_deref()
-            .is_some_and(|registered| registered.eq_ignore_ascii_case(filename))
-        {
-            matches.push(RemoteImageResolution {
-                image_id,
-                project_id,
-                project_name,
-                target_id,
-                target_name,
-            });
+    let mut saw_unrelated_mismatch = false;
+    let mut saw_invalid_exact_mapping = false;
+    for (frame_uuid, source_path) in rows {
+        let mapping = find_remote_calibration_file_mapping(connection, &frame_uuid)?;
+        if let Some((mapped_path, mapped_sha256)) = mapping.as_ref() {
+            let mapped_filename = mapped_path.rsplit(['/', '\\']).next();
+            if mapped_filename.is_some_and(|registered| registered.eq_ignore_ascii_case(filename)) {
+                if !constant_time_eq(mapped_sha256.as_bytes(), expected_sha256.as_bytes()) {
+                    saw_unrelated_mismatch = true;
+                    continue;
+                }
+                if stored_path_is_registered(registered_roots, Path::new(mapped_path)) {
+                    matches.push(PathBuf::from(mapped_path));
+                } else {
+                    saw_invalid_exact_mapping = true;
+                }
+                continue;
+            }
         }
+
+        let registered_filename = source_path.rsplit(['/', '\\']).next();
+        if registered_filename.is_some_and(|registered| registered.eq_ignore_ascii_case(filename)) {
+            let registered_path = Path::new(&source_path);
+            if let Some(path) = registered_receive_file(registered_roots, registered_path) {
+                let actual_sha256 = sha256_file(&path)?;
+                if constant_time_eq(actual_sha256.as_bytes(), expected_sha256.as_bytes()) {
+                    matches.push(path);
+                } else {
+                    saw_unrelated_mismatch = true;
+                }
+            } else {
+                // A missing calibration source cannot safely be associated
+                // with new bytes unless an earlier upload recorded its SHA.
+                saw_unrelated_mismatch = true;
+            }
+        }
+    }
+    let unrelated_flat_names_can_coexist =
+        kind == CalibrationKind::Flat && placement == RemoteImageUploadPlacement::TargetTree;
+    if saw_invalid_exact_mapping || (saw_unrelated_mismatch && !unrelated_flat_names_can_coexist) {
+        return Err(AppError::Conflict(format!(
+            "{filename} matches a calibration record whose uploaded content or stored path does not match"
+        )));
     }
     match matches.len() {
         0 => Ok(None),
         1 => Ok(matches.pop()),
         count => Err(AppError::Conflict(format!(
+            "{filename} matches {count} registered calibration files; remote ingest requires an unambiguous basename"
+        ))),
+    }
+}
+
+fn registered_receive_file(
+    registered_roots: &[PathBuf],
+    registered_path: &Path,
+) -> Option<PathBuf> {
+    let canonical_file = dunce::canonicalize(registered_path).ok()?;
+    let is_registered = registered_roots
+        .iter()
+        .any(|root| dunce::canonicalize(root).is_ok_and(|root| canonical_file.starts_with(root)));
+    (canonical_file.is_file() && is_registered).then_some(canonical_file)
+}
+
+fn stored_path_is_registered(registered_roots: &[PathBuf], stored_path: &Path) -> bool {
+    registered_roots.iter().any(|root| {
+        if stored_path.starts_with(root) {
+            return true;
+        }
+        let Ok(canonical_root) = dunce::canonicalize(root) else {
+            return false;
+        };
+        stored_path.starts_with(&canonical_root)
+    })
+}
+
+fn find_legacy_flat_upload(
+    registered_roots: &[PathBuf],
+    filename: &str,
+    expected_sha256: &str,
+    conflict_on_mismatch: bool,
+) -> Result<Option<PathBuf>, AppError> {
+    let mut matches = Vec::new();
+    let mut saw_different_content = false;
+    for root in registered_roots {
+        let candidate = root.join(filename);
+        if std::fs::symlink_metadata(&candidate)
+            .is_ok_and(|metadata| metadata.file_type().is_symlink())
+        {
+            return Err(AppError::Conflict(format!(
+                "registered image root contains a symbolic link named {filename}"
+            )));
+        }
+        let Some(candidate) = registered_receive_file(registered_roots, &candidate) else {
+            continue;
+        };
+        let actual_sha256 = sha256_file(&candidate)?;
+        if constant_time_eq(actual_sha256.as_bytes(), expected_sha256.as_bytes()) {
+            if !matches.contains(&candidate) {
+                matches.push(candidate);
+            }
+        } else {
+            saw_different_content = true;
+        }
+    }
+    if saw_different_content && conflict_on_mismatch {
+        return Err(AppError::Conflict(format!(
+            "{filename} already exists in a registered image root with different content"
+        )));
+    }
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        count => Err(AppError::Conflict(format!(
+            "{filename} exists in {count} registered image roots; remote ingest requires one unambiguous file"
+        ))),
+    }
+}
+
+struct ExistingImageResolution {
+    resolution: RemoteImageResolution,
+    guid: Option<String>,
+    legacy_identity: Option<String>,
+    registered_path: PathBuf,
+}
+
+fn find_resolution(
+    connection: &rusqlite::Connection,
+    registered_roots: &[PathBuf],
+    filename: &str,
+    expected_sha256: &str,
+    frame: &import::headers::FrameMeta,
+) -> Result<Option<ExistingImageResolution>, AppError> {
+    let resolved_upload_target =
+        import::resolve_existing_target_name(connection, frame, import::DEFAULT_MATCH_RADIUS_DEG)
+            .map_err(|error| {
+            AppError::DatabaseError(format!("resolving the synced upload target: {error:#}"))
+        })?;
+    let guid_column = if crate::db::SchemaCapabilities::detect(connection).has_acquiredimage_guid {
+        "ai.guid"
+    } else {
+        "NULL"
+    };
+    let mut statement = connection
+        .prepare(&format!(
+            "SELECT ai.Id, ai.metadata, ai.acquireddate, ai.filtername, {guid_column},
+                    p.Id, p.name, t.Id, t.name
+             FROM acquiredimage ai
+             JOIN project p ON p.Id = ai.projectId
+             JOIN target t ON t.Id = ai.targetId
+             WHERE ai.metadata LIKE ?1 ESCAPE '!'
+                OR ai.Id IN (
+                    SELECT acquiredimage_id
+                    FROM psf_guard_remote_image_file
+                    WHERE source_sha256 = ?2 OR source_path LIKE ?1 ESCAPE '!'
+                )
+             ORDER BY ai.Id"
+        ))
+        .map_err(AppError::db)?;
+    let pattern = format!("%{}%", escape_like(filename));
+    let rows = statement
+        .query_map(rusqlite::params![pattern, expected_sha256], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, i64>(7)?,
+                row.get::<_, String>(8)?,
+            ))
+        })
+        .map_err(AppError::db)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(AppError::db)?;
+    drop(statement);
+
+    let mut basename_matches = 0usize;
+    let mut matches = Vec::new();
+    for row in rows {
+        let (
+            image_id,
+            metadata,
+            acquired_date,
+            filter_name,
+            guid,
+            project_id,
+            project_name,
+            target_id,
+            target_name,
+        ) = row;
+        let legacy_identity = legacy_image_identity(
+            project_id,
+            target_id,
+            acquired_date,
+            filter_name.as_deref(),
+            &metadata,
+        );
+        let mapping = validate_remote_image_file_mapping(
+            connection,
+            image_id,
+            guid.as_deref(),
+            legacy_identity.as_deref(),
+        )?;
+        let metadata_value = serde_json::from_str::<serde_json::Value>(&metadata).ok();
+        let registered_path = metadata_value
+            .as_ref()
+            .and_then(|value| metadata_text(value, "FileName"))
+            .map(str::to_string);
+        let registered_filename = registered_path
+            .as_deref()
+            .and_then(|path| path.rsplit(['/', '\\']).next());
+        let metadata_basename_matches =
+            registered_filename.is_some_and(|registered| registered.eq_ignore_ascii_case(filename));
+        let mapping_basename_matches = mapping.mapping().is_some_and(|mapping| {
+            mapping
+                .source_path
+                .rsplit(['/', '\\'])
+                .next()
+                .is_some_and(|registered| registered.eq_ignore_ascii_case(filename))
+        });
+        if metadata_basename_matches || mapping_basename_matches {
+            basename_matches += 1;
+            if mapping.is_stale() {
+                continue;
+            }
+            let mapped_content_matches = mapping.mapping().is_some_and(|mapping| {
+                mapping_basename_matches
+                    && constant_time_eq(
+                        mapping.source_sha256.as_bytes(),
+                        expected_sha256.as_bytes(),
+                    )
+            });
+            if mapping_basename_matches && !mapped_content_matches {
+                continue;
+            }
+            let registered_content_matches = registered_path
+                .as_deref()
+                .and_then(|path| registered_receive_file(registered_roots, Path::new(path)))
+                .map(|path| sha256_file(&path))
+                .transpose()?
+                .is_some_and(|actual| {
+                    constant_time_eq(actual.as_bytes(), expected_sha256.as_bytes())
+                });
+            if !registered_content_matches && !mapped_content_matches {
+                let capture_identity = light_capture_identity(
+                    metadata_value.as_ref(),
+                    acquired_date,
+                    filter_name.as_deref(),
+                    frame,
+                );
+                let target_identity = match resolved_upload_target.as_deref() {
+                    Some(resolved) if resolved.eq_ignore_ascii_case(target_name.trim()) => {
+                        CaptureIdentity::Match
+                    }
+                    Some(_) => CaptureIdentity::Mismatch,
+                    None => CaptureIdentity::Incomplete,
+                };
+                match (capture_identity, target_identity) {
+                    (CaptureIdentity::Mismatch, _) | (_, CaptureIdentity::Mismatch) => continue,
+                    (CaptureIdentity::Match, _) | (_, CaptureIdentity::Match) => {}
+                    (CaptureIdentity::Incomplete, CaptureIdentity::Incomplete) => continue,
+                }
+            }
+            matches.push(ExistingImageResolution {
+                resolution: RemoteImageResolution {
+                    image_id,
+                    project_id,
+                    project_name,
+                    target_id,
+                    target_name,
+                },
+                guid,
+                legacy_identity,
+                registered_path: PathBuf::from(
+                    registered_path
+                        .or_else(|| mapping.valid().map(|mapping| mapping.source_path.clone()))
+                        .expect("a matched basename has metadata or upload provenance"),
+                ),
+            });
+        }
+    }
+    match matches.len() {
+        0 if basename_matches == 0 => Ok(None),
+        0 => Err(AppError::Conflict(format!(
+            "{filename} matches an existing scheduler row, but its upload provenance, capture time or filter, or resolved target does not match the uploaded frame"
+        ))),
+        1 => Ok(matches.pop()),
+        count => Err(AppError::Conflict(format!(
             "{filename} matches {count} database rows; remote ingest requires an unambiguous basename"
         ))),
     }
+}
+
+fn light_import_outcome_is_accepted(
+    connection: &rusqlite::Connection,
+    registered_roots: &[PathBuf],
+    filename: &str,
+    expected_sha256: &str,
+    frame: &import::headers::FrameMeta,
+    outcome: &ImportOutcome,
+) -> Result<bool, AppError> {
+    if outcome.imported == 1 {
+        return Ok(true);
+    }
+    if outcome.skipped_existing != 1 {
+        return Ok(false);
+    }
+    // Close the smaller race between the post-publish lookup and
+    // import_frames. Only accept a concurrent scheduler row after the full
+    // upload identity check.
+    find_resolution(
+        connection,
+        registered_roots,
+        filename,
+        expected_sha256,
+        frame,
+    )
+    .map(|resolution| resolution.is_some())
+}
+
+fn metadata_text<'a>(metadata: &'a serde_json::Value, name: &str) -> Option<&'a str> {
+    metadata.as_object()?.iter().find_map(|(key, value)| {
+        key.eq_ignore_ascii_case(name)
+            .then(|| value.as_str())
+            .flatten()
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CaptureIdentity {
+    Match,
+    Incomplete,
+    Mismatch,
+}
+
+fn light_capture_identity(
+    metadata: Option<&serde_json::Value>,
+    acquired_date: Option<i64>,
+    filter_name: Option<&str>,
+    frame: &import::headers::FrameMeta,
+) -> CaptureIdentity {
+    let expected_timestamp = metadata
+        .and_then(|value| metadata_text(value, "ExposureStartTime"))
+        .and_then(import::headers::parse_fits_datetime)
+        .or(acquired_date);
+    let timestamp_identity = match (expected_timestamp, frame.timestamp) {
+        (Some(expected), Some(actual))
+            if expected.abs_diff(actual) <= CAPTURE_IDENTITY_TIME_TOLERANCE_SECS =>
+        {
+            CaptureIdentity::Match
+        }
+        (Some(_), Some(_)) => CaptureIdentity::Mismatch,
+        _ => CaptureIdentity::Incomplete,
+    };
+    let expected_filter = filter_name
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| metadata.and_then(|value| metadata_text(value, "FilterName")));
+    let filter_identity = match (expected_filter, frame.filter.as_deref()) {
+        (Some(expected), Some(actual)) if crate::utils::filter_names_match(expected, actual) => {
+            CaptureIdentity::Match
+        }
+        (Some(_), Some(_)) => CaptureIdentity::Mismatch,
+        _ => CaptureIdentity::Incomplete,
+    };
+    if timestamp_identity == CaptureIdentity::Mismatch
+        || filter_identity == CaptureIdentity::Mismatch
+    {
+        CaptureIdentity::Mismatch
+    } else if timestamp_identity == CaptureIdentity::Match
+        && filter_identity == CaptureIdentity::Match
+    {
+        CaptureIdentity::Match
+    } else {
+        CaptureIdentity::Incomplete
+    }
+}
+
+fn legacy_image_identity(
+    project_id: i64,
+    target_id: i64,
+    acquired_date: Option<i64>,
+    filter_name: Option<&str>,
+    metadata: &str,
+) -> Option<String> {
+    let metadata = serde_json::from_str::<serde_json::Value>(metadata).ok();
+    let capture_time = acquired_date.or_else(|| {
+        metadata
+            .as_ref()
+            .and_then(|value| metadata_text(value, "ExposureStartTime"))
+            .and_then(import::headers::parse_fits_datetime)
+    })?;
+    let filter_name = filter_name
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            metadata
+                .as_ref()
+                .and_then(|value| metadata_text(value, "FilterName"))
+        })?
+        .trim()
+        .to_ascii_lowercase();
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"psf-guard-legacy-image-v2\0");
+    hasher.update(project_id.to_le_bytes());
+    hasher.update(target_id.to_le_bytes());
+    hasher.update(capture_time.to_le_bytes());
+    hasher.update(filter_name.as_bytes());
+    if let Some(object) = metadata.and_then(|value| value.as_object().cloned()) {
+        // Target Scheduler's metadata is not immutable: PSF Guard can add
+        // DetectedStars/HFR after a quality scan and external tools can update
+        // other derived measurements. Hash only acquisition settings that
+        // identify the capture. FileName is intentionally absent because a
+        // sync or operator may relocate the same row.
+        const CAPTURE_KEYS: &[&str] = &[
+            "SessionId",
+            "ExposureStartTime",
+            "ExposureDuration",
+            "ExposureTime",
+            "Gain",
+            "Offset",
+            "Binning",
+            "ReadoutMode",
+            "ROI",
+            "FocuserPosition",
+            "FocuserTemp",
+            "RotatorPosition",
+            "CameraTemp",
+            "CameraTargetTemp",
+            "PierSide",
+        ];
+        let stable = CAPTURE_KEYS
+            .iter()
+            .filter_map(|wanted| {
+                object
+                    .iter()
+                    .find(|(key, _)| key.eq_ignore_ascii_case(wanted))
+                    .map(|(_, value)| (wanted.to_ascii_lowercase(), value))
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+        if let Ok(encoded) = serde_json::to_vec(&stable) {
+            hasher.update(encoded);
+        }
+    }
+    Some(format!("v2:{}", encode_digest(hasher.finalize())))
+}
+
+fn ensure_remote_upload_provenance_schema(
+    connection: &rusqlite::Connection,
+) -> Result<(), AppError> {
+    if !table_exists(connection, "psf_guard_remote_image_file")?
+        || !table_exists(connection, "psf_guard_remote_calibration_file")?
+    {
+        connection
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS psf_guard_remote_image_file (
+                acquiredimage_id INTEGER PRIMARY KEY,
+                acquiredimage_guid TEXT,
+                acquiredimage_identity TEXT,
+                source_path TEXT NOT NULL,
+                source_sha256 TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS psf_guard_remote_calibration_file (
+                frame_uuid TEXT PRIMARY KEY,
+                source_path TEXT NOT NULL,
+                source_sha256 TEXT NOT NULL,
+                updated_at INTEGER NOT NULL
+            );",
+            )
+            .map_err(AppError::db)?;
+    }
+    if !table_has_column(
+        connection,
+        "psf_guard_remote_image_file",
+        "acquiredimage_identity",
+    )? {
+        connection
+            .execute(
+                "ALTER TABLE psf_guard_remote_image_file ADD COLUMN acquiredimage_identity TEXT",
+                [],
+            )
+            .map_err(AppError::db)?;
+    }
+    Ok(())
+}
+
+fn find_mapped_remote_image_file(
+    connection: &rusqlite::Connection,
+    registered_roots: &[PathBuf],
+    resolution: &ExistingImageResolution,
+    expected_sha256: &str,
+) -> Result<Option<PathBuf>, AppError> {
+    let mapping = validate_remote_image_file_mapping(
+        connection,
+        resolution.resolution.image_id,
+        resolution.guid.as_deref(),
+        resolution.legacy_identity.as_deref(),
+    )?;
+    let Some(mapping) = mapping.valid() else {
+        return Ok(None);
+    };
+    if !constant_time_eq(mapping.source_sha256.as_bytes(), expected_sha256.as_bytes()) {
+        return Err(AppError::Conflict(
+            "the uploaded light does not match its recorded upload SHA-256".into(),
+        ));
+    }
+    let path = PathBuf::from(&mapping.source_path);
+    if !stored_path_is_registered(registered_roots, &path) {
+        return Err(AppError::Conflict(
+            "the uploaded light's recorded path is outside the registered image roots".into(),
+        ));
+    }
+    Ok(Some(path))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RemoteImageFileMapping {
+    acquiredimage_guid: Option<String>,
+    acquiredimage_identity: Option<String>,
+    source_path: String,
+    source_sha256: String,
+}
+
+enum MappingValidation {
+    Absent,
+    Stale(RemoteImageFileMapping),
+    Valid(RemoteImageFileMapping),
+}
+
+impl MappingValidation {
+    fn mapping(&self) -> Option<&RemoteImageFileMapping> {
+        match self {
+            Self::Absent => None,
+            Self::Stale(mapping) | Self::Valid(mapping) => Some(mapping),
+        }
+    }
+
+    fn valid(&self) -> Option<&RemoteImageFileMapping> {
+        match self {
+            Self::Valid(mapping) => Some(mapping),
+            Self::Absent | Self::Stale(_) => None,
+        }
+    }
+
+    fn is_stale(&self) -> bool {
+        matches!(self, Self::Stale(_))
+    }
+}
+
+fn validate_remote_image_file_mapping(
+    connection: &rusqlite::Connection,
+    image_id: i64,
+    guid: Option<&str>,
+    legacy_identity: Option<&str>,
+) -> Result<MappingValidation, AppError> {
+    let mapping = load_remote_image_file_mapping(connection, image_id)?;
+    let Some(mapping) = mapping else {
+        return Ok(MappingValidation::Absent);
+    };
+    let identity_matches = match guid {
+        Some(guid) => mapping.acquiredimage_guid.as_deref() == Some(guid),
+        None => {
+            mapping.acquiredimage_guid.is_none()
+                && legacy_identity.is_some()
+                && mapping.acquiredimage_identity.as_deref() == legacy_identity
+        }
+    };
+    if identity_matches {
+        return Ok(MappingValidation::Valid(mapping));
+    }
+    connection
+        .execute(
+            "DELETE FROM psf_guard_remote_image_file WHERE acquiredimage_id = ?1",
+            [image_id],
+        )
+        .map_err(AppError::db)?;
+    Ok(MappingValidation::Stale(mapping))
+}
+
+fn load_remote_image_file_mapping(
+    connection: &rusqlite::Connection,
+    image_id: i64,
+) -> Result<Option<RemoteImageFileMapping>, AppError> {
+    use rusqlite::OptionalExtension as _;
+
+    connection
+        .query_row(
+            "SELECT acquiredimage_guid, acquiredimage_identity, source_path, source_sha256
+             FROM psf_guard_remote_image_file
+             WHERE acquiredimage_id = ?1",
+            [image_id],
+            |row| {
+                Ok(RemoteImageFileMapping {
+                    acquiredimage_guid: row.get(0)?,
+                    acquiredimage_identity: row.get(1)?,
+                    source_path: row.get(2)?,
+                    source_sha256: row.get(3)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(AppError::db)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum MappedLightFile {
+    Absent,
+    Invalid,
+    Missing {
+        artifact_revision: String,
+    },
+    Ready {
+        path: PathBuf,
+        sha256: String,
+        artifact_revision: String,
+    },
+}
+
+fn remote_mapping_artifact_revision(mapping: &RemoteImageFileMapping) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"remote-image-artifact-v1");
+    hasher.update([0]);
+    hasher.update(mapping.source_path.as_bytes());
+    hasher.update([0]);
+    hasher.update(mapping.source_sha256.to_ascii_lowercase().as_bytes());
+    encode_digest(hasher.finalize())[..16].to_string()
+}
+
+fn mapping_matches_image(
+    mapping: &RemoteImageFileMapping,
+    image: &crate::models::AcquiredImage,
+) -> bool {
+    match image.guid.as_deref() {
+        Some(guid) => mapping.acquiredimage_guid.as_deref() == Some(guid),
+        None => {
+            let legacy_identity = legacy_image_identity(
+                i64::from(image.project_id),
+                i64::from(image.target_id),
+                image.acquired_date,
+                Some(&image.filter_name),
+                &image.metadata,
+            );
+            mapping.acquiredimage_guid.is_none()
+                && legacy_identity.is_some()
+                && mapping.acquiredimage_identity.as_deref() == legacy_identity.as_deref()
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MappedLightSource {
+    pub revision: String,
+    pub path: PathBuf,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct MappedLightSources {
+    sources: std::collections::HashMap<i32, MappedLightSource>,
+    invalid: std::collections::HashSet<i32>,
+}
+
+impl MappedLightSources {
+    pub fn get(&self, image_id: &i32) -> Option<&MappedLightSource> {
+        self.sources.get(image_id)
+    }
+
+    pub fn is_invalid(&self, image_id: i32) -> bool {
+        self.invalid.contains(&image_id)
+    }
+
+    pub fn quality_revision(&self, image_id: i32) -> Option<&str> {
+        if self.is_invalid(image_id) {
+            Some("mapping:invalid")
+        } else {
+            self.get(&image_id).map(|source| source.revision.as_str())
+        }
+    }
+}
+
+/// Load live upload provenance for a set of scheduler rows in a single table
+/// scan. Pixel-evidence consumers use this to reject stale caches after restart
+/// without a per-image sidecar or one query per image.
+pub(crate) fn mapped_light_sources<'a>(
+    connection: &rusqlite::Connection,
+    registered_roots: &[PathBuf],
+    images: impl IntoIterator<Item = &'a crate::models::AcquiredImage>,
+) -> Result<MappedLightSources, AppError> {
+    let images = images
+        .into_iter()
+        .map(|image| (image.id, image))
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut sources = MappedLightSources::default();
+    if images.is_empty() || !table_exists(connection, "psf_guard_remote_image_file")? {
+        return Ok(sources);
+    }
+
+    let mut statement = connection
+        .prepare(
+            "SELECT acquiredimage_id, acquiredimage_guid, acquiredimage_identity,
+                    source_path, source_sha256
+             FROM psf_guard_remote_image_file",
+        )
+        .map_err(AppError::db)?;
+    let mappings = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i32>(0)?,
+                RemoteImageFileMapping {
+                    acquiredimage_guid: row.get(1)?,
+                    acquiredimage_identity: row.get(2)?,
+                    source_path: row.get(3)?,
+                    source_sha256: row.get(4)?,
+                },
+            ))
+        })
+        .map_err(AppError::db)?;
+    for mapping in mappings {
+        let (image_id, mapping) = mapping.map_err(AppError::db)?;
+        let Some(image) = images.get(&image_id) else {
+            continue;
+        };
+        if mapping_matches_image(&mapping, image)
+            && stored_path_is_registered(registered_roots, Path::new(&mapping.source_path))
+        {
+            sources.sources.insert(
+                image_id,
+                MappedLightSource {
+                    revision: format!("mapping:{}", remote_mapping_artifact_revision(&mapping)),
+                    path: PathBuf::from(&mapping.source_path),
+                },
+            );
+        } else {
+            sources.invalid.insert(image_id);
+        }
+    }
+    Ok(sources)
+}
+
+/// Resolve upload provenance for a scheduler image without hashing its file.
+/// GUID presence is exact: a NULL mapping can only match a currently NULL
+/// scheduler GUID, and legacy rows must retain their stored capture identity.
+pub(crate) fn resolve_mapped_light_file(
+    connection: &rusqlite::Connection,
+    registered_roots: &[PathBuf],
+    image: &crate::models::AcquiredImage,
+) -> Result<MappedLightFile, AppError> {
+    if !table_exists(connection, "psf_guard_remote_image_file")? {
+        return Ok(MappedLightFile::Absent);
+    }
+    let Some(mapping) = load_remote_image_file_mapping(connection, i64::from(image.id))? else {
+        return Ok(MappedLightFile::Absent);
+    };
+    if !mapping_matches_image(&mapping, image) {
+        return Ok(MappedLightFile::Invalid);
+    };
+    let stored_path = Path::new(&mapping.source_path);
+    if !stored_path_is_registered(registered_roots, stored_path) {
+        return Ok(MappedLightFile::Invalid);
+    }
+    let artifact_revision = remote_mapping_artifact_revision(&mapping);
+    match validated_existing_mapped_file(registered_roots, stored_path)? {
+        Some(path) => Ok(MappedLightFile::Ready {
+            path,
+            sha256: mapping.source_sha256.clone(),
+            artifact_revision,
+        }),
+        None => Ok(MappedLightFile::Missing { artifact_revision }),
+    }
+}
+
+fn validated_existing_mapped_file(
+    registered_roots: &[PathBuf],
+    stored_path: &Path,
+) -> Result<Option<PathBuf>, AppError> {
+    for root in registered_roots {
+        let Ok(canonical_root) = dunce::canonicalize(root) else {
+            continue;
+        };
+        let relative = stored_path
+            .strip_prefix(&canonical_root)
+            .or_else(|_| stored_path.strip_prefix(root));
+        let Ok(relative) = relative else {
+            continue;
+        };
+        let mut current = canonical_root.clone();
+        for component in relative.components() {
+            let std::path::Component::Normal(segment) = component else {
+                return Ok(None);
+            };
+            current.push(segment);
+            let metadata = match std::fs::symlink_metadata(&current) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(error) => {
+                    return Err(AppError::InternalError(format!(
+                        "checking mapped image path {}: {error}",
+                        current.display()
+                    )));
+                }
+            };
+            if metadata_is_link(&metadata) {
+                return Err(AppError::Conflict(
+                    "mapped image path contains a symbolic link or junction".into(),
+                ));
+            }
+        }
+        let canonical_file = dunce::canonicalize(stored_path).map_err(|error| {
+            AppError::InternalError(format!(
+                "resolving mapped image file {}: {error}",
+                stored_path.display()
+            ))
+        })?;
+        return Ok(
+            (canonical_file.is_file() && canonical_file.starts_with(&canonical_root))
+                .then_some(canonical_file),
+        );
+    }
+    Ok(None)
+}
+
+fn record_remote_image_file(
+    connection: &rusqlite::Connection,
+    resolution: &ExistingImageResolution,
+    destination: &Path,
+    sha256: &str,
+) -> Result<bool, AppError> {
+    if resolution.guid.is_none() && resolution.legacy_identity.is_none() {
+        return Ok(false);
+    }
+    let source_path = dunce::canonicalize(destination)
+        .unwrap_or_else(|_| destination.to_path_buf())
+        .to_string_lossy()
+        .into_owned();
+    let mapping = RemoteImageFileMapping {
+        acquiredimage_guid: resolution.guid.clone(),
+        acquiredimage_identity: resolution.legacy_identity.clone(),
+        source_path: source_path.clone(),
+        source_sha256: sha256.to_string(),
+    };
+    let artifact_revision = remote_mapping_artifact_revision(&mapping);
+    let quality_source_revision = format!("mapping:{artifact_revision}");
+    if load_remote_image_file_mapping(connection, resolution.resolution.image_id)?.as_ref()
+        == Some(&mapping)
+    {
+        clear_stale_psf_guard_star_metadata(
+            connection,
+            resolution.resolution.image_id,
+            &quality_source_revision,
+        )?;
+        return Ok(false);
+    }
+    connection
+        .execute(
+            "INSERT INTO psf_guard_remote_image_file
+                (acquiredimage_id, acquiredimage_guid, acquiredimage_identity,
+                 source_path, source_sha256, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(acquiredimage_id) DO UPDATE SET
+                acquiredimage_guid = excluded.acquiredimage_guid,
+                acquiredimage_identity = excluded.acquiredimage_identity,
+                source_path = excluded.source_path,
+                source_sha256 = excluded.source_sha256,
+                updated_at = excluded.updated_at",
+            rusqlite::params![
+                resolution.resolution.image_id,
+                resolution.guid,
+                resolution.legacy_identity.as_deref(),
+                source_path,
+                sha256,
+                chrono::Utc::now().timestamp()
+            ],
+        )
+        .map_err(AppError::db)?;
+    clear_stale_psf_guard_star_metadata(
+        connection,
+        resolution.resolution.image_id,
+        &quality_source_revision,
+    )?;
+    Ok(true)
+}
+
+fn clear_stale_psf_guard_star_metadata(
+    connection: &rusqlite::Connection,
+    image_id: i64,
+    expected_source_revision: &str,
+) -> Result<bool, AppError> {
+    use rusqlite::OptionalExtension as _;
+
+    let Some(metadata) = connection
+        .query_row(
+            "SELECT metadata FROM acquiredimage WHERE Id = ?1",
+            [image_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(AppError::db)?
+    else {
+        return Ok(false);
+    };
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(&metadata) else {
+        return Ok(false);
+    };
+    let Some(object) = value.as_object_mut() else {
+        return Ok(false);
+    };
+    let source = object.iter().find_map(|(key, value)| {
+        key.eq_ignore_ascii_case("PsfGuardQualitySource")
+            .then(|| value.as_str())
+            .flatten()
+    });
+    if source.is_none() || source == Some(expected_source_revision) {
+        return Ok(false);
+    }
+
+    let owned_fields = object
+        .iter()
+        .find_map(|(key, value)| {
+            key.eq_ignore_ascii_case("PsfGuardQualityFields")
+                .then(|| value.as_array())
+                .flatten()
+        })
+        .map(|fields| {
+            fields
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(str::to_ascii_lowercase)
+                .collect::<std::collections::HashSet<_>>()
+        })
+        .unwrap_or_else(|| {
+            // Compatibility with the short-lived marker format that predated
+            // per-field ownership.
+            std::collections::HashSet::from(["detectedstars".into(), "hfr".into()])
+        });
+    object.retain(|key, _| {
+        !key.eq_ignore_ascii_case("PsfGuardQualitySource")
+            && !key.eq_ignore_ascii_case("PsfGuardQualityFields")
+            && !owned_fields.contains(&key.to_ascii_lowercase())
+    });
+    let updated = serde_json::to_string(&value).map_err(|error| {
+        AppError::InternalError(format!(
+            "serializing cleared image quality metadata: {error}"
+        ))
+    })?;
+    connection
+        .execute(
+            "UPDATE acquiredimage SET metadata = ?1 WHERE Id = ?2 AND metadata = ?3",
+            rusqlite::params![updated, image_id, metadata],
+        )
+        .map(|changed| changed == 1)
+        .map_err(AppError::db)
+}
+
+fn find_remote_calibration_file_mapping(
+    connection: &rusqlite::Connection,
+    frame_uuid: &str,
+) -> Result<Option<(String, String)>, AppError> {
+    use rusqlite::OptionalExtension as _;
+
+    connection
+        .query_row(
+            "SELECT source_path, source_sha256
+             FROM psf_guard_remote_calibration_file
+             WHERE frame_uuid = ?1",
+            [frame_uuid],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .map_err(AppError::db)
+}
+
+fn record_remote_calibration_file(
+    connection: &rusqlite::Connection,
+    resolution: &RemoteCalibrationResolution,
+    destination: &Path,
+    sha256: &str,
+) -> Result<(), AppError> {
+    let source_path = dunce::canonicalize(destination)
+        .unwrap_or_else(|_| destination.to_path_buf())
+        .to_string_lossy()
+        .into_owned();
+    connection
+        .execute(
+            "INSERT INTO psf_guard_remote_calibration_file
+                (frame_uuid, source_path, source_sha256, updated_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(frame_uuid) DO UPDATE SET
+                source_path = excluded.source_path,
+                source_sha256 = excluded.source_sha256,
+                updated_at = excluded.updated_at",
+            rusqlite::params![
+                resolution.frame_uuid,
+                source_path,
+                sha256,
+                chrono::Utc::now().timestamp()
+            ],
+        )
+        .map_err(AppError::db)?;
+    Ok(())
+}
+
+fn table_exists(connection: &rusqlite::Connection, table: &str) -> Result<bool, AppError> {
+    use rusqlite::OptionalExtension as _;
+
+    connection
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [table],
+            |_| Ok(()),
+        )
+        .optional()
+        .map(|row| row.is_some())
+        .map_err(AppError::db)
+}
+
+fn table_has_column(
+    connection: &rusqlite::Connection,
+    table: &str,
+    column: &str,
+) -> Result<bool, AppError> {
+    let mut statement = connection
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(AppError::db)?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(AppError::db)?;
+    for existing in columns {
+        if existing.map_err(AppError::db)? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn escape_like(value: &str) -> String {
@@ -482,6 +1996,10 @@ fn required_sha256_header(headers: &HeaderMap) -> Result<String, AppError> {
 }
 
 fn validate_filename(filename: &str) -> Result<(), AppError> {
+    let reserved_filename = Path::new(filename)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(is_windows_reserved_component);
     if filename.is_empty()
         || filename.len() > 240
         || filename == "."
@@ -490,6 +2008,7 @@ fn validate_filename(filename: &str) -> Result<(), AppError> {
         || filename
             .chars()
             .any(|character| character.is_control() || r#"<>:"/\|?*"#.contains(character))
+        || reserved_filename
     {
         return Err(AppError::BadRequest(
             "image filename is not filesystem-safe".into(),
@@ -526,4 +2045,103 @@ fn encode_digest(digest: impl AsRef<[u8]>) -> String {
         write!(encoded, "{byte:02x}").expect("writing to a String cannot fail");
     }
     encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rendered_artifact_revision_tracks_mapping_path_and_content() {
+        let mapping = |path: &str, sha256: &str| RemoteImageFileMapping {
+            acquiredimage_guid: Some("image-guid".into()),
+            acquiredimage_identity: None,
+            source_path: path.into(),
+            source_sha256: sha256.into(),
+        };
+        let first = mapping("C:/images/first.fits", "aa11");
+        let moved = mapping("C:/images/moved.fits", "aa11");
+        let replaced = mapping("C:/images/first.fits", "bb22");
+        let same_checksum_case = mapping("C:/images/first.fits", "AA11");
+
+        assert_ne!(
+            remote_mapping_artifact_revision(&first),
+            remote_mapping_artifact_revision(&moved)
+        );
+        assert_ne!(
+            remote_mapping_artifact_revision(&first),
+            remote_mapping_artifact_revision(&replaced)
+        );
+        assert_eq!(
+            remote_mapping_artifact_revision(&first),
+            remote_mapping_artifact_revision(&same_checksum_case)
+        );
+    }
+
+    #[test]
+    fn skipped_import_accepts_scheduler_row_that_appeared_after_publish() {
+        let temp = tempfile::tempdir().unwrap();
+        let database_path = temp.path().join("scheduler.sqlite");
+        crate::ts_schema::create_fresh_db(&database_path).unwrap();
+        let connection = rusqlite::Connection::open(&database_path).unwrap();
+        ensure_remote_upload_provenance_schema(&connection).unwrap();
+        connection
+            .execute_batch(
+                "INSERT INTO project (Id, profileId, name, isMosaic, flatsHandling, guid)
+                     VALUES (7, 'profile', 'Project', 0, 0, 'project-guid');
+                 INSERT INTO target (Id, name, active, ra, dec, epochcode, projectId, guid)
+                     VALUES (3, 'M 31', 1, 10.0, 20.0, 0, 7, 'target-guid');",
+            )
+            .unwrap();
+        let filename = "race.fits";
+        let frame = import::headers::FrameMeta {
+            path: temp.path().join(filename),
+            readable: true,
+            image_type: Some("LIGHT".into()),
+            object: Some("M 31".into()),
+            filter: Some("Ha".into()),
+            timestamp: Some(1_784_869_200),
+            ..Default::default()
+        };
+        let outcome = ImportOutcome {
+            scanned: 1,
+            skipped_existing: 1,
+            ..Default::default()
+        };
+
+        assert!(!light_import_outcome_is_accepted(
+            &connection,
+            &[],
+            filename,
+            "unused-sha256",
+            &frame,
+            &outcome,
+        )
+        .unwrap());
+
+        let metadata = serde_json::json!({
+            "FileName": format!(r"C:\remote\{filename}"),
+            "ExposureStartTime": "2026-07-24T05:00:00Z",
+            "FilterName": "Ha",
+        });
+        connection
+            .execute(
+                "INSERT INTO acquiredimage
+                    (Id, projectId, targetId, acquireddate, filtername, gradingStatus,
+                     metadata, profileId, guid)
+                 VALUES (42, 7, 3, 1784869200, 'Ha', 0, ?1, 'profile', 'image-guid')",
+                [metadata.to_string()],
+            )
+            .unwrap();
+
+        assert!(light_import_outcome_is_accepted(
+            &connection,
+            &[],
+            filename,
+            "unused-sha256",
+            &frame,
+            &outcome,
+        )
+        .unwrap());
+    }
 }

--- a/src/server/remote_upload_layout.rs
+++ b/src/server/remote_upload_layout.rs
@@ -251,11 +251,22 @@ fn templates_from_sample(root: &Path, path: &Path, sample: &CatalogLayoutSample)
     let mut variants = vec![(Vec::<String>::new(), false, false)];
 
     for component in &components {
-        let replacements = if component.eq_ignore_ascii_case(&sample.target)
+        let target_match = component.eq_ignore_ascii_case(&sample.target)
             || component.eq_ignore_ascii_case(&super::remote_upload::upload_directory_component(
                 &sample.target,
                 "Unknown Target",
-            )) {
+            ));
+        let project_match = component.eq_ignore_ascii_case(&sample.project)
+            || component.eq_ignore_ascii_case(&super::remote_upload::upload_directory_component(
+                &sample.project,
+                "Unknown Project",
+            ));
+        let replacements = if target_match && project_match {
+            vec![
+                ("%TARGET%".to_string(), true, false),
+                ("%PROJECT%".to_string(), false, false),
+            ]
+        } else if target_match {
             vec![("%TARGET%".to_string(), true, false)]
         } else if component.eq_ignore_ascii_case("LIGHT") {
             vec![("%TYPE%".to_string(), false, true)]
@@ -266,13 +277,7 @@ fn templates_from_sample(root: &Path, path: &Path, sample: &CatalogLayoutSample)
                 ))
         {
             vec![("%FILTER%".to_string(), false, false)]
-        } else if (component.eq_ignore_ascii_case(&sample.project)
-            || component.eq_ignore_ascii_case(&super::remote_upload::upload_directory_component(
-                &sample.project,
-                "Unknown Project",
-            )))
-            && !component.eq_ignore_ascii_case(&sample.target)
-        {
+        } else if project_match {
             vec![("%PROJECT%".to_string(), false, false)]
         } else if matching_observing_year(component, observing_night.as_deref()) {
             vec![("%YEAR%".to_string(), false, false)]
@@ -625,6 +630,42 @@ mod tests {
         assert_eq!(
             detected.template,
             "%PROJECT%/%TARGET%/%NIGHT%/%TYPE%/%FILTER%"
+        );
+    }
+
+    #[test]
+    fn identical_project_and_target_levels_leave_the_preset_in_control() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("_Source");
+        let db_path = temp.path().join("scheduler.sqlite");
+        let connection = create_catalog(&db_path);
+        let filename = "m31-001.fits";
+        let directory = root
+            .join("M 31")
+            .join("M 31")
+            .join("2026-04-06")
+            .join("LIGHT");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join(filename), b"fixture").unwrap();
+        add_catalog_image(
+            &connection,
+            1,
+            "M 31",
+            "M 31",
+            "L",
+            filename,
+            crate::commands::import::headers::parse_fits_datetime("2026-04-07T04:00:00").unwrap(),
+        );
+        drop(connection);
+
+        assert!(
+            detect_catalog_directory_layout(
+                db_path.to_str().unwrap(),
+                &dunce::canonicalize(root).unwrap(),
+            )
+            .unwrap()
+            .is_none(),
+            "ambiguous project and target levels must not infer two target directories"
         );
     }
 

--- a/src/server/remote_upload_layout.rs
+++ b/src/server/remote_upload_layout.rs
@@ -1,0 +1,677 @@
+//! Catalog-aware directory templates for remote image intake.
+//!
+//! Detection is deliberately a Settings-time operation. Upload requests only
+//! render the persisted result and never walk an observatory image share.
+
+use anyhow::{Context, Result};
+use rusqlite::OpenFlags;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::directory_tree::DirectoryTree;
+use crate::server::database_context::open_scheduler_connection_with_flags;
+
+pub const MAX_DIRECTORY_TEMPLATE_BYTES: usize = 512;
+const MAX_DIRECTORY_TEMPLATE_COMPONENTS: usize = 16;
+const MAX_LAYOUT_SAMPLES: i64 = 2_000;
+
+pub const DIRECTORY_TEMPLATE_TOKENS: &[&str] = &[
+    "%TARGET%",
+    "%PROJECT%",
+    "%DATE%",
+    "%NIGHT%",
+    "%YEAR%",
+    "%TYPE%",
+    "%FILTER%",
+    "%TELESCOPE%",
+    "%CAMERA%",
+    "%EXPOSURE%",
+    "%GAIN%",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectedDirectoryLayout {
+    pub template: String,
+    pub samples: usize,
+}
+
+#[derive(Debug)]
+struct CatalogLayoutSample {
+    metadata_path: String,
+    project: String,
+    target: String,
+    filter: String,
+    capture_time: Option<i64>,
+}
+
+/// Validate a relative directory-only template. The uploaded basename is
+/// always appended separately by the server.
+pub fn validate_directory_template(template: &str) -> Result<()> {
+    let template = template.trim();
+    if template.is_empty() {
+        anyhow::bail!("remote upload directory template cannot be empty");
+    }
+    if template.len() > MAX_DIRECTORY_TEMPLATE_BYTES {
+        anyhow::bail!(
+            "remote upload directory template cannot exceed {MAX_DIRECTORY_TEMPLATE_BYTES} bytes"
+        );
+    }
+    if template.starts_with(['/', '\\']) || template.contains(':') {
+        anyhow::bail!("remote upload directory template must be a relative path");
+    }
+
+    let components = template.split(['/', '\\']).collect::<Vec<_>>();
+    if components.len() > MAX_DIRECTORY_TEMPLATE_COMPONENTS
+        || components
+            .iter()
+            .any(|component| component.is_empty() || matches!(*component, "." | ".."))
+    {
+        anyhow::bail!("remote upload directory template contains an invalid path component");
+    }
+    if template.chars().any(char::is_control) {
+        anyhow::bail!("remote upload directory template cannot contain control characters");
+    }
+
+    for component in components {
+        let mut remaining = component;
+        while let Some(start) = remaining.find('%') {
+            let after_start = &remaining[start + 1..];
+            let Some(end) = after_start.find('%') else {
+                anyhow::bail!("remote upload directory template contains an incomplete token");
+            };
+            let token = &remaining[start..start + end + 2];
+            if !DIRECTORY_TEMPLATE_TOKENS.contains(&token) {
+                anyhow::bail!("unknown remote upload directory token {token}");
+            }
+            remaining = &remaining[start + end + 2..];
+        }
+    }
+
+    if !template.contains("%TARGET%") || !template.contains("%TYPE%") {
+        anyhow::bail!("remote upload directory template must include %TARGET% and %TYPE%");
+    }
+    Ok(())
+}
+
+/// Scan the selected receive root and match catalog rows to real files. A
+/// layout is returned only when one pattern has a unique lead; mixed catalogs
+/// keep the operator's explicit fallback preset.
+pub fn detect_catalog_directory_layout(
+    database_path: &str,
+    receive_root: &Path,
+) -> Result<Option<DetectedDirectoryLayout>> {
+    let started = std::time::Instant::now();
+    let connection = open_scheduler_connection_with_flags(
+        database_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .with_context(|| format!("opening catalog {} for layout detection", database_path))?;
+    let samples = catalog_layout_samples(&connection)?;
+    if samples.is_empty() {
+        return Ok(None);
+    }
+
+    let tree = DirectoryTree::build(receive_root).with_context(|| {
+        format!(
+            "scanning remote upload receive directory {}",
+            receive_root.display()
+        )
+    })?;
+    let mut patterns = HashMap::<String, usize>::new();
+    let mut matched = 0usize;
+    for sample in &samples {
+        let Some(path) = unambiguous_sample_path(&tree, receive_root, sample) else {
+            continue;
+        };
+        let templates = templates_from_sample(receive_root, &path, sample);
+        if templates.is_empty() {
+            continue;
+        }
+        for template in templates {
+            *patterns.entry(template).or_default() += 1;
+        }
+        matched += 1;
+    }
+
+    let mut ranked = patterns.into_iter().collect::<Vec<_>>();
+    ranked.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    let detected = ranked.first().and_then(|(template, count)| {
+        let runner_up = ranked.get(1).map(|(_, count)| *count).unwrap_or(0);
+        (*count > runner_up).then(|| DetectedDirectoryLayout {
+            template: template.clone(),
+            samples: *count,
+        })
+    });
+
+    tracing::info!(
+        root = %receive_root.display(),
+        catalog_rows = samples.len(),
+        matched_rows = matched,
+        elapsed_ms = started.elapsed().as_millis(),
+        template = detected.as_ref().map(|layout| layout.template.as_str()).unwrap_or("preset"),
+        "Scanned remote image catalog layout"
+    );
+    Ok(detected)
+}
+
+fn catalog_layout_samples(connection: &rusqlite::Connection) -> Result<Vec<CatalogLayoutSample>> {
+    let mut statement = connection.prepare(
+        "SELECT ai.metadata, p.name, t.name, IFNULL(ai.filtername, ''), ai.acquireddate
+         FROM acquiredimage ai
+         JOIN project p ON p.Id = ai.projectId
+         JOIN target t ON t.Id = ai.targetId
+         WHERE ai.metadata IS NOT NULL
+         ORDER BY ai.Id DESC
+         LIMIT ?1",
+    )?;
+    let rows = statement.query_map([MAX_LAYOUT_SAMPLES], |row| {
+        let metadata: String = row.get(0)?;
+        Ok((
+            metadata,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, Option<i64>>(4)?,
+        ))
+    })?;
+    let mut samples = Vec::new();
+    for row in rows {
+        let (metadata, project, target, filter, acquired_date) = row?;
+        let metadata = serde_json::from_str::<serde_json::Value>(&metadata).ok();
+        let Some(metadata_path) = metadata
+            .as_ref()
+            .and_then(|value| metadata_text(value, "FileName"))
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        samples.push(CatalogLayoutSample {
+            metadata_path,
+            project,
+            target,
+            filter,
+            capture_time: acquired_date.or_else(|| {
+                metadata
+                    .as_ref()
+                    .and_then(|value| metadata_text(value, "ExposureStartTime"))
+                    .and_then(crate::commands::import::headers::parse_fits_datetime)
+            }),
+        });
+    }
+    Ok(samples)
+}
+
+fn unambiguous_sample_path(
+    tree: &DirectoryTree,
+    root: &Path,
+    sample: &CatalogLayoutSample,
+) -> Option<PathBuf> {
+    let filename = sample.metadata_path.rsplit(['/', '\\']).next()?;
+    let paths = tree.find_file(filename)?;
+    let sanitized_target =
+        super::remote_upload::upload_directory_component(&sample.target, "Unknown Target");
+    let mut candidates = paths
+        .iter()
+        .filter(|path| {
+            let Ok(relative) = path.strip_prefix(root) else {
+                return false;
+            };
+            let components = relative_components(relative);
+            components.len() >= 3
+                && components.iter().any(|component| {
+                    component.eq_ignore_ascii_case(&sample.target)
+                        || component.eq_ignore_ascii_case(&sanitized_target)
+                })
+                && components
+                    .iter()
+                    .any(|component| component.eq_ignore_ascii_case("LIGHT"))
+                && !components.iter().any(|component| {
+                    matches!(
+                        component.to_ascii_lowercase().as_str(),
+                        "reject" | "rejected" | "processed" | "masters" | "master"
+                    )
+                })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates.dedup();
+    (candidates.len() == 1).then(|| candidates.remove(0))
+}
+
+fn templates_from_sample(root: &Path, path: &Path, sample: &CatalogLayoutSample) -> Vec<String> {
+    let Ok(relative) = path.strip_prefix(root) else {
+        return Vec::new();
+    };
+    let Some(parent) = relative.parent() else {
+        return Vec::new();
+    };
+    let components = relative_components(parent);
+    let (capture_date, observing_night) = sample_capture_dates(path, sample);
+    let mut variants = vec![(Vec::<String>::new(), false, false)];
+
+    for component in &components {
+        let replacements = if component.eq_ignore_ascii_case(&sample.target)
+            || component.eq_ignore_ascii_case(&super::remote_upload::upload_directory_component(
+                &sample.target,
+                "Unknown Target",
+            )) {
+            vec![("%TARGET%".to_string(), true, false)]
+        } else if component.eq_ignore_ascii_case("LIGHT") {
+            vec![("%TYPE%".to_string(), false, true)]
+        } else if !sample.filter.trim().is_empty()
+            && (component.eq_ignore_ascii_case(&sample.filter)
+                || component.eq_ignore_ascii_case(
+                    &super::remote_upload::upload_directory_component(&sample.filter, "NONE"),
+                ))
+        {
+            vec![("%FILTER%".to_string(), false, false)]
+        } else if (component.eq_ignore_ascii_case(&sample.project)
+            || component.eq_ignore_ascii_case(&super::remote_upload::upload_directory_component(
+                &sample.project,
+                "Unknown Project",
+            )))
+            && !component.eq_ignore_ascii_case(&sample.target)
+        {
+            vec![("%PROJECT%".to_string(), false, false)]
+        } else if matching_observing_year(component, observing_night.as_deref()) {
+            vec![("%YEAR%".to_string(), false, false)]
+        } else if is_iso_date(component) {
+            let mut dates = Vec::new();
+            if capture_date.as_deref() == Some(component.as_str()) {
+                dates.push(("%DATE%".to_string(), false, false));
+            }
+            if observing_night.as_deref() == Some(component.as_str()) {
+                dates.push(("%NIGHT%".to_string(), false, false));
+            }
+            if dates.is_empty() {
+                dates.push((component.to_string(), false, false));
+            }
+            dates
+        } else {
+            // A four-digit directory can be a manually named season. Preserve
+            // it unless the catalog supplies evidence for a date transform.
+            vec![(component.to_string(), false, false)]
+        };
+
+        let mut next = Vec::new();
+        for (parts, has_target, has_type) in variants {
+            for (replacement, marks_target, marks_type) in &replacements {
+                let mut expanded = parts.clone();
+                expanded.push(replacement.clone());
+                next.push((
+                    expanded,
+                    has_target || *marks_target,
+                    has_type || *marks_type,
+                ));
+            }
+        }
+        variants = next;
+    }
+
+    variants
+        .into_iter()
+        .filter_map(|(parts, has_target, has_type)| {
+            let template = parts.join("/");
+            (has_target && has_type && validate_directory_template(&template).is_ok())
+                .then_some(template)
+        })
+        .collect()
+}
+
+fn sample_capture_dates(
+    path: &Path,
+    sample: &CatalogLayoutSample,
+) -> (Option<String>, Option<String>) {
+    let frame = crate::commands::import::headers::read_frame_meta(path);
+    let header_date = frame
+        .date_local
+        .as_deref()
+        .or(frame.date_obs.as_deref())
+        .and_then(|value| value.get(..10))
+        .filter(|value| is_iso_date(value))
+        .map(str::to_string);
+    let timestamp = frame
+        .date_local
+        .as_deref()
+        .or(frame.date_obs.as_deref())
+        .and_then(crate::commands::import::headers::parse_fits_datetime)
+        .or(frame.timestamp)
+        .or(sample.capture_time);
+    let Some(timestamp) =
+        timestamp.and_then(|value| chrono::DateTime::<chrono::Utc>::from_timestamp(value, 0))
+    else {
+        return (header_date, None);
+    };
+    (
+        header_date.or_else(|| Some(timestamp.format("%Y-%m-%d").to_string())),
+        Some(
+            (timestamp - chrono::Duration::hours(12))
+                .format("%Y-%m-%d")
+                .to_string(),
+        ),
+    )
+}
+
+fn metadata_text<'a>(value: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    value
+        .as_object()?
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(key))
+        .and_then(|(_, value)| value.as_str())
+}
+
+fn relative_components(path: &Path) -> Vec<String> {
+    path.components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(value) => Some(value.to_string_lossy().into_owned()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn is_iso_date(value: &str) -> bool {
+    value.len() == 10
+        && value.as_bytes().get(4) == Some(&b'-')
+        && value.as_bytes().get(7) == Some(&b'-')
+        && chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d").is_ok()
+}
+
+fn matching_observing_year(component: &str, observing_night: Option<&str>) -> bool {
+    component.len() == 4
+        && component.bytes().all(|byte| byte.is_ascii_digit())
+        && observing_night.and_then(|date| date.get(..4)) == Some(component)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_catalog(path: &Path) -> rusqlite::Connection {
+        let connection = rusqlite::Connection::open(path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE project (Id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+                 CREATE TABLE target (
+                     Id INTEGER PRIMARY KEY,
+                     projectId INTEGER NOT NULL,
+                     name TEXT NOT NULL
+                 );
+                 CREATE TABLE acquiredimage (
+                     Id INTEGER PRIMARY KEY,
+                     projectId INTEGER NOT NULL,
+                     targetId INTEGER NOT NULL,
+                     filtername TEXT,
+                     acquireddate INTEGER,
+                     metadata TEXT NOT NULL
+                 );",
+            )
+            .unwrap();
+        connection
+    }
+
+    fn add_catalog_image(
+        connection: &rusqlite::Connection,
+        id: i64,
+        project: &str,
+        target: &str,
+        filter: &str,
+        filename: &str,
+        capture_time: i64,
+    ) {
+        connection
+            .execute(
+                "INSERT OR IGNORE INTO project (Id, name) VALUES (?1, ?2)",
+                rusqlite::params![id, project],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO target (Id, projectId, name) VALUES (?1, ?1, ?2)",
+                rusqlite::params![id, target],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO acquiredimage
+                     (Id, projectId, targetId, filtername, metadata, acquireddate)
+                 VALUES (?1, ?1, ?1, ?2, ?3, ?4)",
+                rusqlite::params![
+                    id,
+                    filter,
+                    serde_json::json!({ "FileName": format!("D:\\remote\\{filename}") })
+                        .to_string(),
+                    capture_time,
+                ],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn validates_only_safe_allowlisted_templates() {
+        for template in [
+            "%YEAR%/%TARGET%/%NIGHT%/%TYPE%",
+            "%TARGET%/%DATE%/%TYPE%/%FILTER%",
+            "%PROJECT%/%TARGET%/%TYPE%/%EXPOSURE%s_G%GAIN%",
+        ] {
+            validate_directory_template(template).unwrap();
+        }
+        for template in [
+            "../%TARGET%/%TYPE%",
+            "C:/%TARGET%/%TYPE%",
+            "/%TARGET%/%TYPE%",
+            "%TARGET%/%UNKNOWN%/%TYPE%",
+            "%TARGET%/LIGHT",
+        ] {
+            assert!(validate_directory_template(template).is_err(), "{template}");
+        }
+    }
+
+    #[test]
+    fn recognizes_catalog_date_components() {
+        assert!(is_iso_date("2026-08-30"));
+        assert!(!is_iso_date("2026-13-30"));
+        assert!(matching_observing_year("2026", Some("2026-08-30")));
+        assert!(!matching_observing_year("2026", Some("2025-12-31")));
+    }
+
+    #[test]
+    fn detects_the_observing_night_tree_from_real_catalog_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("_Source");
+        let db_path = temp.path().join("scheduler.sqlite");
+        let connection = create_catalog(&db_path);
+        for (id, target, night, captured, filename) in [
+            (
+                1,
+                "Pinwheel Galaxy",
+                "2026-04-06",
+                "2026-04-07T04:00:00",
+                "m101-001.fits",
+            ),
+            (
+                2,
+                "Whirlpool Galaxy",
+                "2026-04-07",
+                "2026-04-08T04:00:00",
+                "m51-001.fits",
+            ),
+        ] {
+            let directory = root.join("2026").join(target).join(night).join("LIGHT");
+            std::fs::create_dir_all(&directory).unwrap();
+            std::fs::write(directory.join(filename), b"fixture").unwrap();
+            add_catalog_image(
+                &connection,
+                id,
+                target,
+                target,
+                "L",
+                filename,
+                crate::commands::import::headers::parse_fits_datetime(captured).unwrap(),
+            );
+        }
+        drop(connection);
+
+        let detected = detect_catalog_directory_layout(
+            db_path.to_str().unwrap(),
+            &dunce::canonicalize(root).unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(detected.template, "%YEAR%/%TARGET%/%NIGHT%/%TYPE%");
+        assert_eq!(detected.samples, 2);
+    }
+
+    #[test]
+    fn detects_capture_date_without_guessing_night() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("_Source");
+        let db_path = temp.path().join("scheduler.sqlite");
+        let connection = create_catalog(&db_path);
+        let filename = "m101-date.fits";
+        let directory = root
+            .join("2026")
+            .join("Pinwheel Galaxy")
+            .join("2026-04-07")
+            .join("LIGHT");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join(filename), b"fixture").unwrap();
+        add_catalog_image(
+            &connection,
+            1,
+            "Pinwheel Galaxy",
+            "Pinwheel Galaxy",
+            "L",
+            filename,
+            crate::commands::import::headers::parse_fits_datetime("2026-04-07T04:00:00").unwrap(),
+        );
+        drop(connection);
+
+        let detected = detect_catalog_directory_layout(
+            db_path.to_str().unwrap(),
+            &dunce::canonicalize(root).unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(detected.template, "%YEAR%/%TARGET%/%DATE%/%TYPE%");
+    }
+
+    #[test]
+    fn preserves_a_manually_named_season_that_differs_from_capture_year() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("_Source");
+        let db_path = temp.path().join("scheduler.sqlite");
+        let connection = create_catalog(&db_path);
+        let filename = "season.fits";
+        let directory = root
+            .join("2025")
+            .join("M 31")
+            .join("2026-01-02")
+            .join("LIGHT");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join(filename), b"fixture").unwrap();
+        add_catalog_image(
+            &connection,
+            1,
+            "M 31",
+            "M 31",
+            "L",
+            filename,
+            crate::commands::import::headers::parse_fits_datetime("2026-01-03T04:00:00").unwrap(),
+        );
+        drop(connection);
+
+        let detected = detect_catalog_directory_layout(
+            db_path.to_str().unwrap(),
+            &dunce::canonicalize(root).unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(detected.template, "2025/%TARGET%/%NIGHT%/%TYPE%");
+    }
+
+    #[test]
+    fn detects_sanitized_project_target_and_filter_components() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("_Source");
+        let db_path = temp.path().join("scheduler.sqlite");
+        let connection = create_catalog(&db_path);
+        let filename = "sanitized.fits";
+        let directory = root
+            .join("Project_One")
+            .join("Target_One")
+            .join("2026-04-06")
+            .join("LIGHT")
+            .join("Ha_OIII");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join(filename), b"fixture").unwrap();
+        add_catalog_image(
+            &connection,
+            1,
+            "Project/One",
+            "Target/One",
+            "Ha/OIII",
+            filename,
+            crate::commands::import::headers::parse_fits_datetime("2026-04-07T04:00:00").unwrap(),
+        );
+        drop(connection);
+
+        let detected = detect_catalog_directory_layout(
+            db_path.to_str().unwrap(),
+            &dunce::canonicalize(root).unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            detected.template,
+            "%PROJECT%/%TARGET%/%NIGHT%/%TYPE%/%FILTER%"
+        );
+    }
+
+    #[test]
+    fn ambiguous_evening_dates_leave_the_preset_in_control() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("_Source");
+        let db_path = temp.path().join("scheduler.sqlite");
+        let connection = create_catalog(&db_path);
+        let filename = "m101-evening.fits";
+        let directory = root
+            .join("2026")
+            .join("Pinwheel Galaxy")
+            .join("2026-04-07")
+            .join("LIGHT");
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join(filename), b"fixture").unwrap();
+        add_catalog_image(
+            &connection,
+            1,
+            "Pinwheel Galaxy",
+            "Pinwheel Galaxy",
+            "L",
+            filename,
+            crate::commands::import::headers::parse_fits_datetime("2026-04-07T20:00:00").unwrap(),
+        );
+        drop(connection);
+
+        assert!(detect_catalog_directory_layout(
+            db_path.to_str().unwrap(),
+            &dunce::canonicalize(root).unwrap(),
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn an_empty_catalog_uses_the_preset_without_scanning_the_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("scheduler.sqlite");
+        drop(create_catalog(&db_path));
+        let missing_root = temp.path().join("does-not-exist");
+
+        assert!(
+            detect_catalog_directory_layout(db_path.to_str().unwrap(), &missing_root)
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/src/server/spatial_scan.rs
+++ b/src/server/spatial_scan.rs
@@ -31,6 +31,11 @@ pub struct StoredSpatialMetrics {
     /// Basename of the FITS file the metrics were computed from; a changed
     /// filename invalidates the entry.
     pub filename: String,
+    /// Durable upload revision, when this row is backed by remote-image
+    /// provenance. Callers compare it with the live mapping before using the
+    /// cached evidence.
+    #[serde(default)]
+    pub source_revision: Option<String>,
     /// Detector used for scheduler-compatible star count and HFR values.
     #[serde(default)]
     pub detector: String,
@@ -128,6 +133,10 @@ pub struct SpatialMetricsStore {
     pub metrics: HashMap<i32, StoredSpatialMetrics>,
     pub progress: SpatialScanProgress,
     loaded_from_disk: bool,
+    /// Incremented when the source behind one scheduler row changes. A scan
+    /// that began before an upload remap may finish, but cannot publish
+    /// measurements from the old pixels afterward.
+    source_generations: HashMap<i32, u64>,
 }
 
 /// One unit of scan work, resolved from the DB before the blocking task runs.
@@ -136,6 +145,8 @@ pub struct ScanWorkItem {
     pub image_id: i32,
     pub filename: String,
     pub fits_path: PathBuf,
+    pub source_generation: u64,
+    pub source_revision: Option<String>,
 }
 
 const PERSIST_FILENAME: &str = "spatial_metrics.json";
@@ -218,6 +229,50 @@ fn persist(store: &RwLock<SpatialMetricsStore>, cache_dir: &Path) {
     }
 }
 
+pub fn source_generation(store: &RwLock<SpatialMetricsStore>, image_id: i32) -> u64 {
+    store
+        .read()
+        .unwrap()
+        .source_generations
+        .get(&image_id)
+        .copied()
+        .unwrap_or(0)
+}
+
+/// Forget pixel evidence for a row whose durable upload source changed and
+/// invalidate any scan work that resolved the old source before the remap.
+pub fn invalidate_image_source(
+    store: &RwLock<SpatialMetricsStore>,
+    cache_dir: &Path,
+    image_id: i32,
+) -> bool {
+    ensure_loaded(store, cache_dir);
+    {
+        let mut state = store.write().unwrap();
+        let generation = state.source_generations.entry(image_id).or_default();
+        *generation = generation.wrapping_add(1);
+        state.metrics.remove(&image_id).is_some()
+    }
+}
+
+fn record_scan_entry_if_current(
+    store: &RwLock<SpatialMetricsStore>,
+    item: &ScanWorkItem,
+    entry: StoredSpatialMetrics,
+) -> bool {
+    let mut state = store.write().unwrap();
+    let current = state
+        .source_generations
+        .get(&item.image_id)
+        .copied()
+        .unwrap_or(0);
+    if current != item.source_generation {
+        return false;
+    }
+    state.metrics.insert(item.image_id, entry);
+    true
+}
+
 /// Try to mark a scan as started. Returns false when one is already running.
 pub fn try_begin_scan(
     store: &RwLock<SpatialMetricsStore>,
@@ -288,10 +343,16 @@ pub fn run_scan(
 
         match outcome {
             Ok(entry) => {
+                let recorded = record_scan_entry_if_current(store, item, entry);
                 let mut s = store.write().unwrap();
-                s.metrics.insert(item.image_id, entry);
                 s.progress.processed += 1;
                 s.progress.spatial_processed += 1;
+                if !recorded {
+                    tracing::info!(
+                        image_id = item.image_id,
+                        "Discarded quality metrics because the image source changed during the scan"
+                    );
+                }
             }
             Err(e) => {
                 tracing::warn!(
@@ -415,6 +476,7 @@ fn compute_one(
     Ok(StoredSpatialMetrics {
         image_id: item.image_id,
         filename: item.filename.clone(),
+        source_revision: item.source_revision.clone(),
         detector: QUALITY_DETECTOR.to_string(),
         detector_version: QUALITY_DETECTOR_VERSION,
         star_count: result.star_list.len(),
@@ -466,20 +528,50 @@ pub fn star_metrics_metadata_patch(
     metadata_json: &str,
     star_count: usize,
     avg_hfr: f64,
+    source_revision: Option<&str>,
 ) -> Option<String> {
     let mut value: serde_json::Value = serde_json::from_str(metadata_json).ok()?;
     let map = value.as_object_mut()?;
     let missing = |map: &serde_json::Map<String, serde_json::Value>, key: &str| {
         map.get(key).is_none_or(serde_json::Value::is_null)
     };
-    let mut changed = false;
+    let same_source = source_revision.is_some_and(|source_revision| {
+        map.iter().any(|(key, value)| {
+            key.eq_ignore_ascii_case("PsfGuardQualitySource")
+                && value.as_str() == Some(source_revision)
+        })
+    });
+    let mut supplied = if same_source {
+        map.iter()
+            .find_map(|(key, value)| {
+                key.eq_ignore_ascii_case("PsfGuardQualityFields")
+                    .then(|| value.as_array())
+                    .flatten()
+            })
+            .map(|fields| {
+                fields
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let supplied_before = supplied.len();
     if missing(map, "DetectedStars") {
         map.insert("DetectedStars".to_string(), (star_count as u64).into());
-        changed = true;
+        supplied.push("DetectedStars".to_string());
     }
     if star_count > 0 && avg_hfr > 0.0 && missing(map, "HFR") {
         map.insert("HFR".to_string(), avg_hfr.into());
-        changed = true;
+        supplied.push("HFR".to_string());
+    }
+    let changed = supplied.len() != supplied_before;
+    if changed && let Some(source_revision) = source_revision {
+        map.insert("PsfGuardQualitySource".to_string(), source_revision.into());
+        map.insert("PsfGuardQualityFields".to_string(), supplied.clone().into());
     }
     changed.then(|| value.to_string())
 }
@@ -497,6 +589,24 @@ pub fn valid_entry(
         .cloned()
 }
 
+/// Look up an entry whose pixel provenance still agrees with the durable
+/// remote-image mapping. Native scheduler files have no mapping revision; in
+/// that case a previously mapped entry must not be reused.
+pub fn valid_entry_for_source(
+    store: &RwLock<SpatialMetricsStore>,
+    image_id: i32,
+    filename: &str,
+    mapped_source_revision: Option<&str>,
+) -> Option<StoredSpatialMetrics> {
+    valid_entry(store, image_id, filename).filter(|entry| match mapped_source_revision {
+        Some(expected) => entry.source_revision.as_deref() == Some(expected),
+        None => !entry
+            .source_revision
+            .as_deref()
+            .is_some_and(|revision| revision.starts_with("mapping:")),
+    })
+}
+
 /// Look up an entry that contains every field produced by the current quality
 /// scan. Older cache files deserialize successfully, but their defaulted grid
 /// dimensions and cell arrays cannot support photometric screening.
@@ -506,6 +616,16 @@ pub fn valid_quality_entry(
     filename: &str,
 ) -> Option<StoredSpatialMetrics> {
     valid_entry(store, image_id, filename).filter(|entry| quality_entry_is_current(entry, filename))
+}
+
+pub fn valid_quality_entry_for_source(
+    store: &RwLock<SpatialMetricsStore>,
+    image_id: i32,
+    filename: &str,
+    mapped_source_revision: Option<&str>,
+) -> Option<StoredSpatialMetrics> {
+    valid_entry_for_source(store, image_id, filename, mapped_source_revision)
+        .filter(|entry| quality_entry_is_current(entry, filename))
 }
 
 /// Whether a cached entry matches the source and current quality model.
@@ -544,6 +664,7 @@ mod tests {
         StoredSpatialMetrics {
             image_id,
             filename: filename.to_string(),
+            source_revision: None,
             detector: String::new(),
             detector_version: 0,
             star_count: 4000,
@@ -631,39 +752,64 @@ mod tests {
         // Header-first import: both keys absent → both filled.
         let imported = r#"{"FileName":"a.xisf","SessionId":0}"#;
         assert!(metadata_lacks_star_metrics(imported));
-        let patched = star_metrics_metadata_patch(imported, 120, 2.5).unwrap();
+        let patched =
+            star_metrics_metadata_patch(imported, 120, 2.5, Some("file:source-a")).unwrap();
         let value: serde_json::Value = serde_json::from_str(&patched).unwrap();
         assert_eq!(value["DetectedStars"], 120);
         assert_eq!(value["HFR"], 2.5);
+        assert_eq!(value["PsfGuardQualitySource"], "file:source-a");
+        assert_eq!(
+            value["PsfGuardQualityFields"],
+            serde_json::json!(["DetectedStars", "HFR"])
+        );
         assert_eq!(value["FileName"], "a.xisf", "existing keys must survive");
 
         // N.I.N.A. catalog: measurements present → untouched.
         let nina = r#"{"DetectedStars":300,"HFR":1.8}"#;
         assert!(!metadata_lacks_star_metrics(nina));
-        assert!(star_metrics_metadata_patch(nina, 120, 2.5).is_none());
+        assert!(star_metrics_metadata_patch(nina, 120, 2.5, None).is_none());
 
         // Null counts as missing (a writer may serialize unknowns as null).
         let with_null = r#"{"DetectedStars":null,"HFR":1.8}"#;
         assert!(metadata_lacks_star_metrics(with_null));
-        let patched = star_metrics_metadata_patch(with_null, 120, 2.5).unwrap();
+        let patched = star_metrics_metadata_patch(with_null, 120, 2.5, None).unwrap();
         let value: serde_json::Value = serde_json::from_str(&patched).unwrap();
         assert_eq!(value["DetectedStars"], 120);
         assert_eq!(value["HFR"], 1.8, "measured HFR must not be overwritten");
+
+        let patched = star_metrics_metadata_patch(
+            r#"{"DetectedStars":300}"#,
+            120,
+            2.5,
+            Some("mapping:current"),
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&patched).unwrap();
+        assert_eq!(value["DetectedStars"], 300);
+        assert_eq!(value["PsfGuardQualityFields"], serde_json::json!(["HFR"]));
+
+        let first = star_metrics_metadata_patch("{}", 0, 0.0, Some("mapping:current")).unwrap();
+        let second = star_metrics_metadata_patch(&first, 20, 2.0, Some("mapping:current")).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&second).unwrap();
+        assert_eq!(
+            value["PsfGuardQualityFields"],
+            serde_json::json!(["DetectedStars", "HFR"])
+        );
     }
 
     #[test]
     fn metadata_star_metrics_fill_handles_edge_inputs() {
         // No detected stars: the count is a real measurement, HFR is not.
-        let patched = star_metrics_metadata_patch("{}", 0, 0.0).unwrap();
+        let patched = star_metrics_metadata_patch("{}", 0, 0.0, None).unwrap();
         let value: serde_json::Value = serde_json::from_str(&patched).unwrap();
         assert_eq!(value["DetectedStars"], 0);
         assert!(value.get("HFR").is_none(), "no stars → no HFR measurement");
 
         // Unparsable or non-object metadata: nothing to check, nothing to fill.
         assert!(!metadata_lacks_star_metrics("not json"));
-        assert!(star_metrics_metadata_patch("not json", 10, 2.0).is_none());
+        assert!(star_metrics_metadata_patch("not json", 10, 2.0, None).is_none());
         assert!(!metadata_lacks_star_metrics("[1,2]"));
-        assert!(star_metrics_metadata_patch("[1,2]", 10, 2.0).is_none());
+        assert!(star_metrics_metadata_patch("[1,2]", 10, 2.0, None).is_none());
     }
 
     #[test]
@@ -681,5 +827,53 @@ mod tests {
         let missing = RwLock::new(SpatialMetricsStore::default());
         ensure_loaded(&missing, Path::new("/nonexistent-dir-for-test"));
         assert_eq!(progress_snapshot(&missing).1, 0);
+    }
+
+    #[test]
+    fn source_invalidation_removes_metrics_and_discards_in_flight_results() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut old_entry = entry(7, "old.fits");
+        old_entry.source_revision = Some("mapping-old".into());
+        let store = store_with(vec![old_entry.clone()]);
+        let item = ScanWorkItem {
+            image_id: 7,
+            filename: "old.fits".into(),
+            fits_path: directory.path().join("old.fits"),
+            source_generation: source_generation(&store, 7),
+            source_revision: Some("mapping-old".into()),
+        };
+
+        assert!(invalidate_image_source(&store, directory.path(), 7));
+        assert!(!store.read().unwrap().metrics.contains_key(&7));
+        assert!(!record_scan_entry_if_current(
+            &store,
+            &item,
+            old_entry.clone()
+        ));
+        assert_eq!(source_generation(&store, 7), 1);
+        persist(&store_with(vec![old_entry]), directory.path());
+        let restarted = RwLock::new(SpatialMetricsStore::default());
+        ensure_loaded(&restarted, directory.path());
+        assert!(
+            valid_quality_entry_for_source(&restarted, 7, "old.fits", Some("mapping-new"))
+                .is_none()
+        );
+
+        let mut current_entry = entry(7, "old.fits");
+        current_entry.source_revision = Some("mapping-new".into());
+        let current_item = ScanWorkItem {
+            source_generation: source_generation(&store, 7),
+            source_revision: Some("mapping-new".into()),
+            ..item
+        };
+        assert!(record_scan_entry_if_current(
+            &store,
+            &current_item,
+            current_entry
+        ));
+        persist(&store, directory.path());
+        let restarted = RwLock::new(SpatialMetricsStore::default());
+        ensure_loaded(&restarted, directory.path());
+        assert!(restarted.read().unwrap().metrics.contains_key(&7));
     }
 }

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -1234,7 +1234,7 @@ fn prepare_job(
     request: &StackPreviewRequest,
 ) -> Result<PreparedJob, AppError> {
     let requested = request.image_ids.iter().copied().collect::<HashSet<_>>();
-    let (project_images, expected_by_image) = {
+    let (project_images, expected_by_image, mapped_sources) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
@@ -1276,10 +1276,15 @@ fn prepare_job(
             })
             .collect::<Result<HashMap<_, _>, _>>()
             .map_err(AppError::db)?;
-        (relevant, expected)
+        let mapped_sources = crate::server::remote_upload::mapped_light_sources(
+            &conn,
+            &ctx.image_dir_paths,
+            relevant.iter().map(|(image, _, _)| image),
+        )?;
+        (relevant, expected, mapped_sources)
     };
 
-    let quality = quality_results(ctx, &project_images, &expected_by_image);
+    let quality = quality_results(ctx, &project_images, &expected_by_image, &mapped_sources);
     let quality_by_id = quality
         .into_iter()
         .map(|result| (result.image_id, result))
@@ -1530,6 +1535,7 @@ fn quality_results(
     ctx: &DatabaseContext,
     images: &[(AcquiredImage, String, String)],
     expected_by_image: &HashMap<i32, Option<(f64, f64)>>,
+    mapped_sources: &crate::server::remote_upload::MappedLightSources,
 ) -> Vec<ImageQualityResult> {
     crate::server::spatial_scan::ensure_loaded(&ctx.spatial_metrics, &ctx.cache_dir_path);
     let mut grouped: BTreeMap<(i32, String, String), Vec<&AcquiredImage>> = BTreeMap::new();
@@ -1553,10 +1559,13 @@ fn quality_results(
         for image in group {
             let mut value =
                 extract_metrics_from_metadata(image.id, &image.metadata, image.acquired_date);
+            let mapped_source = mapped_sources.get(&image.id);
+            let mapped_source_revision = mapped_sources.quality_revision(image.id);
             super::handlers::merge_spatial_metrics(
                 &mut value,
                 &ctx.spatial_metrics,
                 &image.metadata,
+                mapped_source_revision,
             );
             super::handlers::merge_astrometry_metrics(
                 &mut value,
@@ -1564,11 +1573,14 @@ fn quality_results(
                 &image.metadata,
                 &ctx.astrometry_evidence,
                 expected_by_image.get(&image.id).copied().flatten(),
+                mapped_source.map(|source| source.path.as_path()),
+                mapped_sources.is_invalid(image.id),
             );
             entries.push(super::handlers::stored_entry_for(
                 &ctx.spatial_metrics,
                 image.id,
                 &image.metadata,
+                mapped_source_revision,
             ));
             metrics.push(value);
         }

--- a/src/server/stack_preview/artifact.rs
+++ b/src/server/stack_preview/artifact.rs
@@ -487,9 +487,6 @@ fn prepare_search(
     let reference_height = reference_height as usize;
     validate_region_bounds(request.region, reference_width, reference_height)?;
 
-    let conn = ctx.db();
-    let conn = conn.lock().map_err(AppError::db)?;
-    let db = Database::new(&conn);
     let mut groups = Vec::new();
     let mut notes = Vec::new();
     let mut hasher = Sha256::new();
@@ -525,12 +522,16 @@ fn prepare_search(
             .iter()
             .map(|frame| frame.image_id)
             .collect::<Vec<_>>();
-        let images = db
-            .get_images_by_ids(&ids)
-            .map_err(AppError::db)?
-            .into_iter()
-            .map(|image| (image.id, image))
-            .collect::<HashMap<_, _>>();
+        let images = {
+            let conn = ctx.db();
+            let conn = conn.lock().map_err(AppError::db)?;
+            Database::new(&conn)
+                .get_images_by_ids(&ids)
+                .map_err(AppError::db)?
+                .into_iter()
+                .map(|image| (image.id, image))
+                .collect::<HashMap<_, _>>()
+        };
         if images.len() != ids.len() {
             return Err(AppError::Conflict(
                 "One or more stack inputs are no longer in the database".into(),
@@ -1340,6 +1341,7 @@ fn persist_artifact_job(cache_root: &FsPath, job: &ArtifactSearchJob) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::stack_preview::StackFrameDecision;
     use seiza_stacking::LinearImage;
 
     fn crop(image_id: i32, values: Vec<f32>) -> LoadedCrop {
@@ -1367,6 +1369,137 @@ mod tests {
                 values,
             },
         }
+    }
+
+    #[test]
+    fn artifact_preparation_releases_the_database_lock_before_resolving_sources() {
+        let temp = tempfile::tempdir().unwrap();
+        let database_path = temp.path().join("scheduler.sqlite");
+        let connection = crate::ts_schema::create_fresh_db(&database_path).unwrap();
+        connection
+            .execute_batch(
+                "INSERT INTO project (Id, profileId, name) VALUES (1, 'default', 'Project');
+                 INSERT INTO target (Id, name, active, epochcode, projectId)
+                    VALUES (1, 'Target', 1, 0, 1);",
+            )
+            .unwrap();
+
+        let image_root = temp.path().join("images");
+        std::fs::create_dir_all(&image_root).unwrap();
+        let mut frames = Vec::new();
+        for image_id in 1..=3 {
+            let filename = format!("frame-{image_id}.fits");
+            let path = image_root.join(&filename);
+            std::fs::write(&path, b"FITS placeholder").unwrap();
+            let metadata = serde_json::json!({ "FileName": filename }).to_string();
+            connection
+                .execute(
+                    "INSERT INTO acquiredimage
+                        (Id, projectId, targetId, filtername, gradingStatus, metadata, profileId)
+                     VALUES (?1, 1, 1, 'Ha', 0, ?2, 'default')",
+                    rusqlite::params![image_id, metadata],
+                )
+                .unwrap();
+            let mapping = RegisteredFrameMapping::identity(
+                &LinearImage::new(16, 16, 1, vec![0.0; 16 * 16]).unwrap(),
+            );
+            frames.push(StackFrameDecision {
+                image_id,
+                disposition: if image_id == 1 {
+                    "reference".into()
+                } else {
+                    "accepted".into()
+                },
+                reason: None,
+                quality_score: None,
+                matched_stars: None,
+                registration_rms_pixels: None,
+                registration_drift_pixels: None,
+                registered_mapping: Some(mapping),
+                normalization_mean_gain: None,
+                normalization_mean_offset: None,
+                source_fingerprint: Some(source_fingerprint(&path)),
+                overlap_fraction: None,
+                integrated_fraction: None,
+            });
+        }
+        drop(connection);
+
+        let ctx = Arc::new(
+            crate::server::database_context::DatabaseContext::new(
+                "test".into(),
+                "Test".into(),
+                database_path.to_string_lossy().into_owned(),
+                vec![image_root.to_string_lossy().into_owned()],
+                None,
+                None,
+                temp.path().join("cache").to_string_lossy().into_owned(),
+            )
+            .unwrap(),
+        );
+        let job_id = "a".repeat(64);
+        let preview_path = super::super::original_preview_path(&ctx.cache_dir_path, &job_id, 0);
+        std::fs::create_dir_all(preview_path.parent().unwrap()).unwrap();
+        image::GrayImage::new(16, 16).save(preview_path).unwrap();
+        let group = StackGroupStatus {
+            index: 0,
+            target_id: 1,
+            target_name: "Target".into(),
+            filter_name: "Ha".into(),
+            state: StackGroupState::Ready,
+            phase: "ready".into(),
+            total_candidates: 3,
+            eligible_frames: 3,
+            quality_excluded: 0,
+            missing_files: 0,
+            processed_frames: 3,
+            accepted_frames: 3,
+            rejected_frames: 0,
+            reused_frames: 0,
+            resume_note: None,
+            output_channels: 1,
+            sky_orientation: None,
+            reference_image_id: Some(1),
+            total_exposure_seconds: 3.0,
+            preview_url: None,
+            fits_url: None,
+            snr: None,
+            snr_url: None,
+            error: None,
+            calibration: Default::default(),
+            input_images: Vec::new(),
+            frames,
+        };
+        let request = ArtifactSearchRequest {
+            artifact_revision: "revision".into(),
+            region: ReferenceRegion {
+                x: 0,
+                y: 0,
+                width: 8,
+                height: 8,
+            },
+        };
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let result = prepare_search(
+                &ctx,
+                &job_id,
+                "mono",
+                Some(0),
+                &request,
+                vec![(group, None, None)],
+            )
+            .map(|prepared| prepared.groups[0].sources.len())
+            .map_err(|error| format!("{error:?}"));
+            let _ = sender.send(result);
+        });
+
+        let source_count = receiver
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("artifact preparation deadlocked while resolving a source")
+            .unwrap();
+        worker.join().unwrap();
+        assert_eq!(source_count, 3);
     }
 
     #[test]

--- a/src/server/sync_preview.rs
+++ b/src/server/sync_preview.rs
@@ -6,8 +6,11 @@
 //! data the user reviewed or refuses a stale destination.
 
 use crate::server::api::{SchedulerSyncKind, SchedulerSyncRequest, SchedulerSyncResponse};
+use crate::server::database_context::{
+    open_scheduler_connection_with_flags, SCHEDULER_BUSY_TIMEOUT,
+};
 use anyhow::{Context, Result};
-use rusqlite::backup::Backup;
+use rusqlite::backup::{Backup, StepResult};
 use rusqlite::types::ValueRef;
 use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
@@ -17,10 +20,36 @@ use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 
 const PREVIEW_LIFETIME: Duration = Duration::from_secs(30 * 60);
+/// A busy source gets the normal scheduler lock grace period, but even a
+/// source that changes often enough to keep restarting SQLite's online backup
+/// must eventually yield a result or an actionable failure.
+const SNAPSHOT_OVERALL_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+/// The online backup API reports Busy/Locked as retry states rather than
+/// errors. Preserve exhausted retry deadlines as a typed operational failure
+/// so the HTTP layer does not mislabel source contention as bad input.
+#[derive(Debug)]
+pub(crate) struct SyncSnapshotContention {
+    pub(crate) message: String,
+}
+
+impl std::fmt::Display for SyncSnapshotContention {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SyncSnapshotContention {}
+
+pub(crate) fn error_is_sync_snapshot_contention(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<SyncSnapshotContention>().is_some())
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncPreviewRecord {
@@ -94,20 +123,12 @@ impl SyncPreviewManager {
         let published = self.directory.join(&filename);
         let temporary = self.directory.join(format!("{filename}.tmp"));
         let copy = || -> Result<()> {
-            let source = Connection::open_with_flags(source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-                .with_context(|| {
-                    format!("opening {} for transfer snapshot", source_path.display())
-                })?;
-            let mut destination = Connection::open(&temporary)
-                .with_context(|| format!("creating transfer snapshot {}", temporary.display()))?;
-            {
-                let backup = Backup::new(&source, &mut destination)
-                    .context("starting transfer source snapshot")?;
-                backup
-                    .run_to_completion(256, Duration::from_millis(10), None)
-                    .context("copying transfer source snapshot")?;
-            }
-            drop(destination);
+            copy_source_snapshot(
+                source_path,
+                &temporary,
+                SCHEDULER_BUSY_TIMEOUT,
+                SNAPSHOT_OVERALL_TIMEOUT,
+            )?;
             fs::rename(&temporary, &published)
                 .with_context(|| format!("publishing transfer snapshot {}", published.display()))?;
             Ok(())
@@ -290,6 +311,99 @@ impl SyncPreviewManager {
     }
 }
 
+fn copy_source_snapshot(
+    source_path: &Path,
+    temporary: &Path,
+    stall_timeout: Duration,
+    overall_timeout: Duration,
+) -> Result<()> {
+    let source =
+        open_scheduler_connection_with_flags(source_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .with_context(|| {
+                format!(
+                    "opening source scheduler database {}",
+                    source_path.display()
+                )
+            })?;
+    // sqlite3_backup_step reports Busy/Locked as successful retry states. Its
+    // own loop below owns the deadline, so disable the connection handler that
+    // would otherwise wait a full minute inside one step before we can check it.
+    source
+        .busy_timeout(Duration::ZERO)
+        .context("configuring bounded transfer snapshot lock handling")?;
+    let mut destination = Connection::open(temporary)
+        .with_context(|| format!("creating transfer snapshot {}", temporary.display()))?;
+    let backup =
+        Backup::new(&source, &mut destination).context("starting transfer source snapshot")?;
+    let pause = Duration::from_millis(10);
+    let started = Instant::now();
+    let mut last_net_progress = started;
+    let mut lowest_remaining = None;
+    loop {
+        let step = backup
+            .step(256)
+            .context("copying transfer source snapshot")?;
+        let now = Instant::now();
+        let done = matches!(step, StepResult::Done);
+        match step {
+            StepResult::Done => {}
+            StepResult::More => {
+                let remaining = backup.progress().remaining;
+                if record_snapshot_progress(&mut lowest_remaining, remaining) {
+                    last_net_progress = now;
+                }
+            }
+            StepResult::Busy | StepResult::Locked => {}
+            _ => {}
+        }
+
+        let progress = backup.progress();
+        if now.duration_since(started) >= overall_timeout {
+            return Err(SyncSnapshotContention {
+                message: format!(
+                    "source scheduler database {} did not finish a sync preview snapshot within {} seconds ({} of {} pages remain)",
+                    source_path.display(),
+                    overall_timeout.as_secs_f64(),
+                    progress.remaining,
+                    progress.pagecount,
+                ),
+            }
+            .into());
+        }
+        if done {
+            break;
+        }
+        if now.duration_since(last_net_progress) >= stall_timeout {
+            return Err(SyncSnapshotContention {
+                message: format!(
+                    "source scheduler database {} made no snapshot progress for {} seconds while creating a sync preview ({} of {} pages remain; the database may be locked or changing continuously)",
+                    source_path.display(),
+                    stall_timeout.as_secs_f64(),
+                    progress.remaining,
+                    progress.pagecount,
+                ),
+            }
+            .into());
+        }
+        std::thread::sleep(pause);
+    }
+    Ok(())
+}
+
+/// SQLite restarts an online backup when another connection changes the
+/// source. A successful step after that restart is not net progress if it only
+/// reaches a page count we already copied, so retain the lowest remaining-page
+/// count instead of treating every `StepResult::More` as progress.
+fn record_snapshot_progress(lowest_remaining: &mut Option<i32>, remaining: i32) -> bool {
+    match lowest_remaining {
+        Some(lowest) if remaining >= *lowest => false,
+        slot => {
+            *slot = Some(remaining);
+            true
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct FingerprintQuery {
     label: &'static str,
@@ -358,7 +472,7 @@ pub fn fingerprint_queries(request: &SchedulerSyncRequest) -> Vec<FingerprintQue
 }
 
 pub fn database_fingerprint(path: &Path, queries: &[FingerprintQuery]) -> Result<String> {
-    let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+    let connection = open_scheduler_connection_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| format!("opening {} for sync fingerprint", path.display()))?;
     connection_fingerprint(&connection, queries)
 }
@@ -688,6 +802,64 @@ mod tests {
             .query_row("SELECT value FROM sample", [], |row| row.get(0))
             .unwrap();
         assert_eq!(value, "previewed");
+    }
+
+    #[test]
+    fn source_snapshot_stops_waiting_for_a_persistent_lock() {
+        let directory = tempdir().unwrap();
+        let source_path = directory.path().join("source.sqlite");
+        let temporary = directory.path().join("snapshot.tmp");
+        let locker = Connection::open(&source_path).unwrap();
+        locker
+            .execute_batch("CREATE TABLE sample (value TEXT); BEGIN EXCLUSIVE;")
+            .unwrap();
+
+        let started = Instant::now();
+        let error = copy_source_snapshot(
+            &source_path,
+            &temporary,
+            Duration::from_millis(25),
+            Duration::from_secs(1),
+        )
+        .unwrap_err();
+
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(format!("{error:#}").contains("made no snapshot progress"));
+        locker.execute_batch("ROLLBACK").unwrap();
+    }
+
+    #[test]
+    fn source_snapshot_has_a_hard_overall_deadline() {
+        let directory = tempdir().unwrap();
+        let source_path = directory.path().join("source.sqlite");
+        let temporary = directory.path().join("snapshot.tmp");
+        let locker = Connection::open(&source_path).unwrap();
+        locker
+            .execute_batch("CREATE TABLE sample (value TEXT); BEGIN EXCLUSIVE;")
+            .unwrap();
+
+        let started = Instant::now();
+        let error = copy_source_snapshot(
+            &source_path,
+            &temporary,
+            Duration::from_secs(1),
+            Duration::from_millis(25),
+        )
+        .unwrap_err();
+
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(format!("{error:#}").contains("did not finish"));
+        locker.execute_batch("ROLLBACK").unwrap();
+    }
+
+    #[test]
+    fn backup_restarts_do_not_count_as_net_progress() {
+        let mut lowest_remaining = None;
+        assert!(record_snapshot_progress(&mut lowest_remaining, 744));
+        assert!(!record_snapshot_progress(&mut lowest_remaining, 1_000));
+        assert!(!record_snapshot_progress(&mut lowest_remaining, 744));
+        assert!(record_snapshot_progress(&mut lowest_remaining, 743));
+        assert_eq!(lowest_remaining, Some(743));
     }
 
     #[test]

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -367,6 +367,8 @@ export const apiClient = {
         token?: string;
         sync_enabled?: boolean;
         placement?: 'flat' | 'target_tree';
+        directory_template?: string;
+        rescan_directory_layout?: boolean;
       };
       /** New export directory; empty string clears it. */
       export_dir?: string;

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -153,6 +153,11 @@ const dbPath = (dbId: string, path: string) => `/db/${encodeURIComponent(dbId)}$
 
 const withServerUrl = (path: string): string => `${getCachedServerUrl()}${path}`;
 
+// Bump when response cache semantics change. Version 2 moves rendered images
+// from a 24-hour freshness lifetime to mandatory revalidation; changing the
+// URL prevents an older browser entry from hiding that new policy.
+const RENDERED_ARTIFACT_URL_VERSION = '2';
+
 const normalizeStretchPreview = (preview: StackStretchPreview): StackStretchPreview => ({
   ...preview,
   deconvolution_version: preview.deconvolution_version ?? null,
@@ -361,6 +366,7 @@ export const apiClient = {
         image_directory?: string;
         token?: string;
         sync_enabled?: boolean;
+        placement?: 'flat' | 'target_tree';
       };
       /** New export directory; empty string clears it. */
       export_dir?: string;
@@ -1308,6 +1314,7 @@ export const apiClient = {
   getPreviewUrl: (dbId: string, imageId: number, options?: PreviewOptions): string => {
     const serverUrl = getCachedServerUrl();
     const params = new URLSearchParams();
+    params.set('rv', RENDERED_ARTIFACT_URL_VERSION);
     if (options?.size) params.append('size', options.size);
     if (options?.stretch !== undefined) params.append('stretch', String(options.stretch));
     if (options?.midtone !== undefined) params.append('midtone', String(options.midtone));
@@ -1331,6 +1338,7 @@ export const apiClient = {
   ): string => {
     const serverUrl = getCachedServerUrl();
     const params = new URLSearchParams();
+    params.set('rv', RENDERED_ARTIFACT_URL_VERSION);
     params.append('size', size);
     if (maxStars !== undefined) {
       params.append('max_stars', String(maxStars));

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1288,12 +1288,21 @@ export interface RemoteClientSummary {
 }
 
 export type RemoteImageUploadPlacement = 'flat' | 'target_tree';
+export type RemoteImageUploadDirectoryTemplateSource = 'catalog' | 'preset';
 
 export interface RemoteImageUploadSummary {
   enabled: boolean;
   image_directory?: string;
   /** Server-owned layout below the configured receive directory. */
   placement?: RemoteImageUploadPlacement;
+  /** Persisted fallback used when no catalog layout can be detected. */
+  directory_template: string;
+  /** Catalog-derived layout currently taking precedence over the fallback. */
+  catalog_directory_template?: string;
+  /** Whether the effective layout came from existing catalog paths or configuration. */
+  directory_template_source: RemoteImageUploadDirectoryTemplateSource;
+  /** Number of catalog paths supporting a detected layout. */
+  directory_template_samples: number;
   token_configured: boolean;
   /** Remote scheduler sync is a separate grant from image upload. */
   sync_enabled: boolean;

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1287,9 +1287,13 @@ export interface RemoteClientSummary {
   paired_at: number;
 }
 
+export type RemoteImageUploadPlacement = 'flat' | 'target_tree';
+
 export interface RemoteImageUploadSummary {
   enabled: boolean;
   image_directory?: string;
+  /** Server-owned layout below the configured receive directory. */
+  placement?: RemoteImageUploadPlacement;
   token_configured: boolean;
   /** Remote scheduler sync is a separate grant from image upload. */
   sync_enabled: boolean;

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -36,6 +36,19 @@ import './TauriSettings.css';
  */
 type SettingsTab = 'databases' | 'catalogs' | 'sync' | 'setups' | 'review' | 'users';
 
+const DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE =
+  '%YEAR%/%TARGET%/%NIGHT%/%TYPE%';
+const REMOTE_UPLOAD_DIRECTORY_TEMPLATE_PRESETS = [
+  '%YEAR%/%TARGET%/%NIGHT%/%TYPE%',
+  '%TARGET%/%NIGHT%/%TYPE%',
+  '%TARGET%/%DATE%/%TYPE%',
+  '%TARGET%/%TYPE%/%FILTER%',
+  '%NIGHT%/%TARGET%/%TYPE%',
+] as const;
+
+const isRemoteUploadDirectoryTemplatePreset = (value: string) =>
+  REMOTE_UPLOAD_DIRECTORY_TEMPLATE_PRESETS.some((preset) => preset === value);
+
 interface TauriSettingsProps {
   isOpen: boolean;
   onClose: () => void;
@@ -95,6 +108,12 @@ export default function TauriSettings({
   const [formRemoteUploadDir, setFormRemoteUploadDir] = useState('');
   const [formRemoteUploadPlacement, setFormRemoteUploadPlacement] =
     useState<RemoteImageUploadPlacement>('flat');
+  const [formRemoteUploadDirectoryTemplate, setFormRemoteUploadDirectoryTemplate] =
+    useState(DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE);
+  const [formRemoteUploadCatalogMatch, setFormRemoteUploadCatalogMatch] =
+    useState<{ template: string; samples: number } | null>(null);
+  const [formRemoteUploadRescanRequested, setFormRemoteUploadRescanRequested] =
+    useState(false);
   const [formExportDir, setFormExportDir] = useState('');
   const [formRemoteUploadToken, setFormRemoteUploadToken] = useState('');
   const [formRemoteUploadTokenConfigured, setFormRemoteUploadTokenConfigured] =
@@ -153,6 +172,15 @@ export default function TauriSettings({
                   enabled: summary.remote_image_upload?.enabled ?? false,
                   image_dir: summary.remote_image_upload?.image_directory,
                   placement: summary.remote_image_upload?.placement ?? 'flat',
+                  directory_template:
+                    summary.remote_image_upload?.directory_template ??
+                    DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE,
+                  catalog_directory_template:
+                    summary.remote_image_upload?.catalog_directory_template,
+                  directory_template_source:
+                    summary.remote_image_upload?.directory_template_source ?? 'preset',
+                  directory_template_samples:
+                    summary.remote_image_upload?.directory_template_samples ?? 0,
                   token_configured:
                     summary.remote_image_upload?.token_configured ?? false,
                   sync_enabled:
@@ -177,6 +205,15 @@ export default function TauriSettings({
               enabled: s.remote_image_upload?.enabled ?? false,
               image_dir: s.remote_image_upload?.image_directory,
               placement: s.remote_image_upload?.placement ?? 'flat',
+              directory_template:
+                s.remote_image_upload?.directory_template ??
+                DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE,
+              catalog_directory_template:
+                s.remote_image_upload?.catalog_directory_template,
+              directory_template_source:
+                s.remote_image_upload?.directory_template_source ?? 'preset',
+              directory_template_samples:
+                s.remote_image_upload?.directory_template_samples ?? 0,
               token_configured: s.remote_image_upload?.token_configured ?? false,
               sync_enabled: s.remote_image_upload?.sync_enabled ?? false,
               clients: s.remote_image_upload?.clients ?? [],
@@ -234,6 +271,11 @@ export default function TauriSettings({
     setFormRemoteUploadEnabled(false);
     setFormRemoteUploadDir('');
     setFormRemoteUploadPlacement('flat');
+    setFormRemoteUploadDirectoryTemplate(
+      DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE
+    );
+    setFormRemoteUploadCatalogMatch(null);
+    setFormRemoteUploadRescanRequested(false);
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(false);
     setFormRemoteUploadTokenRevealed(false);
@@ -261,6 +303,21 @@ export default function TauriSettings({
     setFormRemoteUploadPlacement(
       entry.remote_image_upload?.placement ?? 'flat'
     );
+    const directoryTemplate =
+      entry.remote_image_upload?.directory_template ??
+      DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE;
+    setFormRemoteUploadDirectoryTemplate(directoryTemplate);
+    setFormRemoteUploadCatalogMatch(
+      entry.remote_image_upload?.directory_template_source === 'catalog'
+        ? {
+            template:
+              entry.remote_image_upload.catalog_directory_template ??
+              directoryTemplate,
+            samples: entry.remote_image_upload.directory_template_samples ?? 0,
+          }
+        : null
+    );
+    setFormRemoteUploadRescanRequested(false);
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(
       entry.remote_image_upload?.token_configured ??
@@ -280,6 +337,11 @@ export default function TauriSettings({
     setFormRemoteUploadEnabled(false);
     setFormRemoteUploadDir('');
     setFormRemoteUploadPlacement('flat');
+    setFormRemoteUploadDirectoryTemplate(
+      DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE
+    );
+    setFormRemoteUploadCatalogMatch(null);
+    setFormRemoteUploadRescanRequested(false);
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(false);
     setFormRemoteUploadTokenRevealed(false);
@@ -296,6 +358,11 @@ export default function TauriSettings({
     setFormRemoteUploadEnabled(false);
     setFormRemoteUploadDir('');
     setFormRemoteUploadPlacement('flat');
+    setFormRemoteUploadDirectoryTemplate(
+      DEFAULT_REMOTE_UPLOAD_DIRECTORY_TEMPLATE
+    );
+    setFormRemoteUploadCatalogMatch(null);
+    setFormRemoteUploadRescanRequested(false);
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(false);
     setFormRemoteUploadTokenRevealed(false);
@@ -495,6 +562,15 @@ export default function TauriSettings({
           return;
         }
         if (
+          formRemoteUploadEnabled &&
+          formRemoteUploadPlacement === 'target_tree' &&
+          !formRemoteUploadDirectoryTemplate.trim()
+        ) {
+          setStatusMessage('Enter a layout for new catalog images');
+          setIsApplying(false);
+          return;
+        }
+        if (
           formRemoteUploadToken.length > 0 &&
           formRemoteUploadToken.length < 24
         ) {
@@ -531,6 +607,17 @@ export default function TauriSettings({
             token: formRemoteUploadToken || undefined,
             sync_enabled: formRemoteSyncEnabled,
             placement: formRemoteUploadPlacement,
+            directory_template:
+              formRemoteUploadEnabled &&
+              formRemoteUploadPlacement === 'target_tree'
+                ? formRemoteUploadDirectoryTemplate.trim()
+                : undefined,
+            rescan_directory_layout:
+              formRemoteUploadEnabled &&
+              formRemoteUploadPlacement === 'target_tree' &&
+              formRemoteUploadRescanRequested
+                ? true
+                : undefined,
           },
         });
       } else {
@@ -1033,8 +1120,81 @@ export default function TauriSettings({
                   className="file-path-input"
                 >
                   <option value="flat">Receive directory</option>
-                  <option value="target_tree">Target and frame type</option>
+                  <option value="target_tree">Match catalog</option>
                 </select>
+                {formRemoteUploadPlacement === 'target_tree' && (
+                  <>
+                    {formRemoteUploadCatalogMatch && (
+                      <small className="remote-upload-token-notice" role="status">
+                        Detected from {formRemoteUploadCatalogMatch.samples}{' '}
+                        catalog {formRemoteUploadCatalogMatch.samples === 1
+                          ? 'image'
+                          : 'images'}:{' '}
+                        <code>{formRemoteUploadCatalogMatch.template}</code>
+                      </small>
+                    )}
+                    <label htmlFor="remote-upload-directory-template">
+                      New catalog layout:
+                    </label>
+                    <div className="file-input-group">
+                      <select
+                        id="remote-upload-directory-template"
+                        value={
+                          isRemoteUploadDirectoryTemplatePreset(
+                            formRemoteUploadDirectoryTemplate
+                          )
+                            ? formRemoteUploadDirectoryTemplate
+                            : 'custom'
+                        }
+                        onChange={(event) =>
+                          setFormRemoteUploadDirectoryTemplate(
+                            event.target.value === 'custom'
+                              ? ''
+                              : event.target.value
+                          )
+                        }
+                        className="file-path-input"
+                      >
+                        {REMOTE_UPLOAD_DIRECTORY_TEMPLATE_PRESETS.map((template) => (
+                          <option key={template} value={template}>
+                            {template}
+                          </option>
+                        ))}
+                        <option value="custom">Custom</option>
+                      </select>
+                      <button
+                        type="button"
+                        className="browse-button"
+                        aria-label="Rescan catalog layout"
+                        aria-pressed={formRemoteUploadRescanRequested}
+                        title={
+                          formRemoteUploadRescanRequested
+                            ? 'Catalog layout rescan queued for Save Changes'
+                            : 'Rescan catalog paths when changes are saved'
+                        }
+                        disabled={formRemoteUploadRescanRequested}
+                        onClick={() => setFormRemoteUploadRescanRequested(true)}
+                      >
+                        ↻ {formRemoteUploadRescanRequested ? 'Rescan queued' : 'Rescan'}
+                      </button>
+                    </div>
+                    {!isRemoteUploadDirectoryTemplatePreset(
+                      formRemoteUploadDirectoryTemplate
+                    ) && (
+                      <input
+                        type="text"
+                        aria-label="Custom catalog layout:"
+                        className="file-path-input"
+                        value={formRemoteUploadDirectoryTemplate}
+                        onChange={(event) =>
+                          setFormRemoteUploadDirectoryTemplate(event.target.value)
+                        }
+                        placeholder="%TARGET%/%NIGHT%/%TYPE%"
+                        maxLength={240}
+                      />
+                    )}
+                  </>
+                )}
               </>
             )}
             <label htmlFor="server-export-directory">
@@ -1231,7 +1391,10 @@ export default function TauriSettings({
                         <div className="path-info muted">
                           Remote receive: {entry.remote_image_upload.image_dir} (
                           {entry.remote_image_upload.placement === 'target_tree'
-                            ? 'target and frame type'
+                            ? entry.remote_image_upload.directory_template_source ===
+                              'catalog'
+                              ? `match catalog, ${entry.remote_image_upload.directory_template_samples ?? 0} ${entry.remote_image_upload.directory_template_samples === 1 ? 'sample' : 'samples'}`
+                              : 'match catalog'
                             : 'receive directory'}
                           )
                         </div>

--- a/static/src/components/TauriSettings.tsx
+++ b/static/src/components/TauriSettings.tsx
@@ -6,7 +6,11 @@ import {
 } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { isTauriApp, tauriConfig, tauriFileSystem } from '../utils/tauri';
-import type { ImportFolder, ImportScope } from '../api/types';
+import type {
+  ImportFolder,
+  ImportScope,
+  RemoteImageUploadPlacement,
+} from '../api/types';
 import type { DbEntry, DbRegistry } from '../utils/tauri';
 import { apiClient } from '../api/client';
 import { useAccess } from '../auth/access';
@@ -89,6 +93,8 @@ export default function TauriSettings({
   const [formRemoteUploadEnabled, setFormRemoteUploadEnabled] = useState(false);
   const [formRemoteSyncEnabled, setFormRemoteSyncEnabled] = useState(false);
   const [formRemoteUploadDir, setFormRemoteUploadDir] = useState('');
+  const [formRemoteUploadPlacement, setFormRemoteUploadPlacement] =
+    useState<RemoteImageUploadPlacement>('flat');
   const [formExportDir, setFormExportDir] = useState('');
   const [formRemoteUploadToken, setFormRemoteUploadToken] = useState('');
   const [formRemoteUploadTokenConfigured, setFormRemoteUploadTokenConfigured] =
@@ -146,6 +152,7 @@ export default function TauriSettings({
                 remote_image_upload: {
                   enabled: summary.remote_image_upload?.enabled ?? false,
                   image_dir: summary.remote_image_upload?.image_directory,
+                  placement: summary.remote_image_upload?.placement ?? 'flat',
                   token_configured:
                     summary.remote_image_upload?.token_configured ?? false,
                   sync_enabled:
@@ -169,6 +176,7 @@ export default function TauriSettings({
             remote_image_upload: {
               enabled: s.remote_image_upload?.enabled ?? false,
               image_dir: s.remote_image_upload?.image_directory,
+              placement: s.remote_image_upload?.placement ?? 'flat',
               token_configured: s.remote_image_upload?.token_configured ?? false,
               sync_enabled: s.remote_image_upload?.sync_enabled ?? false,
               clients: s.remote_image_upload?.clients ?? [],
@@ -225,6 +233,7 @@ export default function TauriSettings({
     setFormImageDirs([]);
     setFormRemoteUploadEnabled(false);
     setFormRemoteUploadDir('');
+    setFormRemoteUploadPlacement('flat');
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(false);
     setFormRemoteUploadTokenRevealed(false);
@@ -249,6 +258,9 @@ export default function TauriSettings({
     setFormRemoteUploadDir(
       entry.remote_image_upload?.image_dir ?? entry.image_dirs[0] ?? ''
     );
+    setFormRemoteUploadPlacement(
+      entry.remote_image_upload?.placement ?? 'flat'
+    );
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(
       entry.remote_image_upload?.token_configured ??
@@ -267,6 +279,7 @@ export default function TauriSettings({
     setFormImageDirs([]);
     setFormRemoteUploadEnabled(false);
     setFormRemoteUploadDir('');
+    setFormRemoteUploadPlacement('flat');
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(false);
     setFormRemoteUploadTokenRevealed(false);
@@ -282,6 +295,7 @@ export default function TauriSettings({
     setFormImageDirs([]);
     setFormRemoteUploadEnabled(false);
     setFormRemoteUploadDir('');
+    setFormRemoteUploadPlacement('flat');
     setFormRemoteUploadToken('');
     setFormRemoteUploadTokenConfigured(false);
     setFormRemoteUploadTokenRevealed(false);
@@ -516,6 +530,7 @@ export default function TauriSettings({
             image_directory: formRemoteUploadDir || undefined,
             token: formRemoteUploadToken || undefined,
             sync_enabled: formRemoteSyncEnabled,
+            placement: formRemoteUploadPlacement,
           },
         });
       } else {
@@ -990,18 +1005,6 @@ export default function TauriSettings({
                 <strong>Accept remote image uploads</strong>
               </span>
             </label>
-            <label htmlFor="server-export-directory">
-              Server export directory:
-            </label>
-            <input
-              id="server-export-directory"
-              type="text"
-              className="file-path-input"
-              placeholder="Absolute server path; empty disables server export"
-              title="Exports triggered from the Overview land here (reflinked where the filesystem supports it). Leave empty to offer the archive download instead."
-              value={formExportDir}
-              onChange={(event) => setFormExportDir(event.target.value)}
-            />
             {formRemoteUploadEnabled && (
               <>
                 <label htmlFor="remote-upload-directory">Receive directory:</label>
@@ -1018,8 +1021,34 @@ export default function TauriSettings({
                     </option>
                   ))}
                 </select>
+                <label htmlFor="remote-upload-placement">Folder layout:</label>
+                <select
+                  id="remote-upload-placement"
+                  value={formRemoteUploadPlacement}
+                  onChange={(event) =>
+                    setFormRemoteUploadPlacement(
+                      event.target.value as RemoteImageUploadPlacement
+                    )
+                  }
+                  className="file-path-input"
+                >
+                  <option value="flat">Receive directory</option>
+                  <option value="target_tree">Target and frame type</option>
+                </select>
               </>
             )}
+            <label htmlFor="server-export-directory">
+              Server export directory:
+            </label>
+            <input
+              id="server-export-directory"
+              type="text"
+              className="file-path-input"
+              placeholder="Absolute server path; empty disables server export"
+              title="Exports triggered from the Overview land here (reflinked where the filesystem supports it). Leave empty to offer the archive download instead."
+              value={formExportDir}
+              onChange={(event) => setFormExportDir(event.target.value)}
+            />
           </div>
         )}
 
@@ -1200,7 +1229,11 @@ export default function TauriSettings({
                       )}
                       {entry.remote_image_upload?.enabled && (
                         <div className="path-info muted">
-                          Remote receive: {entry.remote_image_upload.image_dir}
+                          Remote receive: {entry.remote_image_upload.image_dir} (
+                          {entry.remote_image_upload.placement === 'target_tree'
+                            ? 'target and frame type'
+                            : 'receive directory'}
+                          )
                         </div>
                       )}
                       <CalibrationLibrarySummary

--- a/static/src/components/__tests__/TauriSettings.test.tsx
+++ b/static/src/components/__tests__/TauriSettings.test.tsx
@@ -257,7 +257,11 @@ describe('TauriSettings import state', () => {
   });
 
   it('edits the per-database remote image receiver without exposing its token', async () => {
-    let savedPlacement: string | undefined;
+    const savedUpdates: Array<{
+      placement?: string;
+      directory_template?: string;
+      rescan_directory_layout?: boolean;
+    }> = [];
     server.use(
       http.get('/api/info', () =>
         HttpResponse.json({
@@ -286,6 +290,10 @@ describe('TauriSettings import state', () => {
                 token_configured: true,
                 sync_enabled: false,
                 placement: 'target_tree',
+                directory_template: '%TARGET%/%DATE%/%TYPE%',
+                catalog_directory_template: '2026/%TARGET%/%NIGHT%/%TYPE%',
+                directory_template_source: 'catalog',
+                directory_template_samples: 18,
               },
             },
           ],
@@ -316,9 +324,14 @@ describe('TauriSettings import state', () => {
       ),
       http.put('/api/databases/remote', async ({ request }) => {
         const body = await request.json() as {
-          remote_image_upload?: { placement?: string };
+          remote_image_upload?: {
+            placement?: string;
+            directory_template?: string;
+            rescan_directory_layout?: boolean;
+          };
         };
-        savedPlacement = body.remote_image_upload?.placement;
+        const update = body.remote_image_upload ?? {};
+        savedUpdates.push(update);
         return HttpResponse.json({
           success: true,
           data: {
@@ -331,7 +344,11 @@ describe('TauriSettings import state', () => {
               image_directory: '/images/remote',
               token_configured: true,
               sync_enabled: false,
-              placement: savedPlacement,
+              placement: update.placement,
+              directory_template:
+                update.directory_template ?? '%YEAR%/%TARGET%/%NIGHT%/%TYPE%',
+              directory_template_source: 'preset',
+              directory_template_samples: 0,
             },
           },
           error: null,
@@ -346,7 +363,7 @@ describe('TauriSettings import state', () => {
 
     expect(
       await screen.findByText(
-        'Remote receive: /images/remote (target and frame type)'
+        'Remote receive: /images/remote (match catalog, 18 samples)'
       )
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit Remote catalog' }));
@@ -355,6 +372,28 @@ describe('TauriSettings import state', () => {
     ).toBeChecked();
     expect(screen.getByLabelText('Receive directory:')).toHaveValue('/images/remote');
     expect(screen.getByLabelText('Folder layout:')).toHaveValue('target_tree');
+    const directoryTemplateSelect = screen.getByLabelText('New catalog layout:');
+    expect(directoryTemplateSelect).toHaveValue(
+      '%TARGET%/%DATE%/%TYPE%'
+    );
+    expect(
+      screen.getByText('Detected from 18 catalog images:')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('2026/%TARGET%/%NIGHT%/%TYPE%')
+    ).toBeInTheDocument();
+    expect(
+      within(directoryTemplateSelect)
+        .getAllByRole('option')
+        .map((option) => option.textContent)
+    ).toEqual([
+      '%YEAR%/%TARGET%/%NIGHT%/%TYPE%',
+      '%TARGET%/%NIGHT%/%TYPE%',
+      '%TARGET%/%DATE%/%TYPE%',
+      '%TARGET%/%TYPE%/%FILTER%',
+      '%NIGHT%/%TARGET%/%TYPE%',
+      'Custom',
+    ]);
     expect(screen.getByLabelText('Remote API key:')).toHaveAttribute(
       'placeholder',
       'Unchanged'
@@ -369,11 +408,41 @@ describe('TauriSettings import state', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Copy' })).toBeEnabled();
 
+    fireEvent.change(screen.getByLabelText('New catalog layout:'), {
+      target: { value: 'custom' },
+    });
+    fireEvent.change(screen.getByLabelText('Custom catalog layout:'), {
+      target: { value: '%TARGET%/%DATE%/%TYPE%/%FILTER%' },
+    });
+    const rescanButton = screen.getByRole('button', {
+      name: 'Rescan catalog layout',
+    });
+    fireEvent.click(rescanButton);
+    expect(rescanButton).toHaveAttribute('aria-pressed', 'true');
+    expect(rescanButton).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+    await waitFor(() => expect(savedUpdates).toHaveLength(1));
+    expect(savedUpdates[0]).toMatchObject({
+      placement: 'target_tree',
+      directory_template: '%TARGET%/%DATE%/%TYPE%/%FILTER%',
+      rescan_directory_layout: true,
+    });
+
+    await screen.findByText('Saved.');
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Remote catalog' }));
+    expect(
+      screen.getByRole('button', { name: 'Rescan catalog layout' })
+    ).toHaveAttribute('aria-pressed', 'false');
+
     fireEvent.change(screen.getByLabelText('Folder layout:'), {
       target: { value: 'flat' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
-    await waitFor(() => expect(savedPlacement).toBe('flat'));
+    await waitFor(() => expect(savedUpdates).toHaveLength(2));
+    expect(savedUpdates[1].placement).toBe('flat');
+    expect(savedUpdates[1].directory_template).toBeUndefined();
+    expect(savedUpdates[1].rescan_directory_layout).toBeUndefined();
   });
 
   it('keeps the editor with the selected database in a multi-database list', async () => {

--- a/static/src/components/__tests__/TauriSettings.test.tsx
+++ b/static/src/components/__tests__/TauriSettings.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
 import { describe, expect, it, vi } from 'vitest';
 import { server } from '../../test/msw-server';
@@ -257,6 +257,7 @@ describe('TauriSettings import state', () => {
   });
 
   it('edits the per-database remote image receiver without exposing its token', async () => {
+    let savedPlacement: string | undefined;
     server.use(
       http.get('/api/info', () =>
         HttpResponse.json({
@@ -283,6 +284,8 @@ describe('TauriSettings import state', () => {
                 enabled: true,
                 image_directory: '/images/remote',
                 token_configured: true,
+                sync_enabled: false,
+                placement: 'target_tree',
               },
             },
           ],
@@ -310,19 +313,48 @@ describe('TauriSettings import state', () => {
           error: null,
           status: 'ready',
         })
-      )
+      ),
+      http.put('/api/databases/remote', async ({ request }) => {
+        const body = await request.json() as {
+          remote_image_upload?: { placement?: string };
+        };
+        savedPlacement = body.remote_image_upload?.placement;
+        return HttpResponse.json({
+          success: true,
+          data: {
+            id: 'remote',
+            name: 'Remote catalog',
+            database_path: '/tmp/remote.sqlite',
+            image_directories: ['/images/remote'],
+            remote_image_upload: {
+              enabled: true,
+              image_directory: '/images/remote',
+              token_configured: true,
+              sync_enabled: false,
+              placement: savedPlacement,
+            },
+          },
+          error: null,
+          status: 'ready',
+        });
+      })
     );
 
     render(<TauriSettings isOpen onClose={() => undefined} />, {
       wrapper: createWrapper(),
     });
 
-    expect(await screen.findByText('Remote receive: /images/remote')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'Remote receive: /images/remote (target and frame type)'
+      )
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Edit Remote catalog' }));
     expect(
       screen.getByRole('checkbox', { name: 'Accept remote image uploads' })
     ).toBeChecked();
     expect(screen.getByLabelText('Receive directory:')).toHaveValue('/images/remote');
+    expect(screen.getByLabelText('Folder layout:')).toHaveValue('target_tree');
     expect(screen.getByLabelText('Remote API key:')).toHaveAttribute(
       'placeholder',
       'Unchanged'
@@ -336,6 +368,12 @@ describe('TauriSettings import state', () => {
       screen.getByText('Copy this key now. It will not be shown again after saving.')
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Copy' })).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText('Folder layout:'), {
+      target: { value: 'flat' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+    await waitFor(() => expect(savedPlacement).toBe('flat'));
   });
 
   it('keeps the editor with the selected database in a multi-database list', async () => {

--- a/static/src/hooks/__tests__/previewDescriptorAgreement.test.ts
+++ b/static/src/hooks/__tests__/previewDescriptorAgreement.test.ts
@@ -54,4 +54,12 @@ describe('preview URL and poll descriptor agreement', () => {
       apiClient.getPreviewUrl('db', 7, { size: 'large', color: false })
     );
   });
+
+  it('moves rendered images away from legacy long-lived browser cache entries', () => {
+    const preview = new URL(apiClient.getPreviewUrl('db', 7), 'http://localhost');
+    const annotated = new URL(apiClient.getAnnotatedUrl('db', 7), 'http://localhost');
+
+    expect(preview.searchParams.get('rv')).toBe('2');
+    expect(annotated.searchParams.get('rv')).toBe('2');
+  });
 });

--- a/static/src/utils/__tests__/projectTargetNavigation.test.ts
+++ b/static/src/utils/__tests__/projectTargetNavigation.test.ts
@@ -10,6 +10,9 @@ const database: DatabaseSummary = {
   image_directories: ['/tmp/images'],
   remote_image_upload: {
     enabled: false,
+    directory_template: '%YEAR%/%TARGET%/%NIGHT%/%TYPE%',
+    directory_template_source: 'preset',
+    directory_template_samples: 0,
     token_configured: false,
     sync_enabled: false,
   },

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -65,6 +65,7 @@ export interface DbEntry {
     token_sha256?: string;
     token_configured?: boolean;
     sync_enabled?: boolean;
+    placement?: 'flat' | 'target_tree';
     /** Paired clients; each holds its own revocable credential. */
     clients?: { client_uuid: string; name: string; paired_at: number }[];
   };

--- a/static/src/utils/tauri.ts
+++ b/static/src/utils/tauri.ts
@@ -66,6 +66,10 @@ export interface DbEntry {
     token_configured?: boolean;
     sync_enabled?: boolean;
     placement?: 'flat' | 'target_tree';
+    directory_template?: string;
+    catalog_directory_template?: string;
+    directory_template_source?: 'catalog' | 'preset';
+    directory_template_samples?: number;
     /** Paired clients; each holds its own revocable credential. */
     clients?: { client_uuid: string; name: string; paired_at: number }[];
   };

--- a/tests/integration_db_crud.rs
+++ b/tests/integration_db_crud.rs
@@ -163,6 +163,33 @@ async fn crud_lifecycle_adds_uses_and_removes_a_database() {
     assert_eq!(body["data"].as_array().unwrap().len(), 1);
     assert_eq!(body["data"][0]["id"], slug);
 
+    // A real catalog path teaches the receiver its existing tree while the
+    // operator's preset remains available for an empty/new catalog.
+    let known_directory = image_dir
+        .join("2026")
+        .join("M 31")
+        .join("2026-08-30")
+        .join("LIGHT");
+    std::fs::create_dir_all(&known_directory).unwrap();
+    std::fs::write(known_directory.join("known.fits"), b"fixture").unwrap();
+    let connection = rusqlite::Connection::open(&db_path).unwrap();
+    connection
+        .execute_batch(
+            "INSERT INTO project (Id, name, profileId) VALUES (1, 'Andromeda', 'profile');
+             INSERT INTO target (Id, name, projectId, active, ra, dec)
+                 VALUES (1, 'M 31', 1, 1, 10, 20);",
+        )
+        .unwrap();
+    connection
+        .execute(
+            "INSERT INTO acquiredimage
+                 (Id, projectId, targetId, gradingStatus, metadata, acquireddate, filtername)
+             VALUES (1, 1, 1, 0, ?1, 1788150600, 'Ha')",
+            [serde_json::json!({ "FileName": r"D:\remote\known.fits" }).to_string()],
+        )
+        .unwrap();
+    drop(connection);
+
     let upload_token = "test-remote-upload-token-123456";
     let (status, body) = json_request(
         build_app(state.clone()),
@@ -174,6 +201,7 @@ async fn crud_lifecycle_adds_uses_and_removes_a_database() {
                 "image_directory": image_dir.to_string_lossy(),
                 "token": upload_token,
                 "placement": "target_tree",
+                "directory_template": "%TARGET%/%DATE%/%TYPE%",
             }
         })),
     )
@@ -191,6 +219,22 @@ async fn crud_lifecycle_adds_uses_and_removes_a_database() {
     assert_eq!(
         body["data"]["remote_image_upload"]["placement"],
         "target_tree"
+    );
+    assert_eq!(
+        body["data"]["remote_image_upload"]["directory_template"],
+        "%TARGET%/%DATE%/%TYPE%"
+    );
+    assert_eq!(
+        body["data"]["remote_image_upload"]["catalog_directory_template"],
+        "%YEAR%/%TARGET%/%NIGHT%/%TYPE%"
+    );
+    assert_eq!(
+        body["data"]["remote_image_upload"]["directory_template_source"],
+        "catalog"
+    );
+    assert_eq!(
+        body["data"]["remote_image_upload"]["directory_template_samples"],
+        1
     );
     assert!(!body.to_string().contains(upload_token));
     assert!(!std::fs::read_to_string(&registry_path)

--- a/tests/integration_db_crud.rs
+++ b/tests/integration_db_crud.rs
@@ -173,6 +173,7 @@ async fn crud_lifecycle_adds_uses_and_removes_a_database() {
                 "enabled": true,
                 "image_directory": image_dir.to_string_lossy(),
                 "token": upload_token,
+                "placement": "target_tree",
             }
         })),
     )
@@ -186,6 +187,10 @@ async fn crud_lifecycle_adds_uses_and_removes_a_database() {
     assert_eq!(
         body["data"]["remote_image_upload"]["token_configured"],
         true
+    );
+    assert_eq!(
+        body["data"]["remote_image_upload"]["placement"],
+        "target_tree"
     );
     assert!(!body.to_string().contains(upload_token));
     assert!(!std::fs::read_to_string(&registry_path)
@@ -244,6 +249,7 @@ async fn crud_lifecycle_adds_uses_and_removes_a_database() {
     assert_eq!(dbs.len(), 1);
     assert_eq!(dbs[0]["id"], "renamed-rig");
     assert_eq!(dbs[0]["remote_image_upload"]["enabled"], true);
+    assert_eq!(dbs[0]["remote_image_upload"]["placement"], "target_tree");
 
     // 8) Remove it.
     let (status, body) = json_request(

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -8,7 +8,7 @@ use axum::routing::post;
 use axum::Router;
 use http_body_util::BodyExt;
 use psf_guard::cli::PregenerationConfig;
-use psf_guard::db_registry::{DbEntry, RemoteImageUploadConfig};
+use psf_guard::db_registry::{DbEntry, RemoteImageUploadConfig, RemoteImageUploadPlacement};
 use psf_guard::server::{remote_upload, state::AppState};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -29,6 +29,10 @@ struct Fixture {
 
 impl Fixture {
     fn new() -> Self {
+        Self::with_placement(RemoteImageUploadPlacement::Flat)
+    }
+
+    fn with_placement(placement: RemoteImageUploadPlacement) -> Self {
         let directory = tempdir().unwrap();
         let database_a = directory.path().join("a.sqlite");
         let database_b = directory.path().join("b.sqlite");
@@ -42,6 +46,7 @@ impl Fixture {
         let mut config_a = RemoteImageUploadConfig {
             enabled: true,
             image_dir: images_a.to_string_lossy().into_owned(),
+            placement,
             ..Default::default()
         };
         config_a.set_token(TOKEN_A).unwrap();
@@ -94,6 +99,44 @@ impl Fixture {
             images_b,
         }
     }
+
+    fn reconfigured_state(
+        &self,
+        placement: RemoteImageUploadPlacement,
+        receive_dir: &std::path::Path,
+        image_dirs: &[&std::path::Path],
+    ) -> Arc<AppState> {
+        let mut config = RemoteImageUploadConfig {
+            enabled: true,
+            image_dir: receive_dir.to_string_lossy().into_owned(),
+            placement,
+            ..Default::default()
+        };
+        config.set_token(TOKEN_A).unwrap();
+        Arc::new(
+            AppState::from_databases(
+                vec![DbEntry {
+                    id: "catalog-a".into(),
+                    name: "Catalog A".into(),
+                    db_path: self.database_a.to_string_lossy().into_owned(),
+                    image_dirs: image_dirs
+                        .iter()
+                        .map(|path| path.to_string_lossy().into_owned())
+                        .collect(),
+                    reject_archive: None,
+                    remote_image_upload: Some(config),
+                    export_dir: None,
+                }],
+                self._directory
+                    .path()
+                    .join("cache-reconfigured")
+                    .to_string_lossy()
+                    .into_owned(),
+                PregenerationConfig::default(),
+            )
+            .unwrap(),
+        )
+    }
 }
 
 fn build_app(state: Arc<AppState>) -> Router {
@@ -111,6 +154,15 @@ fn fits_bytes(object: &str, date_obs: &str) -> Vec<u8> {
 }
 
 fn fits_bytes_with_type(image_type: &str, object: &str, date_obs: &str) -> Vec<u8> {
+    fits_bytes_with_identity(image_type, object, Some("Ha"), Some(date_obs))
+}
+
+fn fits_bytes_with_identity(
+    image_type: &str,
+    object: &str,
+    filter: Option<&str>,
+    date_obs: Option<&str>,
+) -> Vec<u8> {
     fn card(output: &mut Vec<u8>, text: &str) {
         let mut bytes = text.as_bytes().to_vec();
         assert!(bytes.len() <= 80);
@@ -126,8 +178,12 @@ fn fits_bytes_with_type(image_type: &str, object: &str, date_obs: &str) -> Vec<u
     card(&mut bytes, "NAXIS2  =                   10");
     card(&mut bytes, &format!("IMAGETYP= '{image_type}'"));
     card(&mut bytes, &format!("OBJECT  = '{object}'"));
-    card(&mut bytes, "FILTER  = 'Ha      '");
-    card(&mut bytes, &format!("DATE-OBS= '{date_obs}'"));
+    if let Some(filter) = filter {
+        card(&mut bytes, &format!("FILTER  = '{filter}'"));
+    }
+    if let Some(date_obs) = date_obs {
+        card(&mut bytes, &format!("DATE-OBS= '{date_obs}'"));
+    }
     card(&mut bytes, "EXPTIME =                300.0");
     card(&mut bytes, "GAIN    =                  100");
     card(&mut bytes, "OFFSET  =                   30");
@@ -315,12 +371,210 @@ async fn upload_is_scoped_to_the_selected_database_and_attaches_followup_frames(
 }
 
 #[tokio::test]
+async fn target_tree_uploads_use_only_sanitized_header_and_catalog_segments() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let image = fits_bytes("../M 31/Panel:West", "2026-07-24T05:00:00");
+    let filename = "m31-panel-001.fits";
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(fixture
+        .images_a
+        .join("_M 31_Panel_West")
+        .join("LIGHT")
+        .join("Ha")
+        .join(filename)
+        .is_file());
+    assert!(!fixture.images_a.join(filename).exists());
+    assert!(!fixture._directory.path().join("M 31").exists());
+}
+
+#[tokio::test]
+async fn target_tree_new_capture_does_not_reuse_an_unregistered_flat_basename() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let filename = "capture.fits";
+    let old_flat = fits_bytes("Old Target", "2026-07-24T04:00:00");
+    std::fs::write(fixture.images_a.join(filename), &old_flat).unwrap();
+    let image = fits_bytes("M 42", "2026-07-24T05:00:00");
+
+    let (status, body) = upload(
+        fixture.state,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(
+        std::fs::read(fixture.images_a.join(filename)).unwrap(),
+        old_flat
+    );
+    assert!(fixture
+        .images_a
+        .join("M 42")
+        .join("LIGHT")
+        .join("Ha")
+        .join(filename)
+        .is_file());
+}
+
+#[tokio::test]
+async fn target_tree_sync_first_capture_ignores_an_unrelated_legacy_flat_basename() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let filename = "synced-capture.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    let old_flat = fits_bytes("Old Target", "2026-07-24T04:00:00");
+    std::fs::write(fixture.images_a.join(filename), &old_flat).unwrap();
+    let image = fits_bytes("M 31", "2026-07-24T05:00:00");
+
+    let (status, body) = upload(
+        fixture.state,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["resolution"]["image_id"], 1);
+    assert_eq!(
+        std::fs::read(fixture.images_a.join(filename)).unwrap(),
+        old_flat
+    );
+    assert!(fixture
+        .images_a
+        .join("M 31")
+        .join("LIGHT")
+        .join("Ha")
+        .join(filename)
+        .is_file());
+}
+
+#[tokio::test]
+async fn target_tree_matches_the_imported_name_for_a_light_without_an_object() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let image = fits_bytes("", "2026-07-24T05:00:00");
+    let filename = "unknown-001.fits";
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(fixture
+        .images_a
+        .join("Unknown Target")
+        .join("LIGHT")
+        .join("Ha")
+        .join(filename)
+        .is_file());
+}
+
+#[tokio::test]
+async fn mapped_light_retry_restores_a_missing_file_without_capture_identity_headers() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let image = fits_bytes_with_identity("LIGHT", "M 31", None, None);
+    let filename = "m31-no-identity.fits";
+    let checksum = sha256(&image);
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let destination = fixture
+        .images_a
+        .join("M 31")
+        .join("LIGHT")
+        .join("NONE")
+        .join(filename);
+    assert!(destination.is_file());
+    std::fs::remove_file(&destination).unwrap();
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["already_present"], false);
+    assert!(destination.is_file());
+    assert_eq!(image_count(&fixture.database_a), 1);
+}
+
+#[tokio::test]
 async fn upload_attaches_bytes_to_a_light_created_by_scheduler_sync() {
     let fixture = Fixture::new();
     let filename = "m31-synced.fits";
     insert_synced_light(&fixture.database_a, filename);
+    let connection = rusqlite::Connection::open(&fixture.database_a).unwrap();
+    let metadata: String = connection
+        .query_row(
+            "SELECT metadata FROM acquiredimage WHERE Id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut metadata: serde_json::Value = serde_json::from_str(&metadata).unwrap();
+    metadata["DetectedStars"] = 99.into();
+    metadata["HFR"] = 9.9.into();
+    metadata["PsfGuardQualitySource"] = "file:old-source".into();
+    metadata["PsfGuardQualityFields"] = serde_json::json!(["HFR"]);
+    connection
+        .execute(
+            "UPDATE acquiredimage SET metadata = ?1 WHERE Id = 1",
+            [metadata.to_string()],
+        )
+        .unwrap();
+    drop(connection);
     let image = fits_bytes("M 31", "2026-07-24T05:00:00");
     let checksum = sha256(&image);
+    let context = fixture.state.get_database("catalog-a").unwrap();
+    let previews = context.cache_dir_path.join("previews");
+    let annotated = context.cache_dir_path.join("annotated");
+    std::fs::create_dir_all(&previews).unwrap();
+    std::fs::create_dir_all(&annotated).unwrap();
+    let stale_preview = previews.join("1_old-source.png");
+    let stale_annotated = annotated.join("annotated_v4_1_old-source.png");
+    let unrelated_preview = previews.join("2_other-image.png");
+    std::fs::write(&stale_preview, b"stale").unwrap();
+    std::fs::write(&stale_annotated, b"stale").unwrap();
+    std::fs::write(&unrelated_preview, b"keep").unwrap();
 
     let (status, body) = upload(
         fixture.state.clone(),
@@ -340,10 +594,33 @@ async fn upload_attaches_bytes_to_a_light_created_by_scheduler_sync() {
     assert_eq!(body["data"]["import"]["imported"], 0);
     assert_eq!(body["data"]["import"]["skipped_existing"], 1);
     assert_eq!(image_count(&fixture.database_a), 1);
+    let metadata: String = rusqlite::Connection::open(&fixture.database_a)
+        .unwrap()
+        .query_row(
+            "SELECT metadata FROM acquiredimage WHERE Id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let metadata: serde_json::Value = serde_json::from_str(&metadata).unwrap();
+    assert_eq!(metadata["DetectedStars"], 99);
+    assert!(metadata.get("HFR").is_none());
+    assert!(metadata.get("PsfGuardQualitySource").is_none());
+    assert!(metadata.get("PsfGuardQualityFields").is_none());
+    // Mapping-aware artifact keys make these unreachable without scanning
+    // whole cache directories on every upload.
+    assert!(stale_preview.exists());
+    assert!(stale_annotated.exists());
+    assert!(unrelated_preview.exists());
     assert_eq!(
         sha256(&std::fs::read(fixture.images_a.join(filename)).unwrap()),
         checksum
     );
+
+    let current_preview = previews.join("1_current-source.png");
+    let current_annotated = annotated.join("annotated_v4_1_current-source.png");
+    std::fs::write(&current_preview, b"current").unwrap();
+    std::fs::write(&current_annotated, b"current").unwrap();
 
     let (status, body) = upload(
         fixture.state,
@@ -357,6 +634,398 @@ async fn upload_attaches_bytes_to_a_light_created_by_scheduler_sync() {
     .await;
     assert_eq!(status, StatusCode::OK, "{body}");
     assert_eq!(body["data"]["already_present"], true);
+    assert_eq!(image_count(&fixture.database_a), 1);
+    assert!(current_preview.exists());
+    assert!(current_annotated.exists());
+}
+
+#[tokio::test]
+async fn synced_light_retry_keeps_its_registered_file_after_target_and_root_changes() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let filename = "m31-synced-retry.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    let image = fits_bytes("M 31", "2026-07-24T05:00:00");
+    let checksum = sha256(&image);
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let original = fixture
+        .images_a
+        .join("M 31")
+        .join("LIGHT")
+        .join("Ha")
+        .join(filename);
+    assert!(original.is_file());
+
+    let connection = rusqlite::Connection::open(&fixture.database_a).unwrap();
+    connection
+        .execute("UPDATE target SET name = 'Renamed target' WHERE Id = 1", [])
+        .unwrap();
+    connection
+        .execute(
+            "UPDATE acquiredimage
+             SET metadata = '{\"FileName\":\"C:\\\\changed\\\\renamed-by-scheduler.fits\"}'
+             WHERE Id = 1",
+            [],
+        )
+        .unwrap();
+    drop(connection);
+    std::fs::remove_dir_all(fixture.images_a.join("M 31")).unwrap();
+    let second_root = fixture._directory.path().join("images-c");
+    std::fs::create_dir_all(&second_root).unwrap();
+    let reconfigured = fixture.reconfigured_state(
+        RemoteImageUploadPlacement::Flat,
+        &second_root,
+        &[&fixture.images_a, &second_root],
+    );
+
+    let (status, body) = upload(
+        reconfigured,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["already_present"], false);
+    assert!(original.is_file());
+    assert!(!second_root.join(filename).exists());
+}
+
+#[tokio::test]
+async fn synced_light_rejects_a_same_named_frame_with_different_capture_headers() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let filename = "m31-synced-mismatch.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    let different_capture = fits_bytes("M 31", "2026-07-24T05:10:00");
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &different_capture,
+        &sha256(&different_capture),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert!(body.to_string().contains("capture time or filter"));
+    assert!(!fixture
+        .images_a
+        .join("M 31")
+        .join("LIGHT")
+        .join("Ha")
+        .join(filename)
+        .exists());
+    assert_eq!(image_count(&fixture.database_a), 1);
+}
+
+#[tokio::test]
+async fn sync_first_light_without_capture_headers_requires_the_resolved_target() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let filename = "m31-synced-target-only.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    let image = fits_bytes_with_identity("LIGHT", "M 31", None, None);
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["resolution"]["image_id"], 1);
+
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let filename = "m31-synced-explicit-filter-mismatch.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    let wrong_filter = fits_bytes_with_identity("LIGHT", "M 31", Some("OIII"), None);
+    let (status, body) = upload(
+        fixture.state,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &wrong_filter,
+        &sha256(&wrong_filter),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert!(body.to_string().contains("capture time or filter"));
+}
+
+#[tokio::test]
+async fn sync_first_light_rejects_conflicting_object_even_when_time_and_filter_match() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let filename = "mismatched-target.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    rusqlite::Connection::open(&fixture.database_a)
+        .unwrap()
+        .execute(
+            "INSERT INTO target (Id, name, active, ra, dec, epochcode, projectId, guid)
+             VALUES (2, 'M 42', 1, 5.59, -5.45, 0, 1, 'm42-target-guid')",
+            [],
+        )
+        .unwrap();
+    let wrong_target = fits_bytes("M 42", "2026-07-24T05:00:00");
+
+    let (status, body) = upload(
+        fixture.state,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &wrong_target,
+        &sha256(&wrong_target),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert!(body.to_string().contains("resolved target"));
+    assert_eq!(image_count(&fixture.database_a), 1);
+    assert!(!fixture.images_a.join("M 31").exists());
+    assert!(!fixture.images_a.join("M 42").exists());
+}
+
+#[tokio::test]
+async fn synced_light_upload_supports_a_legacy_schema_without_image_guids() {
+    let fixture = Fixture::new();
+    let filename = "legacy-synced.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    rusqlite::Connection::open(&fixture.database_a)
+        .unwrap()
+        .execute("ALTER TABLE acquiredimage DROP COLUMN guid", [])
+        .unwrap();
+    let image = fits_bytes("M 31", "2026-07-24T05:00:00");
+    let checksum = sha256(&image);
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let connection = rusqlite::Connection::open(&fixture.database_a).unwrap();
+    let metadata: String = connection
+        .query_row(
+            "SELECT metadata FROM acquiredimage WHERE Id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let mut metadata: serde_json::Value = serde_json::from_str(&metadata).unwrap();
+    metadata["DetectedStars"] = 321.into();
+    metadata["HFR"] = 2.4.into();
+    connection
+        .execute(
+            "UPDATE acquiredimage SET metadata = ?1 WHERE Id = 1",
+            [metadata.to_string()],
+        )
+        .unwrap();
+    drop(connection);
+    let context = fixture.state.get_database("catalog-a").unwrap();
+    let preview = context.cache_dir_path.join("previews/1_legacy-quality.png");
+    let annotated = context
+        .cache_dir_path
+        .join("annotated/annotated_v4_1_legacy-quality.png");
+    std::fs::create_dir_all(preview.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(annotated.parent().unwrap()).unwrap();
+    std::fs::write(&preview, b"current").unwrap();
+    std::fs::write(&annotated, b"current").unwrap();
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["already_present"], true);
+    assert!(preview.exists());
+    assert!(annotated.exists());
+    let mapping_count: i64 = rusqlite::Connection::open(&fixture.database_a)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM psf_guard_remote_image_file",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(mapping_count, 1);
+    let metadata: String = rusqlite::Connection::open(&fixture.database_a)
+        .unwrap()
+        .query_row(
+            "SELECT metadata FROM acquiredimage WHERE Id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let metadata: serde_json::Value = serde_json::from_str(&metadata).unwrap();
+    assert_eq!(metadata["DetectedStars"], 321);
+    assert_eq!(metadata["HFR"], 2.4);
+}
+
+#[tokio::test]
+async fn null_guid_mapping_is_removed_when_a_legacy_image_id_is_reused() {
+    let fixture = Fixture::new();
+    let filename = "legacy-reused-id.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    let connection = rusqlite::Connection::open(&fixture.database_a).unwrap();
+    connection
+        .execute("ALTER TABLE acquiredimage DROP COLUMN guid", [])
+        .unwrap();
+    drop(connection);
+    let image = fits_bytes("M 31", "2026-07-24T05:00:00");
+    let checksum = sha256(&image);
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+
+    let connection = rusqlite::Connection::open(&fixture.database_a).unwrap();
+    connection
+        .execute("DELETE FROM acquiredimage WHERE Id = 1", [])
+        .unwrap();
+    let metadata = serde_json::json!({
+        "FileName": format!(r"C:\new-capture\{filename}"),
+    })
+    .to_string();
+    connection
+        .execute(
+            "INSERT INTO acquiredimage
+                (Id, projectId, targetId, acquireddate, filtername, gradingStatus,
+                 metadata, profileId)
+             VALUES (1, 1, 1, 1784872800, 'OIII', 1, ?1, 'profile')",
+            [&metadata],
+        )
+        .unwrap();
+    drop(connection);
+
+    let (status, body) = upload(
+        fixture.state,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    let mapping_count: i64 = rusqlite::Connection::open(&fixture.database_a)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM psf_guard_remote_image_file",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(mapping_count, 0);
+}
+
+#[tokio::test]
+async fn pre_mapping_flat_upload_is_found_after_the_receive_root_changes() {
+    let fixture = Fixture::new();
+    let filename = "pre-mapping-flat.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    let image = fits_bytes("M 31", "2026-07-24T05:00:00");
+    let checksum = sha256(&image);
+    std::fs::write(fixture.images_a.join(filename), &image).unwrap();
+
+    let second_root = fixture._directory.path().join("images-c");
+    std::fs::create_dir_all(&second_root).unwrap();
+    let reconfigured = fixture.reconfigured_state(
+        RemoteImageUploadPlacement::Flat,
+        &second_root,
+        &[&fixture.images_a, &second_root],
+    );
+    let (status, body) = upload(
+        reconfigured,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["already_present"], true);
+    assert!(fixture.images_a.join(filename).is_file());
+    assert!(!second_root.join(filename).exists());
+}
+
+#[tokio::test]
+async fn pre_mapping_flat_upload_rejects_any_differing_registered_sibling() {
+    let fixture = Fixture::new();
+    let filename = "pre-mapping-conflict.fits";
+    insert_synced_light(&fixture.database_a, filename);
+    let image = fits_bytes("M 31", "2026-07-24T05:00:00");
+    let different = fits_bytes("M 31", "2026-07-24T05:10:00");
+    std::fs::write(fixture.images_a.join(filename), &image).unwrap();
+
+    let second_root = fixture._directory.path().join("images-c");
+    std::fs::create_dir_all(&second_root).unwrap();
+    std::fs::write(second_root.join(filename), different).unwrap();
+    let reconfigured = fixture.reconfigured_state(
+        RemoteImageUploadPlacement::Flat,
+        &second_root,
+        &[&fixture.images_a, &second_root],
+    );
+
+    let (status, body) = upload(
+        reconfigured,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert!(body.to_string().contains("different content"));
     assert_eq!(image_count(&fixture.database_a), 1);
 }
 
@@ -422,6 +1091,200 @@ async fn calibration_uploads_are_cataloged_without_scheduler_images() {
 }
 
 #[tokio::test]
+async fn target_tree_places_calibration_frames_in_predictable_type_folders() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let cases = [
+        ("BIAS", "bias-placed.fits", "BIAS/bias-placed.fits"),
+        ("DARK", "dark-placed.fits", "DARK/dark-placed.fits"),
+        (
+            "DARK FLAT",
+            "dark-flat-placed.fits",
+            "DARKFLAT/dark-flat-placed.fits",
+        ),
+        (
+            "FLAT",
+            "flat-placed.fits",
+            "Calibration/FLAT/Ha/flat-placed.fits",
+        ),
+    ];
+
+    for (index, (image_type, filename, relative)) in cases.iter().enumerate() {
+        let image = fits_bytes_with_type(
+            image_type,
+            "Calibration",
+            &format!("2026-07-24T09:{index:02}:00"),
+        );
+        let (status, body) = upload(
+            fixture.state.clone(),
+            "catalog-a",
+            "catalog-a",
+            TOKEN_A,
+            filename,
+            &image,
+            &sha256(&image),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert!(
+            fixture.images_a.join(relative).is_file(),
+            "missing {relative}"
+        );
+        assert!(!fixture.images_a.join(filename).exists());
+    }
+    assert_eq!(image_count(&fixture.database_a), 0);
+    assert_eq!(calibration_count(&fixture.database_a), 4);
+}
+
+#[tokio::test]
+async fn target_tree_flats_can_reuse_a_basename_across_targets_and_filters() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let filename = "flat-001.fits";
+    let first =
+        fits_bytes_with_identity("FLAT", "Panel A", Some("Ha"), Some("2026-07-24T09:00:00"));
+    let second =
+        fits_bytes_with_identity("FLAT", "Panel B", Some("OIII"), Some("2026-07-24T09:01:00"));
+
+    for image in [&first, &second, &first, &second] {
+        let (status, body) = upload(
+            fixture.state.clone(),
+            "catalog-a",
+            "catalog-a",
+            TOKEN_A,
+            filename,
+            image,
+            &sha256(image),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+    }
+
+    assert!(fixture
+        .images_a
+        .join("Panel A/FLAT/Ha")
+        .join(filename)
+        .is_file());
+    assert!(fixture
+        .images_a
+        .join("Panel B/FLAT/OIII")
+        .join(filename)
+        .is_file());
+    assert_eq!(calibration_count(&fixture.database_a), 2);
+}
+
+#[tokio::test]
+async fn calibration_retry_restores_its_missing_file_after_layout_and_root_changes() {
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let filename = "flat-layout-retry.fits";
+    let image = fits_bytes_with_type("FLAT", "Calibration", "2026-07-24T09:30:00");
+    let checksum = sha256(&image);
+    let target_path = fixture
+        .images_a
+        .join("Calibration")
+        .join("FLAT")
+        .join("Ha")
+        .join(filename);
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert!(target_path.is_file());
+    let original_uuid: String = rusqlite::Connection::open(&fixture.database_a)
+        .unwrap()
+        .query_row(
+            "SELECT frame_uuid FROM psf_guard_calibration_frame",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let (mapped_uuid, mapped_path, mapped_sha256): (String, String, String) =
+        rusqlite::Connection::open(&fixture.database_a)
+            .unwrap()
+            .query_row(
+                "SELECT frame_uuid, source_path, source_sha256
+                 FROM psf_guard_remote_calibration_file",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+    assert_eq!(mapped_uuid, original_uuid);
+    assert_eq!(std::path::Path::new(&mapped_path), target_path);
+    assert_eq!(mapped_sha256, checksum);
+    std::fs::remove_file(&target_path).unwrap();
+
+    let second_root = fixture._directory.path().join("images-c");
+    std::fs::create_dir_all(&second_root).unwrap();
+    let flat_state = fixture.reconfigured_state(
+        RemoteImageUploadPlacement::Flat,
+        &second_root,
+        &[&fixture.images_a, &second_root],
+    );
+    let (status, body) = upload(
+        flat_state,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &image,
+        &checksum,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["data"]["already_present"], false);
+    assert!(target_path.is_file());
+    assert!(!second_root.join(filename).exists());
+    assert_eq!(calibration_count(&fixture.database_a), 1);
+    let restored_uuid: String = rusqlite::Connection::open(&fixture.database_a)
+        .unwrap()
+        .query_row(
+            "SELECT frame_uuid FROM psf_guard_calibration_frame",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(restored_uuid, original_uuid);
+
+    std::fs::remove_dir_all(fixture.images_a.join("Calibration")).unwrap();
+    let changed = fits_bytes_with_type("FLAT", "Calibration", "2026-07-24T09:31:00");
+    let (status, body) = upload(
+        fixture.reconfigured_state(
+            RemoteImageUploadPlacement::Flat,
+            &second_root,
+            &[&fixture.images_a, &second_root],
+        ),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        filename,
+        &changed,
+        &sha256(&changed),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert!(!target_path.exists());
+    assert!(!second_root.join(filename).exists());
+    assert_eq!(calibration_count(&fixture.database_a), 1);
+    let retained_uuid: String = rusqlite::Connection::open(&fixture.database_a)
+        .unwrap()
+        .query_row(
+            "SELECT frame_uuid FROM psf_guard_calibration_frame",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(retained_uuid, original_uuid);
+}
+
+#[tokio::test]
 async fn unsupported_non_light_frame_is_rejected_without_publishing() {
     let fixture = Fixture::new();
     let image = fits_bytes_with_type("SNAPSHOT", "Preview", "2026-07-24T09:00:00");
@@ -440,6 +1303,58 @@ async fn unsupported_non_light_frame_is_rejected_without_publishing() {
     assert!(!fixture.images_a.join("snapshot-001.fits").exists());
     assert_eq!(image_count(&fixture.database_a), 0);
     assert_eq!(calibration_count(&fixture.database_a), 0);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn final_filename_symlink_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = Fixture::new();
+    let image = fits_bytes("M 42", "2026-07-24T06:00:00");
+    let outside = fixture._directory.path().join("outside.fits");
+    std::fs::write(&outside, &image).unwrap();
+    symlink(&outside, fixture.images_a.join("linked.fits")).unwrap();
+
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "linked.fits",
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(image_count(&fixture.database_a), 0);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn target_tree_parent_symlink_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = Fixture::with_placement(RemoteImageUploadPlacement::TargetTree);
+    let outside = fixture._directory.path().join("outside-target");
+    std::fs::create_dir_all(&outside).unwrap();
+    symlink(&outside, fixture.images_a.join("M 31")).unwrap();
+    let image = fits_bytes("M 31", "2026-07-24T06:00:00");
+
+    let (status, body) = upload(
+        fixture.state,
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "linked-parent.fits",
+        &image,
+        &sha256(&image),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert!(!outside.join("LIGHT").exists());
 }
 
 #[tokio::test]
@@ -609,5 +1524,17 @@ async fn upload_still_rejects_a_non_image_extension() {
         body.to_string().contains(".xisf"),
         "the error should list what is accepted: {body}"
     );
+
+    let (status, _) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "CON.fits",
+        &image,
+        &sha256(&image),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(image_count(&fixture.database_a), 0);
 }

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -1216,7 +1216,10 @@ async fn calibration_retry_restores_its_missing_file_after_layout_and_root_chang
             )
             .unwrap();
     assert_eq!(mapped_uuid, original_uuid);
-    assert_eq!(std::path::Path::new(&mapped_path), target_path);
+    assert_eq!(
+        dunce::canonicalize(&mapped_path).unwrap(),
+        dunce::canonicalize(&target_path).unwrap()
+    );
     assert_eq!(mapped_sha256, checksum);
     std::fs::remove_file(&target_path).unwrap();
 

--- a/tests/integration_spatial_scan.rs
+++ b/tests/integration_spatial_scan.rs
@@ -144,6 +144,7 @@ fn stored_entry(image_id: i32, filename: &str, dead: f64, bg_spread: f64) -> Sto
     StoredSpatialMetrics {
         image_id,
         filename: filename.to_string(),
+        source_revision: None,
         detector: psf_guard::server::spatial_scan::QUALITY_DETECTOR.to_string(),
         detector_version: psf_guard::server::spatial_scan::QUALITY_DETECTOR_VERSION,
         star_count: 4000,


### PR DESCRIPTION
## Summary
- apply a shared SQLite busy timeout and bounded snapshot retries to remote scheduler sync/export paths, with lock-specific errors instead of opaque failures
- persist durable upload provenance, restore missing files idempotently, and prevent same-named frames from attaching to the wrong scheduler target
- add opt-in `target_tree` image intake that scans catalog-linked files during Settings save or an explicit rescan, persists only an unambiguous directory pattern, and never walks the tree during upload
- provide preset and custom layouts using `%PROJECT%`, `%TARGET%`, `%DATE%`, `%NIGHT%`, `%YEAR%`, `%TYPE%`, `%FILTER%`, `%TELESCOPE%`, `%CAMERA%`, `%EXPOSURE%`, and `%GAIN%`
- treat components matching identical project and target names as ambiguous so detection cannot invent `%TARGET%/%TARGET%`
- follow N.I.N.A.'s observing-night convention (`DATE-LOC` minus 12 hours), preserve manually named season directories, and use the same Windows-safe component normalization for detection and upload
- keep the operator-selected preset as a fallback for empty, mixed, unavailable, ambiguous, or newly created catalogs; headless configuration remains explicit and backward compatible
- organize lights and calibration frames without letting clients choose paths, while preserving the existing flat and legacy target-tree layouts for older configuration
- strengthen upload verification on Windows with NTFS change time and bound both in-memory verification caches
- release the catalog lock before artifact search resolves mapped source files, with a regression test for the former self-deadlock
- keep Fedora RPM linking within runner memory by disabling unused DWARF, building only the shipped binary, and using one Cargo job

Companion client-side lock retry work: theatrus/psf-guard-nina-plugin#18.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `CARGO_BUILD_JOBS=1 cargo test` (760 passed, 5 ignored; every integration and doc-test target passed before the final focused review fixes)
- `cargo test --lib server::remote_upload_layout::tests -j 1` (9 passed)
- `cargo test --lib remote_file_identity_changes -j 1` (2 passed on Windows)
- `cargo test --lib remote_image_verifications_are_bounded -j 1` (1 passed)
- `cargo test --test integration_remote_upload` (24 passed)
- `cargo test --test integration_db_crud` (6 passed)
- `npm run lint`
- `npx vitest run` (73 files, 333 tests passed)
- `npm run build`
- `cargo test --lib server::stack_preview::artifact::tests::artifact_preparation_releases_the_database_lock_before_resolving_sources -- --exact --nocapture`
- focused Playwright stack-preview scenario (1 passed, including artifact search)
- `git diff --check`

## Compatibility
Image intake still defaults to `flat` when placement is omitted. Existing `target_tree` registry entries without a directory template keep the original target/type/filter behavior. Empty or ambiguous catalogs use the selected preset. Headless `[[remote_upload]]` blocks may set `directory_template`; omitting it selects the legacy target/type/filter layout.

![PSF Guard target placement settings with catalog-detected folder layout](https://github.com/user-attachments/assets/54a9834c-9f60-4823-b605-88415fb280ca)