### PR TITLE
Fix blank FILTER values in PixInsight calibration masters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4968,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.18.9"
+version = "0.18.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc82fde6c8ea09e1c1cbddcbedf4d68f4269b740b4d3c1baf7307f1f6eac3c7"
+checksum = "a66f802d950d2703d2d66c574a453d5abf5eb1f000456e1b1f2fa33edf00ea5f"
 dependencies = [
  "directories",
  "image",
@@ -5044,9 +5044,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-fits"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b956875bf6b87e92eb0aab29b9fe36ffb0575cbab0f802e386bbab0d88b022e"
+checksum = "96da9f0d675870e540417cb4c0268ae6f8b0841f16131b9cd39fb6a21f653a8f"
 dependencies = [
  "multiversion",
  "seiza-stretch",
@@ -5083,9 +5083,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc9c8761fc40a060b3875f14f348d7ead2422b8499e3120d08d0b63b6fd510"
+checksum = "9243f76a26b07f83c72d96494204fb940a0b6cf2c8a15dfe1f4e77ab8e467d8e"
 dependencies = [
  "rayon",
  "seiza",
@@ -5134,9 +5134,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-xisf"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d972a8c14605b1ddd171c964f07522350c30efbe0a917f21f0e357844c6099c"
+checksum = "d8bc46f350b99abb68c689aa947c6b805e22675fb69fe799572aa5e6d00b4eb0"
 dependencies = [
  "flate2",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,13 @@ byteorder = "1.5"
 seiza = "0.18.9"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
-seiza-fits = "=0.2.1"
+seiza-fits = "=0.2.2"
 seiza-satellites = { version = "0.7.0", features = ["serde"] }
 seiza-stacking = "0.11.5"
 seiza-stretch = "0.2.1"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.
-seiza-xisf = "0.2.0"
+seiza-xisf = "0.2.1"
 seiza-background = "0.2.1"
 seiza-calibration = "0.4.2"
 seiza-deconvolution = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.18.9"
+seiza = "0.18.10"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.2"
 seiza-satellites = { version = "0.7.0", features = ["serde"] }
-seiza-stacking = "0.11.5"
+seiza-stacking = "0.11.6"
 seiza-stretch = "0.2.1"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.

--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -73,6 +73,10 @@ again. Two things differ from raw frames:
   other frame and marking a flat as already bias- and dark-subtracted. The
   original is never written to; replacing it re-adopts it.
 
+Blank or undefined optional header values, such as `FILTER` in a PixInsight
+master bias XISF, are preserved in the cached FITS master. They do not prevent
+calibration, and the source file needs no header edits.
+
 **Settings → Calibration matching → Masters from other software** decides
 how they take part: use one whenever it matches (the default), only when raw
 frames cannot build a master, or never.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,3 +9,7 @@
 ## Changed
 
 ## Fixed
+
+- PixInsight master bias files with a blank `FILTER` header now work during
+  stacking. The cached master preserves the undefined value without requiring
+  edits to the original FITS or XISF file.

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -5055,6 +5055,195 @@ mod tests {
     }
 
     #[test]
+    fn an_external_xisf_bias_with_a_blank_filter_is_adopted() {
+        let _policy = POLICY_LOCK.lock().unwrap();
+        configure_external_master_policy(None);
+        for filter_value in ["", "   ", "''", "'   '"] {
+            let temp = tempfile::tempdir().unwrap();
+            let master_path = temp.path().join("masterBias.xisf");
+            write_pixinsight_xisf_bias(&master_path, filter_value);
+            let expected_filter = if filter_value.starts_with('\'') {
+                HeaderValue::String(String::new())
+            } else {
+                HeaderValue::Raw(String::new())
+            };
+            assert_external_bias_is_adopted(&master_path, temp.path(), expected_filter);
+        }
+    }
+
+    #[test]
+    fn an_external_fits_bias_with_an_undefined_filter_is_adopted() {
+        let _policy = POLICY_LOCK.lock().unwrap();
+        configure_external_master_policy(None);
+        let temp = tempfile::tempdir().unwrap();
+        let master_path = temp.path().join("masterBias.fits");
+        write_pixinsight_master(&master_path, "Master Bias", 0.01, None);
+        replace_test_fits_filter(
+            &master_path,
+            "FILTER  =                      / no filter for bias",
+        );
+        assert_external_bias_is_adopted(&master_path, temp.path(), HeaderValue::Raw(String::new()));
+    }
+
+    fn assert_external_bias_is_adopted(
+        master_path: &Path,
+        directory: &Path,
+        expected_filter: HeaderValue,
+    ) {
+        let original_bytes = std::fs::read(master_path).unwrap();
+        let source_filter = crate::image_io::open_linear_frame(master_path)
+            .unwrap()
+            .headers
+            .into_iter()
+            .find_map(|(key, value)| (key == "FILTER").then_some(value))
+            .unwrap();
+        assert_eq!(source_filter, expected_filter);
+        let light_path = directory.join("light.fits");
+        write_test_fits(&light_path, "LIGHT", 1_100);
+        let meta = crate::commands::import::headers::read_frame_meta(master_path);
+        assert!(meta.readable);
+        assert!(meta.processed);
+        assert!(meta
+            .filter
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty()));
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            let outcome = import_calibration_frames(&tx, &[meta], Some("profile")).unwrap();
+            assert_eq!(outcome.bias, 1);
+            tx.commit().unwrap();
+        }
+        let light = crate::commands::import::headers::read_frame_meta(&light_path);
+        let selection = select_for_light(&conn, &light).unwrap();
+        assert_eq!(selection.bias.len(), 1);
+        assert!(selection.bias[0].is_master);
+        let cache = directory.join("cache");
+        let (masters, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        let label = applied.bias_master.as_deref().unwrap_or_else(|| {
+            panic!("blank FILTER must not disable bias calibration: {applied:?}")
+        });
+        assert_eq!(applied.state, "applied");
+        let copy =
+            crate::image_io::open_linear_frame(cache.join("calibration-masters").join(label))
+                .unwrap();
+        copy.validate_master_kind("BIAS").unwrap();
+        assert!(copy
+            .image
+            .data
+            .iter()
+            .all(|sample| (*sample - 0.01 * 65_535.0).abs() < 0.001));
+        let source_name = master_path.file_name().unwrap().to_str().unwrap();
+        assert_eq!(
+            copy.headers
+                .iter()
+                .find_map(|(key, value)| (key == "FILTER").then_some(value)),
+            Some(&source_filter)
+        );
+        assert_eq!(
+            copy.headers
+                .iter()
+                .find_map(|(key, value)| (key == "PSFGSRC").then_some(value)),
+            Some(&HeaderValue::String(source_name.to_string()))
+        );
+        let (source_count, source_uuids, statistics): (i64, String, String) = conn
+            .query_row(
+                "SELECT source_count, source_frame_uuids, statistics_json
+                 FROM psf_guard_calibration_master",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(source_count, 1);
+        assert_eq!(
+            serde_json::from_str::<Vec<String>>(&source_uuids).unwrap(),
+            vec![selection.bias[0].frame_uuid.clone()]
+        );
+        let statistics: serde_json::Value = serde_json::from_str(&statistics).unwrap();
+        assert_eq!(statistics["external"], true);
+        assert_eq!(statistics["source"], source_name);
+
+        let mut calibrated = crate::image_io::open_linear_frame(&light_path).unwrap();
+        masters
+            .apply(
+                &mut calibrated.image,
+                calibrated.exposure_seconds,
+                calibrated.bayer,
+            )
+            .unwrap();
+        let expected = 1_100.0 - 0.01 * 65_535.0;
+        assert!(calibrated
+            .image
+            .data
+            .iter()
+            .all(|sample| (*sample - expected).abs() < 0.001));
+        assert_eq!(std::fs::read(master_path).unwrap(), original_bytes);
+    }
+
+    #[test]
+    fn raw_bias_frames_with_an_undefined_filter_build_a_master() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut sources = Vec::new();
+        let mut original_bytes = Vec::new();
+        let mut metadata = Vec::new();
+        for index in 0..2 {
+            let path = temp.path().join(format!("bias-{index}.fits"));
+            write_test_fits(&path, "BIAS", 100 + index * 2);
+            replace_test_fits_filter(&path, "FILTER  =                      / no filter for bias");
+            metadata.push(crate::commands::import::headers::read_frame_meta(&path));
+            original_bytes.push(std::fs::read(&path).unwrap());
+            sources.push(path);
+        }
+        let light_path = temp.path().join("light.fits");
+        write_test_fits(&light_path, "LIGHT", 1_100);
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            let outcome = import_calibration_frames(&tx, &metadata, Some("profile")).unwrap();
+            assert_eq!(outcome.bias, 2);
+            tx.commit().unwrap();
+        }
+        let cache = temp.path().join("cache");
+        let (masters, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        let label = applied.bias_master.as_deref().unwrap_or_else(|| {
+            panic!("blank FILTER must not prevent a bias master build: {applied:?}")
+        });
+        let copy =
+            crate::image_io::open_linear_frame(cache.join("calibration-masters").join(label))
+                .unwrap();
+        copy.validate_master_kind("BIAS").unwrap();
+        assert!(copy.image.data.iter().all(|sample| *sample == 101.0));
+        let mut calibrated = crate::image_io::open_linear_frame(&light_path).unwrap();
+        masters
+            .apply(
+                &mut calibrated.image,
+                calibrated.exposure_seconds,
+                calibrated.bayer,
+            )
+            .unwrap();
+        assert!(calibrated.image.data.iter().all(|sample| *sample == 999.0));
+        for (path, original) in sources.iter().zip(original_bytes) {
+            assert_eq!(std::fs::read(path).unwrap(), original);
+        }
+    }
+
+    #[test]
     fn the_external_master_policy_decides_between_a_master_and_raw_frames() {
         let _policy = POLICY_LOCK.lock().unwrap();
         let temp = tempfile::tempdir().unwrap();
@@ -5162,6 +5351,46 @@ mod tests {
     /// Serializes the tests that change the process-wide external-master
     /// policy, which every selection in the process reads.
     static POLICY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn replace_test_fits_filter(path: &Path, filter_card: &str) {
+        let mut bytes = std::fs::read(path).unwrap();
+        let card = bytes[..2880]
+            .chunks_exact_mut(80)
+            .find(|card| card.starts_with(b"FILTER  ="))
+            .unwrap();
+        card.fill(b' ');
+        card[..filter_card.len()].copy_from_slice(filter_card.as_bytes());
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    fn write_pixinsight_xisf_bias(path: &Path, filter_value: &str) {
+        // Construct the PixInsight-shaped input independently of Seiza's output
+        // writer, including undefined values for filterless calibration frames.
+        let xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<xisf version="1.0" xmlns="http://www.pixinsight.com/xisf">
+<Image geometry="4:4:1" sampleFormat="Float32" bounds="0:1" colorSpace="Gray" pixelStorage="Planar" location="attachment:4096:64">
+<FITSKeyword name="IMAGETYP" value="'Master Bias'"/>
+<FITSKeyword name="FILTER" value="{filter_value}" comment="Filter name"/>
+<FITSKeyword name="EXPTIME" value="0"/>
+<FITSKeyword name="XBINNING" value="1"/>
+<FITSKeyword name="YBINNING" value="1"/>
+<FITSKeyword name="INSTRUME" value="'Camera'"/>
+<FITSKeyword name="TELESCOP" value="'Scope'"/>
+</Image></xisf>"#
+        );
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"XISF0100");
+        bytes.extend_from_slice(&(xml.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(&[0; 4]);
+        bytes.extend_from_slice(xml.as_bytes());
+        assert!(bytes.len() <= 4096);
+        bytes.resize(4096, 0);
+        for _ in 0..16 {
+            bytes.extend_from_slice(&0.01_f32.to_le_bytes());
+        }
+        std::fs::write(path, bytes).unwrap();
+    }
 
     /// A master as PixInsight's WBPP writes one: 32-bit float samples
     /// normalized to 0..1, `IMAGETYP` naming the master, exposure, camera,


### PR DESCRIPTION
## Summary

Fixes #404.

PixInsight master bias files can contain a blank `FILTER` keyword. The readers preserve that as an undefined FITS value, but the previous writer rejected it while creating the cached master, so stacking continued without the bias.

- Consume the published fixes from [Seiza #171](https://github.com/theatrus/seiza/pull/171) and the workspace release in [Seiza #172](https://github.com/theatrus/seiza/pull/172): `seiza 0.18.10`, `seiza-fits 0.2.2`, `seiza-stacking 0.11.6`, and `seiza-xisf 0.2.1`.
- Update only those four versions and checksums in `Cargo.lock`. All dependencies resolve from crates.io; no path or git patches remain.
- Add calibration regressions for empty, whitespace-only, and quoted-empty XISF FILTER values, undefined FITS FILTER values, and raw-bias master generation.
- Verify cached header value types, physical pixel scale, provenance, source-file preservation, and actual bias subtraction from a light.
- Document the behavior and add the unreleased fix note. Rebased onto main's 0.9.4 release.

No source-file header edits or database migration are needed. The production fix belongs to the shared image writers, so PSF Guard needs only the dependency update.

## Review and Validation

The original dependencies reproduced the exact reported `empty or non-ASCII raw FITS header FILTER` error for both external XISF and FITS bias masters. Independent review of the fix, regressions, and final published dependency graph found no actionable issues.

Local checks against the published registry crates, without local overrides:

- `cargo test --locked --quiet`: 812 unit tests passed, 5 ignored; all integration and doc-test suites passed.
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `cargo metadata --locked --format-version 1`: each updated crate resolves exactly once from the registry.
- `git diff --check`

No frontend code changed; browser/UI tests were not rerun for this dependency and calibration-regression update. Hosted CI results are separate from these local checks.
