### PR TITLE
Inspect calibration masters from stack previews

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -327,9 +327,13 @@ The stack card reports `Calibration applied`, `Calibration set incomplete`, or
 no calibration. It also shows input counts and any missing-file warning.
 Calibration happens on raw CFA samples before debayering.
 
-One stack uses one master set. If its lights need different sets, PSF Guard
-leaves that preview uncalibrated and explains why instead of applying the
-reference light's set to every frame.
+Lights that need different master sets are partitioned into calibration
+sessions, and each light uses its session's masters. Choose **Masters** on a
+completed mono or color stack to inspect its recorded files, their session and
+channel usage, and available rejection statistics. The inspector supports
+display stretch, native-size zoom, and unchanged FITS downloads. Missing cached
+masters are reported without rebuilding them. See
+[Inspect calibration masters](STACKING_PREVIEWS.md#inspect-calibration-masters).
 
 ## Export
 

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -386,6 +386,26 @@ image set, an image is
 accepted/rejected/pended, or the **Accepted only** policy changes. A failed
 rebuild never replaces the last successful result.
 
+## Inspect calibration masters
+
+Choose **Masters** on a completed mono or color stack to inspect the bias,
+dark, dark-flat, and flat files recorded for that result. The picker lists
+each master once and shows the sessions and color channels that used it,
+including fitted pedestal values. Source counts and rejection or star-masking
+statistics appear when their calibration catalog records remain available.
+
+The inspector provides pan, zoom, native-size inspection, and display-only
+midtone and shadow controls. It preserves floating-point flat detail and the
+original sensor grid: CFA masters are not debayered, rotated, or registered.
+Already-RGB masters retain their color channels. **FITS** downloads the cached
+master unchanged; display settings never change calibration or the stack.
+
+Inspection reads the completed artifact's recorded master references, not the
+current library selection. Color stacks follow their recorded channel
+revisions. Missing master files or older stacks without sufficient provenance
+are reported explicitly, without rebuilding masters or substituting today's
+selection. A changed artifact revision requires reopening the inspector.
+
 ## Calibration before registration
 
 Before Seiza registers the reference, PSF Guard matches the light against the
@@ -942,6 +962,13 @@ POST /api/db/{db}/projects/{project}/stack-previews/color
 GET  /api/db/{db}/projects/{project}/stack-previews/color/{job}
 GET  /api/db/{db}/stack-previews/color/{job}/preview[?size=screen|original]
 GET  /api/db/{db}/stack-previews/color/{job}/fits
+GET  /api/db/{db}/stack-previews/{job}/{group}/calibration-masters?revision={revision}
+GET  /api/db/{db}/stack-previews/{job}/{group}/calibration-masters/{master}/preview?revision={revision}
+GET  /api/db/{db}/stack-previews/{job}/{group}/calibration-masters/{master}/fits?revision={revision}
+GET  /api/db/{db}/stack-previews/color/{job}/calibration-masters?revision={revision}
+GET  /api/db/{db}/stack-previews/color/{job}/calibration-masters/{master}/preview?revision={revision}
+GET  /api/db/{db}/stack-previews/color/{job}/calibration-masters/{master}/fits?revision={revision}
+POST /api/db/{db}/stack-previews/calibration-masters/generation-status
 POST /api/db/{db}/stack-previews/{job}/{group}/artifact-searches
 POST /api/db/{db}/stack-previews/color/{job}/artifact-searches
 GET  /api/db/{db}/stack-previews/artifact-searches/{search}
@@ -950,6 +977,11 @@ GET  /api/db/{db}/stack-previews/stretch/{stretch}/preview[?size=screen|original
 GET  /api/db/{db}/stack-previews/stretch/{stretch}/fits
 GET  /api/db/{db}/stack-previews/rc-astro/{id}/fits[?stars=true]
 ```
+
+Master previews return `202` while queued and use the shared generation-status
+poller. They accept `size=screen|original`, `midtone=0.01..0.99` (default `0.2`),
+and `shadow=-10..0` (default `-2.8`). Catalog responses supply opaque master IDs
+and database-scoped preview and FITS URLs; clients never supply file paths.
 
 The stretch GET returns the selected cached preview or `null`. DELETE clears
 the selection and returns `204`. Send the displayed artifact revision as `v`

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,10 @@
 
 ## Added
 
+- Inspect the calibration masters used by a mono or color stack from its
+  **Masters** action, with session/channel provenance, display stretch,
+  native-size zoom, rejection statistics, and unchanged FITS downloads.
+
 - Optional native star masking for flat masters, controlled by **Mask stars
   in flats** in calibration settings. Masked builds retain original unmasked
   measurements, report low coverage, and refuse unsupported pixels without

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -679,7 +679,9 @@ fn requires_write(method: &Method, path: &str, can_compute: bool) -> bool {
         return true;
     }
 
-    if path.ends_with("/images/generation-status") {
+    if path.ends_with("/images/generation-status")
+        || path.ends_with("/stack-previews/calibration-masters/generation-status")
+    {
         return false;
     }
     if !can_compute {
@@ -872,6 +874,11 @@ mod tests {
         assert!(!requires_write(
             &Method::POST,
             "/db/test/images/generation-status",
+            false,
+        ));
+        assert!(!requires_write(
+            &Method::POST,
+            "/db/test/stack-previews/calibration-masters/generation-status",
             false,
         ));
         assert!(requires_write(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -471,6 +471,34 @@ async fn run_server_internal(
             post(stack_preview::artifact::start_mono_artifact_search),
         )
         .route(
+            "/stack-previews/{job_id}/{group_index}/calibration-masters",
+            get(stack_preview::calibration_masters::get_catalog),
+        )
+        .route(
+            "/stack-previews/{job_id}/{group_index}/calibration-masters/{master_id}/preview",
+            get(stack_preview::calibration_masters::get_preview),
+        )
+        .route(
+            "/stack-previews/{job_id}/{group_index}/calibration-masters/{master_id}/fits",
+            get(stack_preview::calibration_masters::download_fits),
+        )
+        .route(
+            "/stack-previews/color/{job_id}/calibration-masters",
+            get(stack_preview::calibration_masters::get_catalog),
+        )
+        .route(
+            "/stack-previews/color/{job_id}/calibration-masters/{master_id}/preview",
+            get(stack_preview::calibration_masters::get_preview),
+        )
+        .route(
+            "/stack-previews/color/{job_id}/calibration-masters/{master_id}/fits",
+            get(stack_preview::calibration_masters::download_fits),
+        )
+        .route(
+            "/stack-previews/calibration-masters/generation-status",
+            post(stack_preview::calibration_masters::post_generation_status),
+        )
+        .route(
             "/stack-previews/{job_id}/{group_index}/fits",
             get(stack_preview::download_stack_preview_fits),
         )

--- a/src/server/preview_queue.rs
+++ b/src/server/preview_queue.rs
@@ -29,7 +29,7 @@ use tokio::sync::Semaphore;
 use crate::concurrency::{self, Priority, WorkerPolicy};
 use crate::server::state::AppState;
 
-/// What to generate for a job. Mirrors the two artifact handlers.
+/// What to generate for a job.
 #[derive(Debug, Clone)]
 pub enum GenKind {
     Preview {
@@ -40,6 +40,13 @@ pub enum GenKind {
         /// A frame with no `BAYERPAT` falls back to greyscale, so this can be
         /// asked for on a mixed rig without breaking the mono frames.
         color: bool,
+    },
+    /// Preserve native floating samples, mono/CFA sensor geometry, and RGB
+    /// channels while applying a display-only stretch. Always encoded as PNG.
+    CalibrationMaster {
+        midtone: f64,
+        shadow: f64,
+        max_dimensions: Option<(u32, u32)>,
     },
     Annotated {
         max_stars: usize,
@@ -372,6 +379,11 @@ fn generate_with_fingerprint(
         GenKind::Annotated { max_stars, size } => {
             generate_annotated(&job.fits_path, &tmp, size, *max_stars, job.encoding)
         }
+        GenKind::CalibrationMaster {
+            midtone,
+            shadow,
+            max_dimensions,
+        } => generate_calibration_master(&job.fits_path, &tmp, *midtone, *shadow, *max_dimensions),
     };
 
     // Clean up the temp file on both a generation failure and a rename
@@ -431,6 +443,93 @@ fn generate_preview(
         max_dimensions,
         encoding,
     )
+}
+
+fn generate_calibration_master(
+    fits_path: &Path,
+    output: &Path,
+    midtone: f64,
+    shadow: f64,
+    max_dimensions: Option<(u32, u32)>,
+) -> anyhow::Result<()> {
+    use crate::server::stack_preview::stretch::{
+        default_linear_config, normalize_linear_image, render_dynamic_image,
+    };
+    use seiza_stretch::{StretchModel, StretchParams};
+
+    anyhow::ensure!(
+        midtone.is_finite() && midtone > 0.0 && midtone < 1.0 && shadow.is_finite(),
+        "invalid calibration master display stretch"
+    );
+    anyhow::ensure!(
+        max_dimensions.is_none_or(|(width, height)| width > 0 && height > 0),
+        "calibration master preview dimensions must be positive"
+    );
+    // This loader retains floating values and the original CFA sample grid.
+    // The ordinary light preview loader debayers and quantizes to camera ADU.
+    let frame = crate::image_io::open_linear_frame(fits_path)?;
+    let mut config = default_linear_config();
+    config.model = StretchModel::AutoMtf(StretchParams {
+        target_median: midtone,
+        shadows_clip: shadow,
+    });
+    let prepared = match normalize_linear_image(&frame.image) {
+        Ok((image, _)) => image,
+        Err(error) => {
+            let (minimum, maximum) = frame
+                .image
+                .data
+                .iter()
+                .filter(|value| value.is_finite())
+                .fold(
+                    (f32::INFINITY, f32::NEG_INFINITY),
+                    |(minimum, maximum), &value| (minimum.min(value), maximum.max(value)),
+                );
+            anyhow::ensure!(minimum.is_finite() && maximum.is_finite(), "{error}");
+            if maximum == minimum {
+                // A uniform calibration frame has no contrast to stretch. A
+                // neutral display level distinguishes it from a failed image.
+                config.model = StretchModel::Identity;
+                let data = frame
+                    .image
+                    .data
+                    .iter()
+                    .map(|value| {
+                        if value.is_finite() {
+                            midtone as f32
+                        } else {
+                            f32::NAN
+                        }
+                    })
+                    .collect();
+                seiza_stacking::LinearImage::new(
+                    frame.image.width,
+                    frame.image.height,
+                    frame.image.channels,
+                    data,
+                )?
+            } else {
+                // Sparse detector defects can lie outside both robust bounds.
+                // Keep them visible using the shared linear transfer; do not
+                // round a near-unity flat or invent a spatial background.
+                let span = f64::from(maximum) - f64::from(minimum);
+                config.model = StretchModel::Linear {
+                    black: f64::from(minimum) - span * midtone / (1.0 - midtone),
+                    white: f64::from(maximum),
+                };
+                frame.image
+            }
+        }
+    };
+    let (dynamic, _) = render_dynamic_image(&prepared, &config).map_err(anyhow::Error::msg)?;
+    let dynamic = match max_dimensions {
+        Some((width, height)) if dynamic.width() > width || dynamic.height() > height => {
+            dynamic.resize(width, height, image::imageops::FilterType::Lanczos3)
+        }
+        _ => dynamic,
+    };
+    dynamic.save_with_format(output, image::ImageFormat::Png)?;
+    Ok(())
 }
 
 /// Unique sibling temp path for atomic-rename generation.
@@ -536,6 +635,195 @@ fn hfr_label_scale_for(native_width: u32, size: &str) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn master_job(directory: &Path, channels: usize, data: Vec<f32>, bayer: bool) -> GenJob {
+        let source = directory.join("master.fits");
+        let cards = if bayer {
+            vec![seiza_fits::WriteHeaderCard::new(
+                "BAYERPAT",
+                seiza_fits::HeaderValue::String("RGGB".into()),
+            )]
+        } else {
+            Vec::new()
+        };
+        let image = seiza_stacking::LinearImage::new(64, 64, channels, data).unwrap();
+        seiza_stacking::write_processed_image_fits_f32(&source, &image, &[], &cards).unwrap();
+        GenJob {
+            fits_path: source,
+            cache_path: directory.join("preview.png"),
+            kind: GenKind::CalibrationMaster {
+                midtone: 0.2,
+                shadow: -2.8,
+                max_dimensions: None,
+            },
+            // Calibration inspection stays lossless regardless of the global
+            // light-preview cache encoding carried by a caller.
+            encoding: crate::preview_format::PreviewEncoding::jpeg(80),
+        }
+    }
+
+    fn assert_no_temporary_files(directory: &Path) {
+        assert!(std::fs::read_dir(directory).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains(".tmp.")
+        }));
+    }
+
+    #[test]
+    fn calibration_master_preview_preserves_near_unity_cfa_and_pixel_defects() {
+        let directory = tempfile::tempdir().unwrap();
+        let data = (0..64 * 64)
+            .map(|index| {
+                let x = index % 64;
+                let y = index / 64;
+                let phase = if x % 2 == y % 2 { 0.0004 } else { 0.0 };
+                0.999 + x as f32 * 0.00003 + phase
+                    - if (20..25).contains(&x) && (20..25).contains(&y) {
+                        0.0003
+                    } else {
+                        0.0
+                    }
+            })
+            .collect::<Vec<_>>();
+        let job = master_job(directory.path(), 1, data, true);
+        let original = std::fs::read(&job.fits_path).unwrap();
+        generate(&job).unwrap();
+        let decoded = image::open(&job.cache_path).unwrap();
+        assert_eq!(
+            decoded.color(),
+            image::ColorType::L8,
+            "raw CFA must stay mono"
+        );
+        assert_eq!((decoded.width(), decoded.height()), (64, 64));
+        let bitmap = decoded.to_luma8();
+        assert!(
+            bitmap.get_pixel(32, 30)[0] > bitmap.get_pixel(33, 30)[0] + 10,
+            "CFA phase contrast must survive without interpolation"
+        );
+        assert!(
+            bitmap.get_pixel(24, 22)[0] + 10 < bitmap.get_pixel(24, 18)[0],
+            "dust response must remain local"
+        );
+        let levels = bitmap.as_raw().iter().copied().collect::<HashSet<_>>();
+        assert!(
+            levels.len() > 30,
+            "sub-ADU response must not collapse to integer levels"
+        );
+        assert_eq!(std::fs::read(&job.fits_path).unwrap(), original);
+        assert_eq!(
+            image::guess_format(&std::fs::read(&job.cache_path).unwrap()).unwrap(),
+            image::ImageFormat::Png
+        );
+        assert_no_temporary_files(directory.path());
+    }
+
+    #[test]
+    fn calibration_master_preview_preserves_rgb_and_bounds_screen_size() {
+        let directory = tempfile::tempdir().unwrap();
+        let data = (0..64 * 64)
+            .flat_map(|index| {
+                let base = 1.0 + (index % 64) as f32 * 0.001;
+                [base + 0.12, base, base - 0.08]
+            })
+            .collect();
+        let mut job = master_job(directory.path(), 3, data, false);
+        generate(&job).unwrap();
+        let original = image::open(&job.cache_path).unwrap();
+        assert_eq!(original.color(), image::ColorType::Rgb8);
+        let rgb = original.to_rgb8();
+        let sample = rgb.get_pixel(32, 32);
+        assert!(
+            sample[0] > sample[1] && sample[1] > sample[2],
+            "native RGB channels must not become luminance"
+        );
+        job.cache_path = directory.path().join("screen.png");
+        job.kind = GenKind::CalibrationMaster {
+            midtone: 0.2,
+            shadow: -2.8,
+            max_dimensions: Some((20, 10)),
+        };
+        generate(&job).unwrap();
+        let screen = image::open(&job.cache_path).unwrap();
+        assert_eq!((screen.width(), screen.height()), (10, 10));
+        job.cache_path = directory.path().join("larger-cap.png");
+        job.kind = GenKind::CalibrationMaster {
+            midtone: 0.2,
+            shadow: -2.8,
+            max_dimensions: Some((1200, 1200)),
+        };
+        generate(&job).unwrap();
+        let screen = image::open(&job.cache_path).unwrap();
+        assert_eq!(
+            (screen.width(), screen.height()),
+            (64, 64),
+            "screen previews must not upscale"
+        );
+        assert_no_temporary_files(directory.path());
+    }
+
+    #[test]
+    fn calibration_master_preview_handles_uniform_frames_and_sparse_defects() {
+        for value in [0.0, 1.0, 1000.0] {
+            let directory = tempfile::tempdir().unwrap();
+            let job = master_job(directory.path(), 1, vec![value; 64 * 64], false);
+            generate(&job).unwrap();
+            let bitmap = image::open(&job.cache_path).unwrap().to_luma8();
+            assert!(bitmap
+                .as_raw()
+                .iter()
+                .all(|value| (49..=52).contains(value)));
+        }
+        let directory = tempfile::tempdir().unwrap();
+        let mut data = vec![1.0; 64 * 64];
+        data[2030] = 1.001;
+        let job = master_job(directory.path(), 1, data, true);
+        generate(&job).unwrap();
+        let bitmap = image::open(&job.cache_path).unwrap().to_luma8();
+        assert_eq!(bitmap.as_raw()[2030], 255);
+        assert!((49..=52).contains(&bitmap.as_raw()[2031]));
+    }
+
+    #[test]
+    fn calibration_master_preview_failures_leave_no_output_or_temporary_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut job = master_job(directory.path(), 1, vec![1.0; 64 * 64], false);
+        job.kind = GenKind::CalibrationMaster {
+            midtone: f64::NAN,
+            shadow: -2.8,
+            max_dimensions: None,
+        };
+        assert!(generate(&job).is_err());
+        assert!(!job.cache_path.exists());
+        assert_no_temporary_files(directory.path());
+        job.kind = GenKind::CalibrationMaster {
+            midtone: 0.2,
+            shadow: -2.8,
+            max_dimensions: Some((0, 64)),
+        };
+        assert!(generate(&job).is_err());
+        assert!(!job.cache_path.exists());
+        job.kind = GenKind::CalibrationMaster {
+            midtone: 0.2,
+            shadow: -2.8,
+            max_dimensions: None,
+        };
+        std::fs::write(&job.fits_path, b"not a FITS master").unwrap();
+        let stale = source_fingerprint(&job.fits_path);
+        assert!(generate(&job).is_err());
+        assert!(!job.cache_path.exists());
+        assert_no_temporary_files(directory.path());
+        let job = master_job(directory.path(), 1, vec![1.001; 64 * 64], false);
+        assert!(generate_with_fingerprint(&job, stale).is_err());
+        assert!(!job.cache_path.exists());
+        assert_no_temporary_files(directory.path());
+        std::fs::create_dir(&job.cache_path).unwrap();
+        assert!(generate(&job).is_err());
+        assert!(job.cache_path.is_dir());
+        assert_no_temporary_files(directory.path());
+    }
 
     #[test]
     fn temp_path_is_unique_sibling() {

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -6,6 +6,7 @@
 //! multi-database server cannot multiply the stacker's full-frame buffers.
 
 pub mod artifact;
+pub mod calibration_masters;
 pub mod color;
 mod execution;
 mod final_integration;

--- a/src/server/stack_preview/calibration_masters.rs
+++ b/src/server/stack_preview/calibration_masters.rs
@@ -1,0 +1,826 @@
+//! Read-only inspection of the master files recorded by a stack artifact.
+
+use super::{
+    color, LatestStackPreviews, StackGroupState, StackGroupStatus, StackJobState, StackPreviewJob,
+};
+use axum::{
+    body::Body,
+    extract::{Path, Query, State},
+    http::{
+        header::{CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE},
+        StatusCode,
+    },
+    response::{IntoResponse, Response},
+    Json,
+};
+use rusqlite::OptionalExtension;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::{Path as FsPath, PathBuf},
+    sync::Arc,
+};
+use tokio_util::io::ReaderStream;
+
+use crate::{
+    calibration::{AppliedCalibration, CalibrationKind},
+    server::{
+        api::ApiResponse,
+        database_context::DatabaseContext,
+        extract::DbContext,
+        handlers::{AppError, GenerationStatusBatch},
+        preview_queue::{GenJob, GenKind, GenerationState, GenerationStatus},
+        state::AppState,
+    },
+};
+
+const PREVIEW_VERSION: u32 = 1;
+const MAX_STATUS_BATCH: usize = 100;
+const KINDS: [CalibrationKind; 4] = [
+    CalibrationKind::Bias,
+    CalibrationKind::Dark,
+    CalibrationKind::DarkFlat,
+    CalibrationKind::Flat,
+];
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    Mono,
+    Color,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MasterSource {
+    pub kind: SourceKind,
+    pub job_id: String,
+    pub group_index: Option<usize>,
+    pub artifact_revision: String,
+}
+
+#[derive(Deserialize)]
+pub struct MasterPath {
+    job_id: String,
+    group_index: Option<usize>,
+    master_id: Option<String>,
+}
+
+impl MasterPath {
+    fn source(&self, revision: String) -> MasterSource {
+        MasterSource {
+            kind: if self.group_index.is_some() {
+                SourceKind::Mono
+            } else {
+                SourceKind::Color
+            },
+            job_id: self.job_id.clone(),
+            group_index: self.group_index,
+            artifact_revision: revision,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct DisplayOptions {
+    pub size: Option<String>,
+    pub midtone: Option<f64>,
+    pub shadow: Option<f64>,
+}
+
+impl DisplayOptions {
+    fn normalized(&self) -> Result<(&str, f64, f64), AppError> {
+        let size = self.size.as_deref().unwrap_or("screen");
+        let midtone = self.midtone.unwrap_or(0.2);
+        let shadow = self.shadow.unwrap_or(-2.8);
+        if !matches!(size, "screen" | "original")
+            || !midtone.is_finite()
+            || !(0.01..=0.99).contains(&midtone)
+            || !shadow.is_finite()
+            || !(-10.0..=0.0).contains(&shadow)
+        {
+            return Err(AppError::BadRequest(
+                "Invalid calibration master display settings".into(),
+            ));
+        }
+        Ok((
+            size,
+            (midtone * 1000.0).round() / 1000.0,
+            (shadow * 100.0).round() / 100.0,
+        ))
+    }
+}
+
+#[derive(Deserialize)]
+pub struct MasterQuery {
+    revision: String,
+    size: Option<String>,
+    midtone: Option<f64>,
+    shadow: Option<f64>,
+}
+
+impl MasterQuery {
+    fn display(&self) -> DisplayOptions {
+        DisplayOptions {
+            size: self.size.clone(),
+            midtone: self.midtone,
+            shadow: self.shadow,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MasterStatusItem {
+    pub source: MasterSource,
+    pub master_id: String,
+    #[serde(flatten)]
+    pub display: DisplayOptions,
+}
+
+#[derive(Deserialize)]
+pub struct MasterStatusRequest {
+    requests: Vec<MasterStatusItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MasterUsage {
+    pub channel: String,
+    pub session: usize,
+    pub lights: usize,
+    pub estimated_pedestal_adu: Option<f32>,
+}
+
+#[derive(Debug, Clone)]
+struct RecordedMaster {
+    id: String,
+    kind: CalibrationKind,
+    label: String,
+    usages: Vec<MasterUsage>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MasterEntry {
+    id: String,
+    kind: CalibrationKind,
+    label: String,
+    available: bool,
+    unavailable_reason: Option<String>,
+    usages: Vec<MasterUsage>,
+    preview_url: Option<String>,
+    original_preview_url: Option<String>,
+    fits_url: Option<String>,
+    source_count: Option<usize>,
+    rejection_method: Option<String>,
+    masked_samples: Option<u64>,
+    rejected_samples: Option<u64>,
+    minimum_clean_samples: Option<u64>,
+    maximum_clean_samples: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MasterCatalog {
+    masters: Vec<MasterEntry>,
+    notes: Vec<String>,
+}
+
+fn validate_source(source: &MasterSource) -> Result<(), AppError> {
+    super::validate_job_id(&source.job_id)?;
+    if source.artifact_revision.is_empty()
+        || source.artifact_revision.len() > 128
+        || !source
+            .artifact_revision
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_'))
+        || (source.kind == SourceKind::Mono) != source.group_index.is_some()
+    {
+        return Err(AppError::BadRequest(
+            "Invalid calibration master source".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn stale() -> AppError {
+    AppError::Conflict("The displayed stack changed; reopen its calibration masters".into())
+}
+
+fn matching_group(
+    job: &StackPreviewJob,
+    ctx: &DatabaseContext,
+    source: &MasterSource,
+) -> Option<StackGroupStatus> {
+    if job.database_id != ctx.id
+        || job.job_id != source.job_id
+        || job.artifact_revision != source.artifact_revision
+    {
+        return None;
+    }
+    job.groups
+        .iter()
+        .find(|g| Some(g.index) == source.group_index && g.state == StackGroupState::Ready)
+        .cloned()
+}
+
+fn load_mono_group(
+    state: &AppState,
+    ctx: &DatabaseContext,
+    source: &MasterSource,
+) -> Result<StackGroupStatus, AppError> {
+    validate_source(source)?;
+    let mut project_id = None;
+    if let Some(job) = state
+        .stack_previews
+        .get(&source.job_id)
+        .filter(|j| j.database_id == ctx.id && j.job_id == source.job_id)
+    {
+        if let Some(group) = matching_group(&job, ctx, source) {
+            return Ok(group);
+        }
+        project_id = Some(job.project_id);
+    }
+    if let Ok(bytes) = std::fs::read(super::manifest_path(&ctx.cache_dir_path, &source.job_id)) {
+        let job: StackPreviewJob = serde_json::from_slice(&bytes)
+            .map_err(|_| AppError::InternalError("Invalid stack manifest".into()))?;
+        if job.database_id != ctx.id || job.job_id != source.job_id {
+            return Err(AppError::NotFound);
+        }
+        if let Some(group) = matching_group(&job, ctx, source) {
+            return Ok(group);
+        }
+        project_id = Some(job.project_id);
+    }
+    // A forced rebuild can replace the live job while the UI still shows the
+    // previous completed artifact. Its durable latest entry owns that history.
+    if let Some(project_id) = project_id {
+        if let Ok(bytes) = std::fs::read(super::latest_path(&ctx.cache_dir_path, project_id)) {
+            let latest: LatestStackPreviews = serde_json::from_slice(&bytes)
+                .map_err(|_| AppError::InternalError("Invalid latest stack index".into()))?;
+            if latest.database_id != ctx.id || latest.project_id != project_id {
+                return Err(AppError::NotFound);
+            }
+            if let Some(entry) = latest.groups.into_iter().find(|entry| {
+                entry.job_id == source.job_id
+                    && entry.artifact_revision == source.artifact_revision
+                    && Some(entry.group.index) == source.group_index
+                    && entry.group.state == StackGroupState::Ready
+            }) {
+                return Ok(entry.group);
+            }
+        }
+        return Err(stale());
+    }
+    Err(AppError::NotFound)
+}
+
+fn load_color_job(
+    state: &AppState,
+    ctx: &DatabaseContext,
+    source: &MasterSource,
+) -> Result<color::StackColorJob, AppError> {
+    validate_source(source)?;
+    let mut project_id = None;
+    let matches = |job: &color::StackColorJob| {
+        job.database_id == ctx.id
+            && job.job_id == source.job_id
+            && job.artifact_revision == source.artifact_revision
+            && job.state == StackJobState::Completed
+    };
+    if let Some(job) = state
+        .stack_previews
+        .get_color(&source.job_id)
+        .filter(|j| j.database_id == ctx.id && j.job_id == source.job_id)
+    {
+        if matches(&job) {
+            return Ok(job);
+        }
+        project_id = Some(job.project_id);
+    }
+    if let Ok(job) = color::load_persisted_color_job(&ctx.cache_dir_path, &source.job_id) {
+        if job.database_id != ctx.id || job.job_id != source.job_id {
+            return Err(AppError::NotFound);
+        }
+        if matches(&job) {
+            return Ok(job);
+        }
+        project_id = Some(job.project_id);
+    }
+    if let Some(project_id) = project_id {
+        if let Some(job) = color::retained_calibration_source(
+            ctx,
+            project_id,
+            &source.job_id,
+            &source.artifact_revision,
+        )? {
+            return Ok(job);
+        }
+        return Err(stale());
+    }
+    Err(AppError::NotFound)
+}
+
+fn valid_label(kind: CalibrationKind, label: &str) -> bool {
+    label
+        .strip_prefix(&format!("{}-", kind.as_str()))
+        .and_then(|s| s.strip_suffix(".fits"))
+        .is_some_and(|hash| hash.len() == 64 && hash.bytes().all(|b| b.is_ascii_hexdigit()))
+}
+
+fn signature_masters(signature: &str) -> Result<Vec<(CalibrationKind, String)>, ()> {
+    let mut seen = HashSet::new();
+    let mut masters = Vec::new();
+    for field in signature.split(';') {
+        let (key, value) = field.split_once('=').ok_or(())?;
+        if key == "pedestal" {
+            continue;
+        }
+        let kind = KINDS
+            .iter()
+            .find(|kind| kind.as_str() == key)
+            .copied()
+            .ok_or(())?;
+        if !seen.insert(kind) {
+            return Err(());
+        }
+        if value != "none" {
+            if !valid_label(kind, value) {
+                return Err(());
+            }
+            masters.push((kind, value.to_string()));
+        }
+    }
+    if seen.len() != KINDS.len() {
+        return Err(());
+    }
+    Ok(masters)
+}
+
+fn master_id(kind: CalibrationKind, label: &str) -> String {
+    digest_hex(format!("{}:{label}", kind.as_str()).as_bytes())
+}
+
+fn digest_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut value = String::with_capacity(64);
+    for byte in Sha256::digest(bytes) {
+        let _ = write!(value, "{byte:02x}");
+    }
+    value
+}
+
+fn add_calibration(
+    calibration: &AppliedCalibration,
+    channel: &str,
+    lights: usize,
+    masters: &mut BTreeMap<(CalibrationKind, String), RecordedMaster>,
+    notes: &mut Vec<String>,
+) {
+    if let Some(warning) = &calibration.warning {
+        notes.push(format!("{channel}: {warning}"));
+    }
+    let mut add = |entries: Vec<(CalibrationKind, String)>, session, count, pedestal| {
+        for (kind, label) in entries {
+            let entry = masters
+                .entry((kind, label.clone()))
+                .or_insert_with(|| RecordedMaster {
+                    id: master_id(kind, &label),
+                    kind,
+                    label,
+                    usages: Vec::new(),
+                });
+            entry.usages.push(MasterUsage {
+                channel: channel.to_string(),
+                session,
+                lights: count,
+                estimated_pedestal_adu: pedestal,
+            });
+        }
+    };
+    if !calibration.session_details.is_empty() {
+        for (index, session) in calibration.session_details.iter().enumerate() {
+            match signature_masters(&session.masters_signature) {
+                Ok(entries) => add(
+                    entries,
+                    index + 1,
+                    session.lights,
+                    session.estimated_pedestal_adu,
+                ),
+                Err(()) => notes.push(format!(
+                    "{channel}, session {}: recorded master references are invalid",
+                    index + 1
+                )),
+            }
+        }
+    } else if calibration.sessions <= 1 {
+        let labels = [
+            &calibration.bias_master,
+            &calibration.dark_master,
+            &calibration.dark_flat_master,
+            &calibration.flat_master,
+        ];
+        let mut entries = Vec::new();
+        for (kind, label) in KINDS.into_iter().zip(labels) {
+            if let Some(label) = label {
+                if valid_label(kind, label) {
+                    entries.push((kind, label.clone()));
+                } else {
+                    notes.push(format!(
+                        "{channel}: recorded {} master reference is invalid",
+                        kind.as_str()
+                    ));
+                }
+            }
+        }
+        add(entries, 1, lights, calibration.estimated_pedestal_adu);
+    } else {
+        notes.push(format!(
+            "{channel}: this older stack did not retain per-session master references"
+        ));
+    }
+}
+
+fn recorded_masters(
+    state: &AppState,
+    ctx: &DatabaseContext,
+    source: &MasterSource,
+) -> Result<(Vec<RecordedMaster>, Vec<String>), AppError> {
+    validate_source(source)?;
+    let mut masters = BTreeMap::new();
+    let mut notes = Vec::new();
+    match source.kind {
+        SourceKind::Mono => {
+            let group = load_mono_group(state, ctx, source)?;
+            let channel = if group.filter_name.is_empty() {
+                "No filter"
+            } else {
+                &group.filter_name
+            };
+            add_calibration(
+                &group.calibration,
+                channel,
+                group.accepted_frames,
+                &mut masters,
+                &mut notes,
+            );
+        }
+        SourceKind::Color => {
+            let color = load_color_job(state, ctx, source)?;
+            for channel in color.sources {
+                let source = MasterSource {
+                    kind: SourceKind::Mono,
+                    job_id: channel.job_id,
+                    group_index: Some(channel.group_index),
+                    artifact_revision: channel.artifact_revision,
+                };
+                match load_mono_group(state, ctx, &source) {
+                    Ok(group) => add_calibration(
+                        &group.calibration,
+                        channel.role.label(),
+                        group.accepted_frames,
+                        &mut masters,
+                        &mut notes,
+                    ),
+                    Err(_) => notes.push(format!(
+                        "{}: the recorded channel stack is no longer available",
+                        channel.role.label()
+                    )),
+                }
+            }
+        }
+    }
+    if masters.is_empty() && notes.is_empty() {
+        notes.push("No calibration master files were recorded for this stack".into());
+    }
+    Ok((masters.into_values().collect(), notes))
+}
+
+fn master_path(ctx: &DatabaseContext, master: &RecordedMaster) -> Result<PathBuf, AppError> {
+    if !valid_label(master.kind, &master.label) {
+        return Err(AppError::BadRequest(
+            "Invalid calibration master reference".into(),
+        ));
+    }
+    let base = std::fs::canonicalize(&ctx.cache_dir_path).map_err(|_| AppError::NotFound)?;
+    let root = std::fs::canonicalize(ctx.cache_dir_path.join("calibration-masters"))
+        .map_err(|_| AppError::NotFound)?;
+    let path = std::fs::canonicalize(root.join(&master.label)).map_err(|_| AppError::NotFound)?;
+    if !root.starts_with(&base) || !path.starts_with(&root) || !path.is_file() {
+        return Err(AppError::NotFound);
+    }
+    Ok(path)
+}
+
+fn source_base(ctx: &DatabaseContext, source: &MasterSource) -> String {
+    match source.kind {
+        SourceKind::Mono => format!(
+            "/api/db/{}/stack-previews/{}/{}/calibration-masters",
+            ctx.id,
+            source.job_id,
+            source.group_index.unwrap_or_default()
+        ),
+        SourceKind::Color => format!(
+            "/api/db/{}/stack-previews/color/{}/calibration-masters",
+            ctx.id, source.job_id
+        ),
+    }
+}
+
+fn supplement_entry(ctx: &DatabaseContext, entry: &mut MasterEntry) {
+    // Catalog provenance is optional: forgotten inputs can remove this row
+    // while the historical master remains on disk. Never rebuild or re-record it.
+    let conn = ctx.db();
+    let Ok(conn) = conn.try_lock() else {
+        return;
+    };
+    let path = ctx
+        .cache_dir_path
+        .join("calibration-masters")
+        .join(&entry.label);
+    let row: Result<Option<(i64, String)>, _> = conn.query_row(
+        "SELECT source_count, statistics_json FROM psf_guard_calibration_master WHERE cache_path = ?1",
+        [path.to_string_lossy().as_ref()], |row| Ok((row.get(0)?, row.get(1)?)),
+    ).optional();
+    let Ok(Some((count, json))) = row else {
+        return;
+    };
+    entry.source_count = usize::try_from(count).ok();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&json) {
+        entry.rejection_method = value
+            .get("rejection_method")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        entry.masked_samples = value.get("masked_samples").and_then(|v| v.as_u64());
+        entry.rejected_samples = value.get("rejected_samples").and_then(|v| v.as_u64());
+        if let Some(mask) = value.get("flat_star_masking") {
+            entry.minimum_clean_samples =
+                mask.get("minimum_clean_samples").and_then(|v| v.as_u64());
+            entry.maximum_clean_samples =
+                mask.get("maximum_clean_samples").and_then(|v| v.as_u64());
+        }
+    }
+}
+
+fn catalog(
+    state: &AppState,
+    ctx: &DatabaseContext,
+    source: &MasterSource,
+) -> Result<MasterCatalog, AppError> {
+    let (recorded, notes) = recorded_masters(state, ctx, source)?;
+    let base = source_base(ctx, source);
+    let masters = recorded
+        .into_iter()
+        .map(|master| {
+            let available = master_path(ctx, &master).is_ok();
+            let url = format!("{base}/{}", master.id);
+            let mut entry = MasterEntry {
+                id: master.id,
+                kind: master.kind,
+                label: master.label,
+                available,
+                unavailable_reason: (!available).then(|| {
+                    "The recorded master file is no longer available in this database's cache"
+                        .into()
+                }),
+                usages: master.usages,
+                preview_url: available
+                    .then(|| format!("{url}/preview?revision={}", source.artifact_revision)),
+                original_preview_url: available.then(|| {
+                    format!(
+                        "{url}/preview?revision={}&size=original",
+                        source.artifact_revision
+                    )
+                }),
+                fits_url: available
+                    .then(|| format!("{url}/fits?revision={}", source.artifact_revision)),
+                source_count: None,
+                rejection_method: None,
+                masked_samples: None,
+                rejected_samples: None,
+                minimum_clean_samples: None,
+                maximum_clean_samples: None,
+            };
+            supplement_entry(ctx, &mut entry);
+            entry
+        })
+        .collect();
+    Ok(MasterCatalog { masters, notes })
+}
+
+fn resolve_master(
+    state: &AppState,
+    ctx: &DatabaseContext,
+    source: &MasterSource,
+    id: &str,
+) -> Result<(RecordedMaster, PathBuf), AppError> {
+    super::validate_job_id(id)?;
+    let (masters, _) = recorded_masters(state, ctx, source)?;
+    let master = masters
+        .into_iter()
+        .find(|m| m.id == id)
+        .ok_or(AppError::NotFound)?;
+    let path = master_path(ctx, &master)?;
+    Ok((master, path))
+}
+
+fn preview_job(
+    ctx: &DatabaseContext,
+    master: &RecordedMaster,
+    path: PathBuf,
+    options: &DisplayOptions,
+) -> Result<GenJob, AppError> {
+    let (size, midtone, shadow) = options.normalized()?;
+    let fingerprint = super::source_fingerprint(&path);
+    let key = digest_hex(
+        format!(
+            "{PREVIEW_VERSION}:{}:{}:{}:{}:{fingerprint}:{size}:{midtone}:{shadow}:png",
+            env!("CARGO_PKG_VERSION"),
+            super::stretch::SEIZA_STRETCH_VERSION,
+            seiza_stacking::VERSION,
+            master.id
+        )
+        .as_bytes(),
+    );
+    let base = std::fs::canonicalize(&ctx.cache_dir_path).map_err(|_| AppError::NotFound)?;
+    let mut directory = base.clone();
+    // Validate each existing ancestor before creating a child, including links.
+    for component in ["previews", "calibration-masters"] {
+        directory.push(component);
+        match std::fs::create_dir(&directory) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(_) => {
+                return Err(AppError::InternalError(
+                    "Could not create master preview cache".into(),
+                ))
+            }
+        }
+        directory = std::fs::canonicalize(&directory).map_err(|_| AppError::NotFound)?;
+        if !directory.starts_with(&base) || !directory.is_dir() {
+            return Err(AppError::NotFound);
+        }
+    }
+    let cache_path = directory.join(format!("{key}.png"));
+    if cache_path.exists()
+        && !std::fs::canonicalize(&cache_path)
+            .map_err(|_| AppError::NotFound)?
+            .starts_with(&directory)
+    {
+        return Err(AppError::NotFound);
+    }
+    Ok(GenJob {
+        fits_path: path,
+        cache_path,
+        kind: GenKind::CalibrationMaster {
+            midtone,
+            shadow,
+            max_dimensions: crate::server::preview_queue::max_dimensions_for_size(size),
+        },
+        encoding: crate::preview_format::PreviewEncoding::png(),
+    })
+}
+
+fn generation_status(state: &Arc<AppState>, job: GenJob) -> GenerationStatus {
+    if let Some(status) = state
+        .preview_queue
+        .status_for_source(&job.cache_path, &job.fits_path)
+    {
+        return status;
+    }
+    state.enqueue_preview(job);
+    GenerationStatus {
+        state: GenerationState::Generating,
+        error: None,
+    }
+}
+
+pub async fn get_catalog(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path(path): Path<MasterPath>,
+    Query(query): Query<MasterQuery>,
+) -> Result<Json<ApiResponse<MasterCatalog>>, AppError> {
+    let source = path.source(query.revision);
+    let result = tokio::task::spawn_blocking(move || catalog(&state, &ctx, &source))
+        .await
+        .map_err(|_| AppError::InternalError("Master inspection failed".into()))??;
+    Ok(Json(ApiResponse::success(result)))
+}
+
+pub async fn get_preview(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path(path): Path<MasterPath>,
+    Query(query): Query<MasterQuery>,
+) -> Result<Response, AppError> {
+    let display = query.display();
+    let source = path.source(query.revision);
+    let id = path.master_id.ok_or(AppError::NotFound)?;
+    let (status, cache_path) = tokio::task::spawn_blocking(move || {
+        let (master, source_path) = resolve_master(&state, &ctx, &source, &id)?;
+        let job = preview_job(&ctx, &master, source_path, &display)?;
+        let path = job.cache_path.clone();
+        Ok::<_, AppError>((generation_status(&state, job), path))
+    })
+    .await
+    .map_err(|_| AppError::InternalError("Master preview preparation failed".into()))??;
+    match status.state {
+        GenerationState::Ready => serve_file(&cache_path, "image/png", None).await,
+        GenerationState::Generating => Ok((
+            StatusCode::ACCEPTED,
+            [(CACHE_CONTROL, "no-store")],
+            Json(ApiResponse::success(status)),
+        )
+            .into_response()),
+        GenerationState::Error => {
+            Err(AppError::InternalError(status.error.unwrap_or_else(|| {
+                "Master preview generation failed".into()
+            })))
+        }
+    }
+}
+
+pub async fn download_fits(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path(path): Path<MasterPath>,
+    Query(query): Query<MasterQuery>,
+) -> Result<Response, AppError> {
+    let source = path.source(query.revision);
+    let id = path.master_id.ok_or(AppError::NotFound)?;
+    let (master, path) =
+        tokio::task::spawn_blocking(move || resolve_master(&state, &ctx, &source, &id))
+            .await
+            .map_err(|_| AppError::InternalError("Master download preparation failed".into()))??;
+    serve_file(&path, "application/fits", Some(&master.label)).await
+}
+
+async fn serve_file(
+    path: &FsPath,
+    content_type: &str,
+    filename: Option<&str>,
+) -> Result<Response, AppError> {
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|_| AppError::NotFound)?;
+    let length = file
+        .metadata()
+        .await
+        .map_err(|_| AppError::InternalError("Could not read master file metadata".into()))?
+        .len();
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, content_type)
+        .header(CONTENT_LENGTH, length)
+        .header(CACHE_CONTROL, "private, no-store");
+    if let Some(filename) = filename {
+        response = response.header(
+            CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{filename}\""),
+        );
+    }
+    response
+        .body(Body::from_stream(ReaderStream::new(file)))
+        .map_err(|_| AppError::InternalError("Could not serve master file".into()))
+}
+
+pub async fn post_generation_status(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Json(request): Json<MasterStatusRequest>,
+) -> Result<Json<ApiResponse<GenerationStatusBatch>>, AppError> {
+    if request.requests.len() > MAX_STATUS_BATCH {
+        return Err(AppError::BadRequest(
+            "Too many master preview status requests".into(),
+        ));
+    }
+    let statuses = tokio::task::spawn_blocking(move || {
+        request
+            .requests
+            .into_iter()
+            .map(|item| {
+                let result = resolve_master(&state, &ctx, &item.source, &item.master_id)
+                    .and_then(|(master, path)| preview_job(&ctx, &master, path, &item.display));
+                match result {
+                    Ok(job) => generation_status(&state, job),
+                    Err(AppError::Conflict(_)) => GenerationStatus {
+                        state: GenerationState::Error,
+                        error: Some(
+                            "The displayed stack changed; reopen its calibration masters".into(),
+                        ),
+                    },
+                    Err(_) => GenerationStatus {
+                        state: GenerationState::Error,
+                        error: Some("The recorded calibration master is unavailable".into()),
+                    },
+                }
+            })
+            .collect()
+    })
+    .await
+    .map_err(|_| AppError::InternalError("Master preview status failed".into()))?;
+    Ok(Json(ApiResponse::success(GenerationStatusBatch {
+        statuses,
+    })))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/server/stack_preview/calibration_masters/tests.rs
+++ b/src/server/stack_preview/calibration_masters/tests.rs
@@ -1,0 +1,845 @@
+use super::*;
+use crate::calibration::CalibrationSessionDetail;
+
+fn label(kind: CalibrationKind, marker: char) -> String {
+    format!("{}-{}.fits", kind.as_str(), marker.to_string().repeat(64))
+}
+
+fn signature(bias: Option<&str>, flat: Option<&str>) -> String {
+    format!(
+        "bias={};dark=none;dark_flat=none;flat={}",
+        bias.unwrap_or("none"),
+        flat.unwrap_or("none"),
+    )
+}
+
+#[test]
+fn signatures_require_all_kinds_and_reject_invalid_or_duplicate_references() {
+    let flat = label(CalibrationKind::Flat, 'a');
+    assert_eq!(
+        signature_masters(&format!(
+            "{};pedestal=estimated-125.0",
+            signature(None, Some(&flat))
+        ))
+        .unwrap(),
+        vec![(CalibrationKind::Flat, flat.clone())],
+    );
+    for invalid in [
+        format!("flat={flat}"),
+        format!("{};flat={flat}", signature(None, Some(&flat))),
+        format!("bias={flat};dark=none;dark_flat=none;flat=none"),
+        signature(None, Some("../flat-secret.fits")),
+        signature(None, Some("C:\\secret.fits")),
+        format!("{};other=none", signature(None, None)),
+    ] {
+        assert!(signature_masters(&invalid).is_err(), "{invalid}");
+    }
+    assert!(signature_masters(&signature(None, None))
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn sessions_deduplicate_files_without_losing_channel_or_pedestal_usage() {
+    let bias = label(CalibrationKind::Bias, 'b');
+    let first_flat = label(CalibrationKind::Flat, 'a');
+    let second_flat = label(CalibrationKind::Flat, 'c');
+    let mut calibration = AppliedCalibration {
+        sessions: 2,
+        session_details: vec![
+            CalibrationSessionDetail {
+                fingerprint: "first".into(),
+                masters_signature: signature(Some(&bias), Some(&first_flat)),
+                estimated_pedestal_adu: Some(120.0),
+                lights: 11,
+            },
+            CalibrationSessionDetail {
+                fingerprint: "second".into(),
+                masters_signature: signature(Some(&bias), Some(&second_flat)),
+                estimated_pedestal_adu: None,
+                lights: 7,
+            },
+        ],
+        ..Default::default()
+    };
+    let mut masters = BTreeMap::new();
+    let mut notes = Vec::new();
+    add_calibration(&calibration, "Red", 18, &mut masters, &mut notes);
+    calibration.session_details.truncate(1);
+    add_calibration(&calibration, "Green", 11, &mut masters, &mut notes);
+    assert!(notes.is_empty());
+    assert_eq!(masters.len(), 3);
+    let usages = &masters[&(CalibrationKind::Bias, bias)].usages;
+    assert_eq!(usages.len(), 3);
+    assert_eq!((usages[0].session, usages[0].lights), (1, 11));
+    assert_eq!(usages[0].estimated_pedestal_adu, Some(120.0));
+    assert_eq!((usages[1].session, usages[1].lights), (2, 7));
+    assert_eq!(usages[2].channel, "Green");
+}
+
+#[test]
+fn legacy_labels_are_used_only_without_recorded_sessions() {
+    let flat = label(CalibrationKind::Flat, 'a');
+    let mut calibration = AppliedCalibration {
+        flat_master: Some(flat.clone()),
+        estimated_pedestal_adu: Some(80.0),
+        ..Default::default()
+    };
+    let mut masters = BTreeMap::new();
+    let mut notes = Vec::new();
+    add_calibration(&calibration, "Ha", 9, &mut masters, &mut notes);
+    assert_eq!(masters[&(CalibrationKind::Flat, flat)].usages[0].lights, 9);
+    assert!(notes.is_empty());
+    calibration.sessions = 2;
+    masters.clear();
+    add_calibration(&calibration, "Ha", 9, &mut masters, &mut notes);
+    assert!(masters.is_empty());
+    assert!(notes[0].contains("did not retain per-session"));
+    calibration.session_details.push(CalibrationSessionDetail {
+        fingerprint: "invalid".into(),
+        masters_signature: "flat=../../private.fits".into(),
+        estimated_pedestal_adu: None,
+        lights: 9,
+    });
+    notes.clear();
+    add_calibration(&calibration, "Ha", 9, &mut masters, &mut notes);
+    assert!(
+        masters.is_empty(),
+        "invalid sessions must not fall back to unrelated labels"
+    );
+    assert!(notes[0].contains("references are invalid"));
+}
+
+#[test]
+fn display_options_are_bounded_finite_and_canonicalized() {
+    assert_eq!(
+        DisplayOptions::default().normalized().unwrap(),
+        ("screen", 0.2, -2.8)
+    );
+    for options in [
+        DisplayOptions {
+            size: Some("thumbnail".into()),
+            ..Default::default()
+        },
+        DisplayOptions {
+            midtone: Some(f64::NAN),
+            ..Default::default()
+        },
+        DisplayOptions {
+            midtone: Some(1.0),
+            ..Default::default()
+        },
+        DisplayOptions {
+            shadow: Some(f64::NEG_INFINITY),
+            ..Default::default()
+        },
+        DisplayOptions {
+            shadow: Some(-10.01),
+            ..Default::default()
+        },
+        DisplayOptions {
+            shadow: Some(0.01),
+            ..Default::default()
+        },
+    ] {
+        assert!(matches!(options.normalized(), Err(AppError::BadRequest(_))));
+    }
+    assert_eq!(
+        DisplayOptions {
+            size: Some("original".into()),
+            midtone: Some(0.2001),
+            shadow: Some(-2.801)
+        }
+        .normalized()
+        .unwrap(),
+        ("original", 0.2, -2.8),
+    );
+}
+
+struct Fixture {
+    _directory: tempfile::TempDir,
+    state: Arc<AppState>,
+    ctx: Arc<DatabaseContext>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = tempfile::tempdir().unwrap();
+        let mut ctx =
+            DatabaseContext::new_for_test(rusqlite::Connection::open_in_memory().unwrap());
+        ctx.cache_dir_path = directory.path().join("cache").join("test");
+        ctx.cache_dir = ctx.cache_dir_path.to_string_lossy().into_owned();
+        std::fs::create_dir_all(ctx.cache_dir_path.join("calibration-masters")).unwrap();
+        Self {
+            _directory: directory,
+            state: Arc::new(AppState::new_for_test(
+                rusqlite::Connection::open_in_memory().unwrap(),
+            )),
+            ctx: Arc::new(ctx),
+        }
+    }
+
+    fn stack(&self, calibration: AppliedCalibration) -> (StackPreviewJob, MasterSource) {
+        let group: StackGroupStatus = serde_json::from_value(serde_json::json!({
+            "index": 0, "target_id": 1, "target_name": "Target", "filter_name": "Ha",
+            "state": "ready", "phase": "ready", "total_candidates": 3, "eligible_frames": 3,
+            "quality_excluded": 0, "missing_files": 0, "processed_frames": 3,
+            "accepted_frames": 3, "rejected_frames": 0, "reused_frames": 0,
+            "output_channels": 1, "total_exposure_seconds": 300.0,
+            "calibration": calibration, "input_images": [], "frames": [],
+        }))
+        .unwrap();
+        let job = StackPreviewJob {
+            schema_version: 2,
+            job_id: "a".repeat(64),
+            database_id: self.ctx.id.clone(),
+            project_id: 7,
+            state: StackJobState::Completed,
+            accepted_only: false,
+            created_unix_seconds: 100,
+            artifact_revision: "revision-old".into(),
+            cache_version: super::super::STACK_PREVIEW_CACHE_VERSION,
+            stacking_version: super::super::SEIZA_STACKING_VERSION.into(),
+            order: super::super::snr::StackFrameOrder::Capture,
+            scoring: super::super::StackScoringSettings::default(),
+            groups: vec![group],
+            error: None,
+        };
+        let source = MasterSource {
+            kind: SourceKind::Mono,
+            job_id: job.job_id.clone(),
+            group_index: Some(0),
+            artifact_revision: job.artifact_revision.clone(),
+        };
+        assert!(self.state.stack_previews.insert(job.clone()));
+        (job, source)
+    }
+
+    fn master(&self, kind: CalibrationKind, marker: char) -> RecordedMaster {
+        let label = label(kind, marker);
+        RecordedMaster {
+            id: master_id(kind, &label),
+            kind,
+            label,
+            usages: Vec::new(),
+        }
+    }
+
+    fn write_master(&self, master: &RecordedMaster) -> PathBuf {
+        let path = self
+            .ctx
+            .cache_dir_path
+            .join("calibration-masters")
+            .join(&master.label);
+        let data = (0..64 * 64)
+            .map(|index| 1.0 + (index % 64) as f32 * 0.001)
+            .collect();
+        let image = seiza_stacking::LinearImage::new(64, 64, 1, data).unwrap();
+        seiza_stacking::write_processed_image_fits_f32(&path, &image, &[], &[]).unwrap();
+        path
+    }
+}
+
+#[test]
+fn historical_catalog_does_not_need_current_catalog_rows_or_a_database_lock() {
+    let fixture = Fixture::new();
+    let master = fixture.master(CalibrationKind::Flat, 'b');
+    fixture.write_master(&master);
+    let (_, source) = fixture.stack(AppliedCalibration {
+        flat_master: Some(master.label.clone()),
+        ..Default::default()
+    });
+    let catalog = catalog(&fixture.state, &fixture.ctx, &source).unwrap();
+    assert_eq!(catalog.masters.len(), 1);
+    let entry = &catalog.masters[0];
+    assert!(entry.available);
+    assert!(entry.source_count.is_none());
+    assert!(entry
+        .preview_url
+        .as_deref()
+        .unwrap()
+        .contains("revision=revision-old"));
+    assert!(entry.fits_url.as_deref().unwrap().contains(&master.id));
+    let db = fixture.ctx.db();
+    let _lock = db.lock().unwrap();
+    let catalog = super::catalog(&fixture.state, &fixture.ctx, &source).unwrap();
+    assert!(
+        catalog.masters[0].available,
+        "optional metadata must not block inspection"
+    );
+}
+
+#[test]
+fn optional_provenance_is_reported_without_recreating_forgotten_catalog_rows() {
+    let fixture = Fixture::new();
+    let master = fixture.master(CalibrationKind::Flat, 'b');
+    let path = fixture.write_master(&master);
+    let (_, source) = fixture.stack(AppliedCalibration {
+        flat_master: Some(master.label),
+        ..Default::default()
+    });
+    let db = fixture.ctx.db();
+    {
+        let conn = db.lock().unwrap();
+        conn.execute_batch("CREATE TABLE psf_guard_calibration_master (cache_path TEXT, source_count INTEGER, statistics_json TEXT)").unwrap();
+        conn.execute(
+            "INSERT INTO psf_guard_calibration_master VALUES (?1, 8, ?2)",
+            rusqlite::params![path.to_string_lossy(), serde_json::json!({
+                "rejection_method": "MEDIAN_MAD", "masked_samples": 120,
+                "rejected_samples": 9, "flat_star_masking": { "minimum_clean_samples": 2, "maximum_clean_samples": 8 }
+            }).to_string()],
+        ).unwrap();
+    }
+    let before = catalog(&fixture.state, &fixture.ctx, &source).unwrap();
+    let entry = &before.masters[0];
+    assert_eq!(entry.source_count, Some(8));
+    assert_eq!(entry.rejection_method.as_deref(), Some("MEDIAN_MAD"));
+    assert_eq!(entry.masked_samples, Some(120));
+    assert_eq!(entry.rejected_samples, Some(9));
+    assert_eq!(
+        (entry.minimum_clean_samples, entry.maximum_clean_samples),
+        (Some(2), Some(8))
+    );
+    db.lock()
+        .unwrap()
+        .execute("DELETE FROM psf_guard_calibration_master", [])
+        .unwrap();
+    let after = catalog(&fixture.state, &fixture.ctx, &source).unwrap();
+    assert!(after.masters[0].available);
+    assert_eq!(after.masters[0].source_count, None);
+    let count: i64 = db
+        .lock()
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM psf_guard_calibration_master",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 0, "inspection must never rebuild or record masters");
+}
+
+#[test]
+fn numeric_display_query_fields_decode_from_real_url_parameters() {
+    let uri = "/masters/preview?revision=revision-old&size=original&midtone=0.325&shadow=-3.75"
+        .parse()
+        .unwrap();
+    let Query(query) = Query::<MasterQuery>::try_from_uri(&uri).unwrap();
+    assert_eq!(query.revision, "revision-old");
+    assert_eq!(
+        query.display().normalized().unwrap(),
+        ("original", 0.325, -3.75)
+    );
+}
+
+#[test]
+fn missing_files_stay_unavailable_and_unrecorded_files_are_not_downloadable() {
+    let fixture = Fixture::new();
+    let missing = fixture.master(CalibrationKind::Flat, 'b');
+    let unrecorded = fixture.master(CalibrationKind::Flat, 'c');
+    fixture.write_master(&unrecorded);
+    let (_, source) = fixture.stack(AppliedCalibration {
+        flat_master: Some(missing.label.clone()),
+        ..Default::default()
+    });
+    let catalog = catalog(&fixture.state, &fixture.ctx, &source).unwrap();
+    assert!(!catalog.masters[0].available);
+    assert!(catalog.masters[0].unavailable_reason.is_some());
+    assert!(catalog.masters[0].preview_url.is_none());
+    assert!(catalog.masters[0].fits_url.is_none());
+    assert!(matches!(
+        resolve_master(&fixture.state, &fixture.ctx, &source, &missing.id),
+        Err(AppError::NotFound)
+    ));
+    assert!(matches!(
+        resolve_master(&fixture.state, &fixture.ctx, &source, &unrecorded.id),
+        Err(AppError::NotFound)
+    ));
+    assert!(!fixture
+        .ctx
+        .cache_dir_path
+        .join("calibration-masters")
+        .join(&missing.label)
+        .exists());
+}
+
+#[test]
+fn invalid_paths_wrong_kind_and_other_database_are_refused() {
+    let fixture = Fixture::new();
+    let mut master = fixture.master(CalibrationKind::Flat, 'b');
+    fixture.write_master(&master);
+    for invalid in [
+        "../private.fits".to_string(),
+        "C:\\private.fits".into(),
+        label(CalibrationKind::Bias, 'c'),
+    ] {
+        master.label = invalid;
+        assert!(matches!(
+            master_path(&fixture.ctx, &master),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+    let (_, source) = fixture.stack(AppliedCalibration::default());
+    let mut other = DatabaseContext::new_for_test(rusqlite::Connection::open_in_memory().unwrap());
+    other.id = "other-db".into();
+    other.cache_dir_path = fixture.ctx.cache_dir_path.clone();
+    assert!(matches!(
+        load_mono_group(&fixture.state, &other, &source),
+        Err(AppError::NotFound)
+    ));
+    let mut invalid = source.clone();
+    invalid.job_id = "../private".into();
+    assert!(matches!(
+        validate_source(&invalid),
+        Err(AppError::BadRequest(_))
+    ));
+    invalid = source.clone();
+    invalid.artifact_revision = "revision&size=original".into();
+    assert!(matches!(
+        validate_source(&invalid),
+        Err(AppError::BadRequest(_))
+    ));
+    invalid = source;
+    invalid.kind = SourceKind::Color;
+    assert!(matches!(
+        validate_source(&invalid),
+        Err(AppError::BadRequest(_))
+    ));
+}
+
+#[test]
+fn a_forced_rebuild_keeps_the_retained_completed_revision_inspectable() {
+    let fixture = Fixture::new();
+    let old_master = fixture.master(CalibrationKind::Flat, 'b');
+    let (mut job, source) = fixture.stack(AppliedCalibration {
+        flat_master: Some(old_master.label.clone()),
+        ..Default::default()
+    });
+    super::super::persist_latest_groups(&fixture.ctx.cache_dir_path, &job).unwrap();
+    job.artifact_revision = "revision-new".into();
+    job.state = StackJobState::Running;
+    job.groups[0].state = StackGroupState::Running;
+    job.groups[0].calibration.flat_master = Some(label(CalibrationKind::Flat, 'c'));
+    assert!(fixture.state.stack_previews.insert(job.clone()));
+    super::super::persist_manifest(&fixture.ctx.cache_dir_path, &job).unwrap();
+    let loaded = load_mono_group(&fixture.state, &fixture.ctx, &source).unwrap();
+    assert_eq!(
+        loaded.calibration.flat_master.as_deref(),
+        Some(old_master.label.as_str())
+    );
+    let mut unknown = source.clone();
+    unknown.artifact_revision = "never-built".into();
+    assert!(matches!(
+        load_mono_group(&fixture.state, &fixture.ctx, &unknown),
+        Err(AppError::Conflict(_))
+    ));
+    job.state = StackJobState::Completed;
+    job.groups[0].state = StackGroupState::Ready;
+    super::super::persist_latest_groups(&fixture.ctx.cache_dir_path, &job).unwrap();
+    assert!(fixture.state.stack_previews.insert(job));
+    assert!(matches!(
+        load_mono_group(&fixture.state, &fixture.ctx, &source),
+        Err(AppError::Conflict(_))
+    ));
+}
+
+#[test]
+fn preview_identity_tracks_source_display_size_and_database_cache() {
+    let fixture = Fixture::new();
+    let master = fixture.master(CalibrationKind::Flat, 'b');
+    let path = fixture.write_master(&master);
+    let options = DisplayOptions::default();
+    let original = preview_job(&fixture.ctx, &master, path.clone(), &options).unwrap();
+    assert_eq!(original.cache_path.extension().unwrap(), "png");
+    assert!(matches!(original.kind, GenKind::CalibrationMaster { .. }));
+    let equivalent = preview_job(
+        &fixture.ctx,
+        &master,
+        path.clone(),
+        &DisplayOptions {
+            midtone: Some(0.2001),
+            shadow: Some(-2.801),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(equivalent.cache_path, original.cache_path);
+    for options in [
+        DisplayOptions {
+            size: Some("original".into()),
+            ..Default::default()
+        },
+        DisplayOptions {
+            midtone: Some(0.3),
+            ..Default::default()
+        },
+        DisplayOptions {
+            shadow: Some(-3.0),
+            ..Default::default()
+        },
+    ] {
+        assert_ne!(
+            preview_job(&fixture.ctx, &master, path.clone(), &options)
+                .unwrap()
+                .cache_path,
+            original.cache_path
+        );
+    }
+    std::fs::write(&path, b"changed source").unwrap();
+    let changed = preview_job(&fixture.ctx, &master, path, &DisplayOptions::default()).unwrap();
+    assert_ne!(changed.cache_path, original.cache_path);
+    let other = Fixture::new();
+    let other_path = other.write_master(&master);
+    assert_ne!(
+        preview_job(&other.ctx, &master, other_path, &DisplayOptions::default())
+            .unwrap()
+            .cache_path,
+        original.cache_path
+    );
+}
+
+fn color_fixture(fixture: &Fixture, mono: &MasterSource) -> MasterSource {
+    let job: color::StackColorJob = serde_json::from_value(serde_json::json!({
+        "schema_version": 1, "job_id": "d".repeat(64), "database_id": fixture.ctx.id,
+        "project_id": 7, "target_id": 1, "target_name": "Target", "kind": "rgb",
+        "palette": null, "label": "RGB", "state": "completed", "phase": "ready",
+        "processed_channels": 2, "total_channels": 2, "created_unix_seconds": 100,
+        "artifact_revision": "color-old", "cache_version": 1,
+        "stacking_version": super::super::SEIZA_STACKING_VERSION,
+        "sources": [
+            { "role": "red", "filter_name": "R", "job_id": mono.job_id,
+              "group_index": 0, "artifact_revision": mono.artifact_revision, "accepted_frames": 3 },
+            { "role": "green", "filter_name": "G", "job_id": "e".repeat(64),
+              "group_index": 0, "artifact_revision": "missing", "accepted_frames": 4 }
+        ],
+        "preview_url": "/preview", "fits_url": "/fits", "error": null,
+    }))
+    .unwrap();
+    let source = MasterSource {
+        kind: SourceKind::Color,
+        job_id: job.job_id.clone(),
+        group_index: None,
+        artifact_revision: job.artifact_revision.clone(),
+    };
+    fixture
+        .state
+        .stack_previews
+        .color_jobs
+        .lock()
+        .unwrap()
+        .insert(job.job_id.clone(), job);
+    source
+}
+
+#[test]
+fn color_inspection_keeps_available_recorded_channels_and_reports_missing_sources() {
+    let fixture = Fixture::new();
+    let master = fixture.master(CalibrationKind::Flat, 'b');
+    fixture.write_master(&master);
+    let (_, mono) = fixture.stack(AppliedCalibration {
+        flat_master: Some(master.label.clone()),
+        ..Default::default()
+    });
+    let source = color_fixture(&fixture, &mono);
+    let catalog = catalog(&fixture.state, &fixture.ctx, &source).unwrap();
+    assert_eq!(catalog.masters.len(), 1);
+    assert!(catalog.masters[0].available);
+    assert_eq!(catalog.masters[0].usages[0].channel, "R");
+    assert!(catalog
+        .notes
+        .iter()
+        .any(|note| note.contains("G:") && note.contains("no longer available")));
+    let mut stale_source = source;
+    stale_source.artifact_revision = "another-color-revision".into();
+    assert!(matches!(
+        load_color_job(&fixture.state, &fixture.ctx, &stale_source),
+        Err(AppError::Conflict(_))
+    ));
+}
+
+#[cfg(any(unix, windows))]
+fn create_test_symlink(target: &FsPath, link: &FsPath, directory: bool) -> bool {
+    #[cfg(unix)]
+    let result = {
+        let _ = directory;
+        std::os::unix::fs::symlink(target, link)
+    };
+    #[cfg(windows)]
+    let result = if directory {
+        std::os::windows::fs::symlink_dir(target, link)
+    } else {
+        std::os::windows::fs::symlink_file(target, link)
+    };
+    match result {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            eprintln!("symlink regression unavailable without symlink privilege: {error}");
+            false
+        }
+        Err(error) => panic!("creating test symlink: {error}"),
+    }
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn master_symlinks_cannot_escape_the_database_cache() {
+    let fixture = Fixture::new();
+    let master = fixture.master(CalibrationKind::Flat, 'b');
+    let outside = fixture._directory.path().join("private.fits");
+    std::fs::write(&outside, b"private").unwrap();
+    let link = fixture
+        .ctx
+        .cache_dir_path
+        .join("calibration-masters")
+        .join(&master.label);
+    if !create_test_symlink(&outside, &link, false) {
+        return;
+    }
+    assert!(matches!(
+        master_path(&fixture.ctx, &master),
+        Err(AppError::NotFound)
+    ));
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn preview_cache_parent_symlink_is_rejected_before_creating_outside_directories() {
+    let fixture = Fixture::new();
+    let master = fixture.master(CalibrationKind::Flat, 'b');
+    let source = fixture.write_master(&master);
+    let outside = fixture._directory.path().join("outside");
+    std::fs::create_dir(&outside).unwrap();
+    if !create_test_symlink(&outside, &fixture.ctx.cache_dir_path.join("previews"), true) {
+        return;
+    }
+    assert!(matches!(
+        preview_job(&fixture.ctx, &master, source, &DisplayOptions::default()),
+        Err(AppError::NotFound)
+    ));
+    assert!(!outside.join("calibration-masters").exists());
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn an_existing_preview_symlink_cannot_serve_an_unrelated_file() {
+    let fixture = Fixture::new();
+    let master = fixture.master(CalibrationKind::Flat, 'b');
+    let source = fixture.write_master(&master);
+    let job = preview_job(
+        &fixture.ctx,
+        &master,
+        source.clone(),
+        &DisplayOptions::default(),
+    )
+    .unwrap();
+    let outside = fixture._directory.path().join("private.png");
+    std::fs::write(&outside, b"private").unwrap();
+    if !create_test_symlink(&outside, &job.cache_path, false) {
+        return;
+    }
+    assert!(matches!(
+        preview_job(&fixture.ctx, &master, source, &DisplayOptions::default()),
+        Err(AppError::NotFound)
+    ));
+}
+
+fn request_path(source: &MasterSource, master: &RecordedMaster) -> MasterPath {
+    MasterPath {
+        job_id: source.job_id.clone(),
+        group_index: source.group_index,
+        master_id: Some(master.id.clone()),
+    }
+}
+
+fn request_query(source: &MasterSource) -> MasterQuery {
+    MasterQuery {
+        revision: source.artifact_revision.clone(),
+        size: None,
+        midtone: None,
+        shadow: None,
+    }
+}
+
+async fn wait_for_generation(state: &Arc<AppState>, job: &GenJob) -> GenerationStatus {
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            if let Some(status) = state
+                .preview_queue
+                .status_for_source(&job.cache_path, &job.fits_path)
+                && status.state != GenerationState::Generating
+            {
+                return status;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("bounded master preview generation must settle")
+}
+
+#[tokio::test]
+async fn preview_queues_then_serves_png_and_download_preserves_original_fits() {
+    let fixture = Fixture::new();
+    let master = fixture.master(CalibrationKind::Flat, 'b');
+    let source_path = fixture.write_master(&master);
+    let original = std::fs::read(&source_path).unwrap();
+    let (_, source) = fixture.stack(AppliedCalibration {
+        flat_master: Some(master.label.clone()),
+        ..Default::default()
+    });
+    let response = get_preview(
+        State(fixture.state.clone()),
+        DbContext(fixture.ctx.clone()),
+        Path(request_path(&source, &master)),
+        Query(request_query(&source)),
+    )
+    .await
+    .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert_eq!(response.headers()[CACHE_CONTROL], "no-store");
+    let job = preview_job(
+        &fixture.ctx,
+        &master,
+        master_path(&fixture.ctx, &master).unwrap(),
+        &DisplayOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        wait_for_generation(&fixture.state, &job).await.state,
+        GenerationState::Ready
+    );
+    let response = get_preview(
+        State(fixture.state.clone()),
+        DbContext(fixture.ctx.clone()),
+        Path(request_path(&source, &master)),
+        Query(request_query(&source)),
+    )
+    .await
+    .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[CONTENT_TYPE], "image/png");
+    let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    assert_eq!(
+        image::guess_format(&bytes).unwrap(),
+        image::ImageFormat::Png
+    );
+    let response = download_fits(
+        State(fixture.state.clone()),
+        DbContext(fixture.ctx.clone()),
+        Path(request_path(&source, &master)),
+        Query(request_query(&source)),
+    )
+    .await
+    .unwrap();
+    assert_eq!(response.headers()[CONTENT_TYPE], "application/fits");
+    assert_eq!(response.headers()[CACHE_CONTROL], "private, no-store");
+    assert!(response.headers()[CONTENT_DISPOSITION]
+        .to_str()
+        .unwrap()
+        .contains(&master.label));
+    let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    assert_eq!(bytes.as_ref(), original);
+}
+
+#[tokio::test]
+async fn generation_failure_is_terminal_and_status_batches_preserve_request_order() {
+    let fixture = Fixture::new();
+    let master = fixture.master(CalibrationKind::Flat, 'b');
+    let source_path = fixture.write_master(&master);
+    std::fs::write(&source_path, b"not a FITS file").unwrap();
+    let (_, source) = fixture.stack(AppliedCalibration {
+        flat_master: Some(master.label.clone()),
+        ..Default::default()
+    });
+    let response = get_preview(
+        State(fixture.state.clone()),
+        DbContext(fixture.ctx.clone()),
+        Path(request_path(&source, &master)),
+        Query(request_query(&source)),
+    )
+    .await
+    .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let job = preview_job(
+        &fixture.ctx,
+        &master,
+        master_path(&fixture.ctx, &master).unwrap(),
+        &DisplayOptions::default(),
+    )
+    .unwrap();
+    let status = wait_for_generation(&fixture.state, &job).await;
+    assert_eq!(status.state, GenerationState::Error);
+    assert!(!status
+        .error
+        .as_ref()
+        .unwrap()
+        .contains(&fixture.ctx.cache_dir));
+    let response = get_preview(
+        State(fixture.state.clone()),
+        DbContext(fixture.ctx.clone()),
+        Path(request_path(&source, &master)),
+        Query(request_query(&source)),
+    )
+    .await;
+    assert!(matches!(response, Err(AppError::InternalError(_))));
+    let mut stale_source = source.clone();
+    stale_source.artifact_revision = "unknown-revision".into();
+    let item = MasterStatusItem {
+        source,
+        master_id: master.id.clone(),
+        display: DisplayOptions::default(),
+    };
+    let missing = MasterStatusItem {
+        master_id: "c".repeat(64),
+        ..item.clone()
+    };
+    let stale = MasterStatusItem {
+        source: stale_source,
+        ..item.clone()
+    };
+    let Json(response) = post_generation_status(
+        State(fixture.state.clone()),
+        DbContext(fixture.ctx.clone()),
+        Json(MasterStatusRequest {
+            requests: vec![item.clone(), missing, stale],
+        }),
+    )
+    .await
+    .unwrap();
+    let statuses = response.data.unwrap().statuses;
+    assert_eq!(statuses.len(), 3);
+    assert!(statuses
+        .iter()
+        .all(|status| status.state == GenerationState::Error));
+    assert!(statuses[0]
+        .error
+        .as_deref()
+        .unwrap()
+        .contains("generation failed"));
+    assert!(statuses[1]
+        .error
+        .as_deref()
+        .unwrap()
+        .contains("unavailable"));
+    assert!(statuses[2]
+        .error
+        .as_deref()
+        .unwrap()
+        .contains("displayed stack changed"));
+    assert!(matches!(
+        post_generation_status(
+            State(fixture.state.clone()),
+            DbContext(fixture.ctx.clone()),
+            Json(MasterStatusRequest {
+                requests: vec![item; MAX_STATUS_BATCH + 1]
+            })
+        )
+        .await,
+        Err(AppError::BadRequest(_))
+    ));
+    assert!(!job.cache_path.exists());
+}

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -2772,6 +2772,24 @@ fn load_latest_colors(
     }
 }
 
+pub(super) fn retained_calibration_source(
+    ctx: &crate::server::database_context::DatabaseContext,
+    project_id: i32,
+    job_id: &str,
+    revision: &str,
+) -> Result<Option<StackColorJob>, AppError> {
+    Ok(load_latest_colors(ctx, project_id)?
+        .jobs
+        .into_iter()
+        .find(|job| {
+            job.database_id == ctx.id
+                && job.project_id == project_id
+                && job.job_id == job_id
+                && job.artifact_revision == revision
+                && job.state == StackJobState::Completed
+        }))
+}
+
 fn collect_sources(
     cache_root: &FsPath,
     latest: &LatestStackPreviews,

--- a/src/server/stack_preview/stretch.rs
+++ b/src/server/stack_preview/stretch.rs
@@ -171,7 +171,7 @@ fn deconvolution_cache_id(
     Ok(id)
 }
 
-pub(super) fn default_linear_config() -> StretchConfig {
+pub(crate) fn default_linear_config() -> StretchConfig {
     StretchConfig::auto_mtf(
         StretchParams {
             target_median: 0.2,
@@ -189,7 +189,7 @@ pub(super) fn display_identity_config() -> StretchConfig {
     }
 }
 
-struct StretchRender {
+pub(crate) struct StretchRender {
     plan: StretchPlan,
 }
 
@@ -261,7 +261,7 @@ pub(super) fn render_image_previews_atomic_with_progress(
     .and_then(|render| serde_json::to_value(render.plan).map_err(|error| error.to_string()))
 }
 
-pub(super) fn normalize_linear_image(
+pub(crate) fn normalize_linear_image(
     image: &LinearImage,
 ) -> Result<(LinearImage, StackStretchInputRange), String> {
     let sampled_pixels = (STRETCH_ANALYSIS_SAMPLES / image.channels).max(1);
@@ -369,7 +369,7 @@ fn render_previews_with_plan(
     save_png_atomic(&resized, screen_destination)
 }
 
-fn render_dynamic_image(
+pub(crate) fn render_dynamic_image(
     image: &LinearImage,
     config: &StretchConfig,
 ) -> Result<(image::DynamicImage, StretchRender), String> {

--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
+import type { StackCalibrationMasters } from '../src/api/types';
 import {
   registerFixtureDb,
   resetDatabases,
@@ -29,7 +30,7 @@ function fitsNumericValue(header: string, keyword: string): number {
   return Number(card!.slice(10).split('/')[0].trim().replace('D', 'E'));
 }
 
-function writeSyntheticMonoStack(destination: string, variant: number): void {
+function writeSyntheticMonoStack(destination: string, variant: number, calibrationMaster = false): void {
   const width = 512;
   const height = 384;
   const values = new Float32Array(width * height);
@@ -79,6 +80,7 @@ function writeSyntheticMonoStack(destination: string, variant: number): void {
     fitsFloatCard('CD1_2', 0),
     fitsFloatCard('CD2_1', 0),
     fitsFloatCard('CD2_2', -0.0004160277777778),
+    ...(calibrationMaster ? [fitsStringCard('BAYERPAT', 'RGGB')] : []),
     'END'.padEnd(80),
   ];
   const headerText = cards.join('');
@@ -86,14 +88,14 @@ function writeSyntheticMonoStack(destination: string, variant: number): void {
   header.write(headerText, 0, 'ascii');
   const pixels = Buffer.alloc(values.length * 4);
   for (let index = 0; index < values.length; index += 1) {
-    pixels.writeFloatBE(values[index], index * 4);
+    pixels.writeFloatBE(calibrationMaster ? values[index] / 10_000 : values[index], index * 4);
   }
   const padding = Buffer.alloc((2880 - (pixels.length % 2880)) % 2880);
   fs.mkdirSync(path.dirname(destination), { recursive: true });
   fs.writeFileSync(destination, Buffer.concat([header, pixels, padding]));
 }
 
-function seedSyntheticColorStacks(databaseId: string, projectId: number): void {
+function seedSyntheticColorStacks(databaseId: string, projectId: number, withCalibration = false): void {
   const cacheRoot = path.join(
     process.env.PSF_GUARD_E2E_TMP!, 'cache', databaseId, 'stack-previews'
   );
@@ -101,7 +103,30 @@ function seedSyntheticColorStacks(databaseId: string, projectId: number): void {
   const groups = filters.map((filterName, index) => {
     const jobId = (index + 1).toString(16).padStart(64, '0');
     writeSyntheticMonoStack(path.join(cacheRoot, jobId, 'group-0.fits'), index);
-    return {
+    const masterRoot = path.join(process.env.PSF_GUARD_E2E_TMP!, 'cache', databaseId, 'calibration-masters');
+    const bias = `bias-${'1'.repeat(64)}.fits`;
+    const dark = `dark-${'2'.repeat(64)}.fits`;
+    const darkFlat = `dark_flat-${'3'.repeat(64)}.fits`;
+    const flat = `flat-${(40 + index).toString(16).padStart(64, '0')}.fits`;
+    const missingFlat = `flat-${(50 + index).toString(16).padStart(64, '0')}.fits`;
+    const signature = `bias=${bias};dark=${dark};dark_flat=${darkFlat};flat=${flat}`;
+    const missingSignature = `bias=${bias};dark=${dark};dark_flat=${darkFlat};flat=${missingFlat}`;
+    const calibration = {
+      mode: 'auto', state: 'applied', bias_frames: 8, dark_frames: 8, dark_flat_frames: 8, flat_frames: 8,
+      bias_master: null, dark_master: null, dark_flat_master: null, flat_master: null,
+      warning: null, fingerprint: `fixture-${index}`, masters_signature: `${signature}||${missingSignature}`,
+      estimated_pedestal_adu: null, sessions: 2,
+      session_details: [
+        { fingerprint: `session-one-${index}`, masters_signature: signature, estimated_pedestal_adu: null, lights: 2 },
+        { fingerprint: `session-two-${index}`, masters_signature: missingSignature, estimated_pedestal_adu: null, lights: 1 },
+      ],
+    };
+    if (withCalibration) {
+      for (const [masterIndex, name] of [bias, dark, darkFlat, flat].entries()) {
+        writeSyntheticMonoStack(path.join(masterRoot, name), masterIndex, true);
+      }
+    }
+    const remembered = {
       job_id: jobId,
       artifact_revision: `synthetic-${index}`,
       accepted_only: false,
@@ -144,8 +169,20 @@ function seedSyntheticColorStacks(databaseId: string, projectId: number): void {
         error: null,
         input_images: [],
         frames: [],
+        ...(withCalibration ? { calibration } : {}),
       },
     };
+    if (withCalibration) {
+      fs.writeFileSync(path.join(cacheRoot, jobId, 'manifest.json'), JSON.stringify({
+        schema_version: 1, database_id: databaseId, project_id: projectId,
+        job_id: jobId, artifact_revision: remembered.artifact_revision,
+        state: 'completed', accepted_only: false,
+        created_unix_seconds: remembered.created_unix_seconds,
+        cache_version: remembered.cache_version, stacking_version: '0.14.0',
+        groups: [remembered.group], error: null,
+      }));
+    }
+    return remembered;
   });
   fs.mkdirSync(cacheRoot, { recursive: true });
   fs.writeFileSync(
@@ -223,7 +260,7 @@ test('retains RC-Astro color steps in saved setups on desktop and mobile', async
   await mobileTools.screenshot({ path: testInfo.outputPath('rc-astro-color-mobile.png') });
 });
 
-test.beforeEach(async ({ request }) => {
+test.beforeEach(async ({ request }, testInfo) => {
   await resetDatabases(request);
   // Setups are global and survive a database reset.
   const setups = (await (await request.get('/api/processing-setups')).json()).data.setups;
@@ -233,10 +270,99 @@ test.beforeEach(async ({ request }) => {
   }
   const entry = await registerFixtureDb(request, {
     name: 'Stack Preview e2e',
-    slug: 'stack-preview-e2e',
+    // Removing a registry entry preserves its cache; each test needs its own slug.
+    slug: `stack-preview-e2e-${testInfo.line}-${testInfo.repeatEachIndex}-${testInfo.retry}`,
   });
   dbId = entry.id;
   await waitForCacheReady(request, dbId);
+});
+
+test('inspects exact calibration masters across mono sessions and color channels', async ({ page, request }, testInfo) => {
+  test.setTimeout(180_000);
+  seedSyntheticColorStacks(dbId, 2, true);
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.route('**/images/*/preview?*', (route) => route.abort());
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=2`);
+  const catalogResponse = page.waitForResponse((response) => response.url().includes('/calibration-masters?'));
+  await page.getByRole('button', { name: 'Inspect calibration masters for R', exact: true }).click();
+  const catalog: StackCalibrationMasters = (await (await catalogResponse).json()).data;
+  expect(catalog.masters).toHaveLength(5);
+  expect(catalog.masters.filter((master) => master.available)).toHaveLength(4);
+  expect(catalog.masters.find((master) => master.kind === 'bias')?.usages).toHaveLength(2);
+  const dialog = page.getByRole('dialog', { name: /Beta Field/ });
+  const selector = dialog.getByRole('combobox', { name: 'Master' });
+  const image = dialog.getByTestId('stack-inspector-image');
+
+  for (const master of catalog.masters.filter((entry) => entry.available)) {
+    await selector.selectOption(master.id);
+    await expect(image).toHaveAttribute('src', new RegExp(master.id));
+    await expect(image).toBeVisible({ timeout: 30_000 });
+    await expect.poll(() => image.evaluate((element: HTMLImageElement) => element.complete && element.naturalWidth)).toBe(512);
+    const pixels = await image.evaluate((element: HTMLImageElement) => {
+      const canvas = document.createElement('canvas');
+      canvas.width = element.naturalWidth;
+      canvas.height = element.naturalHeight;
+      const context = canvas.getContext('2d')!;
+      context.drawImage(element, 0, 0);
+      const values = context.getImageData(0, 0, canvas.width, canvas.height).data;
+      const levels = new Set<number>();
+      let mono = true;
+      for (let index = 0; index < values.length; index += 4) {
+        levels.add(values[index]);
+        mono &&= values[index] === values[index + 1] && values[index] === values[index + 2];
+      }
+      return { levels: levels.size, mono };
+    });
+    expect(pixels.levels).toBeGreaterThan(32);
+    expect(pixels.mono).toBe(true);
+    const download = await request.get(master.fits_url!);
+    expect(download.ok()).toBe(true);
+    const original = fs.readFileSync(path.join(process.env.PSF_GUARD_E2E_TMP!, 'cache', dbId, 'calibration-masters', master.label));
+    expect(Buffer.compare(await download.body(), original)).toBe(0);
+  }
+
+  const availableFlat = catalog.masters.find((master) => master.kind === 'flat' && master.available)!;
+  await selector.selectOption(availableFlat.id);
+  await expect(image).toHaveAttribute('src', new RegExp(availableFlat.id));
+  await expect(image).toBeVisible();
+  await dialog.getByRole('button', { name: '100%', exact: true }).click();
+  const transform = await image.evaluate((element) => element.style.transform);
+  const midtone = dialog.getByRole('slider', { name: 'Master midtone' });
+  await midtone.focus();
+  for (let step = 0; step < 15; step += 1) await midtone.press('ArrowRight');
+  await expect(image).toHaveAttribute('src', /midtone=0.35/);
+  await expect(image).toBeVisible({ timeout: 30_000 });
+  expect(await image.evaluate((element) => element.style.transform)).toBe(transform);
+  await dialog.screenshot({ path: testInfo.outputPath('calibration-masters-desktop.png') });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await dialog.getByRole('button', { name: 'Fit', exact: true }).click();
+  await expect(dialog).toBeInViewport();
+  await expect(dialog.getByRole('link', { name: 'Download master FITS' })).toBeVisible();
+  expect(await dialog.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+  expect(await dialog.locator('.calibration-master-controls').evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+  expect(await image.evaluate((element) => element.getBoundingClientRect().height)).toBeGreaterThan(100);
+  await dialog.screenshot({ path: testInfo.outputPath('calibration-masters-mobile.png') });
+  await selector.selectOption(catalog.masters.find((master) => !master.available)!.id);
+  await expect(dialog.getByRole('status').filter({ hasText: /master|file|available/i })).toBeVisible();
+  await expect(image).toHaveCount(0);
+  await expect(dialog.getByRole('link', { name: 'Download master FITS' })).toHaveCount(0);
+  await dialog.getByRole('button', { name: 'Close calibration master inspector' }).click();
+
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  const rgb = page.locator('.stack-color-card[data-color-kind="rgb"]').first();
+  await rgb.getByRole('button', { name: 'Build RGB color preview', exact: true }).click();
+  await expect(rgb.locator('[data-stack-color-state]')).toHaveAttribute('data-stack-color-state', 'completed', { timeout: 90_000 });
+  const colorResponse = page.waitForResponse((response) => response.url().includes('/color/') && response.url().includes('/calibration-masters?'));
+  await rgb.getByRole('button', { name: 'Inspect calibration masters for RGB', exact: true }).click();
+  const colorCatalog: StackCalibrationMasters = (await (await colorResponse).json()).data;
+  const sharedBias = colorCatalog.masters.filter((master) => master.kind === 'bias');
+  expect(sharedBias).toHaveLength(1);
+  expect(sharedBias[0].usages).toHaveLength(6);
+  await dialog.getByRole('combobox', { name: 'Master' }).selectOption(sharedBias[0].id);
+  await expect(dialog.getByTestId('stack-inspector-image')).toBeVisible({ timeout: 30_000 });
+  await expect(dialog.locator('.calibration-master-provenance')).toContainText(/Session 2/);
+  await dialog.getByRole('button', { name: 'Close calibration master inspector' }).click();
 });
 
 test('builds a real three-frame Seiza stack and exposes its frame decisions', async ({

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -5333,6 +5333,108 @@
   cursor: crosshair;
 }
 
+.calibration-master-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.calibration-master-entry {
+  padding: 0.5rem 0.7rem;
+}
+
+.calibration-master-inspector .stack-inspector-header h2,
+.calibration-master-inspector .stack-inspector-loading {
+  overflow-wrap: anywhere;
+}
+
+.calibration-master-inspector .stack-inspector-loading {
+  padding: 1rem;
+  text-align: center;
+}
+
+.calibration-master-controls {
+  flex-shrink: 0;
+  max-height: 35%;
+  overflow: auto;
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  font-size: 0.78rem;
+}
+
+.calibration-master-options {
+  display: flex;
+  align-items: end;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.calibration-master-selector {
+  display: grid;
+  gap: 0.3rem;
+  flex: 1 1 18rem;
+  min-width: 0;
+}
+
+.calibration-master-selector select {
+  width: 100%;
+  min-width: 0;
+  padding: 0.35rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text-primary);
+  background: var(--color-bg-input);
+}
+
+.calibration-master-stretch {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.3rem;
+  flex: 0 1 9rem;
+  min-width: 6rem;
+}
+
+.calibration-master-stretch input {
+  grid-column: 1 / -1;
+  width: 100%;
+  min-width: 0;
+}
+
+.calibration-master-provenance {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  margin-top: 0.6rem;
+  overflow-wrap: anywhere;
+}
+
+.calibration-master-provenance > strong {
+  flex-basis: 100%;
+}
+
+.calibration-master-statistics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  width: 100%;
+  color: var(--color-text-muted);
+}
+
+.calibration-master-note {
+  margin: 0.5rem 0 0;
+  overflow-wrap: anywhere;
+}
+
+.calibration-master-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--color-error);
+  overflow-wrap: anywhere;
+}
+
 .stack-artifact-region {
   position: absolute;
   z-index: 3;
@@ -5560,6 +5662,10 @@
   .stack-inspector-hint,
   .stack-inspector-toolbar .stack-preview-download {
     display: none;
+  }
+
+  .calibration-master-inspector .stack-inspector-toolbar .stack-preview-download {
+    display: inline-flex;
   }
 
   .stack-inspector-body {

--- a/static/src/api/__tests__/calibrationMasters.test.ts
+++ b/static/src/api/__tests__/calibrationMasters.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import { apiClient } from '../client';
+
+describe('calibration master API', () => {
+  it.each(['mono', 'color'] as const)('binds %s catalogs to the exact artifact revision', async (kind) => {
+    let received: URL | undefined;
+    server.use(http.get('/api/db/:dbId/stack-previews/*/calibration-masters', ({ request }) => {
+      received = new URL(request.url);
+      return HttpResponse.json({ data: { masters: [], notes: ['No file provenance.'] } });
+    }));
+    const source = kind === 'mono'
+      ? { kind, jobId: 'old job', groupIndex: 3, artifactRevision: 'revision&1' }
+      : { kind, jobId: 'old job', artifactRevision: 'revision&1' };
+    const result = await apiClient.getStackCalibrationMasters('db one', source);
+    expect(received?.pathname).toBe(`/api/db/db%20one/stack-previews/${kind === 'mono' ? 'old%20job/3' : 'color/old%20job'}/calibration-masters`);
+    expect(received?.searchParams.get('revision')).toBe('revision&1');
+    expect(result.notes).toEqual(['No file provenance.']);
+  });
+
+  it('partitions mixed preview requests and restores their original status order', async () => {
+    let imageBody: unknown;
+    let masterBody: unknown;
+    server.use(
+      http.post('/api/db/test/images/generation-status', async ({ request }) => {
+        imageBody = await request.json();
+        return HttpResponse.json({ data: { statuses: [{ state: 'ready' }] } });
+      }),
+      http.post('/api/db/test/stack-previews/calibration-masters/generation-status', async ({ request }) => {
+        masterBody = await request.json();
+        return HttpResponse.json({ data: { statuses: [{ state: 'error', error: 'missing' }, { state: 'generating' }] } });
+      }),
+    );
+    const statuses = await apiClient.getGenerationStatus('test', [
+      { kind: 'calibration_master', source: { kind: 'mono', jobId: 'mono', groupIndex: 4, artifactRevision: 'r1' }, masterId: 'master-one', size: 'original', midtone: 0.3, shadow: -2 },
+      { kind: 'preview', imageId: 7, size: 'screen', color: true },
+      { kind: 'calibration_master', source: { kind: 'color', jobId: 'color', artifactRevision: 'r2' }, masterId: 'master-two', size: 'screen' },
+    ]);
+    expect(statuses).toEqual([{ state: 'error', error: 'missing' }, { state: 'ready' }, { state: 'generating' }]);
+    expect(imageBody).toEqual({ requests: [{ kind: 'preview', image_id: 7, size: 'screen', color: true }] });
+    expect(masterBody).toEqual({ requests: [
+      { source: { kind: 'mono', job_id: 'mono', group_index: 4, artifact_revision: 'r1' }, master_id: 'master-one', size: 'original', midtone: 0.3, shadow: -2 },
+      { source: { kind: 'color', job_id: 'color', artifact_revision: 'r2' }, master_id: 'master-two', size: 'screen' },
+    ] });
+  });
+
+  it.each(['image', 'master'])('retains successful statuses when the %s endpoint fails', async (failed) => {
+    server.use(
+      http.post('/api/db/test/images/generation-status', () => failed === 'image'
+        ? HttpResponse.json({ error: 'Image queue unavailable' }, { status: 503 })
+        : HttpResponse.json({ data: { statuses: [{ state: 'ready' }] } })),
+      http.post('/api/db/test/stack-previews/calibration-masters/generation-status', () => failed === 'master'
+        ? HttpResponse.json({ error: 'Master queue unavailable' }, { status: 503 })
+        : HttpResponse.json({ data: { statuses: [{ state: 'ready' }] } })),
+    );
+    const statuses = await apiClient.getGenerationStatus('test', [
+      { kind: 'preview', imageId: 7, size: 'screen' },
+      { kind: 'calibration_master', source: { kind: 'color', jobId: 'color', artifactRevision: 'r2' }, masterId: 'master-two', size: 'screen' },
+    ]);
+    expect(statuses).toEqual(failed === 'image'
+      ? [{ state: 'generating' }, { state: 'ready' }]
+      : [{ state: 'ready' }, { state: 'generating' }]);
+  });
+
+  it('starts both endpoints without waiting for the image queue to respond', async () => {
+    let releaseImages!: () => void;
+    const imagesReleased = new Promise<void>((resolve) => { releaseImages = resolve; });
+    server.use(
+      http.post('/api/db/test/images/generation-status', async () => {
+        await imagesReleased;
+        return HttpResponse.json({ data: { statuses: [{ state: 'ready' }] } });
+      }),
+      http.post('/api/db/test/stack-previews/calibration-masters/generation-status', () => {
+        releaseImages();
+        return HttpResponse.json({ data: { statuses: [{ state: 'ready' }] } });
+      }),
+    );
+    expect(await apiClient.getGenerationStatus('test', [
+      { kind: 'preview', imageId: 7, size: 'screen' },
+      { kind: 'calibration_master', source: { kind: 'color', jobId: 'color', artifactRevision: 'r2' }, masterId: 'master-two', size: 'screen' },
+    ])).toEqual([{ state: 'ready' }, { state: 'ready' }]);
+  });
+});

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -4,6 +4,8 @@ import { AUTH_REQUIRED_EVENT } from '../auth/events';
 import { getServerUrl } from '../utils/tauri';
 import type {
   CalibrationSettings,
+  CalibrationMasterSource,
+  StackCalibrationMasters,
   ExternalMasterPolicy,
   RemoteImageUploadDirectoryTemplateSource,
   ApiResponse,
@@ -1399,8 +1401,12 @@ export const apiClient = {
     requests: PreviewDescriptor[]
   ): Promise<GenerationStatus[]> => {
     const apiInstance = await getApi();
-    const body = {
-      requests: requests.map((d) => ({
+    const imageRequests = requests.filter((d) => d.kind !== 'calibration_master');
+    const masterRequests = requests.filter((d) => d.kind === 'calibration_master');
+    const imageRequest = imageRequests.length ? apiInstance.post<
+      ApiResponse<{ statuses: GenerationStatus[] }>
+    >(dbPath(dbId, '/images/generation-status'), {
+      requests: imageRequests.map((d) => ({
         image_id: d.imageId,
         kind: d.kind,
         size: d.size,
@@ -1410,11 +1416,56 @@ export const apiClient = {
         max_stars: d.maxStars,
         color: d.color,
       })),
-    };
-    const { data } = await apiInstance.post<
+    }).then(({ data }) => data.data?.statuses ?? []) : Promise.resolve([]);
+    const masterRequest = masterRequests.length ? apiInstance.post<
       ApiResponse<{ statuses: GenerationStatus[] }>
-    >(dbPath(dbId, '/images/generation-status'), body);
-    return data.data?.statuses ?? [];
+    >(dbPath(dbId, '/stack-previews/calibration-masters/generation-status'), {
+      requests: masterRequests.map((d) => ({
+        source: {
+          kind: d.source.kind,
+          job_id: d.source.jobId,
+          ...(d.source.kind === 'mono' ? { group_index: d.source.groupIndex } : {}),
+          artifact_revision: d.source.artifactRevision,
+        },
+        master_id: d.masterId,
+        size: d.size,
+        midtone: d.midtone,
+        shadow: d.shadow,
+      })),
+    }).then(({ data }) => data.data?.statuses ?? []) : Promise.resolve([]);
+    // An unavailable endpoint must not stall unrelated previews in this batch.
+    const [images, masters] = await Promise.allSettled([imageRequest, masterRequest]);
+    const imageStatuses = images.status === 'fulfilled' ? images.value : [];
+    const masterStatuses = masters.status === 'fulfilled' ? masters.value : [];
+    let imageIndex = 0;
+    let masterIndex = 0;
+    return requests.map((d) => (d.kind === 'calibration_master'
+      ? masterStatuses[masterIndex++]
+      : imageStatuses[imageIndex++]) ?? { state: 'generating' });
+  },
+
+  getStackCalibrationMasters: async (
+    dbId: string,
+    source: CalibrationMasterSource
+  ): Promise<StackCalibrationMasters> => {
+    const apiInstance = await getApi();
+    const artifactPath = source.kind === 'mono'
+      ? `${encodeURIComponent(source.jobId)}/${source.groupIndex}`
+      : `color/${encodeURIComponent(source.jobId)}`;
+    const { data } = await apiInstance.get<ApiResponse<StackCalibrationMasters>>(
+      dbPath(dbId, `/stack-previews/${artifactPath}/calibration-masters`),
+      { params: { revision: source.artifactRevision } }
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to load calibration masters');
+    return {
+      ...data.data,
+      masters: data.data.masters.map((master) => ({
+        ...master,
+        preview_url: master.preview_url ? withServerUrl(master.preview_url) : null,
+        original_preview_url: master.original_preview_url ? withServerUrl(master.original_preview_url) : null,
+        fits_url: master.fits_url ? withServerUrl(master.fits_url) : null,
+      })),
+    };
   },
 
   getPreviewUrl: (dbId: string, imageId: number, options?: PreviewOptions): string => {

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -374,7 +374,7 @@ export interface GenerationStatus {
 
 // Identifies one artifact for the batch generation-status poll. Mirrors the
 // query params of getPreviewUrl / getAnnotatedUrl.
-export interface PreviewDescriptor {
+export interface ImagePreviewDescriptor {
   imageId: number;
   kind: 'preview' | 'annotated';
   size: 'screen' | 'large' | 'original';
@@ -388,6 +388,49 @@ export interface PreviewDescriptor {
    * the wrong artifact.
    */
   color?: boolean;
+}
+
+export type CalibrationMasterSource =
+  | { kind: 'mono'; jobId: string; groupIndex: number; artifactRevision: string }
+  | { kind: 'color'; jobId: string; artifactRevision: string };
+
+export interface CalibrationMasterPreviewDescriptor {
+  kind: 'calibration_master';
+  source: CalibrationMasterSource;
+  masterId: string;
+  size: 'screen' | 'original';
+  midtone?: number;
+  shadow?: number;
+}
+
+export type PreviewDescriptor = ImagePreviewDescriptor | CalibrationMasterPreviewDescriptor;
+
+export interface StackCalibrationMaster {
+  id: string;
+  kind: 'bias' | 'dark' | 'dark_flat' | 'flat';
+  label: string;
+  available: boolean;
+  unavailable_reason: string | null;
+  usages: Array<{
+    channel: string;
+    session: number;
+    lights: number;
+    estimated_pedestal_adu: number | null;
+  }>;
+  preview_url: string | null;
+  original_preview_url: string | null;
+  fits_url: string | null;
+  source_count: number | null;
+  rejection_method: string | null;
+  masked_samples: number | null;
+  rejected_samples: number | null;
+  minimum_clean_samples: number | null;
+  maximum_clean_samples: number | null;
+}
+
+export interface StackCalibrationMasters {
+  masters: StackCalibrationMaster[];
+  notes: string[];
 }
 
 export type StackJobState = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';

--- a/static/src/components/CalibrationMasterInspector.tsx
+++ b/static/src/components/CalibrationMasterInspector.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Layers, RotateCcw } from 'lucide-react';
+import { apiClient } from '../api/client';
+import type { CalibrationMasterSource, StackCalibrationMaster } from '../api/types';
+import StackPreviewInspector from './StackPreviewInspector';
+
+interface Inspection {
+  dbId: string;
+  source: CalibrationMasterSource;
+  title: string;
+  label: string;
+}
+
+const kindLabels: Record<StackCalibrationMaster['kind'], string> = {
+  bias: 'Bias', dark: 'Dark', dark_flat: 'Dark-flat', flat: 'Flat',
+};
+
+function usageLabel(master: StackCalibrationMaster): string {
+  return master.usages.map((usage) => `${usage.channel} / Session ${usage.session}`).join(', ');
+}
+
+function stretchUrl(url: string | null, midtone: number, shadow: number): string | null {
+  if (!url) return null;
+  const [path, query = ''] = url.split('?');
+  const params = new URLSearchParams(query);
+  params.set('midtone', String(midtone));
+  params.set('shadow', String(shadow));
+  return `${path}?${params}`;
+}
+
+export function CalibrationMasterInspector({ dbId, source, title, label, onClose }: Inspection & {
+  onClose: () => void;
+}) {
+  const catalog = useQuery({
+    queryKey: ['db', dbId, 'stack-calibration-masters', source],
+    queryFn: () => apiClient.getStackCalibrationMasters(dbId, source),
+    retry: false,
+  });
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [draftStretch, setDraftStretch] = useState({ midtone: 0.2, shadow: -2.8 });
+  const [stretch, setStretch] = useState(draftStretch);
+  useEffect(() => {
+    const timer = setTimeout(() => setStretch(draftStretch), 250);
+    return () => clearTimeout(timer);
+  }, [draftStretch]);
+  const masters = catalog.data?.masters ?? [];
+  const master = masters.find((entry) => entry.id === selectedId)
+    ?? masters.find((entry) => entry.available && entry.kind === 'flat')
+    ?? masters.find((entry) => entry.available)
+    ?? masters[0];
+  const masterLabel = master ? kindLabels[master.kind] : 'Calibration masters';
+  const imageUrl = master?.available
+    ? stretchUrl(master.original_preview_url, stretch.midtone, stretch.shadow)
+    : null;
+  const summary = master ? [
+    ...(master.source_count != null ? [`${master.source_count} source frames`] : []),
+    ...(master.rejection_method ? [master.rejection_method] : []),
+    ...(master.masked_samples != null ? [`${master.masked_samples.toLocaleString()} masked samples`] : []),
+    ...(master.rejected_samples != null ? [`${master.rejected_samples.toLocaleString()} rejected samples`] : []),
+    ...(master.minimum_clean_samples != null && master.maximum_clean_samples != null
+      ? [`${master.minimum_clean_samples}-${master.maximum_clean_samples} retained samples / pixel`] : []),
+  ] : [];
+  const emptyMessage = catalog.isPending ? 'Loading calibration masters...'
+    : catalog.isError ? 'Calibration masters could not be loaded.'
+      : !master ? 'No calibration master files were recorded for this stack.'
+        : master.unavailable_reason || 'This calibration master is unavailable.';
+
+  return (
+    <StackPreviewInspector
+      className="calibration-master-inspector"
+      eyebrow="Applied calibration"
+      title={title}
+      label={`${label} / ${masterLabel}`}
+      summary={[]}
+      imageUrl={imageUrl}
+      imageIdentity={master ? `${dbId}:${source.artifactRevision}:${master.id}` : undefined}
+      fitsUrl={master?.available ? master.fits_url : null}
+      imageAlt={`${masterLabel} master for ${title}`}
+      downloadLabel="Download master FITS"
+      closeLabel="Close calibration master inspector"
+      loadingMessage="Loading calibration master..."
+      errorMessage="The calibration master preview could not be loaded."
+      emptyMessage={emptyMessage}
+      asyncPreview={master && imageUrl ? {
+        dbId,
+        descriptor: {
+          kind: 'calibration_master', source, masterId: master.id, size: 'original', ...stretch,
+        },
+      } : undefined}
+      controls={(
+        <div className="calibration-master-controls">
+          {masters.length > 0 && (
+            <div className="calibration-master-options">
+              <label className="calibration-master-selector">
+                Master
+                <select value={master.id} onChange={(event) => setSelectedId(event.target.value)}>
+                  {masters.map((entry) => (
+                    <option key={entry.id} value={entry.id}>
+                      {kindLabels[entry.kind]} / {usageLabel(entry)}{entry.available ? '' : ' (unavailable)'}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="calibration-master-stretch">
+                Midtone <output>{draftStretch.midtone.toFixed(2)}</output>
+                <input type="range" aria-label="Master midtone" min="0.01" max="0.99" step="0.01"
+                  value={draftStretch.midtone} disabled={!imageUrl}
+                  onChange={(event) => setDraftStretch((current) => ({ ...current, midtone: Number(event.target.value) }))} />
+              </label>
+              <label className="calibration-master-stretch">
+                Shadows <output>{draftStretch.shadow.toFixed(1)}</output>
+                <input type="range" aria-label="Master shadows" min="-10" max="0" step="0.1"
+                  value={draftStretch.shadow} disabled={!imageUrl}
+                  onChange={(event) => setDraftStretch((current) => ({ ...current, shadow: Number(event.target.value) }))} />
+              </label>
+              <button type="button" className="stack-preview-card-action" title="Reset master stretch"
+                aria-label="Reset master stretch" disabled={!imageUrl}
+                onClick={() => setDraftStretch({ midtone: 0.2, shadow: -2.8 })}>
+                <RotateCcw size={16} aria-hidden="true" />
+              </button>
+            </div>
+          )}
+          {master && (
+            <div className="calibration-master-provenance">
+              <strong>{master.label}</strong>
+              {master.usages.map((usage, index) => (
+                <span key={`${usage.channel}:${usage.session}:${index}`}>
+                  {usage.channel} / Session {usage.session}: {usage.lights} light frames
+                  {usage.estimated_pedestal_adu != null && ` / Estimated pedestal ${usage.estimated_pedestal_adu.toFixed(1)} ADU`}
+                </span>
+              ))}
+              <div className="calibration-master-statistics">
+                {summary.map((item) => <span key={item}>{item}</span>)}
+              </div>
+            </div>
+          )}
+          {catalog.data?.notes.map((note, index) => <p className="calibration-master-note" key={index}>{note}</p>)}
+          {catalog.isError && (
+            <div className="calibration-master-error" role="alert">
+              <span>{catalog.error instanceof Error ? catalog.error.message : 'Unable to read calibration provenance.'}</span>
+              <button type="button" className="stack-preview-card-action" onClick={() => void catalog.refetch()}
+                disabled={catalog.isFetching} title="Retry loading calibration masters" aria-label="Retry loading calibration masters">
+                <RotateCcw size={16} aria-hidden="true" />
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      onClose={onClose}
+    />
+  );
+}
+
+export default function CalibrationMasterButton(props: Inspection) {
+  const [inspection, setInspection] = useState<Inspection | null>(null);
+  return (
+    <>
+      <button className="stack-preview-card-action calibration-master-button" type="button"
+        title="Inspect applied calibration masters" aria-label={`Inspect calibration masters for ${props.label}`}
+        onClick={() => setInspection({ ...props })}>
+        <Layers size={15} aria-hidden="true" /> Masters
+      </button>
+      {inspection && <CalibrationMasterInspector {...inspection} onClose={() => setInspection(null)} />}
+    </>
+  );
+}

--- a/static/src/components/StackColorPreviewPanel.tsx
+++ b/static/src/components/StackColorPreviewPanel.tsx
@@ -11,6 +11,7 @@ import type {
   StackNarrowbandPalette,
 } from '../api/types';
 import StackPreviewInspector from './StackPreviewInspector';
+import CalibrationMasterButton from './CalibrationMasterInspector';
 import StackColorProcessingControls from './StackColorProcessingControls';
 import {
   processingForColorBuild,
@@ -356,6 +357,16 @@ function ColorCard({
             </span>
           ))}
           {artifact && <span className="stack-color-source-total"><strong>{sourceFrames}</strong> integrated inputs</span>}
+        </div>
+      )}
+      {artifact && (
+        <div className="calibration-master-entry">
+          <CalibrationMasterButton
+            dbId={dbId}
+            source={{ kind: 'color', jobId: artifact.job_id, artifactRevision: artifact.artifact_revision }}
+            title={artifact.target_name}
+            label={artifact.label}
+          />
         </div>
       )}
     </article>

--- a/static/src/components/StackPreviewInspector.tsx
+++ b/static/src/components/StackPreviewInspector.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   MouseEvent as ReactMouseEvent,
   TouchEvent as ReactTouchEvent,
+  ReactNode,
 } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { apiClient } from '../api/client';
-import type { ArtifactSearchJob, ArtifactSearchResult, ReferenceRegion } from '../api/types';
+import type { ArtifactSearchJob, ArtifactSearchResult, PreviewDescriptor, ReferenceRegion } from '../api/types';
 import { useImageZoom } from '../hooks/useImageZoom';
+import { useAsyncImage } from '../hooks/useAsyncImage';
 import { morphologyLabel } from './artifactMorphology';
 import {
   artifactRegionFromPoints,
@@ -33,16 +35,24 @@ export type StackArtifactSource =
     };
 
 interface StackPreviewInspectorProps {
+  className?: string;
   eyebrow: string;
   title: string;
   label: string;
   summary: string[];
-  imageUrl: string;
-  fitsUrl: string;
+  imageUrl: string | null;
+  fitsUrl: string | null;
   imageAlt: string;
   downloadLabel: string;
   artifactSource?: StackArtifactSource;
   artifactEnabled?: boolean;
+  controls?: ReactNode;
+  asyncPreview?: { dbId: string; descriptor: PreviewDescriptor };
+  imageIdentity?: string;
+  emptyMessage?: string;
+  loadingMessage?: string;
+  errorMessage?: string;
+  closeLabel?: string;
   onOpenImage?: (imageId: number) => void;
   onClose: () => void;
 }
@@ -72,6 +82,7 @@ function ArtifactMorphologyBadge({ result }: { result: ArtifactSearchResult }) {
 }
 
 export default function StackPreviewInspector({
+  className = '',
   eyebrow,
   title,
   label,
@@ -82,11 +93,20 @@ export default function StackPreviewInspector({
   downloadLabel,
   artifactSource,
   artifactEnabled = false,
+  controls,
+  asyncPreview,
+  imageIdentity,
+  emptyMessage,
+  loadingMessage = 'Loading full-resolution stack…',
+  errorMessage = 'The full-resolution stack could not be loaded.',
+  closeLabel = 'Close stack inspector',
   onOpenImage,
   onClose,
 }: StackPreviewInspectorProps) {
-  const [loaded, setLoaded] = useState(false);
-  const [error, setError] = useState(false);
+  const image = useAsyncImage(asyncPreview?.dbId, imageUrl ?? '', asyncPreview?.descriptor);
+  const loaded = image.state === 'ready';
+  const error = image.state === 'error';
+  const loadedIdentity = useRef<string | null>(null);
   const [dimensions, setDimensions] = useState<{ width: number; height: number } | null>(null);
   const [selecting, setSelecting] = useState(false);
   const [dragStart, setDragStart] = useState<ImagePoint | null>(null);
@@ -114,8 +134,6 @@ export default function StackPreviewInspector({
   }, [zoom.containerRef]);
 
   useEffect(() => {
-    setLoaded(false);
-    setError(false);
     setDimensions(null);
     setSelecting(false);
     setDragStart(null);
@@ -289,7 +307,7 @@ export default function StackPreviewInspector({
   return (
     <div className="stack-inspector-overlay" role="presentation" onClick={onClose}>
       <section
-        className={`stack-inspector ${activeSearch ? 'with-artifact-results' : ''}`}
+        className={`stack-inspector ${activeSearch ? 'with-artifact-results' : ''} ${className}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby="stack-inspector-title"
@@ -306,10 +324,12 @@ export default function StackPreviewInspector({
             {summary.map((item) => <span key={item}>{item}</span>)}
             {dimensions && <span>{dimensions.width} × {dimensions.height}</span>}
           </div>
-          <button className="close-button" type="button" onClick={onClose} aria-label="Close stack inspector">
+          <button className="close-button" type="button" onClick={onClose} aria-label={closeLabel}>
             ×
           </button>
         </header>
+
+        {controls}
 
         <div className="stack-inspector-body">
           <div
@@ -330,31 +350,35 @@ export default function StackPreviewInspector({
             onKeyDown={zoom.handleKeyDown}
             tabIndex={0}
           >
-            {!loaded && !error && (
+            {!imageUrl ? (
+              <div className="stack-inspector-loading" role="status">{emptyMessage}</div>
+            ) : !loaded && !error && (
               <div className="stack-inspector-loading">
                 <span className="stack-preview-spinner" aria-hidden="true" />
-                Loading full-resolution stack…
+                {image.state === 'generating' ? 'Generating preview…' : loadingMessage}
               </div>
             )}
             {error ? (
               <div className="stack-inspector-loading error" role="alert">
-                The full-resolution stack could not be loaded.
+                {image.error || errorMessage}
               </div>
-            ) : (
+            ) : imageUrl && (
               <img
                 ref={zoom.imageRef}
-                src={imageUrl}
+                src={image.src}
                 alt={imageAlt}
                 data-testid="stack-inspector-image"
                 draggable={false}
-                onError={() => setError(true)}
+                onError={image.onError}
                 onLoad={(event) => {
                   const { naturalWidth: width, naturalHeight: height } = event.currentTarget;
                   if (!width || !height) return;
                   setDimensions({ width, height });
                   zoom.setImageDimensions(width, height, true);
-                  zoom.applyBitmapDimensions(width, height, 'fit');
-                  setLoaded(true);
+                  const identity = imageIdentity ?? imageUrl;
+                  zoom.applyBitmapDimensions(width, height, loadedIdentity.current === identity ? 'preserve' : 'fit');
+                  loadedIdentity.current = identity;
+                  image.onLoad();
                 }}
                 style={{
                   visibility: loaded ? 'visible' : 'hidden',
@@ -507,7 +531,7 @@ export default function StackPreviewInspector({
               {startSearch.error instanceof Error ? startSearch.error.message : 'Search failed'}
             </span>
           )}
-          <a className="stack-preview-download" href={fitsUrl} download>{downloadLabel}</a>
+          {fitsUrl && <a className="stack-preview-download" href={fitsUrl} download>{downloadLabel}</a>}
           <div className="zoom-info-compact">
             <span className="zoom-percentage-compact">{zoom.getZoomPercentage()}%</span>
           </div>

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -14,6 +14,7 @@ import type {
   StackStretchPreview,
 } from '../api/types';
 import StackPreviewInspector from './StackPreviewInspector';
+import CalibrationMasterButton from './CalibrationMasterInspector';
 import StackSnrCurve from './StackSnrCurve';
 import StackColorPreviewPanel from './StackColorPreviewPanel';
 import StackStretchControls from './StackStretchControls';
@@ -886,7 +887,7 @@ export default function StackPreviewPanel({
                 const progressGroup = activeGroup ?? artifact?.group;
                 const liveCurve = groupBusy ? activeGroup?.snr : null;
                 const artifactCurve = artifact?.group.snr;
-                const calibration = progressGroup?.calibration;
+                  const calibration = artifact ? artifact.group.calibration : progressGroup?.calibration;
                 const progressState = progressGroup?.state ?? 'not-built';
                 const processedFrames = progressGroup?.processed_frames ?? 0;
                 const eligibleFrames =
@@ -1207,6 +1208,14 @@ export default function StackPreviewPanel({
 
                     {artifact && (
                       <>
+                        <div className="calibration-master-entry">
+                          <CalibrationMasterButton
+                            dbId={dbId}
+                            source={{ kind: 'mono', jobId: artifact.jobId, groupIndex: artifact.group.index, artifactRevision: artifact.artifactRevision }}
+                            title={artifact.group.target_name}
+                            label={artifact.group.filter_name || 'No filter'}
+                          />
+                        </div>
                         <details className="stack-preview-details">
                           <summary>Frame decisions ({artifact.group.frames.length})</summary>
                           <div className="stack-frame-table-wrap">

--- a/static/src/components/__tests__/CalibrationMasterInspector.test.tsx
+++ b/static/src/components/__tests__/CalibrationMasterInspector.test.tsx
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiClient } from '../../api/client';
+import type { CalibrationMasterSource, StackCalibrationMaster } from '../../api/types';
+import { __resetForTest } from '../../hooks/previewPoll';
+import CalibrationMasterButton, { CalibrationMasterInspector } from '../CalibrationMasterInspector';
+
+const source: CalibrationMasterSource = { kind: 'mono', jobId: 'job-old', groupIndex: 2, artifactRevision: 'revision-old' };
+const flat: StackCalibrationMaster = {
+  id: 'a'.repeat(64), kind: 'flat', label: 'Flat R - first night', available: true,
+  unavailable_reason: null,
+  usages: [{ channel: 'R', session: 1, lights: 10, estimated_pedestal_adu: null },
+    { channel: 'R', session: 2, lights: 8, estimated_pedestal_adu: 201.5 }],
+  preview_url: '/flat.png?revision=old', original_preview_url: '/flat-original.png?revision=old',
+  fits_url: '/flat.fits?revision=old', source_count: 12, rejection_method: 'delta-sigma',
+  masked_samples: 20, rejected_samples: 4, minimum_clean_samples: 2, maximum_clean_samples: 12,
+};
+const bias: StackCalibrationMaster = {
+  ...flat, id: 'b'.repeat(64), kind: 'bias', label: 'Bias master',
+  original_preview_url: '/bias-original.png?revision=old', fits_url: '/bias.fits?revision=old',
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function mountInspector() {
+  return render(<CalibrationMasterInspector dbId="fixture" source={source} title="M42" label="R" onClose={vi.fn()} />, { wrapper });
+}
+
+function loadImage() {
+  const image = screen.getByTestId('stack-inspector-image') as HTMLImageElement;
+  Object.defineProperties(image, {
+    naturalWidth: { configurable: true, value: 512 },
+    naturalHeight: { configurable: true, value: 256 },
+  });
+  Object.defineProperty(image.parentElement, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({ x: 0, y: 0, left: 0, top: 0, right: 256, bottom: 256, width: 256, height: 256 }),
+  });
+  fireEvent.load(image);
+  return image;
+}
+
+beforeEach(() => {
+  vi.spyOn(apiClient, 'getStackCalibrationMasters').mockResolvedValue({ masters: [bias, flat], notes: [] });
+});
+
+afterEach(() => {
+  __resetForTest();
+  vi.restoreAllMocks();
+});
+
+describe('CalibrationMasterInspector', () => {
+  it('shows the exact master once with every session, diagnostics and raw FITS', async () => {
+    mountInspector();
+    expect(await screen.findByRole('combobox', { name: 'Master' })).toHaveValue(flat.id);
+    expect(apiClient.getStackCalibrationMasters).toHaveBeenCalledWith('fixture', source);
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+    expect(screen.getByText('R / Session 1: 10 light frames')).toBeInTheDocument();
+    expect(screen.getByText('R / Session 2: 8 light frames / Estimated pedestal 201.5 ADU')).toBeInTheDocument();
+    expect(screen.getByText('20 masked samples')).toBeInTheDocument();
+    expect(screen.getByText('2-12 retained samples / pixel')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Download master FITS' })).toHaveAttribute('href', flat.fits_url);
+    expect(screen.queryByRole('button', { name: 'Find source artifact' })).not.toBeInTheDocument();
+  });
+
+  it('retains unavailable masters without substituting or downloading a different file', async () => {
+    vi.mocked(apiClient.getStackCalibrationMasters).mockResolvedValue({
+      masters: [flat, { ...bias, available: false, unavailable_reason: 'The recorded file was removed.', original_preview_url: null, fits_url: null }],
+      notes: [],
+    });
+    mountInspector();
+    fireEvent.change(await screen.findByRole('combobox'), { target: { value: bias.id } });
+    expect(screen.getByText('The recorded file was removed.')).toHaveAttribute('role', 'status');
+    expect(screen.queryByTestId('stack-inspector-image')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Download master FITS' })).not.toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'Master midtone' })).toBeDisabled();
+  });
+
+  it('surfaces catalog failures and can retry into a legacy/no-file explanation', async () => {
+    vi.mocked(apiClient.getStackCalibrationMasters).mockRejectedValueOnce(new Error('Stack artifact changed.'))
+      .mockResolvedValueOnce({ masters: [], notes: ['Estimated pedestal only; no bias master was applied.'] });
+    mountInspector();
+    expect(await screen.findByRole('alert')).toHaveTextContent('Stack artifact changed.');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading calibration masters' }));
+    expect(await screen.findByText('Estimated pedestal only; no bias master was applied.')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('No calibration master files were recorded');
+  });
+
+  it('uses shared generation polling and reports terminal generation errors', async () => {
+    const status = vi.spyOn(apiClient, 'getGenerationStatus').mockResolvedValue([{ state: 'ready' }]);
+    mountInspector();
+    const image = await screen.findByTestId('stack-inspector-image');
+    fireEvent.error(image);
+    await waitFor(() => expect(image.getAttribute('src')).toContain('&v=1'));
+    expect(status).toHaveBeenCalledWith('fixture', [{
+      kind: 'calibration_master', source, masterId: flat.id, size: 'original', midtone: 0.2, shadow: -2.8,
+    }]);
+    status.mockResolvedValue([{ state: 'error', error: 'The recorded master no longer exists.' }]);
+    fireEvent.error(image);
+    expect(await screen.findByRole('alert')).toHaveTextContent('The recorded master no longer exists.');
+  });
+
+  it('preserves the inspected pixels across display stretch changes and resets for another master', async () => {
+    mountInspector();
+    await screen.findByTestId('stack-inspector-image');
+    const image = loadImage();
+    const fittedTransform = image.style.transform;
+    fireEvent.click(screen.getByRole('button', { name: '100%' }));
+    const transform = image.style.transform;
+    expect(transform).toContain('scale(1)');
+    fireEvent.change(screen.getByRole('slider', { name: 'Master midtone' }), { target: { value: '0.35' } });
+    await waitFor(() => expect(image.getAttribute('src')).toContain('midtone=0.35'));
+    loadImage();
+    expect(image.style.transform).toBe(transform);
+    expect(screen.getByRole('link', { name: 'Download master FITS' })).toHaveAttribute('href', flat.fits_url);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: bias.id } });
+    loadImage();
+    expect(image.style.transform).toBe(fittedTransform);
+  });
+
+  it('pins the action to the displayed artifact even if a rebuild replaces the card', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const element = (revision: string) => <QueryClientProvider client={client}>
+      <CalibrationMasterButton dbId="fixture" source={{ ...source, artifactRevision: revision }} title="M42" label="R" />
+    </QueryClientProvider>;
+    const view = render(element('old'));
+    fireEvent.click(screen.getByRole('button', { name: 'Inspect calibration masters for R' }));
+    await screen.findByRole('combobox');
+    view.rerender(element('new'));
+    await act(async () => {});
+    expect(apiClient.getStackCalibrationMasters).toHaveBeenCalledTimes(1);
+    expect(apiClient.getStackCalibrationMasters).toHaveBeenLastCalledWith('fixture', { ...source, artifactRevision: 'old' });
+  });
+});

--- a/static/src/components/__tests__/StackPreviewPanel.adopt.test.tsx
+++ b/static/src/components/__tests__/StackPreviewPanel.adopt.test.tsx
@@ -54,6 +54,42 @@ const runningGroup = {
 };
 
 describe('StackPreviewPanel job adoption', () => {
+  it('keeps calibration inspection and summary bound to the displayed artifact during a rebuild', async () => {
+    let inspectedRevision: string | null = null;
+    server.use(
+      http.get('/api/stack-activity', () => ok({ schema_version: 1, active: [{
+        kind: 'mono', job_id: 'rebuild', database_id: 'test', project_id: 1, state: 'running',
+        label: 'Sh2 86 Ha', detail: 'Registering frames', processed_units: 1, total_units: 2, created_unix_seconds: 100,
+      }] })),
+      http.get('/api/db/test/projects/1/stack-previews/latest', () => ok({ groups: [{
+        job_id: 'displayed', artifact_revision: 'displayed-revision', accepted_only: false,
+        group: { ...runningGroup, state: 'ready', phase: 'ready', calibration: {
+          ...runningGroup.calibration, state: 'applied', bias_frames: 20, flat_frames: 5,
+        } },
+      }] })),
+      http.get('/api/db/test/projects/1/stack-previews/color', () => ok({ targets: [], jobs: [] })),
+      http.get('/api/db/test/projects/1/stack-previews/rebuild', () => ok({
+        job_id: 'rebuild', database_id: 'test', project_id: 1, state: 'running', accepted_only: false,
+        artifact_revision: 'new-revision', groups: [{ ...runningGroup, calibration: {
+          ...runningGroup.calibration, state: 'incomplete', bias_frames: 999,
+        } }], error: null,
+      })),
+      http.get('/api/db/test/stack-previews/displayed/0/stretch', () => ok(null)),
+      http.get('/api/db/test/stack-previews/displayed/0/calibration-masters', ({ request }) => {
+        inspectedRevision = new URL(request.url).searchParams.get('revision');
+        return ok({ masters: [], notes: ['Recorded displayed calibration.'] });
+      }),
+    );
+    render(<StackPreviewPanel dbId="test" projectId={1} images={images} selectionSource="visible" onOpenImage={() => undefined} />, { wrapper: wrapper() });
+    await screen.findByText('1/2 frames');
+    expect(screen.getByText('Calibration applied')).toBeInTheDocument();
+    expect(screen.queryByText('Calibration set incomplete')).not.toBeInTheDocument();
+    expect(screen.getByText('20 bias · 0 dark · 0 dark-flat · 5 flat')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Inspect calibration masters for Ha' }));
+    await screen.findByText('Recorded displayed calibration.');
+    expect(inspectedRevision).toBe('displayed-revision');
+  });
+
   it('restores revision-scoped processing on reload and durably reverts without running tools', async () => {
     const user = userEvent.setup();
     let posts = 0;

--- a/static/src/hooks/__tests__/previewPoll.test.ts
+++ b/static/src/hooks/__tests__/previewPoll.test.ts
@@ -13,7 +13,7 @@ import {
   __resetForTest,
 } from '../previewPoll';
 import { apiClient } from '../../api/client';
-import type { PreviewDescriptor, GenerationStatus } from '../../api/types';
+import type { PreviewDescriptor, GenerationStatus, CalibrationMasterPreviewDescriptor } from '../../api/types';
 
 const preview = (imageId: number): PreviewDescriptor => ({
   imageId,
@@ -123,5 +123,41 @@ describe('previewPoll coordinator', () => {
     expect(descriptorKey(preview(1))).not.toBe(
       descriptorKey({ imageId: 1, kind: 'preview', size: 'large' })
     );
+  });
+
+  it('keys calibration previews by exact provenance and display stretch', () => {
+    const master: CalibrationMasterPreviewDescriptor = {
+      kind: 'calibration_master', masterId: 'same-master', size: 'original', midtone: 0.2,
+      source: { kind: 'mono', jobId: 'job', groupIndex: 0, artifactRevision: 'old' },
+    };
+    const variants: CalibrationMasterPreviewDescriptor[] = [
+      { ...master, source: { ...master.source, artifactRevision: 'new' } },
+      { ...master, source: { kind: 'mono', jobId: 'job', groupIndex: 1, artifactRevision: 'old' } },
+      { ...master, source: { kind: 'color', jobId: 'job', artifactRevision: 'old' } },
+      { ...master, masterId: 'another-master' },
+      { ...master, size: 'screen' },
+      { ...master, midtone: 0.4 },
+      { ...master, shadow: -2 },
+    ];
+    expect(new Set([master, ...variants].map(descriptorKey)).size).toBe(8);
+  });
+
+  it('drops an old master subscriber when selection changes while polling', async () => {
+    let resolveStatus!: (statuses: GenerationStatus[]) => void;
+    statusSpy.mockImplementationOnce(() => new Promise((resolve) => { resolveStatus = resolve; }))
+      .mockResolvedValue([{ state: 'ready' }]);
+    const master: CalibrationMasterPreviewDescriptor = {
+      kind: 'calibration_master', masterId: 'old', size: 'original',
+      source: { kind: 'color', jobId: 'job', artifactRevision: 'r' },
+    };
+    const oldReady = vi.fn();
+    const newReady = vi.fn();
+    const unregister = registerPending('db1', master, { onReady: oldReady, onError: vi.fn() });
+    unregister();
+    registerPending('db1', { ...master, masterId: 'new' }, { onReady: newReady, onError: vi.fn() });
+    resolveStatus([{ state: 'ready' }]);
+    await vi.advanceTimersByTimeAsync(900);
+    expect(oldReady).not.toHaveBeenCalled();
+    expect(newReady).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/src/hooks/previewPoll.ts
+++ b/static/src/hooks/previewPoll.ts
@@ -45,6 +45,13 @@ export function __resetForTest(): void {
 }
 
 export function descriptorKey(d: PreviewDescriptor): string {
+  if (d.kind === 'calibration_master') {
+    return JSON.stringify([
+      d.kind, d.source.kind, d.source.jobId,
+      d.source.kind === 'mono' ? d.source.groupIndex : null,
+      d.source.artifactRevision, d.masterId, d.size, d.midtone ?? '', d.shadow ?? '',
+    ]);
+  }
   return [
     d.kind,
     d.imageId,

--- a/static/src/hooks/useAsyncImage.ts
+++ b/static/src/hooks/useAsyncImage.ts
@@ -35,7 +35,7 @@ interface AsyncImageRecord {
 export function useAsyncImage(
   dbId: string | null | undefined,
   src: string,
-  descriptor: PreviewDescriptor
+  descriptor?: PreviewDescriptor
 ): AsyncImageResult {
   const [record, setRecord] = useState<AsyncImageRecord>(() => ({
     baseSrc: src,
@@ -73,7 +73,7 @@ export function useAsyncImage(
 
   const onError = useCallback(() => {
     unregisterRef.current?.();
-    if (!dbId) {
+    if (!dbId || !descRef.current) {
       unregisterRef.current = null;
       setRecord((current) => ({
         baseSrc: src,

--- a/tests/integration_server_auth.rs
+++ b/tests/integration_server_auth.rs
@@ -15,6 +15,7 @@ use psf_guard::{
     server::{
         auth::{self, ServerAuth},
         handlers, organization,
+        stack_preview::calibration_masters,
         state::AppState,
         user_admin,
     },
@@ -78,6 +79,10 @@ fn app_with_management(config: ServerAuthConfig, allow_management: bool) -> Rout
             post(organization::preview),
         )
         .route("/db/{db_id}/organization/apply", post(organization::apply))
+        .route(
+            "/db/{db_id}/stack-previews/calibration-masters/generation-status",
+            post(calibration_masters::post_generation_status),
+        )
         .route(
             "/catalog",
             get(|| async { "catalog" }).put(|| async { "changed" }),
@@ -216,6 +221,18 @@ async fn viewer_compute_is_separate_from_read_access() {
         app.clone().oneshot(compute).await.unwrap().status(),
         StatusCode::FORBIDDEN
     );
+
+    let poll = Request::builder()
+        .method(Method::POST)
+        .uri("/api/db/test/stack-previews/calibration-masters/generation-status")
+        .header(COOKIE, &viewer_cookie)
+        .header("content-type", "application/json")
+        .body(Body::from(r#"{"requests":[]}"#))
+        .unwrap();
+    let (status, _, body) = json(&app, poll).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["statuses"], serde_json::json!([]));
 
     let mut config = auth_config();
     config.allow_read_only_compute = true;


### PR DESCRIPTION
## Summary
- Add a Masters action to completed mono and color stacks, with master selection, native-size pan/zoom, display-only midtone and shadow controls, and unchanged cached FITS downloads.
- Follow the displayed artifact's recorded per-session and per-channel master references. Deduplicate shared files while retaining their usage and fitted pedestal context; show available source counts and rejection/masking statistics.
- Preserve floating-point detail and the native CFA sensor grid when rendering masters. Generate previews on the existing bounded queue and poll through the shared coordinator.
- Report missing files and incomplete historical provenance explicitly, without resolving today's library, rebuilding masters, or changing catalog data.
- Document inspection and correct the obsolete single-master-set description.

## Review
Independent backend and frontend reviews completed. Addressed cache-directory symlink containment before writes, retained color-job scope validation, read-only polling permissions, mixed image/master polling failure isolation, mobile FITS download visibility, and retained-sample wording. No unresolved findings.

## Validation
Local Windows checks, using published Seiza crates and isolated test catalogs:
- `cargo test --locked -j 2`: 893 unit tests and 127 integration tests passed; 5 existing tests ignored.
- `cargo test --locked --lib -j 2`: full unit suite rerun after the final test-helper lint fix; 893 passed, 5 ignored.
- `cargo test --locked --test integration_server_auth -j 2`: 10 passed, including read-only master-status polling.
- All 17 new master API/provenance tests also passed separately, including Windows symlink checks. Four rendering regressions cover near-unity CFA flats, RGB, uniform/sparse-defect frames, and generation failures.
- `cargo clippy --locked --all-targets --all-features -j 2 -- -D warnings`, `cargo fmt -- --check`, and `git diff --check` passed.
- `npm run lint`, `npm run build`, and `npx vitest run`: 389 frontend tests passed.
- `npx playwright test e2e/stack-preview.spec.ts --workers=1`: all 5 tests passed against the built server.
- The master-inspection browser test also passed independently and with `--repeat-each=2 --workers=1`.

Browser validation covers all four master types, real queued PNG generation, nonblank native CFA pixels, exact FITS byte downloads, multi-session and RGB provenance, missing files, stretch/zoom preservation, and desktop/mobile layouts. Screenshots were inspected locally using synthetic fixtures. No user catalogs or source images were modified or published. All test servers were stopped.

Hosted CI is separate from these local results.