### PR TITLE
Make the Images tab Status filter match again

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,3 +9,7 @@
 ## Changed
 
 ## Fixed
+
+- The Images tab's Status filter works again: choosing Accepted, Rejected, or
+  Pending shows those images instead of an empty grid, the summary line names
+  the choice, and links saved with the old numeric value keep filtering.

--- a/static/e2e/image-grid.spec.ts
+++ b/static/e2e/image-grid.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+import { registerFixtureDb, resetDatabases, waitForCacheReady } from './helpers';
+
+// The Images tab's Status filter against the real server. Project Alpha's
+// three frames are graded Pending, Accepted, Pending, so each choice has a
+// known answer.
+
+let dbId: string;
+
+test.beforeEach(async ({ request }) => {
+  await resetDatabases(request);
+  const entry = await registerFixtureDb(request, {
+    name: 'Imaging Rig e2e',
+    slug: 'imaging-rig-e2e',
+  });
+  dbId = entry.id;
+  await waitForCacheReady(request, dbId);
+});
+
+test('the Status filter narrows the grid and says so in the summary', async ({ page }) => {
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1`);
+  const cards = page.locator('.image-card');
+  await expect(cards).toHaveCount(3, { timeout: 15_000 });
+  const status = page.getByLabel('Status:');
+  const stats = page.locator('.grid-stats');
+
+  await status.selectOption('accepted');
+  await expect(cards).toHaveCount(1);
+  await expect(stats).toContainText('1 of 3 images');
+  await expect(stats).toContainText('Accepted');
+  await expect(page).toHaveURL(/status=accepted/);
+
+  await status.selectOption('pending');
+  await expect(cards).toHaveCount(2);
+  await expect(stats).toContainText('2 of 3 images');
+
+  await status.selectOption('rejected');
+  await expect(cards).toHaveCount(0);
+  await expect(page.getByText('No images found')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Reset' }).click();
+  await expect(cards).toHaveCount(3);
+  await expect(status).toHaveValue('all');
+});
+
+test('a link saved with the old numeric status still filters', async ({ page }) => {
+  // Before the fix the select emitted the grade number, so shared links
+  // carry ?status=1. They must keep meaning Accepted.
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=1&status=1`);
+  await expect(page.locator('.image-card')).toHaveCount(1, { timeout: 15_000 });
+  await expect(page.getByLabel('Status:')).toHaveValue('accepted');
+});

--- a/static/src/components/FilterControls.tsx
+++ b/static/src/components/FilterControls.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import { GradingStatus } from '../api/types';
+import {
+  parseStatusFilter,
+  STATUS_FILTER_OPTIONS,
+  type StatusFilter,
+} from '../utils/statusFilter';
 
 export interface FilterOptions {
-  status: GradingStatus | 'all';
+  status: StatusFilter;
   filterName: string | 'all';
   dateRange: {
     start: Date | null;
@@ -37,7 +41,7 @@ export default function FilterControls({ onFilterChange, availableFilters, curre
 
   // Convert URL state (strings) to component state (Date objects)
   const filters = useMemo(() => ({
-    status: currentFilters.status as GradingStatus | 'all',
+    status: parseStatusFilter(currentFilters.status),
     filterName: currentFilters.filterName,
     dateRange: {
       start: currentFilters.dateRange.start ? new Date(currentFilters.dateRange.start) : null,
@@ -46,7 +50,7 @@ export default function FilterControls({ onFilterChange, availableFilters, curre
     searchTerm: currentFilters.searchTerm,
   }), [currentFilters]);
 
-  const handleStatusChange = (status: GradingStatus | 'all') => {
+  const handleStatusChange = (status: StatusFilter) => {
     const newFilters = { ...filters, status };
     onFilterChange(newFilters);
   };
@@ -102,12 +106,13 @@ export default function FilterControls({ onFilterChange, availableFilters, curre
           <select
             id="image-status-filter"
             value={filters.status} 
-            onChange={(e) => handleStatusChange(e.target.value as GradingStatus | 'all')}
+            onChange={(e) => handleStatusChange(parseStatusFilter(e.target.value))}
           >
-            <option value="all">All</option>
-            <option value={GradingStatus.Accepted}>Accepted</option>
-            <option value={GradingStatus.Rejected}>Rejected</option>
-            <option value={GradingStatus.Pending}>Pending</option>
+            {STATUS_FILTER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
           </select>
         </div>
 

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -42,6 +42,7 @@ import { thumbnailGridColumns } from '../utils/thumbnailSizing';
 import { useScopedQuality } from '../hooks/useSequenceAnalysis';
 import { useDisplayPreferences } from '../hooks/useDisplayPreferences';
 import SecondaryScoreToggle from './SecondaryScoreToggle';
+import { matchesStatusFilter, statusFilterLabel } from '../utils/statusFilter';
 
 interface GroupedImageGridProps {
   useLazyImages?: boolean;
@@ -118,11 +119,8 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
   const filteredImages = useMemo(() => {
     return allImages.filter(image => {
       // Status filter
-      if (filters.status !== 'all') {
-        const statusMap: { [key: string]: number } = { 'pending': 0, 'accepted': 1, 'rejected': 2 };
-        if (statusMap[filters.status] !== image.grading_status) {
-          return false;
-        }
+      if (!matchesStatusFilter(filters.status, image.grading_status)) {
+        return false;
       }
       
       // Filter name filter
@@ -901,7 +899,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
             <div className="stats-section">
               <div className="grid-stats">
                 {filteredImages.length} of {allImages.length} images • {imageGroups.length} groups
-                {filters.status !== 'all' && ` • ${filters.status}`}
+                {filters.status !== 'all' && ` • ${statusFilterLabel(filters.status)}`}
                 {filters.filterName !== 'all' && ` • ${filters.filterName}`}
                 {filters.searchTerm && ` • "${filters.searchTerm}"`}
                 {' • '}

--- a/static/src/hooks/useImageNavigation.ts
+++ b/static/src/hooks/useImageNavigation.ts
@@ -14,6 +14,7 @@ import {
   imageDetailPath,
   imageDetailReturnView,
 } from '../utils/imageDetailRoutes';
+import { matchesStatusFilter } from '../utils/statusFilter';
 
 /**
  * Hook for navigating between images in the current context
@@ -42,11 +43,8 @@ export function useImageNavigation(currentImageId?: number) {
   const filteredImages = useMemo(() => {
     return allImages.filter(image => {
       // Status filter
-      if (filters.status !== 'all') {
-        const statusMap: { [key: string]: number } = { 'pending': 0, 'accepted': 1, 'rejected': 2 };
-        if (statusMap[filters.status] !== image.grading_status) {
-          return false;
-        }
+      if (!matchesStatusFilter(filters.status, image.grading_status)) {
+        return false;
       }
       
       // Filter name filter

--- a/static/src/hooks/useUrlState.ts
+++ b/static/src/hooks/useUrlState.ts
@@ -1,6 +1,7 @@
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { useCallback, useMemo, useRef } from 'react';
 import { type GroupingMode, DEFAULT_SINGLE_PROJECT_MODE } from '../types/grouping';
+import { parseStatusFilter } from '../utils/statusFilter';
 
 /**
  * Hook for managing URL search parameters as state
@@ -153,7 +154,7 @@ export function useFilters() {
   const { getParam, updateParams } = useUrlParams();
   
   const filters = useMemo(() => ({
-    status: getParam('status') || 'all',
+    status: parseStatusFilter(getParam('status')),
     filterName: getParam('filter') || 'all', 
     dateRange: {
       start: getParam('dateStart') || null,

--- a/static/src/utils/__tests__/statusFilter.test.ts
+++ b/static/src/utils/__tests__/statusFilter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { GradingStatus } from '../../api/types';
+import {
+  matchesStatusFilter,
+  parseStatusFilter,
+  STATUS_FILTER_OPTIONS,
+  statusFilterLabel,
+} from '../statusFilter';
+
+describe('status filter', () => {
+  it('matches each word against its grade and nothing else', () => {
+    expect(matchesStatusFilter('accepted', GradingStatus.Accepted)).toBe(true);
+    expect(matchesStatusFilter('accepted', GradingStatus.Pending)).toBe(false);
+    expect(matchesStatusFilter('rejected', GradingStatus.Rejected)).toBe(true);
+    expect(matchesStatusFilter('pending', GradingStatus.Pending)).toBe(true);
+    expect(matchesStatusFilter('pending', GradingStatus.Rejected)).toBe(false);
+  });
+
+  it('lets everything through for All and for anything it cannot read', () => {
+    for (const grade of [GradingStatus.Pending, GradingStatus.Accepted, GradingStatus.Rejected]) {
+      expect(matchesStatusFilter('all', grade)).toBe(true);
+      expect(matchesStatusFilter('', grade)).toBe(true);
+      expect(matchesStatusFilter('bogus', grade)).toBe(true);
+    }
+  });
+
+  it('still reads the grade numbers older links carried', () => {
+    // The select used to emit "1" for Accepted; a bookmark with ?status=1
+    // must keep meaning Accepted rather than silently turning into All.
+    expect(parseStatusFilter('1')).toBe('accepted');
+    expect(parseStatusFilter('2')).toBe('rejected');
+    expect(parseStatusFilter('0')).toBe('pending');
+    expect(matchesStatusFilter('1', GradingStatus.Accepted)).toBe(true);
+    expect(matchesStatusFilter('1', GradingStatus.Pending)).toBe(false);
+  });
+
+  it('is case- and whitespace-tolerant and labels every option', () => {
+    expect(parseStatusFilter(' Accepted ')).toBe('accepted');
+    expect(statusFilterLabel('accepted')).toBe('Accepted');
+    expect(statusFilterLabel('1')).toBe('Accepted');
+    expect(statusFilterLabel(null as unknown as string)).toBe('All');
+    expect(STATUS_FILTER_OPTIONS.map((option) => option.value)).toEqual([
+      'all',
+      'accepted',
+      'rejected',
+      'pending',
+    ]);
+  });
+});

--- a/static/src/utils/statusFilter.ts
+++ b/static/src/utils/statusFilter.ts
@@ -1,0 +1,50 @@
+import { GradingStatus } from '../api/types';
+
+/**
+ * The Images tab's Status filter, as one word: what the select emits, what
+ * the URL carries, and what the grid and keyboard navigation test against.
+ *
+ * There used to be two vocabularies — the select emitted the grade number
+ * ("1") while the filter looked the value up by word ("accepted") — so any
+ * choice but All matched nothing. Everything now goes through here.
+ */
+export type StatusFilter = 'all' | 'pending' | 'accepted' | 'rejected';
+
+export const STATUS_FILTER_OPTIONS: ReadonlyArray<{ value: StatusFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'accepted', label: 'Accepted' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'pending', label: 'Pending' },
+];
+
+const GRADE_OF: Record<Exclude<StatusFilter, 'all'>, GradingStatus> = {
+  pending: GradingStatus.Pending,
+  accepted: GradingStatus.Accepted,
+  rejected: GradingStatus.Rejected,
+};
+
+const WORD_OF_GRADE: Record<string, StatusFilter> = {
+  [String(GradingStatus.Pending)]: 'pending',
+  [String(GradingStatus.Accepted)]: 'accepted',
+  [String(GradingStatus.Rejected)]: 'rejected',
+};
+
+/** Read a filter value from a select or the URL. The words are canonical;
+ * the grade numbers are still accepted so links saved while the select
+ * emitted them keep working. Anything else means no filter. */
+export function parseStatusFilter(raw: string | null | undefined): StatusFilter {
+  if (!raw) return 'all';
+  const value = raw.trim().toLowerCase();
+  if (value === 'all' || value in GRADE_OF) return value as StatusFilter;
+  return WORD_OF_GRADE[value] ?? 'all';
+}
+
+export function matchesStatusFilter(filter: string, gradingStatus: number): boolean {
+  const parsed = parseStatusFilter(filter);
+  return parsed === 'all' || GRADE_OF[parsed] === gradingStatus;
+}
+
+export function statusFilterLabel(filter: string): string {
+  const parsed = parseStatusFilter(filter);
+  return STATUS_FILTER_OPTIONS.find((option) => option.value === parsed)?.label ?? 'All';
+}


### PR DESCRIPTION
Fixes #378.

The Status select on the Images tab emitted the grade number (`value={GradingStatus.Accepted}` renders as `"1"`), while both places that apply the filter (`GroupedImageGrid` and `useImageNavigation`) looked the value up in a word-keyed map, so any choice but All matched nothing. The reporter's screenshot shows the leak: `0 of 948 images • 0 groups • 1 • Green`.

- New `utils/statusFilter.ts` owns the vocabulary: `parseStatusFilter`, `matchesStatusFilter`, `statusFilterLabel`, and the option list.
- The select and the URL carry the words; `useFilters` normalizes on the way in, so `?status=1` from a saved link still means Accepted.
- Both filter sites call the one matcher; the summary prints the label.

Checks run locally: tsc, eslint, vitest (341 passed, 4 new), production build, and the full Playwright suite against a rebuilt release binary — 108 passed, including the two new `image-grid.spec.ts` cases (filter narrows and reports; legacy numeric link still filters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv