### PR TITLE
Improve sky-flat rejection and add native star masks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,9 +5014,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.18.12"
+version = "0.18.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca7779e24d13214b7ebc193d15d8c74d025282a3b1de8c123724736b2212366"
+checksum = "b089703cf4f0a4f759e490e563d5c94f3cd9ed00b2ba7b64a10cc887f761e5be"
 dependencies = [
  "directories",
  "image",
@@ -5129,9 +5129,9 @@ dependencies = [
 
 [[package]]
 name = "seiza-stacking"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de5bbd984184633c7be64e2a1091df1c6501d65c23f3adc7813192471e7a031"
+checksum = "b2ab78a25efc9d538cd8a5d7274f2860ce00cd87aea57ac0e0ec2127c28f3403"
 dependencies = [
  "rayon",
  "seiza",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.2"
 seiza-satellites = { version = "0.7.0", features = ["serde"] }
-seiza-stacking = "0.13.1"
+seiza-stacking = "0.14.0"
 seiza-stretch = "0.2.1"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,12 @@ uuid = { version = "1", features = ["v4"] }
 regex = "1.12"
 semver = "1"
 byteorder = "1.5"
-seiza = "0.18.12"
+seiza = "0.18.13"
 seiza-download = "0.6.0"
 seiza-imgproc = { version = "0.3.2", features = ["parallel"] }
 seiza-fits = "=0.2.2"
 seiza-satellites = { version = "0.7.0", features = ["serde"] }
-seiza-stacking = "0.13.0"
+seiza-stacking = "0.13.1"
 seiza-stretch = "0.2.1"
 # XISF reading. Already in the tree through seiza-stacking, which decodes both
 # containers into the same `seiza_fits::FitsImage`.

--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -208,12 +208,21 @@ response is smooth at pixel scale, so dust shadows and vignette structure
 are untouched. Dark and dark-flat masters keep their hot pixels — they are
 what subtracts them from the frames they calibrate.
 
-The defect pass removes pixel-scale impulses, not star images. Stars in
-sky flats are handled by the across-frame clipping instead, and only when
-they move between exposures — let the sky drift or dither between sky
-flats. Sky flats taken with tracking on hold each star on the same pixels
-in every frame, and a star that survives into the master is wider than
-the defect pass can remove. When no dark master
+The defect pass removes pixel-scale impulses, not star images. For sky flats,
+let the sky drift or dither between exposures. Flat integration subtracts the
+available bias/dark calibration, normalizes each exposure to its median
+brightness, then clips each pixel's samples around their temporal median.
+Its sigma estimate comes from the median absolute deviation (MAD), so a few
+star-contaminated samples cannot inflate the threshold and protect each other
+from rejection. The retained samples are averaged, preserving the fixed dust
+shadows and vignette that the flat is meant to measure.
+
+Rejection needs at least three flats; two are only averaged. Use enough
+well-separated sky flats that most samples at each pixel are free of stars.
+A star that stays on the same pixels, or contaminates half or more of the
+samples there, cannot reliably be distinguished from the sensor response.
+The spatial defect pass cannot remove a broad star image that survives this
+combine. When no dark master
 exists anywhere in a stack's plan, the stack instead runs the same impulse
 filter over each calibrated light, and the card says so.
 
@@ -241,8 +250,21 @@ more than a month from their lights.
 ## Stack previews
 
 Stack previews build masters on demand with `seiza-stacking`. Each master needs
-at least two inputs. Seiza uses a two-pass, leave-one-out sigma-clipped mean and
-writes the clipping and source-count provenance into the master FITS.
+at least two inputs. Bias and dark masters use a two-pass, leave-one-out
+sigma-clipped mean. Flat masters use median/MAD clipping after per-frame
+calibration and normalization. Both use 3-sigma low and high thresholds;
+two-frame sets skip rejection. The master FITS records the method in `REJMETH`,
+the clipping thresholds, source count, and rejected-sample counts. Build logs
+and catalog statistics also record the method and counts.
+
+Flat integration decodes each source once and uses temporary disk storage for
+the normalized samples, then combines bounded tiles. This keeps the tile
+memory bounded as the number of flats grows. Scratch files live in the
+database's calibration-master cache directory and are removed when the build
+finishes or fails. Allow roughly 16 GB of free space for 64 mono 61-megapixel
+flats, or three times that for already-RGB inputs. Raw source files are never
+modified. If scratch storage fails, the stack reports the failed master and
+continues without that calibration; it does not silently disable clipping.
 
 Generated masters live below:
 

--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -212,15 +212,21 @@ The defect pass removes pixel-scale impulses, not star images. For sky flats,
 let the sky drift or dither between exposures. Flat integration subtracts the
 available bias/dark calibration, normalizes each exposure to its median
 brightness, then clips each pixel's samples around their temporal median.
-Its sigma estimate comes from the median absolute deviation (MAD), so a few
-star-contaminated samples cannot inflate the threshold and protect each other
-from rejection. The retained samples are averaged, preserving the fixed dust
-shadows and vignette that the flat is meant to measure.
+Its sigma estimate comes from the median absolute deviation (MAD), which is
+less sensitive to star-contaminated samples than a mean/variance estimate.
+The retained samples are averaged, preserving the fixed dust shadows and
+vignette that the flat is meant to measure.
 
 Rejection needs at least three flats; two are only averaged. Use enough
 well-separated sky flats that most samples at each pixel are free of stars.
 A star that stays on the same pixels, or contaminates half or more of the
 samples there, cannot reliably be distinguished from the sensor response.
+Keeping that contaminated majority can even strengthen its imprint compared
+with an ordinary average. A clean majority is necessary, not a guarantee of
+complete removal: with few inputs, noise and faint star wings can still leave
+residuals below the clipping threshold. Move stars clear of their full footprint
+between enough exposures and inspect the resulting master, especially around
+saturated stars.
 The spatial defect pass cannot remove a broad star image that survives this
 combine. When no dark master
 exists anywhere in a stack's plan, the stack instead runs the same impulse

--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -77,7 +77,7 @@ Blank or undefined optional header values, such as `FILTER` in a PixInsight
 master bias XISF, are preserved in the cached FITS master. They do not prevent
 calibration, and the source file needs no header edits.
 
-**Settings → Calibration matching → Masters from other software** decides
+**Settings > Setups > Calibration > Masters from other software** decides
 how they take part: use one whenever it matches (the default), only when raw
 frames cannot build a master, or never.
 
@@ -217,8 +217,9 @@ less sensitive to star-contaminated samples than a mean/variance estimate.
 The retained samples are averaged, preserving the fixed dust shadows and
 vignette that the flat is meant to measure.
 
-Rejection needs at least three flats; two are only averaged. Use enough
-well-separated sky flats that most samples at each pixel are free of stars.
+Without star masking, rejection needs at least three flats; two are only
+averaged. Use enough well-separated sky flats that most samples at each pixel
+are free of stars.
 A star that stays on the same pixels, or contaminates half or more of the
 samples there, cannot reliably be distinguished from the sensor response.
 Keeping that contaminated majority can even strengthen its imprint compared
@@ -231,6 +232,43 @@ The spatial defect pass cannot remove a broad star image that survives this
 combine. When no dark master
 exists anywhere in a stack's plan, the stack instead runs the same impulse
 filter over each calibrated light, and the card says so.
+
+### Native sky-flat masks
+
+Enable **Mask stars in flats** under
+**Settings > Setups > Calibration > Flat masters** to exclude detected stars
+before flat integration. The setting is off by default, applies to every
+database on this server, and persists through a restart. It needs no
+StarXTerminator or other external tool. Imported masters
+are used unchanged; this option only affects masters built from raw flats.
+
+The native detector analyzes each input, expands stellar footprints to include
+halos, and adds masks around multi-pixel clipped cores when the raw encoding
+or headers establish a clipping ceiling. The original sensor samples are not
+resampled, smoothed, or filled. Integration excludes the masks, then applies
+median/MAD clipping to the remaining samples. Two remaining samples are
+averaged without clipping. This can recover a pixel from a minority of usable
+exposures rather than accepting the star-contaminated majority.
+
+Every output sample must retain at least two input measurements. Otherwise
+the flat build fails with coverage counts and is not published or applied.
+The stack can continue without that flat, with the reason shown in its
+calibration warning. Successful masters record masked-sample counts and
+retained coverage in their FITS headers, catalog statistics, and build logs.
+Coverage of only two retained exposures also appears in the stack warning,
+including when the master is reused from cache.
+
+Coverage means unmasked retained measurements, not certified artifact-free
+pixels. Faint halos can escape detection, and the mask does not reconstruct
+response hidden by a star in every exposure. Isolated detector impulses stay
+under the existing defect-suppression policy instead of growing star-sized
+masks; the statistics distinguish unmasked clipped impulses and inputs whose
+clipping ceiling is unknown. Inspect the master and capture enough separated
+flats to measure the whole sensor response.
+
+Masked and unmasked masters have separate cache identities. Changing the
+setting affects new stack requests; a queued or running stack keeps the value
+captured with its cache key.
 
 A master that fails to build does not fail the stack. The frames integrate
 without that master, and the stack card's calibration warning names the
@@ -279,10 +317,10 @@ Generated masters live below:
 ```
 
 The master filename is content-addressed by the source-frame UUIDs, current
-file fingerprints, input master UUIDs, algorithm version, and master-cache
-version. A changed bias therefore invalidates dark and flat masters that used
-it; a changed dark-flat invalidates its flat master. A later stack reuses a
-valid file. The database records its source set, input masters, and Seiza
+file fingerprints, input master UUIDs, algorithm version, flat star-masking
+mode, and master-cache version. A changed bias therefore invalidates dark and
+flat masters that used it; a changed dark-flat invalidates its flat master.
+A later stack reuses a valid file. The database records its source set, input masters, and Seiza
 version.
 
 The stack card reports `Calibration applied`, `Calibration set incomplete`, or

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -10,7 +10,8 @@
 
 ## Fixed
 
-- Sky-flat masters reject overlapping moving-star samples with robust
-  median/MAD clipping after calibration and brightness normalization. Existing
+- Sky-flat masters improve rejection of overlapping moving-star samples with
+  robust median/MAD clipping after calibration and brightness normalization. Existing
   generated masters rebuild with the new algorithm when next needed. Stars
-  fixed on the same pixels still require drift or dithering during capture.
+  need enough drift or dithering to leave most samples at each pixel clean;
+  clipping does not guarantee a star-free master.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -9,3 +9,8 @@
 ## Changed
 
 ## Fixed
+
+- Sky-flat masters reject overlapping moving-star samples with robust
+  median/MAD clipping after calibration and brightness normalization. Existing
+  generated masters rebuild with the new algorithm when next needed. Stars
+  fixed on the same pixels still require drift or dithering during capture.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,11 @@
 
 ## Added
 
+- Optional native star masking for flat masters, controlled by **Mask stars
+  in flats** in calibration settings. Masked builds retain original unmasked
+  measurements, report low coverage, and refuse unsupported pixels without
+  silently smoothing or filling them. No external star-removal tool is needed.
+
 ## Changed
 
 ## Fixed

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -1745,10 +1745,24 @@ pub fn selection_fingerprint(
     light_path: &Path,
     directory_tree: Option<&crate::directory_tree::DirectoryTree>,
 ) -> Result<String> {
+    selection_fingerprint_with_masking(
+        conn,
+        light_path,
+        directory_tree,
+        flat_star_masking_enabled(),
+    )
+}
+
+pub(crate) fn selection_fingerprint_with_masking(
+    conn: &Connection,
+    light_path: &Path,
+    directory_tree: Option<&crate::directory_tree::DirectoryTree>,
+    flat_star_masking: bool,
+) -> Result<String> {
     let light = crate::commands::import::headers::read_frame_meta(light_path);
     let mut selected = select_for_light(conn, &light)?;
     remap_missing_sources(&mut selected, directory_tree);
-    Ok(selection_hash(&selected))
+    Ok(selection_hash(&selected, flat_star_masking))
 }
 
 // ---------- Project calibration report ----------
@@ -2203,8 +2217,17 @@ pub fn resolve_or_build_masters(
         directory_tree,
         cancel,
         mode,
-        None,
+        CalibrationBuildSettings {
+            flat_star_masking: flat_star_masking_enabled(),
+            ..Default::default()
+        },
     )
+}
+
+#[derive(Clone, Copy, Default)]
+struct CalibrationBuildSettings {
+    pinned_pedestal: Option<f32>,
+    flat_star_masking: bool,
 }
 
 /// [`resolve_or_build_masters`] with a previously fitted pedestal carried
@@ -2219,7 +2242,7 @@ fn resolve_or_build_masters_pinned(
     directory_tree: Option<&crate::directory_tree::DirectoryTree>,
     cancel: Option<&AtomicBool>,
     mode: CalibrationMode,
-    pinned_pedestal: Option<f32>,
+    settings: CalibrationBuildSettings,
 ) -> Result<(seiza_stacking::CalibrationMasters, AppliedCalibration)> {
     if mode == CalibrationMode::Off {
         return Ok(calibration_off());
@@ -2230,7 +2253,7 @@ fn resolve_or_build_masters_pinned(
     let light = crate::commands::import::headers::read_frame_meta(light_path);
     let mut selected = select_for_light(conn, &light)?;
     let missing_sources = remap_missing_sources(&mut selected, directory_tree);
-    let fingerprint = selection_hash(&selected);
+    let fingerprint = selection_hash(&selected, settings.flat_star_masking);
     let mut applied = AppliedCalibration {
         mode,
         state: "matching".into(),
@@ -2387,6 +2410,7 @@ fn resolve_or_build_masters_pinned(
             frames,
             inputs,
             master_recording_blocker.as_deref(),
+            settings.flat_star_masking,
         ) {
             // The integrator reads the headers, so it catches what selection
             // could not: a catalog holds only what it recorded at import.
@@ -2524,7 +2548,7 @@ fn resolve_or_build_masters_pinned(
             // pedestal, so the intercept of that line is the pedestal. A
             // pinned value from the stack being reproduced wins over a
             // fresh fit.
-            estimated_pedestal = pinned_pedestal.or_else(|| {
+            estimated_pedestal = settings.pinned_pedestal.or_else(|| {
                 flat.as_ref().and_then(|master| {
                     estimate_flat_pedestal(&master.path, light_paths, header_pedestal_hint(&light))
                 })
@@ -2653,6 +2677,16 @@ fn resolve_or_build_masters_pinned(
         });
     }
     if let Some(note) = flat_note {
+        applied.warning = Some(match applied.warning.take() {
+            Some(previous) => format!("{previous}. {note}"),
+            None => note,
+        });
+    }
+    if let Some(note) = flat
+        .as_ref()
+        .and_then(|master| master.flat_star_masking.as_ref())
+        .and_then(flat_masking_warning)
+    {
         applied.warning = Some(match applied.warning.take() {
             Some(previous) => format!("{previous}. {note}"),
             None => note,
@@ -2793,6 +2827,39 @@ pub fn resolve_or_build_master_plan(
     mode: CalibrationMode,
     pinned: &[CalibrationSessionDetail],
 ) -> Result<CalibrationPlan> {
+    resolve_or_build_master_plan_with_options(
+        conn,
+        cache_root,
+        light_paths,
+        directory_tree,
+        cancel,
+        CalibrationPlanOptions {
+            mode,
+            pinned,
+            flat_star_masking: flat_star_masking_enabled(),
+        },
+    )
+}
+
+pub(crate) struct CalibrationPlanOptions<'a> {
+    pub mode: CalibrationMode,
+    pub pinned: &'a [CalibrationSessionDetail],
+    pub flat_star_masking: bool,
+}
+
+pub(crate) fn resolve_or_build_master_plan_with_options(
+    conn: &Connection,
+    cache_root: &Path,
+    light_paths: &[PathBuf],
+    directory_tree: Option<&crate::directory_tree::DirectoryTree>,
+    cancel: Option<&AtomicBool>,
+    options: CalibrationPlanOptions<'_>,
+) -> Result<CalibrationPlan> {
+    let CalibrationPlanOptions {
+        mode,
+        pinned,
+        flat_star_masking,
+    } = options;
     if mode == CalibrationMode::Off {
         let (masters, applied) = calibration_off();
         return Ok(CalibrationPlan::single(masters, applied, light_paths.len()));
@@ -2834,7 +2901,12 @@ pub fn resolve_or_build_master_plan(
         stop_requested(cancel)?;
         // A session's pin is looked up by its selection fingerprint, which
         // the resolution below recomputes identically from the same lights.
-        let fingerprint = selection_fingerprint(conn, &lights[0], directory_tree)?;
+        let fingerprint = selection_fingerprint_with_masking(
+            conn,
+            &lights[0],
+            directory_tree,
+            flat_star_masking,
+        )?;
         let pinned_pedestal = pinned
             .iter()
             .find(|detail| detail.fingerprint == fingerprint)
@@ -2846,7 +2918,10 @@ pub fn resolve_or_build_master_plan(
             directory_tree,
             cancel,
             mode,
-            pinned_pedestal,
+            CalibrationBuildSettings {
+                pinned_pedestal,
+                flat_star_masking,
+            },
         )?;
         sessions.push(CalibrationSession { masters, applied });
     }
@@ -2966,6 +3041,7 @@ struct BuiltMaster {
     /// Inputs the integrator refused, which only it can see: it reads the
     /// headers, while selection has only what the catalog recorded.
     skipped: Vec<(PathBuf, String)>,
+    flat_star_masking: Option<seiza_stacking::FlatStarMaskingStatistics>,
 }
 
 impl BuiltMaster {
@@ -2976,6 +3052,34 @@ impl BuiltMaster {
             .to_string_lossy()
             .into_owned()
     }
+}
+
+fn flat_masking_warning(statistics: &seiza_stacking::FlatStarMaskingStatistics) -> Option<String> {
+    let mut notes = Vec::new();
+    if statistics.low_coverage_samples > 0 {
+        notes.push(format!(
+            "{} sample(s) have only two retained exposures; coverage ranges from {} to {}. \
+             More well-separated flats improve coverage",
+            statistics.low_coverage_samples,
+            statistics.minimum_clean_samples,
+            statistics.maximum_clean_samples,
+        ));
+    }
+    if statistics.unmasked_saturation_samples > 0 {
+        notes.push(format!(
+            "{} isolated clipped input sample(s) were left to detector-defect suppression, \
+             not star masking",
+            statistics.unmasked_saturation_samples,
+        ));
+    }
+    if statistics.unknown_saturation_inputs > 0 {
+        notes.push(format!(
+            "{} input(s) had no known clipping ceiling; detected stars were masked, \
+             but saturation could not be checked",
+            statistics.unknown_saturation_inputs,
+        ));
+    }
+    (!notes.is_empty()).then(|| format!("Star-masked flat: {}", notes.join(". ")))
 }
 
 #[derive(Default)]
@@ -3012,7 +3116,7 @@ fn adopt_external_master(
     recording_blocker: Option<&str>,
 ) -> Result<AdoptedMaster> {
     let frames = std::slice::from_ref(frame);
-    let source_hash = source_set_hash(frames, None, None);
+    let source_hash = source_set_hash(frames, None, None, false);
     let master_uuid = stable_uuid(&format!("{}:{source_hash}", kind.as_str()));
     let path = root.join(format!("{}-{source_hash}.fits", kind.as_str()));
     let expected_kind = match kind {
@@ -3064,6 +3168,7 @@ fn adopt_external_master(
                     path,
                     master_uuid,
                     skipped: Vec::new(),
+                    flat_star_masking: None,
                 },
                 note: format!("{source_name}{trust_note}"),
             });
@@ -3151,6 +3256,7 @@ fn adopt_external_master(
             path,
             master_uuid,
             skipped: Vec::new(),
+            flat_star_masking: None,
         },
         note: format!("{source_name}{trust_note}{scale_note}"),
     })
@@ -3207,6 +3313,7 @@ fn build_master(
     frames: &[CalibrationFrame],
     inputs: MasterInputs<'_>,
     recording_blocker: Option<&str>,
+    flat_star_masking: bool,
 ) -> Result<Option<BuiltMaster>> {
     // Reduce to the frames that can actually combine (one temperature, one
     // flat session). The master's content hash below covers exactly this
@@ -3222,7 +3329,8 @@ fn build_master(
         bias_dependency,
         dark_dependency,
     } = inputs;
-    let source_hash = source_set_hash(frames, bias_dependency, dark_dependency);
+    let flat_star_masking = kind == CalibrationKind::Flat && flat_star_masking;
+    let source_hash = source_set_hash(frames, bias_dependency, dark_dependency, flat_star_masking);
     let master_uuid = stable_uuid(&format!("{}:{source_hash}", kind.as_str()));
     let path = root.join(format!("{}-{source_hash}.fits", kind.as_str()));
     if path.exists() {
@@ -3258,13 +3366,43 @@ fn build_master(
                     path.display()
                 );
             }
-            return Ok(Some(BuiltMaster {
-                path,
-                master_uuid,
-                // A cached master is served without rebuilding, so there is
-                // no fresh refusal to report.
-                skipped: Vec::new(),
-            }));
+            let masking_statistics = if flat_star_masking {
+                cached_flat_masking_statistics(conn, &path).and_then(|statistics| {
+                    let statistics = statistics
+                        .context("cached star-masked flat is missing coverage statistics")?;
+                    anyhow::ensure!(
+                        statistics.options == seiza_stacking::FlatStarMaskingOptions::default()
+                            && statistics.minimum_clean_samples
+                                >= statistics.options.minimum_clean_samples
+                            && statistics.maximum_clean_samples >= statistics.minimum_clean_samples
+                            && statistics.maximum_clean_samples <= frames.len(),
+                        "cached star-masked flat has invalid coverage statistics"
+                    );
+                    Ok(Some(statistics))
+                })
+            } else {
+                Ok(None)
+            };
+            match masking_statistics {
+                Ok(statistics) => {
+                    return Ok(Some(BuiltMaster {
+                        path,
+                        master_uuid,
+                        // A cached master is served without rebuilding, so there is
+                        // no fresh refusal to report.
+                        skipped: Vec::new(),
+                        flat_star_masking: statistics,
+                    }));
+                }
+                Err(error) => {
+                    if let Some(blocker) = recording_blocker {
+                        anyhow::bail!(
+                            "{blocker}; cached flat coverage cannot be trusted: {error:#}"
+                        );
+                    }
+                    tracing::warn!("rebuilding cached star-masked flat: {error:#}");
+                }
+            }
         }
         if let Some(blocker) = recording_blocker {
             anyhow::bail!(
@@ -3297,6 +3435,7 @@ fn build_master(
         // they are what subtracts them from the frames they calibrate.
         defect_suppression: (kind == CalibrationKind::Flat)
             .then(seiza_stacking::ImpulseFilterOptions::default),
+        flat_star_masking: flat_star_masking.then(seiza_stacking::FlatStarMaskingOptions::default),
         ..Default::default()
     };
     let paths = frames
@@ -3315,6 +3454,16 @@ fn build_master(
         frame.rejected_samples,
         frame.fallback_pixels,
     );
+    if let Some(statistics) = &frame.flat_star_masking {
+        tracing::info!(
+            "master flat masked {} samples across {} pixels; retained coverage {}..{}, {} low-coverage samples",
+            statistics.masked_samples,
+            statistics.masked_pixels,
+            statistics.minimum_clean_samples,
+            statistics.maximum_clean_samples,
+            statistics.low_coverage_samples,
+        );
+    }
     let skipped: Vec<(PathBuf, String)> = frame
         .skipped_inputs
         .iter()
@@ -3354,6 +3503,8 @@ fn build_master(
                 "accepted_samples": frame.accepted_samples,
                 "rejected_samples": frame.rejected_samples,
                 "fallback_pixels": frame.fallback_pixels,
+                "masked_samples": frame.masked_samples,
+                "flat_star_masking": frame.flat_star_masking,
             }),
         },
         MasterInputs {
@@ -3367,7 +3518,28 @@ fn build_master(
         path,
         master_uuid,
         skipped,
+        flat_star_masking: frame.flat_star_masking,
     }))
+}
+
+fn cached_flat_masking_statistics(
+    conn: &Connection,
+    path: &Path,
+) -> Result<Option<seiza_stacking::FlatStarMaskingStatistics>> {
+    let statistics: String = conn.query_row(
+        "SELECT statistics_json FROM psf_guard_calibration_master WHERE cache_path = ?1",
+        [path.to_string_lossy().as_ref()],
+        |row| row.get(0),
+    )?;
+    let statistics: serde_json::Value =
+        serde_json::from_str(&statistics).context("reading cached master statistics")?;
+    statistics
+        .get("flat_star_masking")
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            serde_json::from_value(value.clone()).context("reading cached flat mask coverage")
+        })
+        .transpose()
 }
 
 /// What a master row records about the build beyond its inputs.
@@ -3612,6 +3784,7 @@ fn source_set_hash(
     frames: &[CalibrationFrame],
     bias_dependency: Option<&BuiltMaster>,
     dark_dependency: Option<&BuiltMaster>,
+    flat_star_masking: bool,
 ) -> String {
     let mut values = frames
         .iter()
@@ -3625,6 +3798,9 @@ fn source_set_hash(
         })
         .collect::<Vec<_>>();
     values.sort();
+    if flat_star_masking {
+        values.push("flat-star-masking=native-v1".into());
+    }
     hex_digest(&format!(
         "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
         MASTER_CACHE_VERSION,
@@ -3639,7 +3815,7 @@ fn source_set_hash(
     ))
 }
 
-fn selection_hash(selection: &CalibrationSelection) -> String {
+fn selection_hash(selection: &CalibrationSelection, flat_star_masking: bool) -> String {
     let mut values = Vec::new();
     for (kind, frames) in [
         (CalibrationKind::Bias, &selection.bias),
@@ -3662,6 +3838,9 @@ fn selection_hash(selection: &CalibrationSelection) -> String {
         }
     }
     values.sort();
+    if flat_star_masking && selection.flat.iter().any(|frame| !frame.is_master) {
+        values.push("flat-star-masking=native-v1".into());
+    }
     if values.is_empty() {
         "none".into()
     } else {
@@ -3833,6 +4012,18 @@ impl ExternalMasterPolicy {
 /// a deployment's property, set once from the registry before any catalog
 /// is opened.
 static EXTERNAL_MASTER_POLICY: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+static FLAT_STAR_MASKING: AtomicBool = AtomicBool::new(false);
+
+/// Set the default for new calibration plans; already-running plans keep
+/// their captured value and content-addressed master identity.
+pub fn configure_flat_star_masking(enabled: bool) {
+    FLAT_STAR_MASKING.store(enabled, Ordering::Relaxed);
+}
+
+pub fn flat_star_masking_enabled() -> bool {
+    FLAT_STAR_MASKING.load(Ordering::Relaxed)
+}
 
 /// Choose how external masters are used for every selection this process
 /// makes. `None` keeps the default, [`ExternalMasterPolicy::Prefer`].
@@ -6714,6 +6905,187 @@ mod tests {
         .unwrap();
         assert_eq!(applied.flat_master, reused.flat_master);
         assert_eq!(applied.masters_signature, reused.masters_signature);
+    }
+
+    fn masked_sky_flat_fixture(root: &Path, positions: &[(usize, usize)]) -> (Connection, PathBuf) {
+        let (width, height) = (160, 128);
+        let mut metadata = Vec::new();
+        for index in 0..2 {
+            let path = root.join(format!("bias-{index}.fits"));
+            write_gradient_fits(&path, "BIAS", width, height, "Camera", 10, |_, _| 100.0);
+            metadata.push(crate::commands::import::headers::read_frame_meta(&path));
+        }
+        for (index, &(star_x, star_y)) in positions.iter().enumerate() {
+            let path = root.join(format!("flat-{index}.fits"));
+            let sky = 10_000.0 + index as f64 * 250.0;
+            write_gradient_fits(&path, "FLAT", width, height, "Camera", 10, |x, y| {
+                let distance =
+                    (x as f64 - star_x as f64).powi(2) + (y as f64 - star_y as f64).powi(2);
+                let star = 0.8 * (-distance / 8.0).exp();
+                let response = if x < 12 {
+                    0.8
+                } else if (120..140).contains(&x) && (95..110).contains(&y) {
+                    0.6
+                } else {
+                    1.0
+                };
+                100.0 + sky * (response + star)
+            });
+            metadata.push(crate::commands::import::headers::read_frame_meta(&path));
+        }
+        let light = root.join("light.fits");
+        write_gradient_fits(&light, "LIGHT", width, height, "Camera", 10, |_, _| 1_100.0);
+        let mut conn = Connection::open_in_memory().unwrap();
+        let tx = conn.transaction().unwrap();
+        import_calibration_frames(&tx, &metadata, Some("profile")).unwrap();
+        tx.commit().unwrap();
+        (conn, light)
+    }
+
+    fn resolve_masked_fixture(
+        conn: &Connection,
+        cache: &Path,
+        light: &Path,
+        enabled: bool,
+    ) -> AppliedCalibration {
+        resolve_or_build_masters_pinned(
+            conn,
+            cache,
+            &[light.to_path_buf()],
+            None,
+            None,
+            CalibrationMode::Auto,
+            CalibrationBuildSettings {
+                flat_star_masking: enabled,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .1
+    }
+
+    #[test]
+    fn native_flat_masks_rekey_masters_remove_majority_stars_and_preserve_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut positions = vec![(40, 45); 6];
+        positions.extend([(100, 55); 4]);
+        let (conn, light) = masked_sky_flat_fixture(temp.path(), &positions);
+        let cache = temp.path().join("cache");
+        let unmasked = resolve_masked_fixture(&conn, &cache, &light, false);
+        let masked = resolve_masked_fixture(&conn, &cache, &light, true);
+        assert!(masked.flat_master.is_some(), "{:?}", masked.warning);
+        assert_eq!(masked.bias_master, unmasked.bias_master);
+        assert_ne!(masked.flat_master, unmasked.flat_master);
+        assert_ne!(masked.fingerprint, unmasked.fingerprint);
+        assert_ne!(masked.masters_signature, unmasked.masters_signature);
+        let path = cache
+            .join("calibration-masters")
+            .join(masked.flat_master.as_ref().unwrap());
+        let master = crate::image_io::open_linear_frame(&path).unwrap();
+        for (x, y, expected) in [(40, 45, 1.0), (100, 55, 1.0), (4, 64, 0.8), (130, 102, 0.6)] {
+            assert!(
+                (master.image.data[y * 160 + x] - expected).abs() < 0.001,
+                "response at {x},{y}: {} != {expected}",
+                master.image.data[y * 160 + x],
+            );
+        }
+        let statistics = cached_flat_masking_statistics(&conn, &path)
+            .unwrap()
+            .unwrap();
+        assert!(statistics.masked_samples > 0);
+        assert!(statistics.masked_pixels > 0);
+        assert!(statistics.minimum_clean_samples >= 2);
+        let cached = resolve_masked_fixture(&conn, &cache, &light, true);
+        assert_eq!(cached.flat_master, masked.flat_master);
+        assert_eq!(cached.warning, masked.warning);
+        let restored = resolve_masked_fixture(&conn, &cache, &light, false);
+        assert_eq!(restored.flat_master, unmasked.flat_master);
+    }
+
+    #[test]
+    fn native_flat_mask_coverage_failure_is_visible_and_does_not_record_a_master() {
+        let temp = tempfile::tempdir().unwrap();
+        let (conn, light) = masked_sky_flat_fixture(temp.path(), &[(40, 45); 6]);
+        let cache = temp.path().join("cache");
+        let applied = resolve_masked_fixture(&conn, &cache, &light, true);
+        assert!(applied.bias_master.is_some());
+        assert!(applied.flat_master.is_none());
+        let warning = applied
+            .warning
+            .as_deref()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        assert!(warning.contains("coverage"), "{warning}");
+        assert!(warning.contains("flat"), "{warning}");
+        let recorded: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM psf_guard_calibration_master WHERE kind = 'flat'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(recorded, 0);
+        assert!(cache
+            .join("calibration-masters")
+            .read_dir()
+            .unwrap()
+            .all(|entry| {
+                let name = entry.unwrap().file_name().to_string_lossy().into_owned();
+                !name.starts_with("flat-") && !name.starts_with("seiza-flat-")
+            }));
+    }
+
+    #[test]
+    fn native_flat_mask_low_coverage_warning_survives_cache_reuse() {
+        let temp = tempfile::tempdir().unwrap();
+        let (conn, light) =
+            masked_sky_flat_fixture(temp.path(), &[(40, 45), (40, 45), (100, 55), (100, 55)]);
+        let cache = temp.path().join("cache");
+        let applied = resolve_masked_fixture(&conn, &cache, &light, true);
+        assert!(applied.flat_master.is_some(), "{:?}", applied.warning);
+        assert!(applied
+            .warning
+            .as_deref()
+            .unwrap_or_default()
+            .contains("only two"));
+        let reused = resolve_masked_fixture(&conn, &cache, &light, true);
+        assert_eq!(reused.warning, applied.warning);
+        assert_eq!(reused.flat_master, applied.flat_master);
+
+        for invalid_statistics in ["{}", "not-json"] {
+            conn.execute(
+                "UPDATE psf_guard_calibration_master SET statistics_json = ?1 WHERE kind = 'flat'",
+                [invalid_statistics],
+            )
+            .unwrap();
+            let rebuilt = resolve_masked_fixture(&conn, &cache, &light, true);
+            assert_eq!(rebuilt.flat_master, applied.flat_master);
+            assert_eq!(rebuilt.warning, applied.warning);
+        }
+    }
+
+    #[test]
+    fn native_flat_mask_diagnostics_distinguish_coverage_from_saturation() {
+        let mut statistics = seiza_stacking::FlatStarMaskingStatistics {
+            options: seiza_stacking::FlatStarMaskingOptions::default(),
+            masked_samples: 20,
+            masked_pixels: 10,
+            minimum_clean_samples: 4,
+            maximum_clean_samples: 10,
+            low_coverage_samples: 0,
+            unmasked_saturation_samples: 0,
+            unknown_saturation_inputs: 0,
+        };
+        assert!(flat_masking_warning(&statistics).is_none());
+        statistics.unmasked_saturation_samples = 8;
+        statistics.unknown_saturation_inputs = 3;
+        let warning = flat_masking_warning(&statistics).unwrap();
+        assert!(warning.contains("8 isolated clipped"), "{warning}");
+        assert!(
+            warning.contains("3 input(s) had no known clipping ceiling"),
+            "{warning}"
+        );
+        assert!(!warning.contains("only two"), "{warning}");
     }
 
     #[test]

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -3303,8 +3303,18 @@ fn build_master(
         .iter()
         .map(|frame| frame.source_path.clone())
         .collect::<Vec<_>>();
-    let frame = seiza_stacking::build_master_from_fits(&paths, seiza_kind, &options)
-        .with_context(|| format!("building master {}", kind.as_str()))?;
+    let frame =
+        seiza_stacking::build_master_from_fits_with_scratch(&paths, seiza_kind, &options, root)
+            .with_context(|| format!("building master {}", kind.as_str()))?;
+    tracing::info!(
+        "master {} combined {} frame(s) with {} rejection: {} accepted, {} rejected samples, {} fallback pixels",
+        kind.as_str(),
+        frame.input_frames,
+        frame.rejection_method.as_str(),
+        frame.accepted_samples,
+        frame.rejected_samples,
+        frame.fallback_pixels,
+    );
     let skipped: Vec<(PathBuf, String)> = frame
         .skipped_inputs
         .iter()
@@ -3340,6 +3350,7 @@ fn build_master(
         RecordedMaster {
             exposure_seconds: frame.exposure_seconds,
             statistics: serde_json::json!({
+                "rejection_method": frame.rejection_method.as_str(),
                 "accepted_samples": frame.accepted_samples,
                 "rejected_samples": frame.rejected_samples,
                 "fallback_pixels": frame.fallback_pixels,
@@ -6610,6 +6621,99 @@ mod tests {
         );
         assert!(!masters.is_empty());
         assert!(!applied.masters_signature.is_empty());
+    }
+
+    #[test]
+    fn sky_flat_masters_reject_overlapping_stars_and_keep_sensor_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let (width, height) = (96, 64);
+        let response = |x: usize, y: usize| {
+            if x < 8 || x >= width - 8 {
+                0.8
+            } else if (76..88).contains(&x) && (40..52).contains(&y) {
+                0.5
+            } else {
+                1.0
+            }
+        };
+        let mut calibration_meta = Vec::new();
+        for index in 0..2 {
+            let path = temp.path().join(format!("bias-{index}.fits"));
+            write_gradient_fits(&path, "BIAS", width, height, "Camera", 10, |_, _| 100.0);
+            calibration_meta.push(crate::commands::import::headers::read_frame_meta(&path));
+        }
+        for index in 0..8 {
+            let path = temp.path().join(format!("sky-flat-{index}.fits"));
+            let sky = 1_000.0 + index as f64 * 500.0;
+            let star_left = 10 + index * 6;
+            write_gradient_fits(&path, "FLAT", width, height, "Camera", 10, |x, y| {
+                let star = if (star_left..star_left + 9).contains(&x) && (14..23).contains(&y) {
+                    1.0
+                } else {
+                    0.0
+                };
+                100.0 + sky * (response(x, y) + star)
+            });
+            calibration_meta.push(crate::commands::import::headers::read_frame_meta(&path));
+        }
+        let light_path = temp.path().join("light.fits");
+        write_gradient_fits(&light_path, "LIGHT", width, height, "Camera", 10, |x, y| {
+            100.0 + 1_000.0 * response(x, y)
+        });
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            import_calibration_frames(&tx, &calibration_meta, Some("profile")).unwrap();
+            tx.commit().unwrap();
+        }
+        let cache = temp.path().join("cache");
+        let (_, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        assert!(applied.flat_master.is_some(), "{:?}", applied.warning);
+        let (path, statistics): (String, String) = conn
+            .query_row(
+                "SELECT cache_path, statistics_json FROM psf_guard_calibration_master WHERE kind = 'flat'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let master = crate::image_io::open_linear_frame(Path::new(&path)).unwrap();
+        // Broad overlapping star images survive a pixel-scale impulse filter.
+        for (x, y) in [(17, 18), (23, 18), (29, 18), (3, 32), (82, 46), (50, 40)] {
+            let actual = master.image.data[y * width + x];
+            assert!(
+                (f64::from(actual) - response(x, y)).abs() < 0.001,
+                "flat response at ({x}, {y}): expected {}, got {actual}",
+                response(x, y),
+            );
+        }
+        let statistics: serde_json::Value = serde_json::from_str(&statistics).unwrap();
+        assert_eq!(statistics["rejection_method"], "MEDIAN_MAD");
+        assert!(statistics["rejected_samples"].as_u64().unwrap() > 0);
+        assert_eq!(statistics["fallback_pixels"], 0);
+        assert_eq!(
+            statistics["accepted_samples"].as_u64().unwrap()
+                + statistics["rejected_samples"].as_u64().unwrap(),
+            (8 * width * height) as u64,
+        );
+        let (_, reused) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light_path),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        assert_eq!(applied.flat_master, reused.flat_master);
+        assert_eq!(applied.masters_signature, reused.masters_signature);
     }
 
     #[test]

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -1183,6 +1183,13 @@ pub fn main() -> Result<()> {
                     .as_ref()
                     .and_then(|calibration| calibration.external_masters),
             );
+            crate::calibration::configure_flat_star_masking(
+                db_registry
+                    .calibration
+                    .as_ref()
+                    .and_then(|calibration| calibration.flat_star_masking)
+                    .unwrap_or(false),
+            );
             let cache_directory = app_config.get_cache_directory();
             let server_host = app_config.get_host();
             let server_port = app_config.get_port();

--- a/src/db_registry.rs
+++ b/src/db_registry.rs
@@ -411,6 +411,9 @@ pub struct CalibrationSettings {
     /// default), `fallback`, or `ignore`. Absent means prefer.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_masters: Option<crate::calibration::ExternalMasterPolicy>,
+    /// Mask stars in raw flats before integration. Absent means disabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flat_star_masking: Option<bool>,
 }
 
 /// What the export dialog starts from. The dialog still offers every layout
@@ -900,6 +903,7 @@ mod tests {
             calibration: Some(CalibrationSettings {
                 rotation_tolerance_deg: Some(3.5),
                 external_masters: Some(crate::calibration::ExternalMasterPolicy::Fallback),
+                flat_star_masking: Some(true),
             }),
             ..Default::default()
         };
@@ -911,6 +915,7 @@ mod tests {
         assert!(serialized.contains("\"calibration\""));
         assert!(serialized.contains("rotation_tolerance_deg"));
         assert!(serialized.contains("\"external_masters\": \"fallback\""));
+        assert!(serialized.contains("\"flat_star_masking\": true"));
 
         // A registry that never configured it keeps a clean file: additive
         // within v2, and an older build reading this file sees nothing new.
@@ -918,6 +923,14 @@ mod tests {
         bare.save(&path).unwrap();
         let serialized = std::fs::read_to_string(&path).unwrap();
         assert!(!serialized.contains("calibration"));
+    }
+
+    #[test]
+    fn legacy_calibration_settings_leave_flat_star_masking_disabled() {
+        let settings: CalibrationSettings =
+            serde_json::from_str(r#"{"rotation_tolerance_deg":3.5,"external_masters":"fallback"}"#)
+                .unwrap();
+        assert_eq!(settings.flat_star_masking, None);
     }
 
     #[test]

--- a/src/server/calibration_settings.rs
+++ b/src/server/calibration_settings.rs
@@ -28,6 +28,7 @@ pub struct CalibrationSettingsResponse {
     /// How masters built by other software are used. Always populated: the
     /// default is `prefer`.
     pub external_masters: ExternalMasterPolicy,
+    pub flat_star_masking: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -37,6 +38,9 @@ pub struct UpdateCalibrationSettingsRequest {
     /// Omitted keeps the default, `prefer`.
     #[serde(default)]
     pub external_masters: Option<ExternalMasterPolicy>,
+    /// Omitted preserves the existing setting, including requests from older clients.
+    #[serde(default)]
+    pub flat_star_masking: Option<bool>,
 }
 
 fn current_response(settings: Option<&CalibrationSettings>) -> CalibrationSettingsResponse {
@@ -46,6 +50,9 @@ fn current_response(settings: Option<&CalibrationSettings>) -> CalibrationSettin
         external_masters: settings
             .and_then(|settings| settings.external_masters)
             .unwrap_or_default(),
+        flat_star_masking: settings
+            .and_then(|settings| settings.flat_star_masking)
+            .unwrap_or(false),
     }
 }
 
@@ -91,17 +98,53 @@ pub async fn update_calibration_settings(
     let external_masters = request
         .external_masters
         .filter(|policy| *policy != ExternalMasterPolicy::default());
-    registry.calibration = (request.rotation_tolerance_deg.is_some() || external_masters.is_some())
+    let flat_star_masking = requested_flat_star_masking(&request, registry.calibration.as_ref());
+    registry.calibration = (request.rotation_tolerance_deg.is_some()
+        || external_masters.is_some()
+        || flat_star_masking)
         .then_some(CalibrationSettings {
             rotation_tolerance_deg: request.rotation_tolerance_deg,
             external_masters,
+            flat_star_masking: flat_star_masking.then_some(true),
         });
     registry
         .save(&path)
         .map_err(|error| AppError::InternalError(error.to_string()))?;
     crate::calibration::configure_rotation_tolerance(request.rotation_tolerance_deg);
     crate::calibration::configure_external_master_policy(external_masters);
+    crate::calibration::configure_flat_star_masking(flat_star_masking);
     Ok(Json(ApiResponse::success(current_response(
         registry.calibration.as_ref(),
     ))))
+}
+
+fn requested_flat_star_masking(
+    request: &UpdateCalibrationSettingsRequest,
+    current: Option<&CalibrationSettings>,
+) -> bool {
+    request
+        .flat_star_masking
+        .or_else(|| current.and_then(|settings| settings.flat_star_masking))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flat_star_masking_defaults_off_and_omission_preserves_saved_choice() {
+        assert!(!current_response(None).flat_star_masking);
+        let settings = CalibrationSettings {
+            flat_star_masking: Some(true),
+            ..Default::default()
+        };
+        assert!(current_response(Some(&settings)).flat_star_masking);
+        let mut request: UpdateCalibrationSettingsRequest =
+            serde_json::from_str(r#"{"rotation_tolerance_deg":null}"#).unwrap();
+        assert!(!requested_flat_star_masking(&request, None));
+        assert!(requested_flat_star_masking(&request, Some(&settings)));
+        request.flat_star_masking = Some(false);
+        assert!(!requested_flat_star_masking(&request, Some(&settings)));
+    }
 }

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -766,6 +766,8 @@ struct PreparedGroup {
     /// The mode this channel calibrates under: its request override, or the
     /// request-wide mode.
     calibration: crate::calibration::CalibrationMode,
+    /// Captured with the cache key, so a settings save cannot change a queued job.
+    flat_star_masking: bool,
     frames: Vec<PreparedFrame>,
 }
 
@@ -1372,6 +1374,7 @@ fn prepare_job(
     project_id: i32,
     request: &StackPreviewRequest,
 ) -> Result<PreparedJob, AppError> {
+    let flat_star_masking = crate::calibration::flat_star_masking_enabled();
     let scoring = StackScoringSettings::from_overrides(&request.scoring);
     let requested = request.image_ids.iter().copied().collect::<HashSet<_>>();
     let (project_images, expected_by_image, mapped_sources) = {
@@ -1583,10 +1586,11 @@ fn prepare_job(
             let conn = ctx.db();
             let conn = conn.lock().map_err(AppError::db)?;
             for frame in &frames {
-                let fingerprint = crate::calibration::selection_fingerprint(
+                let fingerprint = crate::calibration::selection_fingerprint_with_masking(
                     &conn,
                     &frame.path,
                     Some(&directory_tree),
+                    flat_star_masking,
                 )
                 .map_err(AppError::db)?;
                 hasher.update(fingerprint.as_bytes());
@@ -1631,6 +1635,7 @@ fn prepare_job(
             frames: decisions,
         });
         prepared_groups.push(PreparedGroup {
+            flat_star_masking,
             index,
             calibration: group_calibration,
             frames,
@@ -2143,16 +2148,20 @@ fn run_group(
     // sessions, each with its own masters; a single-night group gets one
     // session and stacks exactly as before.
     let calibration_mode = group.calibration;
+    let flat_star_masking = group.flat_star_masking;
     let calibration_started = std::time::Instant::now();
     let plan = pool.install(move || {
-        crate::calibration::resolve_or_build_master_plan(
+        crate::calibration::resolve_or_build_master_plan_with_options(
             &calibration_conn,
             cache_root,
             &light_paths,
             Some(&directory_tree),
             Some(cancel.as_ref()),
-            calibration_mode,
-            &[],
+            crate::calibration::CalibrationPlanOptions {
+                mode: calibration_mode,
+                pinned: &[],
+                flat_star_masking,
+            },
         )
     });
     tracing::info!(

--- a/src/server/stack_preview/final_integration.rs
+++ b/src/server/stack_preview/final_integration.rs
@@ -305,6 +305,7 @@ mod tests {
         }
         (
             PreparedGroup {
+                flat_star_masking: false,
                 index: 0,
                 calibration: crate::calibration::CalibrationMode::Off,
                 frames,

--- a/src/tauri_main.rs
+++ b/src/tauri_main.rs
@@ -76,6 +76,13 @@ pub fn main() {
             .as_ref()
             .and_then(|calibration| calibration.external_masters),
     );
+    crate::calibration::configure_flat_star_masking(
+        initial_registry
+            .calibration
+            .as_ref()
+            .and_then(|calibration| calibration.flat_star_masking)
+            .unwrap_or(false),
+    );
     let server_config_for_task = server_config.clone();
     let registry_path_for_task = registry_path.clone();
     rt.spawn(async move {

--- a/static/e2e/calibration-settings.spec.ts
+++ b/static/e2e/calibration-settings.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test, type Page } from '@playwright/test';
+import type { CalibrationSettings } from '../src/api/types';
+import { registerFixtureDb, resetDatabases } from './helpers';
+
+let original: CalibrationSettings;
+
+async function openCalibration(page: Page) {
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  await page.getByRole('tab', { name: 'Setups', exact: true }).click();
+  return page.locator('.calibration-matching-settings');
+}
+
+test.beforeEach(async ({ request }) => {
+  const response = await request.get('/api/settings/calibration');
+  expect(response.ok()).toBeTruthy();
+  original = (await response.json()).data;
+  await resetDatabases(request);
+  await registerFixtureDb(request);
+});
+
+test.afterEach(async ({ request }) => {
+  const response = await request.put('/api/settings/calibration', {
+    data: {
+      rotation_tolerance_deg: original.rotation_tolerance_deg,
+      external_masters: original.external_masters,
+      flat_star_masking: original.flat_star_masking,
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+});
+
+test('flat star masking defaults off and persists on and off across reloads', async ({
+  page, request,
+}, testInfo) => {
+  expect(original.flat_star_masking).toBe(false);
+  await page.goto('/');
+  let settings = await openCalibration(page);
+  let toggle = settings.getByRole('checkbox', { name: 'Mask stars in flats' });
+  await expect(toggle).not.toBeChecked();
+  await expect(settings.getByRole('button', { name: 'Save', exact: true })).toBeDisabled();
+  await toggle.check();
+  const sent = page.waitForRequest((request) =>
+    request.method() === 'PUT' && request.url().endsWith('/api/settings/calibration')
+  );
+  await settings.getByRole('button', { name: 'Save', exact: true }).click();
+  expect((await sent).postDataJSON()).toEqual({
+    rotation_tolerance_deg: original.rotation_tolerance_deg,
+    external_masters: original.external_masters,
+    flat_star_masking: true,
+  });
+  await expect(settings.getByRole('button', { name: 'Save', exact: true })).toBeDisabled();
+  await expect.poll(async () =>
+    (await (await request.get('/api/settings/calibration')).json()).data
+  ).toEqual({
+    ...original,
+    flat_star_masking: true,
+  });
+  const legacyUpdate = await request.put('/api/settings/calibration', {
+    data: {
+      rotation_tolerance_deg: original.rotation_tolerance_deg,
+      external_masters: original.external_masters,
+    },
+  });
+  expect(legacyUpdate.ok()).toBeTruthy();
+  expect((await legacyUpdate.json()).data.flat_star_masking).toBe(true);
+
+  await page.reload();
+  settings = await openCalibration(page);
+  toggle = settings.getByRole('checkbox', { name: 'Mask stars in flats' });
+  await expect(toggle).toBeChecked();
+  await settings.screenshot({ path: testInfo.outputPath('flat-star-masking-desktop.png') });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await toggle.scrollIntoViewIfNeeded();
+  await expect(toggle).toBeVisible();
+  expect(await settings.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+  expect(await settings.getByRole('group', { name: 'Matching', exact: true })
+    .locator('.review-preference > span')
+    .evaluateAll((labels) => labels.every((label) =>
+      label.getBoundingClientRect().width >= label.parentElement!.getBoundingClientRect().width * 0.9
+    ))).toBe(true);
+  await page.locator('.tauri-settings')
+    .screenshot({ path: testInfo.outputPath('flat-star-masking-mobile.png') });
+
+  await toggle.uncheck();
+  await settings.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(async () =>
+    (await (await request.get('/api/settings/calibration')).json()).data.flat_star_masking
+  ).toBe(false);
+  await page.reload();
+  settings = await openCalibration(page);
+  await expect(settings.getByRole('checkbox', { name: 'Mask stars in flats' })).not.toBeChecked();
+});
+
+test('a failed masking save keeps the draft and leaves the saved value unchanged', async ({
+  page, request,
+}) => {
+  await page.route('**/api/settings/calibration', async (route) => {
+    if (route.request().method() !== 'PUT') return route.continue();
+    await route.fulfill({
+      status: 503,
+      json: { success: false, data: null, error: 'Could not save the registry' },
+    });
+  });
+  await page.goto('/');
+  const settings = await openCalibration(page);
+  const toggle = settings.getByRole('checkbox', { name: 'Mask stars in flats' });
+  await toggle.setChecked(!original.flat_star_masking);
+  await settings.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(settings.getByRole('alert')).toHaveText('Could not save the registry');
+  await expect(toggle).toBeChecked({ checked: !original.flat_star_masking });
+  await expect(settings.getByRole('button', { name: 'Save', exact: true })).toBeEnabled();
+  expect((await (await request.get('/api/settings/calibration')).json()).data.flat_star_masking)
+    .toBe(original.flat_star_masking);
+  await page.unroute('**/api/settings/calibration');
+  await settings.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(settings.getByRole('alert')).toHaveCount(0);
+  await expect.poll(async () =>
+    (await (await request.get('/api/settings/calibration')).json()).data.flat_star_masking
+  ).toBe(!original.flat_star_masking);
+});
+
+test('a settings load failure does not show an editable masking default', async ({ page }) => {
+  await page.route('**/api/settings/calibration', async (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    await route.fulfill({
+      status: 503,
+      json: { success: false, data: null, error: 'Registry unavailable' },
+    });
+  });
+  await page.goto('/');
+  const settings = await openCalibration(page);
+  await expect(settings.getByRole('alert')).toHaveText(
+    'Could not load calibration settings.', { timeout: 15_000 }
+  );
+  await expect(settings.getByRole('checkbox', { name: 'Mask stars in flats' })).toHaveCount(0);
+  await expect(settings.getByRole('button', { name: 'Save', exact: true })).toHaveCount(0);
+});

--- a/static/src/api/__tests__/calibration-settings.test.ts
+++ b/static/src/api/__tests__/calibration-settings.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import { apiClient } from '../client';
+import type { CalibrationSettings } from '../types';
+
+const settings = (enabled: boolean): CalibrationSettings => ({
+  rotation_tolerance_deg: 3.5,
+  default_rotation_tolerance_deg: 2,
+  external_masters: 'fallback',
+  flat_star_masking: enabled,
+});
+
+describe('calibration settings API', () => {
+  it.each([false, true])('loads flat masking as %s', async (enabled) => {
+    server.use(http.get('/api/settings/calibration', () => HttpResponse.json({
+      success: true, data: settings(enabled), error: null,
+    })));
+    expect(await apiClient.getCalibrationSettings()).toEqual(settings(enabled));
+  });
+
+  it.each([false, true])('sends explicit flat masking %s alongside matching settings', async (enabled) => {
+    let received: unknown;
+    server.use(http.put('/api/settings/calibration', async ({ request }) => {
+      received = await request.json();
+      return HttpResponse.json({ success: true, data: settings(enabled), error: null });
+    }));
+    const update = {
+      rotation_tolerance_deg: 3.5,
+      external_masters: 'fallback' as const,
+      flat_star_masking: enabled,
+    };
+    expect(await apiClient.updateCalibrationSettings(update)).toEqual(settings(enabled));
+    expect(received).toEqual(update);
+  });
+
+  it('propagates a failed settings load', async () => {
+    server.use(http.get('/api/settings/calibration', () => HttpResponse.json({
+      success: false, data: null, error: 'Registry unavailable',
+    })));
+    await expect(apiClient.getCalibrationSettings()).rejects.toThrow('Registry unavailable');
+  });
+
+  it('propagates a failed settings save', async () => {
+    server.use(http.put('/api/settings/calibration', () => HttpResponse.json({
+      success: false, data: null, error: 'Could not save the registry',
+    })));
+    await expect(apiClient.updateCalibrationSettings({
+      rotation_tolerance_deg: null,
+      external_masters: 'prefer',
+      flat_star_masking: true,
+    })).rejects.toThrow('Could not save the registry');
+  });
+});

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -271,6 +271,7 @@ export const apiClient = {
   updateCalibrationSettings: async (update: {
     rotation_tolerance_deg: number | null;
     external_masters: ExternalMasterPolicy;
+    flat_star_masking: boolean;
   }): Promise<CalibrationSettings> => {
     const apiInstance = await getApi();
     const { data } = await apiInstance.put<ApiResponse<CalibrationSettings>>(

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -1235,6 +1235,8 @@ export interface CalibrationSettings {
   default_rotation_tolerance_deg: number;
   /** How masters built by other software are used; `prefer` by default. */
   external_masters: ExternalMasterPolicy;
+  /** Mask detected stars when building flat masters; off by default. */
+  flat_star_masking: boolean;
 }
 
 export interface ExportSettings {

--- a/static/src/components/CalibrationMatchingSettings.tsx
+++ b/static/src/components/CalibrationMatchingSettings.tsx
@@ -26,10 +26,8 @@ const EXTERNAL_MASTER_OPTIONS: ReadonlyArray<{
 ];
 
 /**
- * The calibration matching knob: how far a flat's rotator angle may sit from
- * the light it corrects. Server-wide — it is a property of the rig, not of a
- * database — persisted in the registry and applied to the next stack
- * immediately, no restart.
+ * Server-wide matching and master-building settings, persisted in the
+ * registry and applied to the next stack without a restart.
  */
 export default function CalibrationMatchingSettings() {
   const queryClient = useQueryClient();
@@ -42,6 +40,7 @@ export default function CalibrationMatchingSettings() {
   // it commits on Save.
   const [draft, setDraft] = useState<string>('');
   const [policy, setPolicy] = useState<ExternalMasterPolicy>('prefer');
+  const [flatStarMasking, setFlatStarMasking] = useState(false);
   useEffect(() => {
     if (settings.data) {
       setDraft(
@@ -50,6 +49,7 @@ export default function CalibrationMatchingSettings() {
           : String(settings.data.rotation_tolerance_deg)
       );
       setPolicy(settings.data.external_masters);
+      setFlatStarMasking(settings.data.flat_star_masking ?? false);
     }
   }, [settings.data]);
 
@@ -57,6 +57,7 @@ export default function CalibrationMatchingSettings() {
     mutationFn: (update: {
       rotation_tolerance_deg: number | null;
       external_masters: ExternalMasterPolicy;
+      flat_star_masking: boolean;
     }) => apiClient.updateCalibrationSettings(update),
     onSuccess: (updated) => {
       queryClient.setQueryData(['calibration-settings'], updated);
@@ -67,8 +68,8 @@ export default function CalibrationMatchingSettings() {
   if (settings.isError) {
     return (
       <div className="calibration-matching-settings">
-        <h3>Calibration matching</h3>
-        <p className="muted">Could not load calibration settings.</p>
+        <h3>Calibration</h3>
+        <p className="muted" role="alert">Could not load calibration settings.</p>
       </div>
     );
   }
@@ -80,69 +81,89 @@ export default function CalibrationMatchingSettings() {
   const dirty =
     (parsed === null) !== (current.rotation_tolerance_deg === null) ||
     (parsed !== null && parsed !== current.rotation_tolerance_deg) ||
-    policy !== current.external_masters;
+    policy !== current.external_masters ||
+    flatStarMasking !== (current.flat_star_masking ?? false);
   const policyHint =
     EXTERNAL_MASTER_OPTIONS.find((option) => option.value === policy)?.hint ?? '';
 
   return (
     <div className="calibration-matching-settings">
-      <h3>Calibration matching</h3>
-      <label className="review-preference">
-        <span>
-          Rotation tolerance (degrees)
-          <small>
-            How far a flat's rotator angle may sit from the light it corrects.
-            Wider accepts a rotator that re-homes loosely between nights;
-            narrower keeps dust motes pinned. Empty uses the default of{' '}
-            {current.default_rotation_tolerance_deg}°. Applies to every
-            database on this server, starting with the next stack.
-          </small>
-        </span>
-        <input
-          type="number"
-          min={0}
-          max={180}
-          step={0.1}
-          value={draft}
-          placeholder={String(current.default_rotation_tolerance_deg)}
-          aria-label="Rotation tolerance in degrees"
-          aria-invalid={invalid}
-          onChange={(event) => setDraft(event.target.value)}
-        />
-      </label>
-      {invalid && (
-        <p className="error-text">Enter a value between 0 and 180 degrees.</p>
-      )}
-      <label className="review-preference">
-        <span>
-          Masters from other software
-          <small>
-            A master dark, bias, or flat integrated by PixInsight, Siril, or
-            another tool is matched on what its header kept — such files
-            usually drop gain, offset, and temperature — and used as-is rather
-            than integrated again. {policyHint}
-          </small>
-        </span>
-        <select
-          value={policy}
-          aria-label="Masters from other software"
-          onChange={(event) => setPolicy(event.target.value as ExternalMasterPolicy)}
-        >
-          {EXTERNAL_MASTER_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      </label>
+      <h3>Calibration</h3>
+      <fieldset className="calibration-settings-group calibration-matching-group" disabled={save.isPending}>
+        <legend>Matching</legend>
+        <label className="review-preference">
+          <span>
+            Rotation tolerance (degrees)
+            <small>
+              How far a flat's rotator angle may sit from the light it corrects.
+              Wider accepts a rotator that re-homes loosely between nights;
+              narrower keeps dust motes pinned. Empty uses the default of{' '}
+              {current.default_rotation_tolerance_deg}°. Applies to every
+              database on this server, starting with the next stack.
+            </small>
+          </span>
+          <input
+            type="number"
+            min={0}
+            max={180}
+            step={0.1}
+            value={draft}
+            placeholder={String(current.default_rotation_tolerance_deg)}
+            aria-label="Rotation tolerance in degrees"
+            aria-invalid={invalid}
+            onChange={(event) => setDraft(event.target.value)}
+          />
+        </label>
+        {invalid && (
+          <p className="error-text">Enter a value between 0 and 180 degrees.</p>
+        )}
+        <label className="review-preference">
+          <span>
+            Masters from other software
+            <small>
+              A master dark, bias, or flat integrated by PixInsight, Siril, or
+              another tool is matched on what its header kept — such files
+              usually drop gain, offset, and temperature — and used as-is rather
+              than integrated again. {policyHint}
+            </small>
+          </span>
+          <select
+            value={policy}
+            aria-label="Masters from other software"
+            onChange={(event) => setPolicy(event.target.value as ExternalMasterPolicy)}
+          >
+            {EXTERNAL_MASTER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </fieldset>
+      <fieldset className="calibration-settings-group" disabled={save.isPending}>
+        <legend>Flat masters</legend>
+        <label className="review-preference">
+          <input
+            type="checkbox"
+            checked={flatStarMasking}
+            onChange={(event) => setFlatStarMasking(event.target.checked)}
+          />
+          <span>Mask stars in flats</span>
+        </label>
+      </fieldset>
       {save.isError && (
-        <p className="error-text">{(save.error as Error).message}</p>
+        <p className="error-text" role="alert">{(save.error as Error).message}</p>
       )}
       <button
         type="button"
+        className="save-button"
         disabled={invalid || !dirty || save.isPending}
         onClick={() =>
-          save.mutate({ rotation_tolerance_deg: parsed, external_masters: policy })
+          save.mutate({
+            rotation_tolerance_deg: parsed,
+            external_masters: policy,
+            flat_star_masking: flatStarMasking,
+          })
         }
       >
         {save.isPending ? 'Saving…' : 'Save'}

--- a/static/src/components/TauriSettings.css
+++ b/static/src/components/TauriSettings.css
@@ -1685,6 +1685,60 @@
   margin: 0.4rem 0 0;
 }
 
+.calibration-settings-group {
+  min-width: 0;
+  margin: 0 0 1rem;
+  padding: 0;
+  border: 0;
+}
+
+.calibration-settings-group legend {
+  margin-bottom: 0.5rem;
+  padding: 0;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.calibration-settings-group .review-preference + .review-preference {
+  margin-top: 0.75rem;
+}
+
+.calibration-settings-group .review-preference > span {
+  min-width: 0;
+}
+
+.calibration-settings-group input[type="checkbox"] {
+  flex: 0 0 auto;
+}
+
+.calibration-matching-group .review-preference {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(9rem, 17rem);
+}
+
+.calibration-matching-group input,
+.calibration-matching-group select {
+  box-sizing: border-box;
+  min-width: 0;
+  width: 100%;
+}
+
+.calibration-matching-group input[type="number"] {
+  max-width: 8rem;
+  justify-self: end;
+}
+
+@media (max-width: 640px) {
+  .calibration-matching-group .review-preference {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .calibration-matching-group input[type="number"] {
+    justify-self: start;
+  }
+}
+
 .remote-sync-previews {
   margin-top: 1.2rem;
   border-top: 1px solid var(--color-border, #444);

--- a/static/src/components/__tests__/CalibrationMatchingSettings.test.tsx
+++ b/static/src/components/__tests__/CalibrationMatchingSettings.test.tsx
@@ -15,12 +15,13 @@ function wrapper() {
   };
 }
 
-const current = (rotation: number | null) => ({
+const current = (rotation: number | null, flatStarMasking = false) => ({
   success: true,
   data: {
     rotation_tolerance_deg: rotation,
     default_rotation_tolerance_deg: 2,
     external_masters: 'prefer',
+    flat_star_masking: flatStarMasking,
   },
   error: null,
 });
@@ -34,6 +35,7 @@ describe('CalibrationMatchingSettings', () => {
     const input = await screen.findByLabelText('Rotation tolerance in degrees');
     expect(input).toHaveValue(null);
     expect(input).toHaveAttribute('placeholder', '2');
+    expect(screen.getByRole('checkbox', { name: 'Mask stars in flats' })).not.toBeChecked();
     // Nothing to save while the field matches what the server holds.
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
@@ -52,7 +54,11 @@ describe('CalibrationMatchingSettings', () => {
     fireEvent.change(input, { target: { value: '3.5' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() =>
-      expect(saved).toEqual({ rotation_tolerance_deg: 3.5, external_masters: 'prefer' })
+      expect(saved).toEqual({
+        rotation_tolerance_deg: 3.5,
+        external_masters: 'prefer',
+        flat_star_masking: false,
+      })
     );
     // The response is the new truth; the button falls back to disabled.
     await waitFor(() =>
@@ -78,7 +84,11 @@ describe('CalibrationMatchingSettings', () => {
     fireEvent.change(select, { target: { value: 'fallback' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() =>
-      expect(saved).toEqual({ rotation_tolerance_deg: null, external_masters: 'fallback' })
+      expect(saved).toEqual({
+        rotation_tolerance_deg: null,
+        external_masters: 'fallback',
+        flat_star_masking: false,
+      })
     );
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
@@ -96,5 +106,116 @@ describe('CalibrationMatchingSettings', () => {
       screen.getByText('Enter a value between 0 and 180 degrees.')
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('saves masking on and off and reloads its saved state', async () => {
+    let masking = false;
+    const updates: unknown[] = [];
+    server.use(
+      http.get('/api/settings/calibration', () => HttpResponse.json(current(3.5, masking))),
+      http.put('/api/settings/calibration', async ({ request }) => {
+        const update = await request.json() as { flat_star_masking: boolean };
+        updates.push(update);
+        masking = update.flat_star_masking;
+        return HttpResponse.json(current(3.5, masking));
+      })
+    );
+    const first = render(<CalibrationMatchingSettings />, { wrapper: wrapper() });
+    const toggle = await screen.findByRole('checkbox', { name: 'Mask stars in flats' });
+    expect(toggle).not.toBeChecked();
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(masking).toBe(true));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled());
+    first.unmount();
+
+    const second = render(<CalibrationMatchingSettings />, { wrapper: wrapper() });
+    const restored = await screen.findByRole('checkbox', { name: 'Mask stars in flats' });
+    await waitFor(() => expect(restored).toBeChecked());
+    fireEvent.click(restored);
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(masking).toBe(false));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled());
+    second.unmount();
+
+    render(<CalibrationMatchingSettings />, { wrapper: wrapper() });
+    expect(await screen.findByRole('checkbox', { name: 'Mask stars in flats' })).not.toBeChecked();
+    expect(updates).toEqual([true, false].map((enabled) => ({
+      rotation_tolerance_deg: 3.5,
+      external_masters: 'prefer',
+      flat_star_masking: enabled,
+    })));
+  });
+
+  it('keeps masking off when an older server omits the field', async () => {
+    server.use(http.get('/api/settings/calibration', () => HttpResponse.json({
+      success: true,
+      data: {
+        rotation_tolerance_deg: null,
+        default_rotation_tolerance_deg: 2,
+        external_masters: 'prefer',
+      },
+      error: null,
+    })));
+    render(<CalibrationMatchingSettings />, { wrapper: wrapper() });
+    expect(await screen.findByRole('checkbox', { name: 'Mask stars in flats' })).not.toBeChecked();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('retains an unsaved masking change after a failed save and allows retry', async () => {
+    let attempts = 0;
+    server.use(
+      http.get('/api/settings/calibration', () => HttpResponse.json(current(null))),
+      http.put('/api/settings/calibration', () => {
+        attempts += 1;
+        return HttpResponse.json(attempts === 1
+          ? { success: false, data: null, error: 'Could not save the registry' }
+          : current(null, true));
+      })
+    );
+    render(<CalibrationMatchingSettings />, { wrapper: wrapper() });
+    const toggle = await screen.findByRole('checkbox', { name: 'Mask stars in flats' });
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not save the registry');
+    expect(toggle).toBeChecked();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled());
+    expect(toggle).toBeChecked();
+    expect(attempts).toBe(2);
+  });
+
+  it('disables draft controls while saving to avoid losing a newer edit', async () => {
+    let finishSave: () => void = () => {};
+    const pending = new Promise<void>((resolve) => { finishSave = resolve; });
+    server.use(
+      http.get('/api/settings/calibration', () => HttpResponse.json(current(null))),
+      http.put('/api/settings/calibration', async () => {
+        await pending;
+        return HttpResponse.json(current(null, true));
+      })
+    );
+    render(<CalibrationMatchingSettings />, { wrapper: wrapper() });
+    const toggle = await screen.findByRole('checkbox', { name: 'Mask stars in flats' });
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(toggle).toBeDisabled());
+    expect(screen.getByLabelText('Rotation tolerance in degrees')).toBeDisabled();
+    expect(screen.getByLabelText('Masters from other software')).toBeDisabled();
+    finishSave();
+    await waitFor(() => expect(toggle).toBeEnabled());
+    expect(toggle).toBeChecked();
+  });
+
+  it('does not offer editable defaults when loading the settings fails', async () => {
+    server.use(http.get('/api/settings/calibration', () => HttpResponse.json({
+      success: false, data: null, error: 'Registry unavailable',
+    })));
+    render(<CalibrationMatchingSettings />, { wrapper: wrapper() });
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load calibration settings.');
+    expect(screen.queryByRole('checkbox', { name: 'Mask stars in flats' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Published dependencies

[Seiza #176](https://github.com/theatrus/seiza/pull/176) is merged, and `seiza` 0.18.13 and `seiza-stacking` 0.14.0 are published on crates.io. The publication blocker is resolved.

Commit `3b27069` updates only those two Cargo.lock versions and their registry checksums. `cargo metadata --locked` confirms all Seiza dependencies come from crates.io, without source overrides. Independent review verified package checksums and byte-for-byte source parity with reviewed Seiza commit `2ff0c7aee0a6c828e5a191f27b4a4a2863a367d5`. Registry-only Rust and browser validation passed. Hosted CI is separate from the local results below.

## Summary

- Adopt flat-only median/MAD rejection after calibration and per-frame brightness normalization. This reduces threshold inflation from overlapping star samples, but does not guarantee a star-free master.
- Add the saved, off-by-default **Mask stars in flats** setting under **Settings > Setups > Calibration > Flat masters**, available in server and desktop modes. It applies to this server's databases; imported external masters stay unchanged.
- When enabled, ask Seiza to mask detected stellar footprints and multi-pixel saturated cores before flat normalization and rejection. Preserve the original sensor measurements: no registration, smoothing, or filling of masked response holes.
- Require at least two retained clean measurements for every output sample. A failed build produces no flat master; the stack can continue without it and shows the coverage failure in its calibration warning. Successful masters with only two retained samples also show a warning, including on cache reuse.
- Record masked/clipped counts and coverage statistics in FITS provenance, the catalog, and logs. Distinguish isolated clipped detector impulses and inputs without a known saturation ceiling from low retained coverage.
- Separate masked and unmasked cache identities. Snapshot the setting into queued stack jobs and multi-session calibration plans so changing settings cannot mismatch a job's cache key and master.
- Rebuild writable cached masked masters whose coverage metadata is missing or invalid; refuse reuse with a clear reason when rebuilding is blocked.
- Keep temporary flat storage under the database's calibration-master cache. Seiza cleans scratch files on completion, cancellation, or failure. Raw source files are never changed.

## Limits

Without masking, rejection needs at least three flats and a clean majority at each pixel; two samples are averaged. Median/MAD improves some moving-star imprints but can strengthen a contaminated majority. Faint wings can remain below the rejection threshold even with a clean majority.

Masking can recover pixels from a clean minority, but cannot reconstruct response hidden in every exposure. The default native mask uses a 4-sigma detector, 3x halo expansion, a minimum 6-pixel radius, and at least two retained input measurements. Coverage means unmasked retained measurements, not certified artifact-free pixels. Faint undetected halos remain a limit; users must inspect masters and capture well-separated flats.

Scratch storage is four bytes per sample per flat: about 15.6 GB for 64 mono 61 MP inputs, three times that for already-RGB inputs. The 64 MiB bound covers integration tiles, not total memory: the detector, decoded frame, output image, and calibration masters have separate image-sized storage. Each input is decoded once. This PR does not add in-master cancellation wiring to PSF Guard.

## Review and validation

Independent reviews covered the native algorithm, PSF settings and cache integration, warnings, and frontend failure states. Findings addressed include invalid cached coverage metadata, missing saturation diagnostics, a browser-test save-request race, and cramped mobile matching controls. Screenshot review also caught an unstyled Save button, which now uses the shared style. New exhaustive Seiza API fields require the 0.14.0 stacking release.

The Rust and browser checks below were repeated after publication with the committed lockfile and registry dependencies. No local Seiza source overrides were used.

- Full Rust suite (`cargo test --locked -j 2 --quiet`): 872 unit and 127 integration tests passed; 5 existing tests ignored.
- `cargo build --locked -j 2 --bin psf-guard`: passed.
- `cargo clippy --locked -j 2 --all-targets --all-features -- -D warnings`: passed.
- `npx playwright test e2e/calibration-settings.spec.ts e2e/stack-preview.spec.ts`: all seven tests passed against the registry-built binary in 2.3 minutes, including settings persistence, legacy updates, error handling, real-frame stacking, resume, reload, and color composition. Desktop/mobile screenshots were inspected: readable labels, fitting controls, and no overflow. Tests used fresh isolated registries and explicit `PSF_GUARD_E2E_BINARY`; all disposable servers stopped.
- Previous frontend checks remain applicable because this follow-up changes only Cargo.lock: `npm run lint`, `npx vitest run`, and `npm run build` passed. Full Vitest: 79 files, 374 tests passed.
- `cargo fmt -- --check` and `git diff --cached --check`: passed. The committed lockfile contains published registry checksums, with no path overrides.
- Seiza workspace tests, all-target/all-feature Clippy, Rust 1.89 locked workspace check, and standalone Python locked check passed; exact results and the native/CLI regressions are recorded in [Seiza #176](https://github.com/theatrus/seiza/pull/176).

New PSF regressions cover majority-contaminated moving stars with changing exposure brightness, preserved dust/vignette response, independent bias reuse, masked/unmasked master identities, enabling/disabling and cache reuse, stationary-star coverage failures with no recorded master or scratch, cached warning persistence, corrupt metadata rebuilding, and distinct saturation diagnostics. Settings tests cover off defaults, legacy requests, explicit disable, loading failures, and save failures.

## Real sky-flat validation

Used ten user-supplied 6248 x 4176 mono red-filter sky flats from one session, with a common five-frame bias master. Camera/gain/offset/binning match; bias temperature differs and no matched dark-flat was available. These are bias-only diagnostics, not certified calibration products. Raw files and derived plots remain local. These measurements were collected before publication using the reviewed source; the published engine's source parity was verified separately.

### Native masked mode, 0.14.0

- Ran the complete full-resolution set with unchanged default mask settings, without cropping, registration, or spatial defect suppression.
- The build correctly refused the master: 4,648 of 26,091,648 output samples (about 0.018%) had fewer than two clean retained measurements. Observed coverage was 0..10; 168,846 input samples were masked. Build time was 8.098 seconds on this machine.
- No master FITS was written and scratch storage was empty. No response holes were filled and no thresholds were weakened to force success.
- The broad saturated-star footprints overlap because the stars move only about 14 pixels in this set. Masking detects the coverage failure; it does not make this flat set usable. A separate synthetic 6/4-position star fixture passes, removes both majority/minority star cores, and preserves fixed sensor response.

### Earlier unmasked comparison

Compared published stacking 0.13.0 with this PR's earlier median/MAD implementation, using identical 3-sigma thresholds and no spatial defect suppression. All ten inputs were accepted with no fallback pixels.

- Old: 5,636,888 rejected samples, 3.124 seconds. Median/MAD: 7,273,460 rejected samples, 7.716 seconds. Timings are local measurements, not a speedup claim.
- Stars dwell near one position for six frames and another for four. Median/MAD substantially reduced the four-frame-site imprints but left measurable residuals. Majority-site stars remained; the broad saturated core could become stronger.
- Reversing the ten inputs produced a bit-identical 26,091,648-pixel master and identical total/per-input counts; scratch was cleaned.
- Pixel/reference review used centroid-distance-selected exposure groups and matched blank-aperture controls. Broad-star halo references were not certified clean. These measurements do not establish complete star removal.
