### PR TITLE
Release 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,40 +6,6 @@
 
 ## Added
 
-- Remote image receivers can match an existing catalog folder tree or use a
-  preset/custom target, date, frame type, filter, camera, and exposure layout,
-  while keeping the existing flat layout as the default.
-- Reject limits like N.I.N.A. subframe selection: set Max HFR and Min stars
-  in the Sequence view's Scoring control (or `screen-fits --max-hfr` /
-  `--min-stars`) and any frame over the HFR limit or under the star limit
-  is recommended for rejection, whatever the rest of the sequence looks
-  like.
-- Satellite-trail checking can be turned off: set the satellite penalty to
-  0% (or pass `screen-fits --ignore-satellites`) and trails no longer lower
-  scores or drive reject recommendations, while still showing as warnings.
-
 ## Changed
 
 ## Fixed
-
-- Calibration matching now tells readout modes apart on cameras whose
-  driver names the mode (N.I.N.A. writes `READOUTM = 'High Gain Mode'` rather
-  than a number). Before, every frame from such a rig recorded no readout
-  mode and a High Gain dark could serve an Extend Fullwell light. The name is
-  kept on import, shown in the calibration library, and read off existing
-  frames' headers the first time an older library is opened. Frames that
-  never named a mode keep matching as before, so mixed libraries lose
-  nothing.
-- Stack previews now remember the scoring settings used to admit their frames.
-  Changing a penalty or absolute reject limit marks the preview out of date,
-  gives the rebuild its own cache identity, and prevents it from resuming a
-  checkpoint whose frame decisions came from the old settings.
-- Remote scheduler sync and export now wait for transient SQLite locks instead
-  of failing immediately while N.I.N.A. or another server task is using the
-  catalog.
-- Remote uploads now retain a durable path and content identity, restore
-  missing files on an identical retry, and avoid attaching same-named frames
-  to the wrong scheduler target.
-- Replacing an uploaded image now invalidates its rendered, quality,
-  astrometry, and satellite evidence, including star and HFR values PSF Guard
-  previously wrote back, without scanning the full cache tree.

--- a/docs/releases/v0.9.2.md
+++ b/docs/releases/v0.9.2.md
@@ -1,0 +1,43 @@
+# v0.9.2
+
+PSF Guard 0.9.2 adds Max HFR and Min stars reject limits, a switch to turn
+satellite-trail checking off, and fixes to remote image intake, stack
+preview caching, and calibration matching.
+
+## Added
+
+- Remote image receivers can match an existing catalog folder tree or use a
+  preset/custom target, date, frame type, filter, camera, and exposure layout,
+  while keeping the existing flat layout as the default.
+- Reject limits like N.I.N.A. subframe selection: set Max HFR and Min stars
+  in the Sequence view's Scoring control (or `screen-fits --max-hfr` /
+  `--min-stars`) and any frame over the HFR limit or under the star limit
+  is recommended for rejection, whatever the rest of the sequence looks
+  like.
+- Satellite-trail checking can be turned off: set the satellite penalty to
+  0% (or pass `screen-fits --ignore-satellites`) and trails no longer lower
+  scores or drive reject recommendations, while still showing as warnings.
+
+## Fixed
+
+- Calibration matching now tells readout modes apart on cameras whose
+  driver names the mode (N.I.N.A. writes `READOUTM = 'High Gain Mode'` rather
+  than a number). Before, every frame from such a rig recorded no readout
+  mode and a High Gain dark could serve an Extend Fullwell light. The name is
+  kept on import, shown in the calibration library, and read off existing
+  frames' headers the first time an older library is opened. Frames that
+  never named a mode keep matching as before, so mixed libraries lose
+  nothing.
+- Stack previews now remember the scoring settings used to admit their frames.
+  Changing a penalty or absolute reject limit marks the preview out of date,
+  gives the rebuild its own cache identity, and prevents it from resuming a
+  checkpoint whose frame decisions came from the old settings.
+- Remote scheduler sync and export now wait for transient SQLite locks instead
+  of failing immediately while N.I.N.A. or another server task is using the
+  catalog.
+- Remote uploads now retain a durable path and content identity, restore
+  missing files on an identical retry, and avoid attaching same-named frames
+  to the wrong scheduler target.
+- Replacing an uploaded image now invalidates its rendered, quality,
+  astrometry, and satellite evidence, including star and HFR values PSF Guard
+  previously wrote back, without scanning the full cache tree.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -8,7 +8,7 @@
 %global rustflags_debuginfo 0
 
 Name:           psf-guard
-Version:        0.9.1
+Version:        0.9.2
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -93,6 +93,14 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Tue Sep 01 2026 Yann Ramin <github@theatr.us> - 0.9.2-1
+- Max HFR and Min stars reject limits, like N.I.N.A. subframe selection
+- Satellite-trail checking can be turned off for grading
+- Calibration matching tells named readout modes apart
+- Stack previews remember the scoring settings that admitted their frames
+- Remote image intake keeps a durable identity and can match a catalog folder tree
+- Remote sync waits out transient SQLite locks
+
 * Fri Aug 29 2026 Yann Ramin <github@theatr.us> - 0.9.1-1
 - Every view lays out for phone screens
 - RC-Astro steps cache one by one, so changing a later step reuses earlier work

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
Point release: Max HFR and Min stars reject limits, a satellite-check off switch, and fixes to remote image intake, stack preview caching, and calibration matching (#391, #392).

Bumps `Cargo.toml`, `Cargo.lock`, `tauri.conf.json`, and the RPM spec to 0.9.2; adds `docs/releases/v0.9.2.md` and restarts `unreleased.md`.

Local checks (release worktree off `16dad82`):

- `cargo fmt --all -- --check`: clean
- `cargo clippy --locked --all-targets --all-features -- -D warnings`: clean
- `cargo test --locked`: 910 passed
- `cargo build --release --locked --bin psf-guard-cli`: built
- `node scripts/check-release-version.mjs v0.9.2`: 0.9.2
- `npm ci`, `npm run lint`, `npx vitest run` (337 passed), `npm run build`, `npm run test:release` (14 passed)
- `git diff --check`: clean
- `cargo tauri build`: compiled and bundled the .deb and .rpm at 0.9.2; the AppImage step failed locally on `linuxdeploy` (a host tooling step, see comment below); CI's Ubuntu Tauri job on main@16dad82 built the AppImage

Local Node was 22; CI runs the frontend on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv