### PR TITLE
Loosen file permissions on remote image uploads

### DIFF
--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -82,7 +82,27 @@ pub async fn upload_image(
         // so it must not carry a frame extension: a folder scan running
         // alongside the upload would pick up the half-written file as a
         // frame. The header read below is told the declared name instead.
-        let temporary = tempfile::NamedTempFile::new_in(&upload_dir).map_err(|error| {
+        let temporary = {
+            let upload_dir: &PathBuf = &upload_dir;
+            #[cfg(unix)]
+            {
+                // Default permissions on temp files on Linux and Unix are created
+                // 0600, accessible only for the user creating the file. By setting
+                // a permission to 0666 here, it allows the user's umask or the
+                // destination directory's default ACL to determine the
+                // permissions.
+                use std::os::unix::fs::PermissionsExt;
+                tempfile::Builder::new()
+                    .disable_cleanup(true)
+                    .permissions(std::fs::Permissions::from_mode(0o666))
+                    .tempfile_in(upload_dir)
+            }
+            #[cfg(windows)]
+            {
+                tempfile::NamedTempFile::new_in(&upload_dir)
+            }
+        }
+        .map_err(|error| {
             AppError::InternalError(format!(
                 "creating upload temporary file in {}: {error}",
                 upload_dir.display()

--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -99,7 +99,7 @@ pub async fn upload_image(
             }
             #[cfg(windows)]
             {
-                tempfile::NamedTempFile::new_in(&upload_dir)
+                tempfile::NamedTempFile::new_in(upload_dir)
             }
         }
         .map_err(|error| {


### PR DESCRIPTION
When an image is transferred via the remote upload functionality, the image is staged without a file extension to prevent it from being prematurely included in some other processing that could be going on. It is created using the standard temporary file functionality of the OS where the service is running.

On Linux and Unix systems, the default permissions created on temporary files is restricted to being read/write only for the owner of the file. When you're dealing with temporary files getting written to a shared path, such as `/tmp`, that's a safe default. However, that's not necessarily the desired behavior for images being uploaded to a server.

By setting the default permissions to `0600`, permissions that would normally be set via `umask` or default ACL at the directory as ignored. In order to allow those to be respected, the file needs to be created with a base permission of `0666`, and when the file is written, the OS will apply the `umask` or default ACL.