### PR TITLE
Release v0.9.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "psf-guard"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psf-guard"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 # With two bins (psf-guard = GUI/CLI smart binary, psf-guard-cli = console-only
 # CLI), name the default so `cargo run` and tauri-cli pick the app binary, not

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,40 +6,6 @@
 
 ## Added
 
-- Color-stack processing now offers RC-Astro tools per linear input channel,
-  including saved tool steps and separate starless/stars FITS downloads.
-
-- Merge alternate target names in Overview and move selected exposures to an
-  existing or new target or project from Grid, with a preview before Apply.
-  Image files and grades stay unchanged, and Target Scheduler plan counts
-  follow the new grouping.
-
 ## Changed
 
 ## Fixed
-
-- Stack previews now overlap frame preparation within the configured worker
-  and memory budgets instead of silently preparing frames sequentially.
-  Builds that fit serial processing but cannot fit a preparation queue keep
-  working with one frame at a time. Batch logs expose execution mode, worker
-  counts, memory fallback, and stage timings.
-
-- Completed stacks revisit early admitted samples to reject bright transient
-  trails, with pass/frame progress and consistent results after resuming a
-  build. Low-coverage pixels and overlapping trails can still retain artifacts.
-
-- Scheduler merge no longer duplicates frames that an import or remote upload
-  had already added before the telescope's own rows arrived: the existing row
-  is recognized by target, file name, and capture time, updated in place, and
-  takes the telescope's identity, keeping any grade it already had.
-
-- Applied stack processing survives reloads, restoring the cached result,
-  RC-Astro versions, and editor settings. Reverting also survives reloads.
-
-- PixInsight master bias files with a blank `FILTER` header now work during
-  stacking. The cached master preserves the undefined value without requiring
-  edits to the original FITS or XISF file.
-- A calibration frame that was imported, then moved by a filer and imported
-  again no longer fails every master with `duplicate calibration input`: the
-  import updates the row's path instead of adding a twin, and stacking hands
-  a file to the integrator once even when two rows point at it.

--- a/docs/releases/v0.9.5.md
+++ b/docs/releases/v0.9.5.md
@@ -1,0 +1,45 @@
+# v0.9.5
+
+PSF Guard 0.9.5 adds previewed target merges and exposure moves, removes
+trails from the first frames of a completed stack, and stops scheduler merges
+and re-imports of moved calibration files from doubling frames.
+
+## Added
+
+- Color-stack processing now offers RC-Astro tools per linear input channel,
+  including saved tool steps and separate starless/stars FITS downloads.
+
+- Merge alternate target names in Overview and move selected exposures to an
+  existing or new target or project from Grid, with a preview before Apply.
+  Image files and grades stay unchanged, and Target Scheduler plan counts
+  follow the new grouping.
+
+## Fixed
+
+- Stack previews now overlap frame preparation within the configured worker
+  and memory budgets instead of silently preparing frames sequentially.
+  Builds that fit serial processing but cannot fit a preparation queue keep
+  working with one frame at a time. Batch logs expose execution mode, worker
+  counts, memory fallback, and stage timings.
+
+- Completed stacks revisit early admitted samples to reject bright transient
+  trails, with pass/frame progress and consistent results after resuming a
+  build. Low-coverage pixels and overlapping trails can still retain artifacts.
+  Stacks and checkpoints built by earlier versions are rebuilt once.
+
+- Scheduler merge no longer duplicates frames that an import or remote upload
+  had already added before the telescope's own rows arrived: the existing row
+  is recognized by target, file name, and capture time, updated in place, and
+  takes the telescope's identity, keeping any grade it already had.
+
+- Applied stack processing survives reloads, restoring the cached result,
+  RC-Astro versions, and editor settings. Reverting also survives reloads.
+
+- PixInsight master bias files with a blank `FILTER` header now work during
+  stacking. The cached master preserves the undefined value without requiring
+  edits to the original FITS or XISF file.
+
+- A calibration frame that was imported, then moved by a filer and imported
+  again no longer fails every master with `duplicate calibration input`: the
+  import updates the row's path instead of adding a twin, and stacking hands
+  a file to the integrator once even when two rows point at it.

--- a/packaging/rpm/psf-guard.spec
+++ b/packaging/rpm/psf-guard.spec
@@ -8,7 +8,7 @@
 %global rustflags_debuginfo 0
 
 Name:           psf-guard
-Version:        0.9.4
+Version:        0.9.5
 Release:        1%{?dist}
 Summary:        Astronomical image analysis and quality assessment tool for N.I.N.A.
 
@@ -93,6 +93,16 @@ install -Dpm0644 packaging/rpm/systemd/psf-guard-server.conf \
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 
 %changelog
+* Tue Sep 08 2026 Yann Ramin <github@theatr.us> - 0.9.5-1
+- Merge alternate target names and move exposures between targets, with a preview
+- RC-Astro tool steps per linear input channel in color-stack processing
+- Completed stacks get a second integration pass that rejects trails in early frames
+- Bounded, pool-aware stack preparation with a serial fallback when memory is short
+- Scheduler merge adopts rows an import or upload already added instead of duplicating them
+- A calibration file moved by a filer and imported again keeps one row; stacking hands each file to the integrator once
+- Applied stack processing and reverts survive reloads
+- PixInsight master bias files with a blank FILTER header work during stacking
+
 * Mon Sep 08 2026 Yann Ramin <github@theatr.us> - 0.9.4-1
 - Browser sign-in works over direct HTTP; local servers on different ports keep separate sessions
 - Remote uploads take the receive directory's usual file permissions

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "PSF Guard",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "identifier": "com.theatrus.psf-guard",
   "mainBinaryName": "psf-guard",
   "build": {


### PR DESCRIPTION
Point release with everything merged since v0.9.4: previewed target merges and exposure moves, RC-Astro per-channel steps, two-pass trail rejection and pool-aware preparation for completed stacks, the scheduler-merge adoption fix, the moved-calibration-file fix, processing that survives reloads, and the blank `FILTER` master fix.

Release files only: `Cargo.toml`, `Cargo.lock` root package, `tauri.conf.json`, the RPM spec version and changelog, `docs/releases/v0.9.5.md` (from `unreleased.md`, which is reset), no code changes.

Checks run locally in the release worktree at this head: `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test --locked` (995 passed, 0 failed), `cargo build --release --locked --bin psf-guard-cli` (reports 0.9.5), `node scripts/check-release-version.mjs v0.9.5`, and in `static/`: `npm ci`, `npm run lint`, `npx vitest run` (363 passed), `npm run build`, `npm run test:release` (14 passed), plus `git diff --check`. Local Node is 22, CI runs 24. No Tauri, updater, packaging, or signing code changed since v0.9.4 (the dependency bump touched no Tauri crate), so no local Tauri bundle was built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv
