### PR TITLE
Flag frames shot with a warm sensor, and filter hot pixels per calibration session

### DIFF
--- a/docs/SCREENING.md
+++ b/docs/SCREENING.md
@@ -106,6 +106,18 @@ condemned score and gets an `[Auto]` reject recommendation. A frame missing
 the measurement is exempt. The CLI equivalents are `screen-fits --max-hfr`
 and `--min-stars`.
 
+A third absolute check is always on: **sensor temperature**. A frame whose
+sensor ran more than 10 °C warmer than the median of its capture session,
+or more than 20 °C above the cooler's recorded set point, is capped and
+recommended for rejection the same way, with a `Sensor Temperature` issue.
+Dark current and hot pixels climb steeply with temperature, and no dark
+shot at the set point removes them, so a cooler dropout ruins a frame even
+when its stars still measure well. Colder never flags, and a frame without
+a temperature reading is exempt. Target Scheduler records the temperature
+and set point per exposure; PSF Guard imports carry the sensor temperature
+from the FITS header. API callers can change the margin with
+`sensor_temp_tolerance_c`.
+
 The preference is remembered and applies to every scoring surface —
 Sequence view, grid badges, and the detail panel — so a frame scores the
 same everywhere. The zero-star cap does not scale: a frame measured to

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -440,6 +440,14 @@ The panel's **Calibration** control chooses how the next build calibrates:
   Auto refuses. The calibration warning still says what to expect.
 - **Off** stacks the raw frames without touching the library.
 
+Lights whose calibration session has no dark master keep their hot pixels,
+so a spatial impulse filter runs over each of those frames before
+integration; the calibration card says which sessions it covered. A session
+with a dark master is left to the dark, which subtracts hot pixels with
+real measurements. The online pass that admits frames can hold only one
+setting for the whole group, so it filters only when no session has a dark;
+the final integration that produces the stack decides per session.
+
 The choice is remembered across reloads, becomes part of the stack job key,
 and a finished preview built under a different mode is marked out of date.
 Source-frame searches re-create the stack's own mode, whatever the control

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -15,6 +15,17 @@
   measurements, report low coverage, and refuse unsupported pixels without
   silently smoothing or filling them. No external star-removal tool is needed.
 
+- A frame shot with a warm sensor is flagged **Sensor Temperature**, capped
+  to a rejected score, and given an `[Auto]` reject recommendation: more
+  than 10 °C warmer than its capture session, or more than 20 °C above the
+  cooler's set point. A cooler dropout no longer slips into a stack because
+  the stars still measured well.
+
+- In a multi-night stack, lights from a session with no dark master now get
+  hot-pixel suppression even when other sessions have darks; the calibration
+  card says which sessions were filtered. Existing stack previews rebuild
+  when next opened.
+
 ## Changed
 
 ## Fixed

--- a/src/commands/screen_fits.rs
+++ b/src/commands/screen_fits.rs
@@ -920,6 +920,8 @@ fn score_records(
                     eccentricity: None,
                     snr: None,
                     background: Some(r.median_adu),
+                    camera_temp: None,
+                    camera_target_temp: None,
                     dead_cell_fraction: r.dead_cell_fraction,
                     bg_cell_spread: Some(r.bg_cell_spread),
                     transparency: sig.and_then(|s| s.transparency),
@@ -1006,6 +1008,7 @@ fn category_label(category: &Option<IssueCategory>) -> &'static str {
         Some(IssueCategory::NoStarsDetected) => "no-stars",
         Some(IssueCategory::HfrAboveLimit) => "hfr-limit",
         Some(IssueCategory::StarCountBelowLimit) => "star-limit",
+        Some(IssueCategory::SensorTemperature) => "sensor-warm",
         Some(IssueCategory::UnknownDegradation) => "unknown",
         None => "-",
     }

--- a/src/sequence_analysis.rs
+++ b/src/sequence_analysis.rs
@@ -32,6 +32,11 @@ pub enum IssueCategory {
     HfrAboveLimit,
     /// Measured star count fell below the operator's absolute reject limit.
     StarCountBelowLimit,
+    /// The sensor ran far warmer than the rest of its session, or far above
+    /// its set point: the cooler dropped out. Dark current and hot pixels
+    /// climb steeply with temperature, and no dark shot at the set point
+    /// removes them, so the frame is condemned on its own evidence.
+    SensorTemperature,
     UnknownDegradation,
 }
 
@@ -457,6 +462,12 @@ pub struct ImageMetrics {
     pub eccentricity: Option<f64>,
     pub snr: Option<f64>,
     pub background: Option<f64>,
+    /// Sensor temperature the camera reported for this exposure, in Celsius.
+    #[serde(default)]
+    pub camera_temp: Option<f64>,
+    /// Cooler set point the camera was asked to hold, in Celsius.
+    #[serde(default)]
+    pub camera_target_temp: Option<f64>,
     /// Fraction of frame grid cells with collapsed star density
     /// (see `spatial_analysis::SpatialMetrics::star_dead_cell_fraction`).
     /// Detects partial occlusion (trees, dome, stray light) that global star
@@ -950,6 +961,17 @@ pub struct SequenceAnalyzerConfig {
     /// `None` (the default) disables the check; unmeasured frames are exempt.
     #[serde(default)]
     pub star_count_reject_below: Option<f64>,
+    /// How much warmer than its session a frame's sensor may run before the
+    /// frame is condemned, in Celsius. A frame also fails at twice this
+    /// above its recorded set point: a healthy cooler in summer holds a few
+    /// degrees above target, a cooler that dropped out sits thirty above.
+    /// Colder never flags, and a frame without a reading is exempt.
+    #[serde(default = "default_sensor_temp_tolerance_c")]
+    pub sensor_temp_tolerance_c: f64,
+}
+
+fn default_sensor_temp_tolerance_c() -> f64 {
+    10.0
 }
 
 fn default_dead_cell_rise_threshold() -> f64 {
@@ -1017,6 +1039,7 @@ impl Default for SequenceAnalyzerConfig {
             bg_glow_threshold: default_bg_glow_threshold(),
             hfr_reject_above: None,
             star_count_reject_below: None,
+            sensor_temp_tolerance_c: default_sensor_temp_tolerance_c(),
         }
     }
 }
@@ -1045,6 +1068,9 @@ impl SequenceAnalyzerConfig {
         self.star_count_reject_below = self
             .star_count_reject_below
             .filter(|limit| limit.is_finite() && *limit > 0.0);
+        if !(self.sensor_temp_tolerance_c.is_finite() && self.sensor_temp_tolerance_c > 0.0) {
+            self.sensor_temp_tolerance_c = default_sensor_temp_tolerance_c();
+        }
         self
     }
 }
@@ -1627,22 +1653,20 @@ impl SequenceAnalyzer {
         }
     }
 
-    /// Enforce the operator's absolute reject limits (HFR ceiling and
-    /// star-count floor). Unlike the sequence-relative metrics these are
-    /// explicit operator thresholds, so a violation both caps the score
-    /// and proposes an `[Auto]` rejection. A frame without the measurement
-    /// is exempt: grading must not punish an image because an optional
-    /// scan has not run.
+    /// Enforce the absolute reject limits: the operator's HFR ceiling and
+    /// star-count floor, and the sensor-temperature rule. Unlike the
+    /// sequence-relative metrics these judge a frame on its own, so a
+    /// violation both caps the score and proposes an `[Auto]` rejection. A
+    /// frame without the measurement is exempt: grading must not punish an
+    /// image because an optional scan has not run.
     fn apply_absolute_metric_limits(
         &self,
         results: &mut [ImageQualityResult],
         images: &[ImageMetrics],
     ) {
-        if self.config.hfr_reject_above.is_none() && self.config.star_count_reject_below.is_none() {
-            return;
-        }
+        let session_temp = median_camera_temp(images);
         for (result, image) in results.iter_mut().zip(images) {
-            for (category, detail, reason) in self.absolute_limit_violations(image) {
+            for (category, detail, reason) in self.absolute_limit_violations(image, session_temp) {
                 result.quality_score = result.quality_score.min(ABSOLUTE_LIMIT_SCORE_CAP);
                 if !result.flags.contains(&category) {
                     result.flags.push(category.clone());
@@ -1660,8 +1684,12 @@ impl SequenceAnalyzer {
     fn absolute_limit_violations(
         &self,
         image: &ImageMetrics,
+        session_temp: Option<f64>,
     ) -> Vec<(IssueCategory, String, String)> {
         let mut violations = Vec::new();
+        if let Some((detail, reason)) = self.sensor_temperature_violation(image, session_temp) {
+            violations.push((IssueCategory::SensorTemperature, detail, reason));
+        }
         if let (Some(limit), Some(hfr)) = (self.config.hfr_reject_above, image.hfr)
             && hfr > limit
         {
@@ -1692,6 +1720,37 @@ impl SequenceAnalyzer {
             ));
         }
         violations
+    }
+
+    /// Why a frame's sensor temperature condemns it, if it does: warmer than
+    /// the session median by more than the tolerance, or warmer than the
+    /// recorded set point by more than twice it. The second rule catches a
+    /// whole session shot with the cooler off, which the first cannot see.
+    fn sensor_temperature_violation(
+        &self,
+        image: &ImageMetrics,
+        session_temp: Option<f64>,
+    ) -> Option<(String, String)> {
+        let temp = image.camera_temp.filter(|temp| temp.is_finite())?;
+        let tolerance = self.config.sensor_temp_tolerance_c;
+        let over_session = session_temp.filter(|median| temp - median > tolerance);
+        let over_set_point = image
+            .camera_target_temp
+            .filter(|target| target.is_finite() && temp - target > 2.0 * tolerance);
+        let (reference, label) = match (over_session, over_set_point) {
+            (Some(median), _) => (median, "the session's"),
+            (None, Some(target)) => (target, "its set point of"),
+            (None, None) => return None,
+        };
+        let excess = temp - reference;
+        Some((
+            format!(
+                "Sensor at {temp:.1} °C, {excess:.0} °C warmer than {label} {reference:.1} °C. \
+                 Dark current and hot pixels rise steeply with temperature and no dark \
+                 shot at the set point removes them, so this frame is judged on its own."
+            ),
+            format!("[Auto] Sensor warm - {temp:.1} °C vs {label} {reference:.1} °C"),
+        ))
     }
 
     /// Compute EWMA-based temporal deviation scores for the sequence.
@@ -2917,9 +2976,9 @@ fn append_regrade_reason(slot: &mut Option<String>, reason: String) {
 fn absolute_cap_for(flag: &IssueCategory) -> Option<f64> {
     match flag {
         IssueCategory::NoStarsDetected => Some(ZERO_STAR_SCORE_CAP),
-        IssueCategory::HfrAboveLimit | IssueCategory::StarCountBelowLimit => {
-            Some(ABSOLUTE_LIMIT_SCORE_CAP)
-        }
+        IssueCategory::HfrAboveLimit
+        | IssueCategory::StarCountBelowLimit
+        | IssueCategory::SensorTemperature => Some(ABSOLUTE_LIMIT_SCORE_CAP),
         _ => None,
     }
 }
@@ -2958,6 +3017,27 @@ fn apply_zero_star_cap(results: &mut [ImageQualityResult], images: &[ImageMetric
 /// every view (below the 0.35 screening default), above the zero-star cap
 /// so a merely soft frame still outranks a ruined one.
 const ABSOLUTE_LIMIT_SCORE_CAP: f64 = 0.25;
+
+/// Median of the sensor temperatures a sequence recorded, or None when no
+/// frame carries one. The median, not the mean: a cooler that drops out
+/// mid-session must not drag the reference up towards itself.
+fn median_camera_temp(images: &[ImageMetrics]) -> Option<f64> {
+    let mut temps: Vec<f64> = images
+        .iter()
+        .filter_map(|image| image.camera_temp)
+        .filter(|temp| temp.is_finite())
+        .collect();
+    if temps.is_empty() {
+        return None;
+    }
+    temps.sort_by(f64::total_cmp);
+    let middle = temps.len() / 2;
+    Some(if temps.len().is_multiple_of(2) {
+        (temps[middle - 1] + temps[middle]) / 2.0
+    } else {
+        temps[middle]
+    })
+}
 
 const STAR_COUNT_TOLERANCE: RelativeMetricTolerance = RelativeMetricTolerance::new(0.10, 0.40);
 const HFR_TOLERANCE: RelativeMetricTolerance = RelativeMetricTolerance::new(0.05, 0.30);
@@ -3256,6 +3336,12 @@ pub fn extract_metrics_from_metadata(
         eccentricity,
         snr,
         background,
+        // Target Scheduler records CameraTemp; PSF Guard's own quality
+        // backfill writes Temperature.
+        camera_temp: metadata["CameraTemp"]
+            .as_f64()
+            .or_else(|| metadata["Temperature"].as_f64()),
+        camera_target_temp: metadata["CameraTargetTemp"].as_f64(),
         dead_cell_fraction,
         bg_cell_spread,
         transparency: metadata["Transparency"].as_f64(),
@@ -3285,6 +3371,8 @@ mod tests {
             eccentricity: None,
             snr: None,
             background: None,
+            camera_temp: None,
+            camera_target_temp: None,
             dead_cell_fraction: None,
             bg_cell_spread: None,
             transparency: None,
@@ -3318,6 +3406,8 @@ mod tests {
             eccentricity: Some(ecc),
             snr: Some(snr),
             background: Some(bg),
+            camera_temp: None,
+            camera_target_temp: None,
             dead_cell_fraction: None,
             bg_cell_spread: None,
             transparency: None,
@@ -3350,6 +3440,8 @@ mod tests {
             eccentricity: None,
             snr: None,
             background: None,
+            camera_temp: None,
+            camera_target_temp: None,
             dead_cell_fraction: Some(dead),
             bg_cell_spread: Some(bg_spread),
             transparency: None,
@@ -3823,6 +3915,114 @@ mod tests {
         }
     }
 
+    fn warm_and_cold(temps: &[f64], set_point: Option<f64>) -> Vec<ImageMetrics> {
+        temps
+            .iter()
+            .enumerate()
+            .map(|(i, temp)| {
+                let mut image = make_image(i as i32, i as i64 * 300, 500.0, 2.5);
+                image.camera_temp = Some(*temp);
+                image.camera_target_temp = set_point;
+                image
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_cooler_dropout_inside_a_session_condemns_only_the_warm_frames() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        // The NGC 7023 night: -6 °C holding a -10 set point, then the
+        // cooler drops out and the last frames run at +27 to +31.
+        let temps = [
+            -6.3, -6.1, -6.1, -5.9, -6.0, -6.2, -6.3, -6.1, 26.6, 30.1, 31.1, 31.1,
+        ];
+        let images = warm_and_cold(&temps, Some(-10.0));
+        let sequence = &analyzer.analyze(&images, 1, "target", "G")[0];
+        for (index, result) in sequence.images.iter().enumerate() {
+            let warm = temps[index] > 0.0;
+            assert_eq!(
+                result.flags.contains(&IssueCategory::SensorTemperature),
+                warm,
+                "frame {index} at {} °C",
+                temps[index]
+            );
+            if warm {
+                assert!(result.quality_score <= ABSOLUTE_LIMIT_SCORE_CAP);
+                assert!(result
+                    .regrade_reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.contains("[Auto] Sensor warm")));
+                assert!(result
+                    .details
+                    .as_deref()
+                    .is_some_and(|details| details.contains("warmer than the session's")));
+            } else {
+                assert!(result.regrade_reason.is_none(), "frame {index} rejected");
+            }
+        }
+    }
+
+    #[test]
+    fn a_session_shot_with_the_cooler_off_fails_against_its_set_point() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        let images = warm_and_cold(&[30.9, 31.0, 31.1, 31.1, 30.8, 31.0], Some(-10.0));
+        let sequence = &analyzer.analyze(&images, 1, "target", "G")[0];
+        for result in &sequence.images {
+            assert!(result.flags.contains(&IssueCategory::SensorTemperature));
+            assert!(result.quality_score <= ABSOLUTE_LIMIT_SCORE_CAP);
+            assert!(result
+                .regrade_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("vs its set point of -10.0 °C")));
+        }
+        // Without a recorded set point the session is its own reference,
+        // and a uniformly warm night cannot be told from a warm camera.
+        let unknown = warm_and_cold(&[30.9, 31.0, 31.1, 31.1, 30.8, 31.0], None);
+        let sequence = &analyzer.analyze(&unknown, 1, "target", "G")[0];
+        assert!(sequence
+            .images
+            .iter()
+            .all(|result| !result.flags.contains(&IssueCategory::SensorTemperature)));
+    }
+
+    #[test]
+    fn a_healthy_cooler_a_cold_frame_and_a_missing_reading_never_flag() {
+        let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig::default());
+        // Summer: the cooler holds 4 to 9 °C above its -10 set point.
+        let mut images = warm_and_cold(&[-1.5, -2.0, -3.0, -4.0, -5.0, -6.0], Some(-10.0));
+        // One frame colder than the rest, one with no reading at all.
+        images[2].camera_temp = Some(-12.0);
+        images[4].camera_temp = None;
+        let sequence = &analyzer.analyze(&images, 1, "target", "R")[0];
+        for result in &sequence.images {
+            assert!(!result.flags.contains(&IssueCategory::SensorTemperature));
+            assert!(result.regrade_reason.is_none());
+        }
+    }
+
+    #[test]
+    fn sensor_temperature_tolerance_is_configurable_and_sanitized() {
+        let strict = SequenceAnalyzer::new(SequenceAnalyzerConfig {
+            sensor_temp_tolerance_c: 3.0,
+            ..Default::default()
+        });
+        let images = warm_and_cold(&[-6.0, -6.0, -6.0, -6.0, -6.0, -1.0], Some(-10.0));
+        let sequence = &strict.analyze(&images, 1, "target", "L")[0];
+        assert!(sequence.images[5]
+            .flags
+            .contains(&IssueCategory::SensorTemperature));
+        let nonsense = SequenceAnalyzer::new(SequenceAnalyzerConfig {
+            sensor_temp_tolerance_c: -4.0,
+            ..Default::default()
+        });
+        assert_eq!(nonsense.config.sensor_temp_tolerance_c, 10.0);
+        assert_eq!(median_camera_temp(&[]), None);
+        assert_eq!(
+            median_camera_temp(&warm_and_cold(&[3.0, 1.0, 2.0, 40.0], None)),
+            Some(2.5)
+        );
+    }
+
     #[test]
     fn near_threshold_hfr_reason_preserves_the_comparison() {
         let analyzer = SequenceAnalyzer::new(SequenceAnalyzerConfig {
@@ -3832,7 +4032,7 @@ mod tests {
         let mut image = make_image(1, 0, 500.0, 2.55041);
         image.hfr = Some(2.55041);
 
-        let violations = analyzer.absolute_limit_violations(&image);
+        let violations = analyzer.absolute_limit_violations(&image, None);
         assert_eq!(violations.len(), 1);
         assert!(violations[0]
             .1
@@ -4969,6 +5169,19 @@ mod tests {
         assert_eq!(metrics.star_count, Some(342.0));
         assert_eq!(metrics.hfr, Some(2.5));
         assert_eq!(metrics.session_id.as_deref(), Some("5"));
+        assert_eq!(metrics.camera_temp, None);
+        assert_eq!(metrics.camera_target_temp, None);
+
+        let scheduler = extract_metrics_from_metadata(
+            2,
+            r#"{"CameraTemp": 31.1, "CameraTargetTemp": -10.0}"#,
+            None,
+        );
+        assert_eq!(scheduler.camera_temp, Some(31.1));
+        assert_eq!(scheduler.camera_target_temp, Some(-10.0));
+        let backfilled = extract_metrics_from_metadata(3, r#"{"Temperature": -5.5}"#, None);
+        assert_eq!(backfilled.camera_temp, Some(-5.5));
+        assert_eq!(backfilled.camera_target_temp, None);
         assert_eq!(
             metrics.capture_profile.as_deref(),
             Some("exposure=60|gain=100|offset=10|binning=1x1|readout=0|roi=100")

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -53,7 +53,91 @@ use crate::server::state::AppState;
 pub const SEIZA_STACKING_VERSION: &str = seiza_stacking::VERSION;
 /// Bump whenever stack admission, rendering, or persisted artifact semantics
 /// change. This deliberately versions PSF Guard policy separately from Seiza.
-pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 14;
+pub(super) const STACK_PREVIEW_CACHE_VERSION: u32 = 15;
+
+/// Which calibration sessions get the spatial impulse filter.
+///
+/// A dark master subtracts hot pixels with real measurements; a session
+/// without one has only the filter. Calibration switched off means the
+/// user asked for raw frames, so nothing is filtered.
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct SessionCosmetics {
+    per_session: Vec<Option<seiza_stacking::ImpulseFilterOptions>>,
+    /// The filter for a frame whose session masters were refused and that
+    /// stacked raw: nothing subtracted its hot pixels either.
+    bypassed: Option<seiza_stacking::ImpulseFilterOptions>,
+}
+
+impl SessionCosmetics {
+    pub(super) fn for_plan(
+        plan: &crate::calibration::CalibrationPlan,
+        mode: crate::calibration::CalibrationMode,
+    ) -> Self {
+        Self {
+            per_session: plan
+                .sessions
+                .iter()
+                .map(|session| impulse_filter_for(mode, session.applied.dark_master.is_some()))
+                .collect(),
+            bypassed: impulse_filter_for(mode, false),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn none(sessions: usize) -> Self {
+        Self {
+            per_session: vec![None; sessions],
+            bypassed: None,
+        }
+    }
+
+    /// The filter for one frame: its session's, or the raw-frame filter
+    /// when its masters were bypassed.
+    pub(super) fn for_frame(
+        &self,
+        session: usize,
+        calibration_bypassed: bool,
+    ) -> Option<seiza_stacking::ImpulseFilterOptions> {
+        if calibration_bypassed {
+            return self.bypassed;
+        }
+        self.per_session.get(session).copied().flatten()
+    }
+
+    /// The one filter the live stacker can hold for the whole group: set
+    /// only when every session lacks a dark, as before sessions could differ.
+    pub(super) fn whole_group(&self) -> Option<seiza_stacking::ImpulseFilterOptions> {
+        if !self.per_session.is_empty() && self.per_session.iter().all(Option::is_some) {
+            self.per_session[0]
+        } else {
+            None
+        }
+    }
+
+    /// What the calibration card says about hot pixels, if anything.
+    pub(super) fn card_note(&self) -> Option<String> {
+        let filtered = self.per_session.iter().filter(|c| c.is_some()).count();
+        let sessions = self.per_session.len();
+        match filtered {
+            0 => None,
+            n if n == sessions => {
+                Some("Hot pixels suppressed in each light (no dark master to subtract them)".into())
+            }
+            n => Some(format!(
+                "Hot pixels suppressed in {n} of {sessions} calibration sessions, the ones \
+                 with no dark master to subtract them"
+            )),
+        }
+    }
+}
+
+fn impulse_filter_for(
+    mode: crate::calibration::CalibrationMode,
+    has_dark_master: bool,
+) -> Option<seiza_stacking::ImpulseFilterOptions> {
+    (!has_dark_master && mode != crate::calibration::CalibrationMode::Off)
+        .then(seiza_stacking::ImpulseFilterOptions::default)
+}
 const MAX_REQUEST_IMAGES: usize = 10_000;
 const MAX_REMEMBERED_JOBS: usize = 64;
 const PREVIEW_MAX_DIMENSION: u32 = 2400;
@@ -2201,21 +2285,19 @@ fn run_group(
         }
     };
     let mut applied_calibration = plan.applied.clone();
-    // With no dark master anywhere in the plan, the lights keep their hot
-    // pixels and the stack runs the spatial impulse filter over each frame.
-    // Say so on the card; display only, after the identity is computed.
-    let no_dark_master = plan
-        .sessions
-        .iter()
-        .all(|session| session.applied.dark_master.is_none());
-    let cosmetic = (no_dark_master
-        && group.calibration != crate::calibration::CalibrationMode::Off)
-        .then(seiza_stacking::ImpulseFilterOptions::default);
-    if no_dark_master && group.calibration != crate::calibration::CalibrationMode::Off {
-        let note = "Hot pixels suppressed in each light (no dark master to subtract them)";
+    // A session without a dark master keeps its lights' hot pixels, and a
+    // handful of frames cannot reject them statistically, so the spatial
+    // impulse filter runs over that session's frames. The live stacker
+    // fixes its filter at construction, so the online pass filters only
+    // when no session has a dark; the final integration, which produces
+    // the stack, decides per session. Say so on the card; display only,
+    // after the identity is computed.
+    let session_cosmetics = SessionCosmetics::for_plan(&plan, group.calibration);
+    let cosmetic = session_cosmetics.whole_group();
+    if let Some(note) = session_cosmetics.card_note() {
         applied_calibration.warning = Some(match applied_calibration.warning.take() {
             Some(previous) => format!("{previous}. {note}"),
-            None => note.into(),
+            None => note,
         });
     }
     // The resume checkpoint key carries the applied-master signature too:
@@ -2835,7 +2917,7 @@ fn run_group(
                 &group,
                 &ledger,
                 &plan,
-                cosmetic,
+                &session_cosmetics,
                 cancel,
                 |pass, index, count| {
                     let pass = match pass {
@@ -3311,6 +3393,53 @@ fn publish_snr_artifact(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn hot_pixel_filter_follows_each_session_s_dark() {
+        use super::SessionCosmetics;
+        use crate::calibration::CalibrationMode;
+        let filter = Some(seiza_stacking::ImpulseFilterOptions::default());
+        assert_eq!(
+            super::impulse_filter_for(CalibrationMode::Auto, false),
+            filter
+        );
+        assert_eq!(super::impulse_filter_for(CalibrationMode::Auto, true), None);
+        assert_eq!(super::impulse_filter_for(CalibrationMode::Off, false), None);
+
+        let mixed = SessionCosmetics {
+            per_session: vec![None, filter, None],
+            bypassed: filter,
+        };
+        assert_eq!(mixed.for_frame(0, false), None);
+        assert_eq!(mixed.for_frame(1, false), filter);
+        // Masters refused: the frame stacked raw and keeps only the filter.
+        assert_eq!(mixed.for_frame(0, true), filter);
+        assert_eq!(
+            mixed.whole_group(),
+            None,
+            "the live stacker holds one filter"
+        );
+        assert_eq!(
+            mixed.card_note().as_deref(),
+            Some(
+                "Hot pixels suppressed in 1 of 3 calibration sessions, the ones with no dark \
+                 master to subtract them"
+            )
+        );
+
+        let none_have_darks = SessionCosmetics {
+            per_session: vec![filter, filter],
+            bypassed: filter,
+        };
+        assert_eq!(none_have_darks.whole_group(), filter);
+        assert_eq!(
+            none_have_darks.card_note().as_deref(),
+            Some("Hot pixels suppressed in each light (no dark master to subtract them)")
+        );
+        let all_have_darks = SessionCosmetics::none(2);
+        assert_eq!(all_have_darks.card_note(), None);
+        assert_eq!(all_have_darks.whole_group(), None);
+    }
 
     #[test]
     fn processing_selection_rejects_a_stale_displayed_revision() {

--- a/src/server/stack_preview/final_integration.rs
+++ b/src/server/stack_preview/final_integration.rs
@@ -1,6 +1,6 @@
 //! Revisit admitted frames without repeating their registration decisions.
 
-use super::{resume, PreparedGroup};
+use super::{resume, PreparedGroup, SessionCosmetics};
 use seiza_stacking::{
     BatchStackOptions, BatchStackPass, BatchStackResult, CalibrationMasters, FitsFrame,
     ImpulseFilterOptions, LinearImage, ReferenceRegion, RegisteredFrameMapping,
@@ -12,7 +12,7 @@ pub(super) fn integrate(
     group: &PreparedGroup,
     ledger: &[resume::ResumeFrame],
     plan: &crate::calibration::CalibrationPlan,
-    cosmetic: Option<ImpulseFilterOptions>,
+    cosmetics: &SessionCosmetics,
     cancel: &Arc<AtomicBool>,
     mut progress: impl FnMut(BatchStackPass, usize, usize),
 ) -> seiza_stacking::Result<BatchStackResult> {
@@ -45,8 +45,9 @@ pub(super) fn integrate(
         let mapping = record.decision.registered_mapping.as_ref().ok_or_else(|| {
             seiza_stacking::Error::Stack("An admitted frame has no registered mapping".into())
         })?;
-        let masters = (!record.calibration_bypassed)
-            .then_some(&plan.sessions[plan.assignments[source_index]].masters);
+        let session = plan.assignments[source_index];
+        let masters = (!record.calibration_bypassed).then_some(&plan.sessions[session].masters);
+        let cosmetic = cosmetics.for_frame(session, record.calibration_bypassed);
         let image = prepare_registered_frame(frame, masters, cosmetic, mapping)?;
         if super::source_fingerprint(&source.path) != source.source_fingerprint {
             return Err(seiza_stacking::Error::Stack(format!(
@@ -324,7 +325,7 @@ mod tests {
             &group,
             &ledger,
             &plan,
-            None,
+            &SessionCosmetics::none(plan.sessions.len()),
             &Arc::new(AtomicBool::new(false)),
             |pass, index, count| progress.push((pass, index, count)),
         )
@@ -344,11 +345,12 @@ mod tests {
         let plan = crate::calibration::CalibrationPlan::without_calibration(group.frames.len());
         let cancel = Arc::new(AtomicBool::new(false));
         group.frames[0].source_fingerprint = "changed".into();
-        let error = integrate(&group, &ledger, &plan, None, &cancel, |_, _, _| {}).unwrap_err();
+        let none = SessionCosmetics::none(plan.sessions.len());
+        let error = integrate(&group, &ledger, &plan, &none, &cancel, |_, _, _| {}).unwrap_err();
         assert!(error.to_string().contains("changed during stacking"));
         cancel.store(true, Ordering::Relaxed);
         assert!(matches!(
-            integrate(&group, &ledger, &plan, None, &cancel, |_, _, _| {}),
+            integrate(&group, &ledger, &plan, &none, &cancel, |_, _, _| {}),
             Err(seiza_stacking::Error::Cancelled)
         ));
     }

--- a/static/e2e/stack-preview.spec.ts
+++ b/static/e2e/stack-preview.spec.ts
@@ -134,7 +134,7 @@ function seedSyntheticColorStacks(databaseId: string, projectId: number, withCal
       // Must track STACK_PREVIEW_CACHE_VERSION in src/server/stack_preview.rs.
       // The server hides remembered stacks from an older build, so a stale
       // number here leaves the color panel with no channels to combine.
-      cache_version: 14,
+      cache_version: 15,
       group: {
         index: 0,
         target_id: 2,

--- a/static/src/utils/__tests__/issueCategory.test.ts
+++ b/static/src/utils/__tests__/issueCategory.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { formatCategory } from '../issueCategory';
+
+describe('formatCategory', () => {
+  it('names the fixed labels', () => {
+    expect(formatCategory('satellite_trail_risk')).toBe('Satellite Trail Detected');
+    expect(formatCategory('hfr_above_limit')).toBe('HFR Above Limit');
+  });
+
+  it('title-cases every other category, including sensor temperature', () => {
+    expect(formatCategory('sensor_temperature')).toBe('Sensor Temperature');
+    expect(formatCategory('likely_clouds')).toBe('Likely Clouds');
+    expect(formatCategory('star_count_below_limit')).toBe('Star Count Below Limit');
+  });
+});


### PR DESCRIPTION
Found on the starfront-ultracat131 NGC 7023 green run: the cooler dropped out mid-night and the last 15 lights (ids 151-165, 2026-09-09 09:36-10:50 UTC) were shot at +26.6 to +31.1 °C against a -10 °C set point. Stars and HFR still measured well, so every one was Accepted. The stack calibrated 14 of them with a three-frame dark shot at 30 °C, and the 26.6 °C frame got no dark and, because the other sessions had darks, no hot-pixel cleanup either.

**Sensor temperature issue.** Grading reads `CameraTemp` and `CameraTargetTemp` from the Target Scheduler metadata (falling back to the `Temperature` key PSF Guard's quality backfill writes). A frame is flagged `sensor_temperature`, capped to the rejected score, and given an `[Auto] Sensor warm` reason when its sensor ran more than `sensor_temp_tolerance_c` (default 10 °C) warmer than the median of its capture session, or more than twice that above its recorded set point. The second rule catches a whole session shot with the cooler off. Colder never flags; a missing reading never flags. The tolerance is a `SequenceAnalyzerConfig` field with a serde default, sanitized like the other limits.

Against the real data: the 85 cold green frames sit at -1.5 to -6.3 °C and the R and B frames 3 to 9 °C above set point; none flag. All 15 warm frames flag (37 to 41 °C over the session median).

**Hot pixels per session.** `final_integration::integrate` now takes a per-session filter set: a session with no dark master gets the impulse filter even when other sessions have darks, and a frame whose masters were refused and stacked raw gets it too. The live stacker takes one `StackOptions.cosmetic` at construction and has no setter, so the online admission pass keeps the old whole-group rule (filter only when no session has a dark). For stacks of three or more frames the final integration produces the output, so that is where the per-session decision matters; the card note says "Hot pixels suppressed in N of M calibration sessions" when they differ. `STACK_PREVIEW_CACHE_VERSION` 14 → 15 so checkpoints built under the old rule are not resumed.

Frontend: the shared `formatCategory` already renders the new category as "Sensor Temperature"; a vitest pins it. No component switches on category strings for icons. Docs: SCREENING.md (the rule and defaults), STACKING_PREVIEWS.md (per-session filtering), release notes.

Tests: cooler dropout inside a session flags only the warm frames with cap, reason, and details; a session with the cooler off flags via the set point and not without one; a healthy summer cooler, a colder frame, and a missing reading never flag; the tolerance is configurable and nonsense values fall back; metrics extraction reads both key sets; the per-session filter decision, raw-frame fallback, whole-group rule, and card notes.

Checks run locally: `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test --locked` (1028 passed, 0 failed), `git diff --check`; in `static/`: `npm ci`, `npm run lint`, `npx vitest run` (391 passed), `npm run build`. No rendering change, so the browser suite is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv
