### PR TITLE
Release 0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,21 +6,6 @@
 
 ## Added
 
-- `keep_failed_uploads` under `[server]` keeps a rejected remote upload's
-  staged file in the receive directory, and names it in the log, so what a
-  client sent can be examined. Off by default, a failed upload leaves nothing
-  behind.
-
 ## Changed
 
 ## Fixed
-
-- Remote image uploads now take the receive directory's usual file
-  permissions (umask or default ACL) instead of a temporary file's
-  owner-only `0600`, so other tools on the server can read what arrived.
-
-- Browser accounts can sign in over a same-origin direct HTTP connection when
-  `secure_cookie` is omitted, while HTTPS and untrusted requests remain
-  Secure. Direct HTTP sign-in shows a cleartext warning, failed cookie
-  persistence produces a useful error, and local servers on different ports
-  no longer overwrite each other's sessions.

--- a/docs/releases/v0.9.4.md
+++ b/docs/releases/v0.9.4.md
@@ -1,0 +1,23 @@
+# v0.9.4
+
+PSF Guard 0.9.4 fixes browser sign-in over plain HTTP, gives remote uploads
+the receive directory's usual file permissions, and adds a server option to
+keep a rejected upload's staged file for inspection.
+
+## Added
+
+- `keep_failed_uploads` under `[server]` keeps a rejected remote upload's
+  staged file in the receive directory, and names it in the log, so what a
+  client sent can be examined. Off by default, a failed upload leaves nothing
+  behind.
+
+## Fixed
+
+- Remote image uploads now take the receive directory's usual file
+  permissions (umask or default ACL) instead of a temporary file's
+  owner-only `0600`, so other tools on the server can read what arrived.
+- Browser accounts can sign in over a same-origin direct HTTP connection when
+  `secure_cookie` is omitted, while HTTPS and untrusted requests remain
+  Secure. Direct HTTP sign-in shows a cleartext warning, failed cookie
+  persistence produces a useful error, and local servers on different ports
+  no longer overwrite each other's sessions.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -8,7 +8,7 @@
 %global rustflags_debuginfo 0
 
 Name:           psf-guard
-Version:        0.9.3
+Version:        0.9.4
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -93,6 +93,11 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Mon Sep 08 2026 Yann Ramin <github@theatr.us> - 0.9.4-1
+- Browser sign-in works over direct HTTP; local servers on different ports keep separate sessions
+- Remote uploads take the receive directory's usual file permissions
+- New server option keep_failed_uploads keeps a rejected upload's staged file for inspection
+
 * Tue Sep 01 2026 Yann Ramin <github@theatr.us> - 0.9.3-1
 - Images tab Status filter works again
 - Master darks, biases, and flats from PixInsight or Siril match and calibrate stacks

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
Point release: browser sign-in over direct HTTP (#407), remote uploads take the receive directory's file permissions (#406), and the new `[server] keep_failed_uploads` option (#408).

Bumps `Cargo.toml`, `Cargo.lock`, `tauri.conf.json`, and the RPM spec to 0.9.4; adds `docs/releases/v0.9.4.md` and restarts `unreleased.md`.

Local checks (release worktree off `91b511e`):

- `cargo fmt --all -- --check`: clean
- `cargo clippy --locked --all-targets --all-features -- -D warnings`: clean
- `cargo test --locked`: 938 passed
- `cargo build --release --locked --bin psf-guard-cli`: built
- `node scripts/check-release-version.mjs v0.9.4`: 0.9.4
- `npm ci`, `npm run lint`, `npx vitest run` (343 passed), `npm run build`, `npm run test:release` (14 passed)
- `git diff --check`: clean
- `NO_STRIP=true cargo tauri build`: .deb, .rpm (`psf-guard 0.9.4-1`), and .AppImage bundled at 0.9.4

Local Node is 22; CI runs the frontend on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv