### PR TITLE
ci: allow the macOS signing path to be dispatched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  # The macOS signing steps below are skipped for pull_request, so a PR cannot
+  # exercise them and the only other trigger is a push to main. That makes a
+  # release the first place a bad signing certificate shows up. A dispatch
+  # reaches them without publishing anything.
+  workflow_dispatch:
 
 # Supersede a PR's earlier run when it is pushed again. Pushes to main keep
 # running to completion — each one is a distinct commit whose result we want,


### PR DESCRIPTION
The macOS signing steps in `test-tauri` are guarded by `github.event_name != 'pull_request'`, and the only other trigger on this workflow is a push to `main`. So the signing path cannot be exercised deliberately — a release is the first thing that tries it.

That came up while rotating the Developer ID certificate. The old one is on Apple's previous sub-CA, which expires 2027-02-01 regardless of issue date; the replacement is issued under the G2 sub-CA and runs to 2031-09-03. toposaic could be proved before trusting it, and that mattered — the first attempt failed at `security import`, and the error blamed the password when the real cause was the PKCS#12 MAC algorithm. psf-guard had no equivalent way to check.

`workflow_dispatch` reaches the signing steps and publishes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LM1PboB918MBcutoqdrVa