### PR TITLE
Release 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,33 +6,6 @@
 
 ## Added
 
-- Before upgrading its tables in a scheduler catalog, PSF Guard now copies the
-  catalog beside itself (`…psf-guard-backup-v<schema>-<time>.sqlite`), keeps
-  the three newest copies, and refuses to upgrade if the copy cannot be
-  written.
-
 ## Changed
 
 ## Fixed
-
-- Choosing a preset or custom folder layout for remote uploads now replaces
-  the layout detected from the catalog instead of being filed as its
-  fallback. Detection reads a date inside a folder name (`NIGHT_2025-12-14`)
-  as `%NIGHT%` instead of a fixed day, and a layout saved by 0.9.2 with such
-  a fixed day is retired in favour of its fallback the next time the server
-  starts; rescan the catalog to detect it afresh.
-
-- Starting 0.9.2 on a large calibration library could take minutes with
-  nothing logged: the schema upgrade read every calibration frame's header
-  before the server was up. Upgrades no longer read frame files; readout-mode
-  names are recorded after startup, in the background, with progress in the
-  log.
-
-- The Images tab's Status filter works again: choosing Accepted, Rejected, or
-  Pending shows those images instead of an empty grid, the summary line names
-  the choice, and links saved with the old numeric value keep filtering.
-- Master darks, biases, and flats built by PixInsight or Siril now match and
-  calibrate stacks. Their headers drop gain, offset, and temperature, so they
-  were refused; they are now matched on what they do record, placed on the
-  right scale, and used as-is. A new Calibration matching setting chooses
-  whether such a master is preferred, a fallback, or ignored.

--- a/docs/releases/v0.9.3.md
+++ b/docs/releases/v0.9.3.md
@@ -1,0 +1,36 @@
+# v0.9.3
+
+PSF Guard 0.9.3 makes the Images tab's Status filter work again, uses master
+darks, biases, and flats built by PixInsight or Siril, lets a chosen remote
+upload folder layout override the detected one, backs the catalog up before
+each schema upgrade, and no longer stalls startup on a large calibration
+library.
+
+## Added
+
+- Before upgrading its tables in a scheduler catalog, PSF Guard now copies the
+  catalog beside itself (`…psf-guard-backup-v<schema>-<time>.sqlite`), keeps
+  the three newest copies, and refuses to upgrade if the copy cannot be
+  written.
+
+## Fixed
+
+- Starting 0.9.2 on a large calibration library could take minutes with
+  nothing logged: the schema upgrade read every calibration frame's header
+  before the server was up. Upgrades no longer read frame files; readout-mode
+  names are recorded after startup, in the background, with progress in the
+  log.
+- The Images tab's Status filter works again: choosing Accepted, Rejected, or
+  Pending shows those images instead of an empty grid, the summary line names
+  the choice, and links saved with the old numeric value keep filtering.
+- Master darks, biases, and flats built by PixInsight or Siril now match and
+  calibrate stacks. Their headers drop gain, offset, and temperature, so they
+  were refused; they are now matched on what they do record, placed on the
+  right scale, and used as-is. A new Calibration matching setting chooses
+  whether such a master is preferred, a fallback, or ignored.
+- Choosing a preset or custom folder layout for remote uploads now replaces
+  the layout detected from the catalog instead of being filed as its
+  fallback. Detection reads a date inside a folder name (`NIGHT_2025-12-14`)
+  as `%NIGHT%` instead of a fixed day, and a layout saved by 0.9.2 with such
+  a fixed day is retired in favour of its fallback the next time the server
+  starts; rescan the catalog to detect it afresh.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -8,7 +8,7 @@
 %global rustflags_debuginfo 0
 
 Name:           psf-guard
-Version:        0.9.2
+Version:        0.9.3
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -93,6 +93,13 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Tue Sep 01 2026 Yann Ramin <github@theatr.us> - 0.9.3-1
+- Images tab Status filter works again
+- Master darks, biases, and flats from PixInsight or Siril match and calibrate stacks
+- The catalog is backed up beside itself before each schema upgrade
+- Startup no longer reads every calibration frame's header; readout names fill in afterwards
+- A chosen remote upload folder layout replaces the detected one; dates inside folder names become tokens
+
 * Tue Sep 01 2026 Yann Ramin <github@theatr.us> - 0.9.2-1
 - Max HFR and Min stars reject limits, like N.I.N.A. subframe selection
 - Satellite-trail checking can be turned off for grading

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
Point release: the Images tab Status filter fix (#395), masters built by PixInsight or Siril (#396), catalog backups before schema upgrades and no more startup stall on large calibration libraries (#397).

Bumps `Cargo.toml`, `Cargo.lock`, `tauri.conf.json`, and the RPM spec to 0.9.3; adds `docs/releases/v0.9.3.md` and restarts `unreleased.md`. Rebased onto #398 so the release builds from the same tree that proved the rotated macOS certificate.

Local checks (release worktree):

- `cargo fmt --all -- --check`: clean
- `cargo clippy --locked --all-targets --all-features -- -D warnings`: clean
- `cargo test --locked`: 916 passed
- `cargo build --release --locked --bin psf-guard-cli`: built
- `node scripts/check-release-version.mjs v0.9.3`: 0.9.3
- `npm ci`, `npm run lint`, `npx vitest run` (342 passed), `npm run build`, `npm run test:release` (14 passed)
- `git diff --check`: clean
- `NO_STRIP=true cargo tauri build`: .deb, .rpm (`psf-guard 0.9.3-1`), and .AppImage bundled at 0.9.3

Local Node was 22; CI runs the frontend on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv