### PR TITLE
Bring merged pool-aware stacking changes onto main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4968,9 +4968,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.18.11"
+version = "0.18.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6487e888f70918c5b6fc4e5e6eca050f20a272a42bde4ccc2c16e83d559d12"
+checksum = "bca7779e24d13214b7ebc193d15d8c74d025282a3b1de8c123724736b2212366"
 dependencies = [
  "directories",
  "image",
@@ -5083,9 +5083,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d58f942188b2cf3f404b25e824e52d971c698e6cafb42fa87214306e8a1291"
+checksum = "7de5bbd984184633c7be64e2a1091df1c6501d65c23f3adc7813192471e7a031"
 dependencies = [
  "rayon",
  "seiza",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.18.11"
+seiza = "0.18.12"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.2"
 seiza-satellites = { version = "0.7.0", features = ["serde"] }
-seiza-stacking = "0.12.0"
+seiza-stacking = "0.13.0"
 seiza-stretch = "0.2.1"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -71,6 +71,45 @@ building again continues where the stop landed instead of starting over.
 Checkpoints live in the project cache and cost one full-frame state file per
 target/channel.
 
+### Frame preparation and worker budgets
+
+Within one channel, upcoming frames can be read, calibrated, debayered,
+registered, and normalized while earlier frames are integrated. A coordinator
+outside Rayon submits CPU preparation and integration to the group's explicit
+compute pool. Integration remains in source order, including frame decisions,
+calibration-session boundaries, signal-to-noise measurements, and checkpoints.
+
+The existing interactive worker allowance is split between bounded read/decode
+workers and the compute pool, reserving at most two reader slots. A one-worker
+allowance keeps the sequential path. Calibration setup, initialization, depth
+measurements, checkpoints, and final processing use the full allowance after
+readers have drained; those stages never run concurrently with preparation.
+The memory plan reserves stack buffers, every session's resident masters, and
+the active-master replacement peak before allowing queued frames. If even one
+preparation worker cannot fit but known RAM supports the serial-processing
+estimate, the build processes one frame at a time with the full compute pool
+and logs the memory fallback. If serial processing cannot fit either, the build
+reports that clearly.
+Admission reserves 40 bytes per output sample before budgeting preparation.
+Initialization, checkpoints, and final rejection have a separate 96-byte
+per-sample estimate because their peaks do not overlap the preparation queue.
+Both checks include the resident masters and two copies of the largest active
+master set. If available RAM cannot be queried, preparation gets a bounded
+1 GiB allowance, but the serial-processing peak cannot be checked.
+An unknown-RAM build that cannot fit one preparation worker in that allowance
+fails instead of silently starting an unbounded serial job. The intentional
+one-CPU serial path applies the same allowance to its single-frame workspace.
+These are reference-sized estimates, not a hard process-memory limit: larger
+source frames, decoder scratch buffers, and other activity can need more RAM.
+Separate channels and queued stack jobs still run one at a time.
+
+Logs report the configured worker split, estimated memory, actual pipeline mode
+and worker count, and batch elapsed time. Batch timing also separates read/decode,
+CPU preparation, integration, and coordinator waits. Worker-time sums overlap
+and can exceed elapsed time; they must not be added together as a wall-clock
+total. Final transient rejection still replays frames sequentially within the
+compute pool. No extra full-frame pre-measurement pass is required.
+
 ### Cache housekeeping
 
 Stack artifacts are content-addressed by job, so every rebuild writes a new

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -18,6 +18,12 @@
 
 ## Fixed
 
+- Stack previews now overlap frame preparation within the configured worker
+  and memory budgets instead of silently preparing frames sequentially.
+  Builds that fit serial processing but cannot fit a preparation queue keep
+  working with one frame at a time. Batch logs expose execution mode, worker
+  counts, memory fallback, and stage timings.
+
 - Completed stacks revisit early admitted samples to reject bright transient
   trails, with pass/frame progress and consistent results after resuming a
   build. Low-coverage pixels and overlapping trails can still retain artifacts.

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -7,6 +7,7 @@
 
 pub mod artifact;
 pub mod color;
+mod execution;
 mod final_integration;
 mod janitor;
 pub mod rc_astro;
@@ -2090,6 +2091,35 @@ fn run_group(
         worker_policy,
         cancel,
     } = job;
+    let available_memory = crate::concurrency::available_memory_bytes();
+    let reference_path = &group
+        .frames
+        .first()
+        .ok_or_else(|| "Stack group has no input frames".to_string())?
+        .path;
+    let budget = crate::concurrency::plan_workers(
+        None,
+        worker_policy,
+        crate::concurrency::Priority::Interactive,
+        crate::concurrency::probe_frame_pixels(reference_path),
+    );
+    let threads = execution::ThreadBudget::from_total(budget.workers);
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(budget.workers)
+        .thread_name(|index| format!("stack-preview-{index}"))
+        .build()
+        .map_err(|error| error.to_string())?;
+    tracing::info!(
+        job_id,
+        group_index = group.index,
+        total_worker_budget = budget.workers,
+        phase_workers = budget.workers,
+        compute_workers = threads.compute_workers,
+        preparation_workers = threads.preparation_workers,
+        serial = threads.serial,
+        rationale = %budget.rationale,
+        "Stack worker budget configured"
+    );
     let ctx = state
         .get_database(database_id)
         .ok_or_else(|| format!("Database {database_id} is no longer configured"))?;
@@ -2112,14 +2142,24 @@ fn run_group(
     // between them too. The plan partitions a multi-night group into
     // sessions, each with its own masters; a single-night group gets one
     // session and stacks exactly as before.
-    let plan = crate::calibration::resolve_or_build_master_plan(
-        &calibration_conn,
-        cache_root,
-        &light_paths,
-        Some(&directory_tree),
-        Some(cancel.as_ref()),
-        group.calibration,
-        &[],
+    let calibration_mode = group.calibration;
+    let calibration_started = std::time::Instant::now();
+    let plan = pool.install(move || {
+        crate::calibration::resolve_or_build_master_plan(
+            &calibration_conn,
+            cache_root,
+            &light_paths,
+            Some(&directory_tree),
+            Some(cancel.as_ref()),
+            calibration_mode,
+            &[],
+        )
+    });
+    tracing::info!(
+        job_id,
+        group_index = group.index,
+        elapsed_seconds = calibration_started.elapsed().as_secs_f64(),
+        "Stack calibration plan finished"
     );
     if cancel.load(Ordering::Relaxed) {
         return Ok(GroupOutcome::Cancelled);
@@ -2232,37 +2272,26 @@ fn run_group(
         reference_frame.image.channels as u64
     };
     let pixels = reference_frame.image.pixel_count();
-    let estimate = (pixels as u64)
-        .saturating_mul(output_channels)
-        .saturating_mul(STACK_BYTES_PER_OUTPUT_SAMPLE);
-    if let Some(available) = crate::concurrency::available_memory_bytes()
-        && estimate > (available as f64 * worker_policy.memory_budget_fraction) as u64
-    {
-        return Err(format!(
-            "Estimated stack memory {} MiB exceeds the configured available-memory budget",
-            estimate / (1024 * 1024)
-        ));
-    }
-    let budget = crate::concurrency::plan_workers(
-        None,
+    let pipeline_budget = execution::plan_pipeline(
+        available_memory,
         worker_policy,
-        crate::concurrency::Priority::Interactive,
-        Some(pixels),
-    );
-    let pool = ThreadPoolBuilder::new()
-        .num_threads(budget.workers)
-        .thread_name(|index| format!("stack-preview-{index}"))
-        .build()
-        .map_err(|error| error.to_string())?;
+        pixels,
+        pixels.saturating_mul(output_channels as usize),
+        &plan,
+        &threads,
+    )?;
+    let threads = pipeline_budget.threads;
     tracing::info!(
-        "Stack preview {} group {}: {} worker(s) — {}",
         job_id,
-        group.index,
-        budget.workers,
-        budget.rationale
+        group_index = group.index,
+        compute_workers = threads.compute_workers,
+        preparation_workers = threads.preparation_workers,
+        serial = threads.serial,
+        memory = %pipeline_budget.summary(),
+        "Stack pipeline memory planned"
     );
 
-    pool.install(|| {
+    let (mut stacker, mut ledger, mut points, mut orientation_vote) = pool.install(|| {
         // A checkpoint that fails to reopen — a Seiza version change, a
         // truncated file — is discarded and the group builds from scratch.
         let restored = checkpoint.and_then(|checkpoint| {
@@ -2301,7 +2330,7 @@ fn run_group(
             }
         });
         let mut orientation_vote = OrientationVote::default();
-        let (mut stacker, mut ledger, mut points) = match restored {
+        let (stacker, ledger, points) = match restored {
             Some((stacker, manifest)) => {
                 // Replay the checkpointed ledger: the per-frame record, the
                 // counters, and each accepted frame's orientation vote. The
@@ -2442,16 +2471,19 @@ fn run_group(
                 (stacker, ledger, Vec::new())
             }
         };
-        // The reference frame alone is the first depth on the curve and the
-        // baseline every later depth is read against: one frame's noise.
-        if points.is_empty()
-            && let Some(sample) = seiza_stacking::measure_depth(stacker.view())
-        {
-            points.push(snr::point(sample, integrated_exposure(&ledger)));
-        }
-        let save_checkpoint = |stacker: &LiveStacker,
-                               ledger: &[resume::ResumeFrame],
-                               points: &[snr::SnrPoint]| {
+        Ok::<_, String>((stacker, ledger, points, orientation_vote))
+    })?;
+    // The reference frame alone is the first depth on the curve and the
+    // baseline every later depth is read against: one frame's noise.
+    if points.is_empty()
+        && let Some(sample) = pool.install(|| seiza_stacking::measure_depth(stacker.view()))
+    {
+        points.push(snr::point(sample, integrated_exposure(&ledger)));
+    }
+    let save_checkpoint = |stacker: &LiveStacker,
+                           ledger: &[resume::ResumeFrame],
+                           points: &[snr::SnrPoint]| {
+        pool.install(|| {
             // A quality-ordered build is a full restack by nature. Writing its
             // accumulator here would leave a checkpoint no later build can
             // extend, in place of the capture-order one that can be.
@@ -2504,105 +2536,125 @@ fn run_group(
                 tracing::warn!("Failed to save stack checkpoint: {error}");
                 resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
             }
-        };
+        })
+    };
 
-        // Pending frames keep their index into `group.frames`, which is what
-        // the calibration plan's session assignments are aligned with.
-        let pending: Vec<(usize, &PreparedFrame)> =
-            group.frames.iter().enumerate().skip(ledger.len()).collect();
-        // Reads, calibration, registration and normalization overlap across
-        // frames while integration stays in this order, so the accumulator
-        // sees exactly the sequence a frame-at-a-time loop would. A frame
-        // declaring itself normalized is put on the same 16-bit scale the
-        // rest of the catalog uses as it is read.
-        let pipeline = seiza_stacking::PipelineOptions {
-            normalized_full_scale: Some(crate::image_io::NORMALIZED_FULL_SCALE),
-            ..seiza_stacking::PipelineOptions::default()
-        };
-        let mut cancelled = false;
-        // Depths already behind us were measured by the build that wrote the
-        // checkpoint, so only the ones ahead split this run's batches.
-        let start_depth = ledger.len();
-        let mut checkpoints: std::collections::VecDeque<usize> =
-            seiza_stacking::checkpoint_depths(start_depth + pending.len())
-                .into_iter()
-                .filter(|depth| *depth > start_depth)
-                .collect();
-        // Consecutive frames of one calibration session push as one
-        // pipelined batch, with the session's masters swapped in first. The
-        // frames after the reference are chronological, so a night is one
-        // batch and a single-session group is exactly one call. On a
-        // resumed stack this also replaces whatever masters the checkpoint
-        // stored with the ones this batch needs.
-        // Frames the stacker turned away for calibration, folded into the
-        // group warning below: each carries its reason in the frame list,
-        // but nobody reads a hundred rows to learn that six frames shared
-        // one cause.
-        let mut calibration_rejections: Vec<String> = Vec::new();
-        let mut batch_start = 0usize;
-        while batch_start < pending.len() && !cancelled {
-            let session = plan.assignments[pending[batch_start].0];
-            let mut batch_end = pending[batch_start..]
-                .iter()
-                .position(|(index, _)| plan.assignments[*index] != session)
-                .map(|offset| batch_start + offset)
-                .unwrap_or(pending.len());
-            // A batch also ends at the next depth the curve is measured at.
-            // The accumulator can only be read between batches, and the
-            // doubling ladder keeps this to about one extra boundary per
-            // doubling — nine of them across five hundred frames.
-            if let Some(&next) = checkpoints.front() {
-                let limit = next.saturating_sub(start_depth);
-                if limit > batch_start {
-                    batch_end = batch_end.min(limit);
-                }
+    // Pending frames keep their index into `group.frames`, which is what
+    // the calibration plan's session assignments are aligned with.
+    let pending: Vec<(usize, &PreparedFrame)> =
+        group.frames.iter().enumerate().skip(ledger.len()).collect();
+    // Reads, calibration, registration and normalization overlap across
+    // frames while integration stays in this order, so the accumulator
+    // sees exactly the sequence a frame-at-a-time loop would. A frame
+    // declaring itself normalized is put on the same 16-bit scale the
+    // rest of the catalog uses as it is read.
+    // Only the pipeline uses the reduced compute allowance. Its readers are
+    // joined before any SNR, checkpoint or final-processing work uses `pool`.
+    let pipeline_pool = if threads.serial {
+        None
+    } else {
+        Some(
+            ThreadPoolBuilder::new()
+                .num_threads(threads.compute_workers)
+                .thread_name(|index| format!("stack-pipeline-{index}"))
+                .build()
+                .map_err(|error| error.to_string())?,
+        )
+    };
+    let pipeline_pool = pipeline_pool.as_ref().unwrap_or(&pool);
+    let pipeline = pipeline_budget.options;
+    let mut cancelled = false;
+    // Depths already behind us were measured by the build that wrote the
+    // checkpoint, so only the ones ahead split this run's batches.
+    let start_depth = ledger.len();
+    let mut checkpoints: std::collections::VecDeque<usize> =
+        seiza_stacking::checkpoint_depths(start_depth + pending.len())
+            .into_iter()
+            .filter(|depth| *depth > start_depth)
+            .collect();
+    // Consecutive frames of one calibration session push as one
+    // pipelined batch, with the session's masters swapped in first. The
+    // frames after the reference are chronological, so a night is one
+    // batch and a single-session group is exactly one call. On a
+    // resumed stack this also replaces whatever masters the checkpoint
+    // stored with the ones this batch needs.
+    // Frames the stacker turned away for calibration, folded into the
+    // group warning below: each carries its reason in the frame list,
+    // but nobody reads a hundred rows to learn that six frames shared
+    // one cause.
+    let mut calibration_rejections: Vec<String> = Vec::new();
+    let mut batch_start = 0usize;
+    while batch_start < pending.len() && !cancelled {
+        let session = plan.assignments[pending[batch_start].0];
+        let mut batch_end = pending[batch_start..]
+            .iter()
+            .position(|(index, _)| plan.assignments[*index] != session)
+            .map(|offset| batch_start + offset)
+            .unwrap_or(pending.len());
+        // A batch also ends at the next depth the curve is measured at.
+        // The accumulator can only be read between batches, and the
+        // doubling ladder keeps this to about one extra boundary per
+        // doubling — nine of them across five hundred frames.
+        if let Some(&next) = checkpoints.front() {
+            let limit = next.saturating_sub(start_depth);
+            if limit > batch_start {
+                batch_end = batch_end.min(limit);
             }
-            let batch = &pending[batch_start..batch_end];
-            let paths: Vec<PathBuf> = batch.iter().map(|(_, frame)| frame.path.clone()).collect();
-            // Auto mode's contract: a calibration problem is something to
-            // warn about and work around, never a reason to abandon a stack
-            // half-integrated. A swap the stacker refuses falls back to
-            // stacking this session's frames raw, and the group warning says
-            // so and why. Forced calibration keeps the hard error: the user
-            // explicitly asked for these masters.
-            let mut calibration_bypassed = false;
-            if let Err(error) = stacker.set_calibration(plan.sessions[session].masters.clone()) {
-                if group.calibration == crate::calibration::CalibrationMode::On {
-                    return Err(error.to_string());
-                }
-                tracing::warn!(
-                    "session {session} masters refused; stacking its frames uncalibrated: {error}"
-                );
-                stacker
-                    .set_calibration(seiza_stacking::CalibrationMasters::default())
-                    .map_err(|error| error.to_string())?;
-                calibration_bypassed = true;
-                let note = format!(
-                    "Session {} stacked uncalibrated: its masters were refused — {error}",
-                    session + 1
-                );
-                state.stack_previews.update(job_id, |job| {
-                    let calibration = &mut job.groups[group.index].calibration;
-                    calibration.warning = Some(match calibration.warning.take() {
-                        Some(previous) if previous.contains(&note) => previous,
-                        Some(previous) => format!("{previous}. {note}"),
-                        None => note,
-                    });
+        }
+        let batch = &pending[batch_start..batch_end];
+        let paths: Vec<PathBuf> = batch.iter().map(|(_, frame)| frame.path.clone()).collect();
+        // Auto mode's contract: a calibration problem is something to
+        // warn about and work around, never a reason to abandon a stack
+        // half-integrated. A swap the stacker refuses falls back to
+        // stacking this session's frames raw, and the group warning says
+        // so and why. Forced calibration keeps the hard error: the user
+        // explicitly asked for these masters.
+        let mut calibration_bypassed = false;
+        if let Err(error) =
+            pool.install(|| stacker.set_calibration(plan.sessions[session].masters.clone()))
+        {
+            if group.calibration == crate::calibration::CalibrationMode::On {
+                return Err(error.to_string());
+            }
+            tracing::warn!(
+                "session {session} masters refused; stacking its frames uncalibrated: {error}"
+            );
+            pool.install(|| stacker.set_calibration(seiza_stacking::CalibrationMasters::default()))
+                .map_err(|error| error.to_string())?;
+            calibration_bypassed = true;
+            let note = format!(
+                "Session {} stacked uncalibrated: its masters were refused — {error}",
+                session + 1
+            );
+            state.stack_previews.update(job_id, |job| {
+                let calibration = &mut job.groups[group.index].calibration;
+                calibration.warning = Some(match calibration.warning.take() {
+                    Some(previous) if previous.contains(&note) => previous,
+                    Some(previous) => format!("{previous}. {note}"),
+                    None => note,
                 });
-            }
-            let mut consumed = 0usize;
-            // Every frame's outcome is recorded in the callback above, so the
-            // summary adds nothing here.
-            let _report = stacker
-                .push_fits_pipelined(&paths, &pipeline, |_, outcome| {
-                    let (_, frame) = batch[consumed];
-                    consumed += 1;
-                    let exposure = frame.exposure_seconds;
-                    let (decision, retryable_failure) = match outcome {
-                        Ok(FrameDisposition::Accepted(diagnostics)) => {
-                            orientation_vote
-                                .add(diagnostics.mapping.transform().rotation_radians, exposure);
-                            (StackFrameDecision {
+            });
+        }
+        let mut consumed = 0usize;
+        // The coordinator stays outside Rayon; Seiza submits CPU work to
+        // this pool and commits outcomes in source order.
+        let batch_started = std::time::Instant::now();
+        let report = execution::run_pipeline(
+            &mut stacker,
+            &paths,
+            &pipeline,
+            pipeline_pool,
+            &threads,
+            |_, outcome| {
+                let (_, frame) = batch[consumed];
+                consumed += 1;
+                let exposure = frame.exposure_seconds;
+                let (decision, retryable_failure) = match outcome {
+                    Ok(FrameDisposition::Accepted(diagnostics)) => {
+                        orientation_vote
+                            .add(diagnostics.mapping.transform().rotation_radians, exposure);
+                        (
+                            StackFrameDecision {
                                 image_id: frame.image_id,
                                 disposition: "accepted".into(),
                                 reason: None,
@@ -2620,130 +2672,141 @@ fn run_group(
                                 source_fingerprint: Some(frame.source_fingerprint.clone()),
                                 overlap_fraction: Some(diagnostics.overlap_fraction),
                                 integrated_fraction: Some(diagnostics.integrated_fraction),
-                            }, false)
-                        }
-                        // A frame the stack turned away and one that could not be
-                        // read are both "not integrated" to a caller reading the
-                        // group's decisions; only the reason differs.
-                        Ok(FrameDisposition::Rejected(reason)) => {
-                            if let seiza_stacking::FrameRejectionReason::Calibration(message) =
-                                &reason
-                            {
-                                calibration_rejections.push(message.clone());
-                            }
-                            (rejected_decision(frame, reason.to_string()), false)
-                        }
-                        Err(error) => (rejected_decision(frame, error.to_string()), true),
-                    };
-                    ledger.push(resume::ResumeFrame {
-                        decision: decision.clone(),
-                        exposure_seconds: exposure,
-                        calibration_bypassed,
-                        retryable_failure,
-                        rotation_radians: if decision.disposition == "accepted" {
-                            decision
-                                .registered_mapping
-                                .as_ref()
-                                .map(|mapping| mapping.transform().rotation_radians)
-                        } else {
-                            None
-                        },
-                    });
-                    state.stack_previews.update(job_id, |job| {
-                        let status = &mut job.groups[group.index];
-                        status.processed_frames += 1;
-                        if matches!(decision.disposition.as_str(), "accepted") {
-                            status.accepted_frames += 1;
-                            status.total_exposure_seconds += exposure;
-                        } else {
-                            status.rejected_frames += 1;
-                        }
-                        status.frames.push(decision);
-                    });
-
-                    // Integrating one frame is the unit of work, so this is where
-                    // a stop takes effect. Frames already prepared are discarded.
-                    if cancel.load(Ordering::Relaxed) {
-                        cancelled = true;
-                        seiza_stacking::Continue::No
-                    } else {
-                        seiza_stacking::Continue::Yes
+                            },
+                            false,
+                        )
                     }
-                })
-                .map_err(|error| error.to_string())?;
-            batch_start = batch_end;
-
-            // Read the accumulator whenever this batch carried it past a
-            // depth on the ladder, and once more wherever a stop landed, so a
-            // stopped build still publishes the curve it paid for.
-            let depth = start_depth + batch_start;
-            let crossed = checkpoints.front().is_some_and(|next| *next <= depth);
-            while checkpoints.front().is_some_and(|next| *next <= depth) {
-                checkpoints.pop_front();
-            }
-            // Frames the stack turned away move the depth without moving the
-            // accepted count, and a step that integrated nothing is not a
-            // depth on the curve.
-            let advanced = points
-                .last()
-                .is_none_or(|last| last.frames < stacker.view().accepted_frames);
-            if (crossed || cancelled)
-                && advanced
-                && let Some(sample) = seiza_stacking::measure_depth(stacker.view())
-            {
-                points.push(snr::point(sample, integrated_exposure(&ledger)));
-                let exposures = accepted_exposures(&ledger);
-                let progressive =
-                    snr::ProgressiveSnr::new(order, points.clone(), &exposures);
+                    // A frame the stack turned away and one that could not be
+                    // read are both "not integrated" to a caller reading the
+                    // group's decisions; only the reason differs.
+                    Ok(FrameDisposition::Rejected(reason)) => {
+                        if let seiza_stacking::FrameRejectionReason::Calibration(message) = &reason
+                        {
+                            calibration_rejections.push(message.clone());
+                        }
+                        (rejected_decision(frame, reason.to_string()), false)
+                    }
+                    Err(error) => (rejected_decision(frame, error.to_string()), true),
+                };
+                ledger.push(resume::ResumeFrame {
+                    decision: decision.clone(),
+                    exposure_seconds: exposure,
+                    calibration_bypassed,
+                    retryable_failure,
+                    rotation_radians: if decision.disposition == "accepted" {
+                        decision
+                            .registered_mapping
+                            .as_ref()
+                            .map(|mapping| mapping.transform().rotation_radians)
+                    } else {
+                        None
+                    },
+                });
                 state.stack_previews.update(job_id, |job| {
-                    job.groups[group.index].snr = Some(progressive);
+                    let status = &mut job.groups[group.index];
+                    status.processed_frames += 1;
+                    if matches!(decision.disposition.as_str(), "accepted") {
+                        status.accepted_frames += 1;
+                        status.total_exposure_seconds += exposure;
+                    } else {
+                        status.rejected_frames += 1;
+                    }
+                    status.frames.push(decision);
                 });
-            }
-        }
 
-        if cancelled {
-            // The frames that did land are checkpointed, so building again
-            // continues from them.
-            save_checkpoint(&stacker, &ledger, &points);
-            return Ok(GroupOutcome::Cancelled);
-        }
-        // The accumulator is complete: checkpoint it before the snapshot
-        // consumes the stacker, so an additive rebuild can pick it up here.
-        save_checkpoint(&stacker, &ledger, &points);
-        // The per-frame reasons live in the frame list; the summary is what a
-        // person actually reads. One line per distinct cause, with a count.
-        if !calibration_rejections.is_empty() {
-            let mut counts: Vec<(String, usize)> = Vec::new();
-            for reason in &calibration_rejections {
-                match counts.iter_mut().find(|(existing, _)| existing == reason) {
-                    Some((_, count)) => *count += 1,
-                    None => counts.push((reason.clone(), 1)),
+                // Integrating one frame is the unit of work, so this is where
+                // a stop takes effect. Frames already prepared are discarded.
+                if cancel.load(Ordering::Relaxed) {
+                    cancelled = true;
+                    seiza_stacking::Continue::No
+                } else {
+                    seiza_stacking::Continue::Yes
                 }
-            }
-            let note = format!(
-                "{} frame(s) could not be calibrated and were left out — {}",
-                calibration_rejections.len(),
-                counts
-                    .iter()
-                    .map(|(reason, count)| format!("{count}× {reason}"))
-                    .collect::<Vec<_>>()
-                    .join("; ")
-            );
+            },
+        )
+        .map_err(|error| error.to_string())?;
+        tracing::info!(
+            job_id,
+            group_index = group.index,
+            session,
+            batch_frames = paths.len(),
+            elapsed_seconds = batch_started.elapsed().as_secs_f64(),
+            pipeline = ?report,
+            "Stack preparation batch finished"
+        );
+        batch_start = batch_end;
+
+        // Read the accumulator whenever this batch carried it past a
+        // depth on the ladder, and once more wherever a stop landed, so a
+        // stopped build still publishes the curve it paid for.
+        let depth = start_depth + batch_start;
+        let crossed = checkpoints.front().is_some_and(|next| *next <= depth);
+        while checkpoints.front().is_some_and(|next| *next <= depth) {
+            checkpoints.pop_front();
+        }
+        // Frames the stack turned away move the depth without moving the
+        // accepted count, and a step that integrated nothing is not a
+        // depth on the curve.
+        let advanced = points
+            .last()
+            .is_none_or(|last| last.frames < stacker.view().accepted_frames);
+        if (crossed || cancelled)
+            && advanced
+            && let Some(sample) = pool.install(|| seiza_stacking::measure_depth(stacker.view()))
+        {
+            points.push(snr::point(sample, integrated_exposure(&ledger)));
+            let exposures = accepted_exposures(&ledger);
+            let progressive = snr::ProgressiveSnr::new(order, points.clone(), &exposures);
             state.stack_previews.update(job_id, |job| {
-                let calibration = &mut job.groups[group.index].calibration;
-                calibration.warning = Some(match calibration.warning.take() {
-                    Some(previous) if previous.contains(&note) => previous,
-                    Some(previous) => format!("{previous}. {note}"),
-                    None => note,
-                });
+                job.groups[group.index].snr = Some(progressive);
             });
         }
-        // Last exit before the job writes anything. Orienting and rendering
-        // follow, and a stop after this point would have to clean up published
-        // artifacts.
-        if cancel.load(Ordering::Relaxed) {
-            return Ok(GroupOutcome::Cancelled);
+    }
+
+    if cancelled {
+        // The frames that did land are checkpointed, so building again
+        // continues from them.
+        save_checkpoint(&stacker, &ledger, &points);
+        return Ok(GroupOutcome::Cancelled);
+    }
+    // The accumulator is complete: checkpoint it before the snapshot
+    // consumes the stacker, so an additive rebuild can pick it up here.
+    save_checkpoint(&stacker, &ledger, &points);
+    // The per-frame reasons live in the frame list; the summary is what a
+    // person actually reads. One line per distinct cause, with a count.
+    if !calibration_rejections.is_empty() {
+        let mut counts: Vec<(String, usize)> = Vec::new();
+        for reason in &calibration_rejections {
+            match counts.iter_mut().find(|(existing, _)| existing == reason) {
+                Some((_, count)) => *count += 1,
+                None => counts.push((reason.clone(), 1)),
+            }
         }
+        let note = format!(
+            "{} frame(s) could not be calibrated and were left out — {}",
+            calibration_rejections.len(),
+            counts
+                .iter()
+                .map(|(reason, count)| format!("{count}× {reason}"))
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+        state.stack_previews.update(job_id, |job| {
+            let calibration = &mut job.groups[group.index].calibration;
+            calibration.warning = Some(match calibration.warning.take() {
+                Some(previous) if previous.contains(&note) => previous,
+                Some(previous) => format!("{previous}. {note}"),
+                None => note,
+            });
+        });
+    }
+    // Last exit before the job writes anything. Orienting and rendering
+    // follow, and a stop after this point would have to clean up published
+    // artifacts.
+    if cancel.load(Ordering::Relaxed) {
+        return Ok(GroupOutcome::Cancelled);
+    }
+    pool.install(|| {
         let reference_headers = stacker.reference_headers().to_vec();
         let snapshot = stacker.into_snapshot().map_err(|error| error.to_string())?;
         let accepted_frames = snapshot.accepted_frames;
@@ -2752,9 +2815,18 @@ fn run_group(
             // The online checkpoint remains useful for admission and the depth
             // curve. Release its buffers before revisiting early transients.
             drop(snapshot);
-            tracing::info!(job_id, group_index = group.index, accepted_frames, "Starting final transient rejection");
+            tracing::info!(
+                job_id,
+                group_index = group.index,
+                accepted_frames,
+                "Starting final transient rejection"
+            );
             let result = final_integration::integrate(
-                &group, &ledger, &plan, cosmetic, cancel,
+                &group,
+                &ledger,
+                &plan,
+                cosmetic,
+                cancel,
                 |pass, index, count| {
                     let pass = match pass {
                         seiza_stacking::BatchStackPass::Estimate => 1,
@@ -2762,7 +2834,8 @@ fn run_group(
                     };
                     state.stack_previews.update(job_id, |job| {
                         job.groups[group.index].phase = format!(
-                            "Rejecting transients: pass {pass}/2, frame {}/{count}", index + 1
+                            "Rejecting transients: pass {pass}/2, frame {}/{count}",
+                            index + 1
                         );
                     });
                 },
@@ -2778,13 +2851,25 @@ fn run_group(
                     if matches!(frame.disposition.as_str(), "reference" | "accepted")
                         && let Some(diagnostic) = diagnostics.next()
                     {
-                        frame.integrated_fraction = Some(diagnostic.integrated_samples as f32
-                            / result.snapshot.image.sample_count() as f32);
+                        frame.integrated_fraction = Some(
+                            diagnostic.integrated_samples as f32
+                                / result.snapshot.image.sample_count() as f32,
+                        );
                     }
                 }
             });
-            let rejected_samples: u64 = result.snapshot.rejected_samples.iter().map(|&count| u64::from(count)).sum();
-            tracing::info!(job_id, group_index = group.index, rejected_samples, "Final transient rejection completed");
+            let rejected_samples: u64 = result
+                .snapshot
+                .rejected_samples
+                .iter()
+                .map(|&count| u64::from(count))
+                .sum();
+            tracing::info!(
+                job_id,
+                group_index = group.index,
+                rejected_samples,
+                "Final transient rejection completed"
+            );
             result.snapshot.image
         } else {
             snapshot.image

--- a/src/server/stack_preview/execution.rs
+++ b/src/server/stack_preview/execution.rs
@@ -1,0 +1,856 @@
+//! Reserve stack and calibration buffers before enabling frame preparation.
+//!
+//! These reference-sized estimates are not a hard RSS limit. Larger source
+//! frames, decoder scratch space, allocator overhead and other jobs can exceed
+//! them. Capture available RAM before loading the group's masters and reference
+//! so their buffers are not charged twice against an already reduced reading.
+
+use crate::calibration::CalibrationPlan;
+use crate::concurrency::WorkerPolicy;
+use seiza_stacking::{LiveStacker, PipelineOptions, PoolPipelineMemory, PoolPipelineReport};
+use std::path::{Path, PathBuf};
+
+const UNKNOWN_RAM_PIPELINE_BYTES: u64 = 1024 * 1024 * 1024;
+const ADMISSION_BYTES_PER_SAMPLE: u64 = 40;
+const MIB: u64 = 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ThreadBudget {
+    pub compute_workers: usize,
+    pub preparation_workers: usize,
+    pub serial: bool,
+}
+
+impl ThreadBudget {
+    pub fn from_total(total: usize) -> Self {
+        let total = total.max(1);
+        if total == 1 {
+            return Self {
+                compute_workers: 1,
+                preparation_workers: 1,
+                serial: true,
+            };
+        }
+        // Container decoding uses CPU on the reader threads too. Two readers
+        // can overlap a read with another frame's preparation without keeping
+        // half the compute allowance idle while readers wait for the pool.
+        let preparation_workers = (total / 2).clamp(1, 2);
+        Self {
+            compute_workers: total - preparation_workers,
+            preparation_workers,
+            serial: false,
+        }
+    }
+
+    fn sequential(self) -> Self {
+        Self {
+            compute_workers: self.compute_workers.saturating_add(if self.serial {
+                0
+            } else {
+                self.preparation_workers
+            }),
+            preparation_workers: 1,
+            serial: true,
+        }
+    }
+}
+
+pub(super) fn run_pipeline(
+    stacker: &mut LiveStacker,
+    paths: &[PathBuf],
+    options: &PipelineOptions,
+    pool: &rayon::ThreadPool,
+    threads: &ThreadBudget,
+    on_frame: impl FnMut(
+            &Path,
+            seiza_stacking::Result<seiza_stacking::FrameDisposition>,
+        ) -> seiza_stacking::Continue
+        + Send,
+) -> seiza_stacking::Result<PoolPipelineReport> {
+    if threads.compute_workers == 0
+        || threads.preparation_workers == 0
+        || pool.current_num_threads() != threads.compute_workers
+    {
+        return Err(seiza_stacking::Error::Stack(
+            "Stack compute pool does not match its thread budget".into(),
+        ));
+    }
+    let options = PipelineOptions {
+        workers: Some(
+            options
+                .workers
+                .unwrap_or(threads.preparation_workers)
+                .clamp(1, threads.preparation_workers),
+        ),
+        ..*options
+    };
+    if threads.serial {
+        return stacker.push_fits_sequential_with_pool(
+            paths,
+            options.normalized_full_scale,
+            pool,
+            on_frame,
+        );
+    }
+    if rayon::current_thread_index().is_some() {
+        return Err(seiza_stacking::Error::Stack(
+            "Parallel stack preparation requires a coordinator outside the Rayon pool".into(),
+        ));
+    }
+    stacker.push_fits_pipelined_with_pool(paths, &options, pool, on_frame)
+}
+
+pub(super) struct PipelineBudget {
+    pub options: PipelineOptions,
+    pub threads: ThreadBudget,
+    total_budget_bytes: Option<u64>,
+    admission_baseline_bytes: u64,
+    serial_peak_bytes: u64,
+    resident_master_bytes: u64,
+    master_clone_bytes: u64,
+    integration_bytes: u64,
+    worker_bytes: u64,
+    sequential_bytes: u64,
+    memory_limited: bool,
+    workers: usize,
+}
+
+impl PipelineBudget {
+    pub fn summary(&self) -> String {
+        let total = self.total_budget_bytes.map_or_else(
+            || "available RAM unknown; serial peak cannot be checked".to_string(),
+            |bytes| format!("{} MiB total budget", bytes / MIB),
+        );
+        let execution = if self.threads.serial {
+            let reason = if self.memory_limited {
+                "memory limit"
+            } else {
+                "CPU limit"
+            };
+            let unknown_limit = if self.total_budget_bytes.is_none() {
+                "; 1024 MiB scratch allowance"
+            } else {
+                ""
+            };
+            format!(
+                "serial preparation ({reason}), {} compute worker(s), {} MiB scratch estimate{unknown_limit}; no preparation queue",
+                self.threads.compute_workers,
+                self.sequential_bytes / MIB,
+            )
+        } else {
+            format!(
+                "{} MiB parallel admission baseline; {} MiB pipeline budget ({} MiB integration, {} MiB per preparation worker); {} preparation worker(s)",
+                self.admission_baseline_bytes / MIB,
+                self.options.max_in_flight_bytes as u64 / MIB,
+                self.integration_bytes / MIB,
+                self.worker_bytes / MIB,
+                self.workers,
+            )
+        };
+        format!(
+            "{total}; {} MiB serial peak including masters; \
+             {} MiB session masters, {} MiB master clones; \
+             {execution}; reference-sized estimates, not an RSS limit",
+            self.serial_peak_bytes / MIB,
+            self.resident_master_bytes / MIB,
+            self.master_clone_bytes / MIB,
+        )
+    }
+}
+
+pub(super) fn plan_pipeline(
+    available_bytes: Option<u64>,
+    policy: &WorkerPolicy,
+    output_pixels: usize,
+    output_samples: usize,
+    master_plan: &CalibrationPlan,
+    threads: &ThreadBudget,
+) -> Result<PipelineBudget, String> {
+    if output_pixels == 0 || output_samples < output_pixels {
+        return Err("Stack pipeline requires a non-empty reference image".into());
+    }
+    if output_samples
+        .checked_mul(std::mem::size_of::<f32>())
+        .is_none()
+    {
+        return Err("Stack reference exceeds the supported address space".into());
+    }
+    if threads.preparation_workers == 0 || threads.compute_workers == 0 {
+        return Err("Stack pipeline requires non-zero thread allowances".into());
+    }
+    if !policy.memory_budget_fraction.is_finite()
+        || policy.memory_budget_fraction <= 0.0
+        || policy.memory_budget_fraction > 1.0
+    {
+        return Err(
+            "Stack memory budget fraction must be greater than zero and at most one".into(),
+        );
+    }
+
+    let admission_baseline_bytes =
+        (output_samples as u64).saturating_mul(ADMISSION_BYTES_PER_SAMPLE);
+    let (resident_master_bytes, largest_master_bytes) =
+        master_plan
+            .sessions
+            .iter()
+            .fold((0_u64, 0_u64), |(total, largest), session| {
+                let bytes = session.masters.image_buffer_bytes() as u64;
+                (total.saturating_add(bytes), largest.max(bytes))
+            });
+    // The plan keeps every session. Swapping a deep-cloned active master set
+    // can briefly retain both the previous and incoming stacker copies.
+    let master_clone_bytes = largest_master_bytes.saturating_mul(2);
+    let master_reserve_bytes = resident_master_bytes.saturating_add(master_clone_bytes);
+    let reserved_bytes = admission_baseline_bytes.saturating_add(master_reserve_bytes);
+    // Initialization, checkpoints and final rejection run without the frame
+    // preparation queue. Check their peak separately, not as simultaneous work.
+    let serial_peak_bytes = (output_samples as u64)
+        .saturating_mul(super::STACK_BYTES_PER_OUTPUT_SAMPLE)
+        .saturating_add(master_reserve_bytes);
+    if serial_peak_bytes == u64::MAX {
+        return Err("Stack memory estimate exceeds the supported address space".into());
+    }
+    let total_budget_bytes =
+        available_bytes.map(|available| (available as f64 * policy.memory_budget_fraction) as u64);
+    if let Some(total) = total_budget_bytes
+        && serial_peak_bytes > total
+    {
+        return Err(format!(
+            "Insufficient stack memory budget for serial processing: {} MiB needed for \
+             initialization, checkpoints or final rejection including masters, {} MiB available \
+             (reference-sized estimate)",
+            serial_peak_bytes.div_ceil(MIB),
+            total / MIB,
+        ));
+    }
+    let pipeline_bytes = total_budget_bytes.map_or(UNKNOWN_RAM_PIPELINE_BYTES, |total| {
+        total.saturating_sub(reserved_bytes)
+    });
+    let max_in_flight_bytes = usize::try_from(pipeline_bytes).unwrap_or(usize::MAX);
+
+    // Seiza's budget includes the frame currently being integrated; do not
+    // subtract that from the budget twice.
+    let memory = PoolPipelineMemory::for_reference(output_pixels, output_samples);
+    let worker_bytes = memory.worker_bytes as u64;
+    let integration_bytes = memory.integration_bytes as u64;
+    let sequential_bytes = memory.sequential_bytes as u64;
+    let affordable = (max_in_flight_bytes as u64).saturating_sub(integration_bytes) / worker_bytes;
+    if total_budget_bytes.is_none()
+        && threads.serial
+        && sequential_bytes > UNKNOWN_RAM_PIPELINE_BYTES
+    {
+        return Err(format!(
+            "Available RAM is unknown: serial preparation needs {} MiB of scratch space, \
+             exceeding the bounded {} MiB allowance (reference-sized estimate)",
+            sequential_bytes.div_ceil(MIB),
+            UNKNOWN_RAM_PIPELINE_BYTES / MIB,
+        ));
+    }
+    if affordable == 0 && total_budget_bytes.is_none() && !threads.serial {
+        return Err(format!(
+            "Available RAM is unknown: the bounded {} MiB preparation allowance cannot fit \
+             one preparation worker and integration frame ({} MiB estimated); \
+             memory-limited serial fallback requires a known RAM budget",
+            max_in_flight_bytes as u64 / MIB,
+            worker_bytes.saturating_add(integration_bytes).div_ceil(MIB),
+        ));
+    }
+    let memory_limited = affordable == 0 && !threads.serial;
+    let mut threads = if threads.serial || memory_limited {
+        threads.sequential()
+    } else {
+        *threads
+    };
+    let workers = if threads.serial {
+        1
+    } else {
+        threads
+            .preparation_workers
+            .min(policy.hard_max_workers.max(1))
+            .min(seiza_stacking::MAXIMUM_WORKERS)
+            .min(usize::try_from(affordable).unwrap_or(usize::MAX))
+    };
+    if !threads.serial {
+        // A memory-limited reader count leaves CPU slots for the shared pool.
+        let total = threads
+            .compute_workers
+            .saturating_add(threads.preparation_workers);
+        threads.preparation_workers = workers;
+        threads.compute_workers = total.saturating_sub(workers).max(1);
+    }
+    Ok(PipelineBudget {
+        options: PipelineOptions {
+            max_in_flight_bytes: if threads.serial {
+                0
+            } else {
+                max_in_flight_bytes
+            },
+            normalized_full_scale: Some(crate::image_io::NORMALIZED_FULL_SCALE),
+            workers: Some(workers),
+        },
+        threads,
+        total_budget_bytes,
+        admission_baseline_bytes,
+        serial_peak_bytes,
+        resident_master_bytes,
+        master_clone_bytes,
+        integration_bytes,
+        worker_bytes,
+        sequential_bytes,
+        memory_limited,
+        workers,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::calibration::{AppliedCalibration, CalibrationSession};
+    use seiza_stacking::{
+        CalibrationMasters, Continue, FrameDisposition, LinearImage, PipelineExecution,
+        StackOptions,
+    };
+
+    fn pipeline_fixture() -> (tempfile::TempDir, LiveStacker, Vec<PathBuf>) {
+        let (width, height) = (192, 160);
+        // Match Seiza's pipeline fixture: a nondegenerate star field and a
+        // measured background spread, so the default normalization is valid.
+        let stars = (0..24)
+            .map(|index| {
+                let x = ((index * 7919) % 1000) as f32 / 1000.0 * (width as f32 - 24.0) + 12.0;
+                let y = ((index * 6271) % 1000) as f32 / 1000.0 * (height as f32 - 24.0) + 12.0;
+                (x, y, 6000.0 + ((index * 37) % 41) as f32 * 300.0)
+            })
+            .collect::<Vec<_>>();
+        let directory = tempfile::tempdir().unwrap();
+        let mut paths = (0..3)
+            .map(|frame| {
+                let shift_x = ((frame * 13) % 5) as f32 - 2.0;
+                let shift_y = ((frame * 7) % 3) as f32 - 1.0;
+                let data = (0..width * height)
+                    .map(|index| {
+                        let (x, y) = (index % width, index / width);
+                        let noise = ((x * 17 + y * 31 + frame * 11) % 23) as f32 * 1.5;
+                        let mut value = 1000.0 + noise;
+                        for &(star_x, star_y, brightness) in &stars {
+                            let dx = x as f32 - (star_x + shift_x);
+                            let dy = y as f32 - (star_y + shift_y);
+                            let radius_squared = dx.mul_add(dx, dy * dy);
+                            if radius_squared < 40.0 {
+                                value += brightness * (-radius_squared / 3.2).exp();
+                            }
+                        }
+                        value.clamp(0.0, 65535.0) as u16 as f32
+                    })
+                    .collect::<Vec<_>>();
+                let path = directory.path().join(format!("source-{frame}.fits"));
+                seiza_fits::write_f32_image(
+                    &path,
+                    width,
+                    height,
+                    seiza_fits::F32ImageData::Mono(&data),
+                    &[
+                        seiza_fits::WriteHeaderCard::new(
+                            "IMAGETYP",
+                            seiza_fits::HeaderValue::String("LIGHT".into()),
+                        ),
+                        seiza_fits::WriteHeaderCard::new(
+                            "EXPTIME",
+                            seiza_fits::HeaderValue::Float(60.0),
+                        ),
+                    ],
+                )
+                .unwrap();
+                path
+            })
+            .collect::<Vec<_>>();
+        let reference = crate::image_io::open_linear_frame(paths.remove(0)).unwrap();
+        let stacker = LiveStacker::new(
+            reference,
+            CalibrationMasters::default(),
+            StackOptions::default(),
+        )
+        .unwrap();
+        (directory, stacker, paths)
+    }
+
+    fn compute_pool(threads: &ThreadBudget) -> rayon::ThreadPool {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads.compute_workers)
+            .build()
+            .unwrap()
+    }
+
+    fn policy() -> WorkerPolicy {
+        WorkerPolicy {
+            memory_budget_fraction: 1.0,
+            ..WorkerPolicy::default()
+        }
+    }
+
+    fn raw_plan() -> CalibrationPlan {
+        CalibrationPlan::without_calibration(10)
+    }
+
+    fn allowance(total: usize) -> ThreadBudget {
+        ThreadBudget::from_total(total)
+    }
+
+    fn session(pixels: usize) -> CalibrationSession {
+        CalibrationSession {
+            masters: CalibrationMasters::new(
+                Some(LinearImage::new(pixels, 1, 1, vec![10.0; pixels]).unwrap()),
+                None,
+                None,
+            )
+            .unwrap(),
+            applied: AppliedCalibration::default(),
+        }
+    }
+
+    #[test]
+    fn zero_dimensions_workers_and_invalid_policy_are_refused() {
+        assert!(plan_pipeline(None, &policy(), 0, 0, &raw_plan(), &allowance(4)).is_err());
+        assert!(plan_pipeline(None, &policy(), 10, 9, &raw_plan(), &allowance(4)).is_err());
+        let invalid = ThreadBudget {
+            compute_workers: 0,
+            ..allowance(4)
+        };
+        assert!(plan_pipeline(None, &policy(), 10, 10, &raw_plan(), &invalid).is_err());
+        for fraction in [f64::NAN, f64::INFINITY, -0.1, 0.0, 1.1] {
+            let policy = WorkerPolicy {
+                memory_budget_fraction: fraction,
+                ..policy()
+            };
+            assert!(plan_pipeline(None, &policy, 10, 10, &raw_plan(), &allowance(4)).is_err());
+        }
+    }
+
+    #[test]
+    fn tiny_budget_does_not_force_an_unaffordable_worker() {
+        let baseline = 100 * ADMISSION_BYTES_PER_SAMPLE;
+        let one_worker = 100 * 80;
+        let integrating = 100 * 4;
+        let serial_peak = 100 * super::super::STACK_BYTES_PER_OUTPUT_SAMPLE;
+        for available in [0, baseline, serial_peak - 1] {
+            assert!(plan_pipeline(
+                Some(available),
+                &policy(),
+                100,
+                100,
+                &raw_plan(),
+                &allowance(4)
+            )
+            .is_err());
+        }
+        let plan = plan_pipeline(
+            Some(baseline + one_worker + integrating),
+            &policy(),
+            100,
+            100,
+            &raw_plan(),
+            &allowance(4),
+        )
+        .unwrap();
+        assert_eq!(plan.options.workers, Some(1));
+        assert_eq!(
+            plan.options.max_in_flight_bytes as u64,
+            one_worker + integrating
+        );
+    }
+
+    #[test]
+    fn rgb_samples_reduce_worker_capacity_without_triple_charging_detector_pixels() {
+        let budget = 30_000;
+        let mono = plan_pipeline(
+            Some(budget),
+            &policy(),
+            100,
+            100,
+            &raw_plan(),
+            &allowance(8),
+        )
+        .unwrap();
+        let rgb = plan_pipeline(
+            Some(budget),
+            &policy(),
+            100,
+            300,
+            &raw_plan(),
+            &allowance(8),
+        )
+        .unwrap();
+        assert_eq!(mono.worker_bytes, 8_000);
+        assert_eq!(rgb.worker_bytes, 11_200);
+        assert_eq!(rgb.integration_bytes, 1_200);
+        assert_eq!(mono.options.workers, Some(2));
+        assert_eq!(rgb.options.workers, Some(1));
+        assert_eq!(rgb.threads.preparation_workers, 1);
+        assert_eq!(rgb.threads.compute_workers, 7);
+    }
+
+    #[test]
+    fn reserves_all_sessions_and_two_largest_active_master_copies() {
+        let mut masters = raw_plan();
+        masters.sessions = vec![session(100), session(200), session(50)];
+        let budget =
+            plan_pipeline(Some(100_000), &policy(), 100, 100, &masters, &allowance(4)).unwrap();
+        assert_eq!(budget.resident_master_bytes, 1_400);
+        assert_eq!(budget.master_clone_bytes, 1_600);
+        assert_eq!(
+            budget.options.max_in_flight_bytes as u64,
+            100_000 - budget.admission_baseline_bytes - 1_400 - 1_600,
+        );
+    }
+
+    #[test]
+    fn unknown_ram_uses_a_bounded_fallback_and_preserves_compute_limit() {
+        let budget = plan_pipeline(None, &policy(), 100, 100, &raw_plan(), &allowance(3)).unwrap();
+        assert_eq!(
+            budget.options.max_in_flight_bytes as u64,
+            UNKNOWN_RAM_PIPELINE_BYTES
+        );
+        assert_eq!(budget.options.workers, Some(1));
+        assert_eq!(
+            budget.options.normalized_full_scale,
+            Some(crate::image_io::NORMALIZED_FULL_SCALE),
+        );
+        assert!(budget.summary().contains("available RAM unknown"));
+        assert!(budget.summary().contains("serial peak cannot be checked"));
+        assert!(budget.summary().contains("not an RSS limit"));
+    }
+
+    #[test]
+    fn separate_phases_fit_without_reserving_their_sum() {
+        let (pixels, samples) = (100, 300);
+        let admission = samples as u64 * ADMISSION_BYTES_PER_SAMPLE;
+        let serial_peak = samples as u64 * super::super::STACK_BYTES_PER_OUTPUT_SAMPLE;
+        let pipeline = PoolPipelineMemory::for_reference(pixels, samples).in_flight_bytes(1) as u64;
+        let total = serial_peak.max(admission + pipeline);
+        assert!(total < serial_peak + pipeline);
+        let budget = plan_pipeline(
+            Some(total),
+            &policy(),
+            pixels,
+            samples,
+            &raw_plan(),
+            &allowance(4),
+        )
+        .unwrap();
+        assert_eq!(budget.admission_baseline_bytes, admission);
+        assert_eq!(budget.serial_peak_bytes, serial_peak);
+        assert_eq!(budget.options.max_in_flight_bytes as u64, total - admission);
+        assert_eq!(budget.options.workers, Some(1));
+    }
+
+    #[test]
+    fn serial_peak_is_checked_even_when_a_preparation_worker_would_fit() {
+        let (pixels, samples) = (100, 300);
+        let admission = samples as u64 * ADMISSION_BYTES_PER_SAMPLE;
+        let pipeline = PoolPipelineMemory::for_reference(pixels, samples).in_flight_bytes(1) as u64;
+        let total = admission + pipeline;
+        assert!(total < samples as u64 * super::super::STACK_BYTES_PER_OUTPUT_SAMPLE);
+        let error = plan_pipeline(
+            Some(total),
+            &policy(),
+            pixels,
+            samples,
+            &raw_plan(),
+            &allowance(4),
+        )
+        .err()
+        .unwrap();
+        assert!(error.contains("serial processing"));
+    }
+
+    #[test]
+    fn serial_preparation_is_selected_when_only_the_serial_peak_fits() {
+        let total = 100 * super::super::STACK_BYTES_PER_OUTPUT_SAMPLE;
+        let budget =
+            plan_pipeline(Some(total), &policy(), 100, 100, &raw_plan(), &allowance(8)).unwrap();
+        assert!(budget.threads.serial);
+        assert!(budget.memory_limited);
+        assert_eq!(budget.threads.compute_workers, 8);
+        assert_eq!(budget.options.max_in_flight_bytes, 0);
+        assert!(budget.summary().contains("memory limit"));
+    }
+
+    #[test]
+    fn full_sensor_serial_stack_remains_available_without_a_preparation_queue() {
+        let pixels = 61_000_000;
+        let total = 6034 * MIB;
+        let budget = plan_pipeline(
+            Some(total),
+            &policy(),
+            pixels,
+            pixels,
+            &raw_plan(),
+            &allowance(8),
+        )
+        .unwrap();
+        assert!(budget.threads.serial);
+        assert!(budget.memory_limited);
+        assert_eq!(budget.threads.compute_workers, 8);
+        assert_eq!(budget.options.max_in_flight_bytes, 0);
+        assert!(budget.serial_peak_bytes <= total);
+    }
+
+    #[test]
+    fn unknown_ram_refuses_an_unbounded_memory_fallback() {
+        let error = plan_pipeline(
+            None,
+            &policy(),
+            61_000_000,
+            61_000_000,
+            &raw_plan(),
+            &allowance(8),
+        )
+        .err()
+        .unwrap();
+        assert!(error.contains("Available RAM is unknown"));
+        assert!(error.contains("bounded 1024 MiB preparation allowance"));
+        assert!(error.contains("serial fallback requires a known RAM budget"));
+    }
+
+    #[test]
+    fn one_cpu_unknown_ram_checks_serial_scratch_not_a_nonexistent_queue() {
+        let one_pixel = PoolPipelineMemory::for_reference(1, 1);
+        let pixels = UNKNOWN_RAM_PIPELINE_BYTES as usize / one_pixel.in_flight_bytes(1) + 1;
+        let memory = PoolPipelineMemory::for_reference(pixels, pixels);
+        assert!(memory.in_flight_bytes(1) as u64 > UNKNOWN_RAM_PIPELINE_BYTES);
+        assert!(memory.sequential_bytes as u64 <= UNKNOWN_RAM_PIPELINE_BYTES);
+        let budget =
+            plan_pipeline(None, &policy(), pixels, pixels, &raw_plan(), &allowance(1)).unwrap();
+        assert!(budget.threads.serial);
+        assert!(!budget.memory_limited);
+        assert_eq!(budget.options.max_in_flight_bytes, 0);
+        assert!(budget.summary().contains("1024 MiB scratch allowance"));
+
+        let too_large = UNKNOWN_RAM_PIPELINE_BYTES as usize / one_pixel.sequential_bytes + 1;
+        let error = plan_pipeline(
+            None,
+            &policy(),
+            too_large,
+            too_large,
+            &raw_plan(),
+            &allowance(1),
+        )
+        .err()
+        .unwrap();
+        assert!(error.contains("serial preparation needs"));
+        assert!(error.contains("bounded 1024 MiB allowance"));
+    }
+
+    #[test]
+    fn serial_peak_includes_all_session_masters_and_clone_reserve() {
+        let mut masters = raw_plan();
+        masters.sessions = vec![session(100), session(200), session(50)];
+        let bare_serial_peak = 300 * super::super::STACK_BYTES_PER_OUTPUT_SAMPLE;
+        let total = bare_serial_peak + 1_400 + 1_600;
+        let budget =
+            plan_pipeline(Some(total), &policy(), 100, 300, &masters, &allowance(4)).unwrap();
+        assert_eq!(budget.serial_peak_bytes, total);
+        let error = plan_pipeline(
+            Some(total - 1),
+            &policy(),
+            100,
+            300,
+            &masters,
+            &allowance(4),
+        )
+        .err()
+        .unwrap();
+        assert!(error.contains("serial processing"));
+    }
+
+    #[test]
+    fn memory_fraction_and_worker_caps_are_applied() {
+        let configured = WorkerPolicy {
+            memory_budget_fraction: 0.5,
+            hard_max_workers: 2,
+            ..policy()
+        };
+        let budget = plan_pipeline(
+            Some(200_000),
+            &configured,
+            100,
+            100,
+            &raw_plan(),
+            &allowance(16),
+        )
+        .unwrap();
+        assert_eq!(budget.total_budget_bytes, Some(100_000));
+        assert_eq!(budget.options.workers, Some(2));
+        let capped =
+            plan_pipeline(None, &policy(), 1, 1, &raw_plan(), &allowance(usize::MAX)).unwrap();
+        assert_eq!(capped.options.workers, Some(2));
+    }
+
+    #[test]
+    fn thread_budget_counts_decoders_and_compute_within_the_total() {
+        for total in [0, 1] {
+            assert_eq!(
+                ThreadBudget::from_total(total),
+                ThreadBudget {
+                    compute_workers: 1,
+                    preparation_workers: 1,
+                    serial: true,
+                },
+            );
+        }
+        for (total, readers) in [(2, 1), (3, 1), (4, 2), (7, 2), (16, 2), (usize::MAX, 2)] {
+            let budget = ThreadBudget::from_total(total);
+            assert!(!budget.serial);
+            assert_eq!(budget.compute_workers + budget.preparation_workers, total);
+            assert_eq!(budget.preparation_workers, readers);
+            assert_eq!(budget.compute_workers, total - readers);
+        }
+    }
+
+    #[test]
+    fn parallel_wrapper_refuses_an_accidental_rayon_coordinator() {
+        let threads = ThreadBudget::from_total(4);
+        let pool = compute_pool(&threads);
+        let (_directory, mut stacker, paths) = pool.install(pipeline_fixture);
+        let result = pool.install(|| {
+            run_pipeline(
+                &mut stacker,
+                &paths,
+                &PipelineOptions::default(),
+                &pool,
+                &threads,
+                |_, _| panic!("a nested parallel coordinator must not start the batch"),
+            )
+        });
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("coordinator outside the Rayon pool"),);
+        assert!(stacker.input_paths().is_empty());
+    }
+
+    #[test]
+    fn one_cpu_budget_uses_explicit_sequential_processing() {
+        let threads = ThreadBudget::from_total(1);
+        let pool = compute_pool(&threads);
+        let (_directory, mut stacker, paths) = pool.install(pipeline_fixture);
+        let mut seen = Vec::new();
+        let coordinator = std::thread::current().id();
+        let report = run_pipeline(
+            &mut stacker,
+            &paths,
+            &PipelineOptions::default(),
+            &pool,
+            &threads,
+            |path, outcome| {
+                assert_eq!(std::thread::current().id(), coordinator);
+                assert!(rayon::current_thread_index().is_none());
+                let outcome = outcome.unwrap();
+                assert!(
+                    matches!(&outcome, FrameDisposition::Accepted(_)),
+                    "{outcome:?}"
+                );
+                seen.push(path.to_path_buf());
+                Continue::Yes
+            },
+        )
+        .unwrap();
+        assert_eq!(seen, paths);
+        assert_eq!(report.execution, PipelineExecution::SequentialRequested);
+        assert_eq!(report.workers, 1);
+        assert_eq!(report.frames.integrated, 2);
+    }
+
+    #[test]
+    fn parallel_wrapper_caps_readers_and_preserves_callback_order() {
+        let threads = ThreadBudget::from_total(4);
+        let pool = compute_pool(&threads);
+        let (_directory, mut stacker, paths) = pool.install(pipeline_fixture);
+        let options = PipelineOptions {
+            workers: Some(64),
+            ..PipelineOptions::default()
+        };
+        let coordinator = std::thread::current().id();
+        let mut seen = Vec::new();
+        let report = run_pipeline(
+            &mut stacker,
+            &paths,
+            &options,
+            &pool,
+            &threads,
+            |path, outcome| {
+                assert_eq!(std::thread::current().id(), coordinator);
+                assert!(rayon::current_thread_index().is_none());
+                let outcome = outcome.unwrap();
+                assert!(
+                    matches!(&outcome, FrameDisposition::Accepted(_)),
+                    "{outcome:?}"
+                );
+                seen.push(path.to_path_buf());
+                Continue::Yes
+            },
+        )
+        .unwrap();
+        assert_eq!(seen, paths);
+        assert_eq!(report.execution, PipelineExecution::Overlapped);
+        assert_eq!(report.workers, threads.preparation_workers);
+        assert_eq!(report.frames.integrated, 2);
+    }
+
+    #[test]
+    fn memory_limited_wrapper_integrates_on_the_full_phase_pool() {
+        let initial = allowance(4);
+        let pixels = 192 * 160;
+        let total = pixels as u64 * super::super::STACK_BYTES_PER_OUTPUT_SAMPLE;
+        let budget = plan_pipeline(
+            Some(total),
+            &policy(),
+            pixels,
+            pixels,
+            &raw_plan(),
+            &initial,
+        )
+        .unwrap();
+        assert!(budget.threads.serial);
+        assert_eq!(budget.threads.compute_workers, 4);
+        let pool = compute_pool(&budget.threads);
+        let (_directory, mut stacker, paths) = pool.install(pipeline_fixture);
+        let coordinator = std::thread::current().id();
+        let mut seen = Vec::new();
+        let report = run_pipeline(
+            &mut stacker,
+            &paths,
+            &budget.options,
+            &pool,
+            &budget.threads,
+            |path, outcome| {
+                assert_eq!(std::thread::current().id(), coordinator);
+                let outcome = outcome.unwrap();
+                assert!(
+                    matches!(&outcome, FrameDisposition::Accepted(_)),
+                    "{outcome:?}"
+                );
+                seen.push(path.to_path_buf());
+                Continue::Yes
+            },
+        )
+        .unwrap();
+        assert_eq!(seen, paths);
+        assert_eq!(report.execution, PipelineExecution::SequentialRequested);
+        assert_eq!(report.frames.integrated, 2);
+        assert_eq!(report.workers, 1);
+    }
+
+    #[test]
+    fn overflowing_image_estimates_saturate_and_fail_closed() {
+        assert!(plan_pipeline(
+            Some(u64::MAX),
+            &policy(),
+            usize::MAX,
+            usize::MAX,
+            &raw_plan(),
+            &allowance(usize::MAX),
+        )
+        .is_err());
+    }
+}


### PR DESCRIPTION
## Summary

#415 was squash-merged to `main`, but #417 was then squash-merged into the old `codex/final-stack-rejection` branch. Consequently, the pool-aware pipeline changes are not yet on `main`.

This PR cherry-picks the single #417 squash commit onto current `main`. It contains only the six previously reviewed pipeline/dependency/documentation files, with no new implementation changes or conflict resolutions.

- Consume published `seiza` 0.18.12 and `seiza-stacking` 0.13.0.
- Use bounded preparation workers and an explicitly shared compute pool, preserving ordered integration, cancellation, calibration boundaries, and checkpoint/resume behavior.
- Fall back to serial preparation when its memory peak fits but a preparation queue does not. Log worker allocation, memory planning, execution mode, and stage timings.

## Review and validation

- Independent review confirmed the merge-target issue and the narrow promotion. No new actionable findings.
- Verified current `main` (`7b7b622`) has exactly the same Git tree as #415's reviewed head (`2925e05`).
- Verified this PR's complete tree (`1320489c48445b9e2aad51d40ce9d01f12f847b2`) is identical to #417's fully validated head (`1b7f934`) and squash commit (`5fe31c1`).
- Fresh checks on this branch: `cargo fmt -- --check`, `git diff --check origin/main...HEAD`, and `git diff --quiet 1b7f934 HEAD` all passed.
- Prior local validation on that identical tree: 989 Rust tests passed (5 existing tests ignored), all-target/all-feature Clippy, locked binary build, frontend lint/build, 363 frontend tests, and all 4 Playwright stack-preview tests passed.
- The real 61 MP browser fixture exercised the serial fallback, checkpoint/resume and final rejection, processing reload, and desktop/mobile RC-Astro controls. It did not measure an overlap speedup; deterministic Seiza tests cover concurrent overlap.
- [Original full CI run](https://github.com/theatrus/psf-guard/actions/runs/34280549860) passed all seven jobs, including all three platforms and Linux browser E2E. This PR targets `main` and will receive its own CI run.

The full test suite was not rerun locally for this history-only promotion because the entire resulting tree is identical to the tested tree. No local dependency patches, release actions, or registry changes are included.
