### PR TITLE
Make keeping a failed upload's staged file a server option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ size:
 preview_format = "jpeg"      # "png" (default) or "jpeg"
 preview_jpeg_quality = 88    # 50–100, ignored for PNG
 preview_color = true         # colour by default for OSC frames
+keep_failed_uploads = false  # keep a rejected remote upload's staged file
 ```
 
 On a realistic stretched sub, JPEG at the default quality is roughly a third
@@ -1025,6 +1026,14 @@ demand; changing it back finds the originals still valid. An artifact is always
 served as whatever it was written as, not as whatever the setting says now.
 Nothing removes the old set — the server reports how much of the cache is in
 the other format at startup, and deleting it is yours to decide.
+
+`keep_failed_uploads` is a debugging aid for remote image intake. A frame
+arrives as an extension-less staging file in the receive directory and is
+moved into place only after its checksum, header, and destination check out;
+a rejected upload normally leaves nothing behind. With the key on, the staged
+file stays, and the log names it, so what the client actually sent can be
+examined. Published frames take the receive directory's usual permissions
+(umask or default ACL) rather than a temporary file's `0600`.
 
 `preview_color` also decides which rendition background pre-generation warms.
 A viewer that disagrees with it still gets what it asked for, generated on

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,9 +6,18 @@
 
 ## Added
 
+- `keep_failed_uploads` under `[server]` keeps a rejected remote upload's
+  staged file in the receive directory, and names it in the log, so what a
+  client sent can be examined. Off by default, a failed upload leaves nothing
+  behind.
+
 ## Changed
 
 ## Fixed
+
+- Remote image uploads now take the receive directory's usual file
+  permissions (umask or default ACL) instead of a temporary file's
+  owner-only `0600`, so other tools on the server can read what arrived.
 
 - Browser accounts can sign in over a same-origin direct HTTP connection when
   `secure_cookie` is omitted, while HTTPS and untrusted requests remain

--- a/psf-guard.toml.example
+++ b/psf-guard.toml.example
@@ -25,6 +25,11 @@ host = "0.0.0.0"
 # Enable CORS (default: true)
 cors = true
 
+# Keep a rejected remote image upload's staged file in the receive directory
+# so what the client sent can be examined (default: false). The log names the
+# file. Off, a failed upload leaves nothing behind.
+# keep_failed_uploads = false
+
 # Optional browser session policy. Managed users live in auth.json and can be
 # added with:
 #   psf-guard users add editor --role read-write

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -1235,6 +1235,7 @@ pub fn main() -> Result<()> {
                     worker_policy,
                     preview_encoding,
                     preview_color_default,
+                    app_config.server.keep_failed_uploads(),
                     astrometry_config,
                 )
                 .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,6 +275,13 @@ pub struct ServerConfig {
     /// unaffected either way.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preview_color: Option<bool>,
+    /// Keep a remote upload's staged file in the receive directory when the
+    /// upload fails (bad checksum, unreadable header, publish conflict).
+    /// Off by default: a failed upload leaves nothing behind. On, the
+    /// extension-less staging file stays where the log names it, which is
+    /// how you find out what a client actually sent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keep_failed_uploads: Option<bool>,
 }
 
 /// Browser session policy. Users and password hashes live in auth.json.
@@ -299,6 +306,11 @@ impl ServerConfig {
     /// Whether previews default to colour.
     pub fn preview_color(&self) -> bool {
         self.preview_color.unwrap_or(true)
+    }
+
+    /// Whether a failed remote upload's staging file is kept for inspection.
+    pub fn keep_failed_uploads(&self) -> bool {
+        self.keep_failed_uploads.unwrap_or(false)
     }
 
     /// How generated previews are encoded. An unreadable format name is an
@@ -445,6 +457,7 @@ impl Default for ServerConfig {
             preview_format: None,
             preview_jpeg_quality: None,
             preview_color: None,
+            keep_failed_uploads: None,
         }
     }
 }
@@ -888,6 +901,19 @@ directory = "./cache"
         let policy = config.get_worker_policy();
         assert_eq!(policy.interactive_ratio, 0.05);
         assert_eq!(policy.background_ratio, 1.0);
+    }
+
+    #[test]
+    fn keep_failed_uploads_is_off_unless_the_file_says_so() {
+        let config: Config =
+            toml_edit::de::from_str("[server]\nport = 3000\n\n[cache]\ndirectory = \"./cache\"\n")
+                .unwrap();
+        assert!(!config.server.keep_failed_uploads());
+        let config: Config = toml_edit::de::from_str(
+            "[server]\nport = 3000\nkeep_failed_uploads = true\n\n[cache]\ndirectory = \"./cache\"\n",
+        )
+        .unwrap();
+        assert!(config.server.keep_failed_uploads());
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -80,6 +80,8 @@ pub struct ServerConfig {
     pub preview_encoding: crate::preview_format::PreviewEncoding,
     /// Whether previews default to colour.
     pub preview_color_default: bool,
+    /// Keep a failed remote upload's staging file for inspection.
+    pub keep_failed_uploads: bool,
     /// Process-global Seiza catalog configuration from the shared registry.
     pub astrometry_config: Option<crate::astrometry::AstrometryConfig>,
 }
@@ -100,6 +102,7 @@ pub async fn run_server(
     worker_policy: crate::concurrency::WorkerPolicy,
     preview_encoding: crate::preview_format::PreviewEncoding,
     preview_color_default: bool,
+    keep_failed_uploads: bool,
     astrometry_config: Option<crate::astrometry::AstrometryConfig>,
 ) -> anyhow::Result<()> {
     // Initialize tracing with environment-based filtering (for CLI mode)
@@ -130,6 +133,7 @@ pub async fn run_server(
         worker_policy,
         preview_encoding,
         preview_color_default,
+        keep_failed_uploads,
         astrometry_config,
     };
 
@@ -237,6 +241,13 @@ async fn run_server_internal(
             state.set_worker_policy(config.worker_policy);
             state.set_preview_encoding(config.preview_encoding);
             state.set_preview_color_default(config.preview_color_default);
+            remote_upload::configure_keep_failed_uploads(config.keep_failed_uploads);
+            if config.keep_failed_uploads {
+                tracing::info!(
+                    "🧪 keep_failed_uploads is on: a failed remote upload leaves its staged file \
+                     in the receive directory for inspection"
+                );
+            }
             if let Some(banner) = &config.site_banner {
                 tracing::info!("📢 Site banner enabled: {}", banner.title);
             }

--- a/src/server/remote_upload.rs
+++ b/src/server/remote_upload.rs
@@ -36,6 +36,23 @@ const CONTENT_SHA256_HEADER: &str = "x-content-sha256";
 const MAX_UPLOAD_DIRECTORY_COMPONENT_BYTES: usize = 120;
 const CAPTURE_IDENTITY_TIME_TOLERANCE_SECS: u64 = 2;
 
+/// Whether a failed upload's staging file stays in the receive directory.
+///
+/// Process-wide like the other `[server]` knobs: set once at startup from
+/// the config file. Off, the staging file is removed when the request ends
+/// in an error, as it always was; on, it stays where the log names it so
+/// what a client actually sent can be examined.
+static KEEP_FAILED_UPLOADS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn configure_keep_failed_uploads(keep: bool) {
+    KEEP_FAILED_UPLOADS.store(keep, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn keep_failed_uploads() -> bool {
+    KEEP_FAILED_UPLOADS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 pub async fn upload_image(
     ctx: DbContext,
     headers: HeaderMap,
@@ -82,32 +99,36 @@ pub async fn upload_image(
         // so it must not carry a frame extension: a folder scan running
         // alongside the upload would pick up the half-written file as a
         // frame. The header read below is told the declared name instead.
-        let temporary = {
-            let upload_dir: &PathBuf = &upload_dir;
-            #[cfg(unix)]
-            {
-                // Default permissions on temp files on Linux and Unix are created
-                // 0600, accessible only for the user creating the file. By setting
-                // a permission to 0666 here, it allows the user's umask or the
-                // destination directory's default ACL to determine the
-                // permissions.
-                use std::os::unix::fs::PermissionsExt;
-                tempfile::Builder::new()
-                    .disable_cleanup(true)
-                    .permissions(std::fs::Permissions::from_mode(0o666))
-                    .tempfile_in(upload_dir)
-            }
-            #[cfg(windows)]
-            {
-                tempfile::NamedTempFile::new_in(upload_dir)
-            }
+        let keep_on_failure = keep_failed_uploads();
+        let mut builder = tempfile::Builder::new();
+        // The staging file is removed when the request ends in an error,
+        // unless the operator asked to keep it (`[server]
+        // keep_failed_uploads`) to see what a client sent. On success it is
+        // moved into place below, so the setting never touches a published
+        // frame.
+        builder.disable_cleanup(keep_on_failure);
+        #[cfg(unix)]
+        {
+            // A temporary file is created 0600, readable by nobody but the
+            // server. An uploaded frame is not a secret; created 0666, it
+            // takes the mode the receive directory's umask or default ACL
+            // gives every other file there.
+            use std::os::unix::fs::PermissionsExt;
+            builder.permissions(std::fs::Permissions::from_mode(0o666));
         }
-        .map_err(|error| {
+        let temporary = builder.tempfile_in(&upload_dir).map_err(|error| {
             AppError::InternalError(format!(
                 "creating upload temporary file in {}: {error}",
                 upload_dir.display()
             ))
         })?;
+        if keep_on_failure {
+            tracing::info!(
+                database = %ctx.id,
+                staged = %temporary.path().display(),
+                "Staging {filename}; the file stays there if this upload fails"
+            );
+        }
         let reopened = temporary.reopen().map_err(|error| {
             AppError::InternalError(format!("opening upload temporary file: {error}"))
         })?;

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -294,6 +294,7 @@ async fn start_server_for_tauri(
         // keeps the exact rendition.
         preview_encoding: crate::preview_format::PreviewEncoding::png(),
         preview_color_default: true,
+        keep_failed_uploads: false,
         astrometry_config,
     };
 

--- a/tests/integration_remote_upload.rs
+++ b/tests/integration_remote_upload.rs
@@ -1508,6 +1508,71 @@ async fn upload_accepts_an_xisf_frame_and_imports_it_like_a_fits_one() {
 }
 
 #[tokio::test]
+async fn a_failed_upload_leaves_no_staged_file_unless_asked_to() {
+    // The staging file lives in the receive directory without an extension.
+    // A rejected upload must not leave it there — unless the operator turned
+    // on `keep_failed_uploads` to see what a client sent.
+    let fixture = Fixture::new();
+    let receive_dir = fixture.images_a.clone();
+    let staged = |dir: &std::path::Path| -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().is_file())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    };
+    let before = staged(&receive_dir);
+    let image = fits_bytes("M 81", "2026-07-24T06:00:00");
+
+    remote_upload::configure_keep_failed_uploads(false);
+    let (status, body) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "m81-001.fits",
+        &image,
+        &sha256(b"not the bytes that were sent"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(
+        staged(&receive_dir),
+        before,
+        "a rejected upload is cleaned up"
+    );
+
+    remote_upload::configure_keep_failed_uploads(true);
+    let (status, _) = upload(
+        fixture.state.clone(),
+        "catalog-a",
+        "catalog-a",
+        TOKEN_A,
+        "m81-001.fits",
+        &image,
+        &sha256(b"not the bytes that were sent"),
+    )
+    .await;
+    remote_upload::configure_keep_failed_uploads(false);
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let after = staged(&receive_dir);
+    assert_eq!(
+        after.len(),
+        before.len() + 1,
+        "the staged file is kept: {after:?}"
+    );
+    let kept = after.iter().find(|name| !before.contains(name)).unwrap();
+    assert!(
+        kept.starts_with(".tmp") && !kept.ends_with(".fits"),
+        "the staged file is the extension-less temporary, not a published frame: {kept}"
+    );
+    assert_eq!(image_count(&fixture.database_a), 0);
+}
+
+#[tokio::test]
 async fn upload_still_rejects_a_non_image_extension() {
     let fixture = Fixture::new();
     let image = fits_bytes("M 81", "2026-07-24T06:00:00");


### PR DESCRIPTION
Follow-up to #406.

#406 created the upload staging file `0666` so the receive directory's umask or default ACL sets the final mode — good — but the same change also set `disable_cleanup(true)` on the staging file, which the description didn't mention. Before it, a rejected upload (empty body, checksum mismatch, unreadable header, wrong frame type, publish conflict) dropped its staging file automatically; after it, every one of those paths leaves an extension-less `.tmpXXXX` behind in the receive directory. The success path moves the file into place with `persist_noclobber`, so the flag bought nothing there.

Keeping the file is useful when debugging what a client actually sent, so rather than simply reverting it this makes it a choice:

- `[server] keep_failed_uploads = true` keeps a rejected upload's staged file and logs its path at staging time (`Staging <name>; the file stays there if this upload fails`). Default `false`: a failed upload leaves nothing behind, as before #406.
- The staging builder is one code path for every platform now (`disable_cleanup(keep)`, plus the `0666` mode on Unix), instead of a Unix branch and a Windows branch that behaved differently on failure.
- Wired like the other `[server]` knobs: `ServerConfig::keep_failed_uploads()` → `run_server` → a process-wide switch in `remote_upload`, set once at startup (Tauri passes `false`).

Also adds the release note #406 was missing (uploads take the receive directory's usual permissions) and one for the new key; documents the key in the README's `[server]` section and in `psf-guard.toml.example`.

Tests: a config test for the default and the key; an integration test that a checksum-rejected upload leaves the receive directory unchanged with the key off, and leaves exactly one `.tmp*` staging file with it on.

Checks run locally: cargo fmt, clippy `-D warnings`, `cargo test`, `git diff --check`. No frontend change; the browser suite is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv
