### PR TITLE
Fix browser login over direct HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,7 +872,8 @@ host = "0.0.0.0"
 # docs/AUTHENTICATION.md.
 [server.auth]
 session_hours = 168
-secure_cookie = true
+# Omit to follow a same-origin browser's HTTP or HTTPS scheme.
+# secure_cookie = true
 allow_read_only_compute = false
 
 # Optional plain-text notice shown below the application header.

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -99,7 +99,6 @@ list:
 ```toml
 [server.auth]
 session_hours = 168
-secure_cookie = true
 allow_read_only_compute = false
 ```
 
@@ -108,9 +107,18 @@ the browser will show a PSF Guard login page. A successful login creates an
 HttpOnly, SameSite=Strict session cookie. Sessions live in server memory,
 expire after `session_hours`, and end when the server restarts.
 
-Secure cookies are the default. Set
-`secure_cookie = false` only for a direct HTTP development server; a browser
-will not send a Secure cookie to a plain HTTP URL.
+When `secure_cookie` is omitted, a same-origin browser login on a direct
+connection follows the URL: HTTPS receives a Secure cookie and direct HTTP
+receives a non-Secure cookie. A proxy must preserve Host for automatic mode.
+Requests whose Origin does not match Host, and clients that send no Origin,
+remain Secure by default. Set `secure_cookie = true` to require HTTPS, or set
+it to `false` for a direct HTTP client that cannot send an Origin header or a
+plain-HTTP proxy that rewrites Host.
+
+Direct HTTP exposes both the password and session to anyone who can observe
+the connection. Prefer HTTPS outside a trusted network. Each server port uses
+a different cookie name, so two loopback instances no longer sign each other
+out.
 
 ## Roles
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,3 +9,9 @@
 ## Changed
 
 ## Fixed
+
+- Browser accounts can sign in over a same-origin direct HTTP connection when
+  `secure_cookie` is omitted, while HTTPS and untrusted requests remain
+  Secure. Direct HTTP sign-in shows a cleartext warning, failed cookie
+  persistence produces a useful error, and local servers on different ports
+  no longer overwrite each other's sessions.

--- a/psf-guard.toml.example
+++ b/psf-guard.toml.example
@@ -25,25 +25,19 @@ host = "0.0.0.0"
 # Enable CORS (default: true)
 cors = true
 
-# Optional browser session policy and bootstrap accounts. Managed users live
-# in auth.json and can be added with:
+# Optional browser session policy. Managed users live in auth.json and can be
+# added with:
 #   psf-guard users add editor --role read-write
-# With no managed or bootstrap users, the server stays open. Use password
-# files for bootstrap accounts. Secure cookies are the default; set
-# secure_cookie = false only for a direct HTTP development server.
+# An account-less server stays open only on a loopback bind unless
+# --allow-anonymous-access is set. When secure_cookie is omitted, same-origin
+# browser requests follow their HTTP or HTTPS scheme. Set it explicitly to
+# require Secure cookies or support an HTTP client that sends no Origin.
 #
 # [server.auth]
 # session_hours = 168
-# secure_cookie = true
+# secure_cookie = true  # Require HTTPS.
+# secure_cookie = false # Allow direct HTTP clients that send no Origin.
 # allow_read_only_compute = false
-#
-# [server.auth.read_only]
-# username = "viewer"
-# password_file = "/run/secrets/psf-guard-viewer"
-#
-# [server.auth.read_write]
-# username = "editor"
-# password_file = "/run/secrets/psf-guard-editor"
 
 # Optional notice shown below the application header on every page.
 # Values are plain text. Set both link fields or omit both.

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -1202,6 +1202,7 @@ pub fn main() -> Result<()> {
             let server_auth = crate::server::auth::ServerAuth::from_sources(
                 app_config.server.auth.as_ref(),
                 &auth_registry,
+                server_port,
             )?;
             // Open the configured databases for remote sync and image upload.
             // This edits the in-memory list only — the registry on disk keeps

--- a/src/config.rs
+++ b/src/config.rs
@@ -284,18 +284,15 @@ pub struct ServerAuthConfig {
     /// Browser session lifetime. Defaults to seven days.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_hours: Option<u64>,
-    /// Mark the session cookie Secure. Defaults to true; leave it false only
-    /// for direct HTTP development servers.
-    #[serde(default = "default_secure_cookie")]
-    pub secure_cookie: bool,
+    /// Override whether the session cookie is marked Secure. When omitted,
+    /// matching same-origin browser requests follow their HTTP or HTTPS
+    /// scheme; requests without a trustworthy origin remain Secure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secure_cookie: Option<bool>,
     /// Allow read-only accounts to start costly derived-data jobs such as
     /// stacks, plate solves, and satellite predictions. Defaults to false.
     #[serde(default)]
     pub allow_read_only_compute: bool,
-}
-
-fn default_secure_cookie() -> bool {
-    true
 }
 
 impl ServerConfig {
@@ -742,12 +739,12 @@ directory = "./cache"
         let config: Config = toml_edit::de::from_str(toml).unwrap();
         let auth = config.get_server_auth_config().unwrap().unwrap();
         assert_eq!(auth.session_hours, Some(24));
-        assert!(auth.secure_cookie);
+        assert_eq!(auth.secure_cookie, Some(true));
         assert!(auth.allow_read_only_compute);
     }
 
     #[test]
-    fn server_auth_defaults_to_secure_cookies() {
+    fn server_auth_defaults_to_automatic_cookie_security() {
         let config: Config = toml_edit::de::from_str(
             r#"
 [server.auth]
@@ -759,7 +756,7 @@ directory = "./cache"
         .unwrap();
 
         let auth = config.server.auth.unwrap();
-        assert!(auth.secure_cookie);
+        assert_eq!(auth.secure_cookie, None);
         assert!(!auth.allow_read_only_compute);
     }
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,8 +1,9 @@
 use axum::{
     extract::{Request, State},
     http::{
-        header::{CACHE_CONTROL, COOKIE, SET_COOKIE},
-        HeaderMap, HeaderValue, Method, StatusCode,
+        header::{CACHE_CONTROL, COOKIE, HOST, ORIGIN, SET_COOKIE},
+        uri::Authority,
+        HeaderMap, HeaderValue, Method, StatusCode, Uri,
     },
     middleware::Next,
     response::{IntoResponse, Response},
@@ -24,7 +25,7 @@ use crate::{
 
 pub use crate::auth_registry::AccessRole;
 
-const SESSION_COOKIE: &str = "psf_guard_session";
+const SESSION_COOKIE_PREFIX: &str = "psf_guard_session";
 const DEFAULT_SESSION_HOURS: u64 = 24 * 7;
 const MAX_SESSIONS_PER_USER: usize = 128;
 const LOGIN_ATTEMPTS_PER_SECOND: f64 = 4.0;
@@ -43,8 +44,16 @@ pub struct ServerAuth {
     login_rate_limit: Arc<Mutex<LoginRateLimit>>,
     user_management_lock: Arc<Mutex<()>>,
     session_ttl: Duration,
-    secure_cookie: bool,
+    cookie_security: CookieSecurity,
+    session_cookie_name: String,
     allow_read_only_compute: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CookieSecurity {
+    Auto,
+    Always,
+    Never,
 }
 
 #[derive(Clone)]
@@ -90,7 +99,8 @@ impl std::fmt::Debug for ServerAuth {
                     .collect::<Vec<_>>(),
             )
             .field("session_ttl", &self.session_ttl)
-            .field("secure_cookie", &self.secure_cookie)
+            .field("cookie_security", &self.cookie_security)
+            .field("session_cookie_name", &self.session_cookie_name)
             .finish()
     }
 }
@@ -99,6 +109,7 @@ impl ServerAuth {
     pub fn from_sources(
         config: Option<&ServerAuthConfig>,
         registry: &AuthRegistry,
+        server_port: u16,
     ) -> anyhow::Result<Option<Self>> {
         let users = registry
             .users
@@ -128,7 +139,12 @@ impl ServerAuth {
             })),
             user_management_lock: Arc::new(Mutex::new(())),
             session_ttl: Duration::from_secs(session_hours * 60 * 60),
-            secure_cookie: config.is_none_or(|config| config.secure_cookie),
+            cookie_security: match config.and_then(|config| config.secure_cookie) {
+                Some(true) => CookieSecurity::Always,
+                Some(false) => CookieSecurity::Never,
+                None => CookieSecurity::Auto,
+            },
+            session_cookie_name: format!("{SESSION_COOKIE_PREFIX}_{server_port}"),
             allow_read_only_compute: config.is_some_and(|config| config.allow_read_only_compute),
         }))
     }
@@ -221,23 +237,35 @@ impl ServerAuth {
         self.sessions.lock().unwrap().remove(token);
     }
 
-    fn cookie(&self, token: &str) -> HeaderValue {
+    fn cookie(&self, token: &str, headers: &HeaderMap) -> HeaderValue {
         let mut value = format!(
-            "{SESSION_COOKIE}={token}; Path=/; HttpOnly; SameSite=Strict; Max-Age={}",
+            "{}={token}; Path=/; HttpOnly; SameSite=Strict; Max-Age={}",
+            self.session_cookie_name,
             self.session_ttl.as_secs()
         );
-        if self.secure_cookie {
+        if self.cookie_is_secure(headers) {
             value.push_str("; Secure");
         }
         HeaderValue::from_str(&value).expect("session cookie contains safe characters")
     }
 
-    fn clear_cookie(&self) -> HeaderValue {
-        let mut value = format!("{SESSION_COOKIE}=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0");
-        if self.secure_cookie {
+    fn clear_cookie(&self, headers: &HeaderMap) -> HeaderValue {
+        let mut value = format!(
+            "{}=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0",
+            self.session_cookie_name
+        );
+        if self.cookie_is_secure(headers) {
             value.push_str("; Secure");
         }
         HeaderValue::from_str(&value).expect("clear cookie contains safe characters")
+    }
+
+    fn cookie_is_secure(&self, headers: &HeaderMap) -> bool {
+        match self.cookie_security {
+            CookieSecurity::Always => true,
+            CookieSecurity::Never => false,
+            CookieSecurity::Auto => same_origin_request_is_https(headers).unwrap_or(true),
+        }
     }
 
     fn can_compute(&self, role: AccessRole) -> bool {
@@ -415,6 +443,7 @@ pub async fn status(State(state): State<Arc<AppState>>, headers: HeaderMap) -> R
 
 pub async fn login(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(request): Json<LoginRequest>,
 ) -> Response {
     let Some(auth) = state.server_auth() else {
@@ -472,7 +501,7 @@ pub async fn login(
     (
         StatusCode::OK,
         [
-            (SET_COOKIE, auth.cookie(&token)),
+            (SET_COOKIE, auth.cookie(&token, &headers)),
             (CACHE_CONTROL, HeaderValue::from_static("no-store")),
         ],
         Json(ApiResponse::success(AuthStatus {
@@ -490,13 +519,13 @@ pub async fn logout(State(state): State<Arc<AppState>>, headers: HeaderMap) -> R
     let Some(auth) = state.server_auth() else {
         return StatusCode::NO_CONTENT.into_response();
     };
-    if let Some(token) = cookie_value(&headers, SESSION_COOKIE) {
+    if let Some(token) = cookie_value(&headers, &auth.session_cookie_name) {
         auth.remove_session(token);
     }
     (
         StatusCode::NO_CONTENT,
         [
-            (SET_COOKIE, auth.clear_cookie()),
+            (SET_COOKIE, auth.clear_cookie(&headers)),
             (CACHE_CONTROL, HeaderValue::from_static("no-store")),
         ],
     )
@@ -592,7 +621,36 @@ pub(crate) fn host_is_loopback(host: &str) -> bool {
 }
 
 fn session_from_headers(auth: &ServerAuth, headers: &HeaderMap) -> Option<Session> {
-    auth.session(cookie_value(headers, SESSION_COOKIE)?)
+    auth.session(cookie_value(headers, &auth.session_cookie_name)?)
+}
+
+/// Infer the browser-facing scheme only from a same-origin request. `Origin`
+/// is supplied by browsers for the login POST and survives an ordinary HTTPS
+/// reverse proxy. Missing or mismatched headers return `None`, which keeps the
+/// automatic policy fail-secure for scripts and cross-origin requests.
+fn same_origin_request_is_https(headers: &HeaderMap) -> Option<bool> {
+    let host = headers
+        .get(HOST)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<Authority>()
+        .ok()?;
+    let origin = headers.get(ORIGIN)?.to_str().ok()?.parse::<Uri>().ok()?;
+    let scheme_is_https = match origin.scheme_str() {
+        Some(scheme) if scheme.eq_ignore_ascii_case("https") => true,
+        Some(scheme) if scheme.eq_ignore_ascii_case("http") => false,
+        _ => return None,
+    };
+    let origin_authority = origin.authority()?;
+    let default_port = if scheme_is_https { 443 } else { 80 };
+    if !origin_authority.host().eq_ignore_ascii_case(host.host())
+        || origin_authority.port_u16().unwrap_or(default_port)
+            != host.port_u16().unwrap_or(default_port)
+    {
+        return None;
+    }
+    Some(scheme_is_https)
 }
 
 fn cookie_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
@@ -674,12 +732,12 @@ mod tests {
     fn test_config() -> ServerAuthConfig {
         ServerAuthConfig {
             session_hours: Some(12),
-            secure_cookie: true,
+            secure_cookie: Some(true),
             allow_read_only_compute: false,
         }
     }
 
-    fn test_auth() -> ServerAuth {
+    fn test_auth_with_cookie_policy(secure_cookie: Option<bool>, port: u16) -> ServerAuth {
         let mut registry = AuthRegistry::default();
         registry
             .add(
@@ -693,9 +751,22 @@ mod tests {
                 false,
             )
             .unwrap();
-        ServerAuth::from_sources(Some(&test_config()), &registry)
+        let mut config = test_config();
+        config.secure_cookie = secure_cookie;
+        ServerAuth::from_sources(Some(&config), &registry, port)
             .unwrap()
             .unwrap()
+    }
+
+    fn test_auth() -> ServerAuth {
+        test_auth_with_cookie_policy(Some(true), 3000)
+    }
+
+    fn browser_headers(origin: &str, host: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(ORIGIN, HeaderValue::from_str(origin).unwrap());
+        headers.insert(HOST, HeaderValue::from_str(host).unwrap());
+        headers
     }
 
     #[tokio::test]
@@ -712,12 +783,62 @@ mod tests {
             .is_none());
 
         let token = auth.create_session(&viewer).unwrap();
-        let cookie = auth.cookie(&token).to_str().unwrap().to_string();
+        let cookie = auth
+            .cookie(&token, &HeaderMap::new())
+            .to_str()
+            .unwrap()
+            .to_string();
         assert!(cookie.contains("HttpOnly"));
         assert!(cookie.contains("SameSite=Strict"));
         assert!(cookie.contains("Max-Age=43200"));
         assert!(cookie.contains("Secure"));
         assert_eq!(auth.session(&token).unwrap().username, "viewer");
+    }
+
+    #[test]
+    fn automatic_cookie_security_follows_only_a_matching_browser_origin() {
+        let auth = test_auth_with_cookie_policy(None, 3000);
+
+        for headers in [
+            browser_headers("http://guard.local:3000", "guard.local:3000"),
+            browser_headers("http://guard.local", "guard.local:80"),
+            browser_headers("http://[::1]", "[::1]:80"),
+        ] {
+            assert_eq!(same_origin_request_is_https(&headers), Some(false));
+            assert!(!auth.cookie_is_secure(&headers));
+        }
+        for headers in [
+            browser_headers("https://guard.local", "guard.local"),
+            browser_headers("https://guard.local", "guard.local:443"),
+        ] {
+            assert_eq!(same_origin_request_is_https(&headers), Some(true));
+            assert!(auth.cookie_is_secure(&headers));
+        }
+        let mismatched = browser_headers("http://other.local:3000", "guard.local:3000");
+        assert_eq!(same_origin_request_is_https(&mismatched), None);
+        assert!(auth.cookie_is_secure(&mismatched));
+        assert!(auth.cookie_is_secure(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn explicit_cookie_security_overrides_the_browser_origin() {
+        let http_headers = browser_headers("http://guard.local:3000", "guard.local:3000");
+        assert!(test_auth_with_cookie_policy(Some(true), 3000).cookie_is_secure(&http_headers));
+        assert!(
+            !test_auth_with_cookie_policy(Some(false), 3000).cookie_is_secure(&HeaderMap::new())
+        );
+    }
+
+    #[test]
+    fn session_cookie_names_keep_loopback_ports_separate() {
+        assert_eq!(
+            test_auth_with_cookie_policy(None, 3000).session_cookie_name,
+            "psf_guard_session_3000"
+        );
+        assert_eq!(
+            test_auth_with_cookie_policy(None, 3001).session_cookie_name,
+            "psf_guard_session_3001"
+        );
     }
 
     #[tokio::test]
@@ -834,14 +955,14 @@ mod tests {
     #[test]
     fn session_policy_without_users_keeps_authentication_off() {
         assert!(
-            ServerAuth::from_sources(Some(&test_config()), &AuthRegistry::default())
+            ServerAuth::from_sources(Some(&test_config()), &AuthRegistry::default(), 3000)
                 .unwrap()
                 .is_none()
         );
     }
 
     #[tokio::test]
-    async fn registry_users_enable_secure_auth_without_session_policy() {
+    async fn registry_users_enable_automatic_auth_without_session_policy() {
         let mut registry = AuthRegistry::default();
         registry
             .add(
@@ -855,8 +976,10 @@ mod tests {
             )
             .unwrap();
 
-        let auth = ServerAuth::from_sources(None, &registry).unwrap().unwrap();
-        assert!(auth.secure_cookie);
+        let auth = ServerAuth::from_sources(None, &registry, 3000)
+            .unwrap()
+            .unwrap();
+        assert_eq!(auth.cookie_security, CookieSecurity::Auto);
         let user = auth
             .authenticate_password("viewer", "viewer-password")
             .await
@@ -877,7 +1000,9 @@ mod tests {
             )
             .unwrap();
         registry.save(&path).unwrap();
-        let auth = ServerAuth::from_sources(None, &registry).unwrap().unwrap();
+        let auth = ServerAuth::from_sources(None, &registry, 3000)
+            .unwrap()
+            .unwrap();
         let stale_user = auth
             .authenticate_password("only-editor", "editor-password")
             .await

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -7105,6 +7105,12 @@
   color: var(--color-error-light) !important;
 }
 
+.auth-warning {
+  padding-left: 0.75rem;
+  border-left: 3px solid var(--color-warning);
+  color: var(--color-warning) !important;
+}
+
 .access-badge {
   align-self: center;
   padding: 0.25rem 0.55rem;

--- a/static/src/auth/AccessContext.tsx
+++ b/static/src/auth/AccessContext.tsx
@@ -19,8 +19,17 @@ export default function AuthGate({ children }: { children: ReactNode }) {
     retry: false,
   });
   const login = useMutation({
-    mutationFn: ({ username, password }: { username: string; password: string }) =>
-      apiClient.login(username, password),
+    mutationFn: async ({ username, password }: { username: string; password: string }) => {
+      await apiClient.login(username, password);
+      const status = await apiClient.getAuthStatus();
+      if (!status.authenticated) {
+        throw new Error(
+          'Sign in succeeded, but this browser did not retain the session. ' +
+          'Use HTTPS, or set secure_cookie = false in [server.auth] for a trusted direct HTTP connection.'
+        );
+      }
+      return status;
+    },
     onSuccess: (status) => {
       queryClient.removeQueries({
         predicate: (query) => query.queryKey[0] !== 'authStatus',
@@ -131,6 +140,12 @@ function LoginScreen({
         <img src="/psf-guard.svg" alt="" className="auth-logo" />
         <h1>Sign in to PSF Guard</h1>
         <p>Use the viewer or editor account configured for this server.</p>
+        {window.isSecureContext === false && (
+          <p className="auth-warning" role="note">
+            This HTTP connection is not encrypted. Your password and session can be observed on
+            the network.
+          </p>
+        )}
         <label>
           <span>Username</span>
           <input

--- a/static/src/auth/__tests__/AccessContext.test.tsx
+++ b/static/src/auth/__tests__/AccessContext.test.tsx
@@ -41,13 +41,15 @@ describe('AuthGate', () => {
   });
 
   it('shows a normal login form and exposes the signed-in role', async () => {
+    let authenticated = false;
     server.use(
       http.get('/api/auth/status', () =>
         HttpResponse.json({
           success: true,
           data: {
             authentication_required: true,
-            authenticated: false,
+            authenticated,
+            ...(authenticated ? { role: 'read_only', username: 'viewer' } : {}),
             can_compute: false,
           },
           error: null,
@@ -67,6 +69,7 @@ describe('AuthGate', () => {
             { status: 401 },
           );
         }
+        authenticated = true;
         return HttpResponse.json({
           success: true,
           data: {
@@ -80,7 +83,10 @@ describe('AuthGate', () => {
           status: 'ready',
         });
       }),
-      http.post('/api/auth/logout', () => new HttpResponse(null, { status: 204 })),
+      http.post('/api/auth/logout', () => {
+        authenticated = false;
+        return new HttpResponse(null, { status: 204 });
+      }),
     );
     render(
       <AuthGate><ProtectedContent /></AuthGate>,
@@ -102,5 +108,51 @@ describe('AuthGate', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
     expect(await screen.findByRole('heading', { name: 'Sign in to PSF Guard' }))
       .toBeInTheDocument();
+  });
+
+  it('explains when the browser does not retain a successful login session', async () => {
+    server.use(
+      http.get('/api/auth/status', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            authentication_required: true,
+            authenticated: false,
+            can_compute: false,
+          },
+          error: null,
+          status: 'ready',
+        })
+      ),
+      http.post('/api/auth/login', () =>
+        HttpResponse.json({
+          success: true,
+          data: {
+            authentication_required: true,
+            authenticated: true,
+            role: 'read_write',
+            username: 'editor',
+            can_compute: true,
+          },
+          error: null,
+          status: 'ready',
+        })
+      ),
+    );
+    render(
+      <AuthGate><ProtectedContent /></AuthGate>,
+      { wrapper: wrapper() },
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Sign in to PSF Guard' }))
+      .toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'editor' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'this browser did not retain the session'
+    );
+    expect(screen.getByRole('heading', { name: 'Sign in to PSF Guard' })).toBeInTheDocument();
   });
 });

--- a/tests/integration_server_auth.rs
+++ b/tests/integration_server_auth.rs
@@ -27,7 +27,7 @@ use tower::ServiceExt;
 fn auth_config() -> ServerAuthConfig {
     ServerAuthConfig {
         session_hours: Some(1),
-        secure_cookie: false,
+        secure_cookie: Some(false),
         allow_read_only_compute: false,
     }
 }
@@ -58,7 +58,7 @@ fn app_with_auth(config: ServerAuthConfig) -> Router {
         Connection::open_in_memory().unwrap(),
     ));
     state.set_server_auth(Some(
-        ServerAuth::from_sources(Some(&config), &auth_registry())
+        ServerAuth::from_sources(Some(&config), &auth_registry(), 3000)
             .unwrap()
             .unwrap(),
     ));
@@ -128,10 +128,10 @@ fn user_management_app(directory: &tempfile::TempDir) -> Router {
     registry.save(&auth_registry_path).unwrap();
     let config = ServerAuthConfig {
         session_hours: Some(1),
-        secure_cookie: false,
+        secure_cookie: Some(false),
         allow_read_only_compute: false,
     };
-    let auth = ServerAuth::from_sources(Some(&config), &registry)
+    let auth = ServerAuth::from_sources(Some(&config), &registry, 3000)
         .unwrap()
         .unwrap();
     let state = Arc::new(AppState::new_for_test(
@@ -240,7 +240,7 @@ async fn login_status_and_logout_use_an_http_only_session_cookie() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(login["data"]["role"], "read_only");
     assert_eq!(login["data"]["can_compute"], false);
-    assert!(cookie.starts_with("psf_guard_session="));
+    assert!(cookie.starts_with("psf_guard_session_3000="));
 
     let authenticated = Request::builder()
         .uri("/api/auth/status")
@@ -265,6 +265,72 @@ async fn login_status_and_logout_use_an_http_only_session_cookie() {
         .to_str()
         .unwrap()
         .contains("Max-Age=0"));
+}
+
+#[tokio::test]
+async fn automatic_cookie_policy_keeps_a_direct_http_browser_session() {
+    let mut config = auth_config();
+    config.secure_cookie = None;
+    let app = app_with_auth(config);
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/api/auth/login")
+        .header("host", "guard.local:3000")
+        .header("origin", "http://guard.local:3000")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({
+                "username": "viewer",
+                "password": "viewer-secret"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let (status, headers, body) = json(&app, request).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["data"]["authenticated"], true);
+    let set_cookie = headers["set-cookie"].to_str().unwrap();
+    assert!(set_cookie.starts_with("psf_guard_session_3000="));
+    assert!(!set_cookie.contains("; Secure"));
+
+    let cookie = set_cookie.split(';').next().unwrap();
+    let status_request = Request::builder()
+        .uri("/api/auth/status")
+        .header(COOKIE, cookie)
+        .body(Body::empty())
+        .unwrap();
+    assert_eq!(
+        json(&app, status_request).await.2["data"]["authenticated"],
+        true
+    );
+}
+
+#[tokio::test]
+async fn automatic_cookie_policy_keeps_https_and_untrusted_origins_secure() {
+    for origin in ["https://guard.local", "http://other.local"] {
+        let mut config = auth_config();
+        config.secure_cookie = None;
+        let app = app_with_auth(config);
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/api/auth/login")
+            .header("host", "guard.local")
+            .header("origin", origin)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "username": "viewer",
+                    "password": "viewer-secret"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let (status, headers, _) = json(&app, request).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(headers["set-cookie"].to_str().unwrap().contains("; Secure"));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- choose the session cookie's `Secure` attribute from a matching same-origin browser request when `secure_cookie` is omitted, while preserving explicit `true` and `false` overrides
- scope session cookie names by server port so local PSF Guard instances do not overwrite one another
- verify the session after login and show useful messages for rejected cookies and cleartext HTTP
- document the cookie policy and remove stale bootstrap-account examples that the config parser rejects

## Root cause
The login endpoint created a valid server session and returned `authenticated: true`, but the default `Secure` cookie was discarded by browsers on direct non-loopback HTTP. The next API call returned 401 and the UI silently returned to the login form. Chromium's trustworthy-loopback exception hid this on `localhost` and `127.0.0.1`; multiple local ports could still collide because cookies are not scoped by port.

Automatic mode trusts the browser-facing scheme only when `Origin` and `Host` identify the same authority, with default ports normalized. Missing, malformed, or cross-origin evidence remains fail-secure. Explicit `secure_cookie = true` still requires HTTPS; `false` still supports HTTP clients that send no Origin or proxies that rewrite Host.

## Validation
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (808 unit tests, all integration suites, and doc tests passed; 5 synthetic tests ignored)
- `npm test` (343 tests)
- `npm run lint -- --quiet`
- `npm run build`
- live Playwright Chromium against `http://192.168.0.92`: cleartext warning visible, login screen closed, `psf_guard_session_39130` stored with `secure: false`, and the follow-up auth status remained authenticated

The repository's configured Playwright suite could not start locally on Windows because its existing generated sync-fixture TOML writes unescaped backslashes. The focused live Chromium validation above used an isolated registry and no real catalogs.