### PR TITLE
fix(macos): name the signing identity instead of pinning its thumbprint

### DIFF
--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -41,7 +41,7 @@
       "minimumSystemVersion": "10.13",
       "hardenedRuntime": true,
       "entitlements": "./Entitlements.plist",
-      "signingIdentity": "441406E5BD6181EAB2253AACAF9A591AA7D11D9C"
+      "signingIdentity": "Developer ID Application: StackFoundry LLC (HSRHLHH333)"
     },
     "resources": [],
     "shortDescription": "Astronomical image analysis tool",


### PR DESCRIPTION
## What broke

Rotating the Developer ID certificate broke the macOS build, on `main`, in a way a release would have hit too:

```
Signing with identity "441406E5BD6181EAB2253AACAF9A591AA7D11D9C"
441406E5BD6181EAB2253AACAF9A591AA7D11D9C: no identity found
Error failed to bundle project: failed codesign application: failed to sign app
```

`tauri.conf.json` pinned `signingIdentity` to the old certificate's SHA-1 thumbprint. The certificate imported fine and `find-identity` reported it — `1 valid identities found`, `Developer ID Application: StackFoundry LLC (HSRHLHH333)` — and the workflow duly exported `CERT_ID`. The pin in the config then overrode all of that.

Both `ci.yml` and `release.yml` bundle through this config, so this was not CI-only.

## The change

Use the identity **name**, which does not change when a certificate is renewed.

The tradeoff is honest: pinning a thumbprint means only one exact certificate can sign, and this gives that up. Against it — the keychain is created from our own secret inside the job and deleted afterwards, and a pin that silently invalidates itself on renewal fails at the worst possible moment. `toposaic` already resolves the identity by name and asserts the expected string.

## Why now

The old certificate came from Apple's previous Developer ID sub-CA, which expires **2027-02-01** no matter when a certificate is issued from it. The replacement is issued under the **G2** sub-CA and runs to 2031-09-03. This was found by exercising the new certificate via `workflow_dispatch` (#398) rather than discovering it during a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LM1PboB918MBcutoqdrVa