### PR TITLE
Check a flat master against the flats that made it

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -135,10 +135,11 @@ bright bead at every spot wherever the sky is bright. So PSF Guard reads a
 freshly built flat master back against its own inputs. Pixels where the
 master departs from the smooth response around it by more than 10% are its
 features. A frame that departs from the master by more than 5% of the local
-response at enough of those pixels (one in fifty thousand of the sensor, at
-least sixteen) was not looking at the same window. A dust shadow or a dead
-cluster is a feature too, but one every frame shows the same way, and it
-stays. On a colour camera the smooth response is judged per CFA phase.
+response at a fifth of those pixels (never fewer than sixteen, never more
+than one in two hundred thousand of the sensor) was not looking at the same
+window. A dust shadow or a dead cluster is a feature too, but one every
+frame shows the same way, and it stays. On a colour camera the smooth
+response is judged per CFA phase.
 
 - When the frames that disagree are a minority, the master rebuilds from the
   rest and the stack card says how many were left out.
@@ -147,9 +148,11 @@ stays. On a colour camera the smooth response is judged per CFA phase.
 - When there is no other set, the master serves and the card says the set
   was unstable and needs retaking.
 
-The check runs once per build. The master's record keeps the judgement, so a
-cached master repeats its note, and a set that was set aside is remembered
-rather than read again. Flat masters built before this check rebuild once.
+The check runs once per build, before the master is published, so nothing
+else can pick up a master that is about to be set aside. The master's record
+keeps the judgement: a cached master repeats its note, and a set that was
+set aside is remembered rather than read again. Flat masters built before
+this check rebuild once; bias and dark masters stay as they are.
 
 ## Upgrades and backups
 

--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -129,24 +129,27 @@ duplicate-input error.
 ## Flats that changed while they were shot
 
 Dew or frost drying off the sensor window leaves small spots that fade from
-one flat to the next. Across-frame clipping keeps a middling copy of each
-spot, because every frame has one, and each light divided by that master
-gets a bright bead at every spot wherever the sky is bright. So a freshly
-built flat master is read back against its own inputs. Pixels where the
+one flat to the next. Every frame has one, so across-frame clipping keeps a
+middling copy of each spot, and each light divided by that master gets a
+bright bead at every spot wherever the sky is bright. So PSF Guard reads a
+freshly built flat master back against its own inputs. Pixels where the
 master departs from the smooth response around it by more than 10% are its
-features; a frame that disagrees with the master at more than a fifth of
-them was not looking at the same window. A dust shadow or a dead cluster is
-a feature too, but one every frame shows the same way, and it stays.
+features. A frame that departs from the master by more than 5% of the local
+response at enough of those pixels (one in fifty thousand of the sensor, at
+least sixteen) was not looking at the same window. A dust shadow or a dead
+cluster is a feature too, but one every frame shows the same way, and it
+stays. On a colour camera the smooth response is judged per CFA phase.
 
-- When the frames that disagree are a minority, the master is rebuilt from
-  the rest and the stack card says how many were left out.
+- When the frames that disagree are a minority, the master rebuilds from the
+  rest and the stack card says how many were left out.
 - When the set as a whole disagrees with itself, the next-nearest flat set
-  is built and used instead, and the card names both.
-- When there is no other set, the master is used and the card says the set
-  was unstable and should be retaken.
+  takes its place and the card names both.
+- When there is no other set, the master serves and the card says the set
+  was unstable and needs retaking.
 
-The check runs once per build and is recorded with the master, so a cached
-master repeats its note. Flat masters built before this check rebuild once.
+The check runs once per build. The master's record keeps the judgement, so a
+cached master repeats its note, and a set that was set aside is remembered
+rather than read again. Flat masters built before this check rebuild once.
 
 ## Upgrades and backups
 

--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -126,6 +126,28 @@ followed by name, and a file is handed to the integrator once even when two
 rows point at it, so a stale row can no longer fail a master with a
 duplicate-input error.
 
+## Flats that changed while they were shot
+
+Dew or frost drying off the sensor window leaves small spots that fade from
+one flat to the next. Across-frame clipping keeps a middling copy of each
+spot, because every frame has one, and each light divided by that master
+gets a bright bead at every spot wherever the sky is bright. So a freshly
+built flat master is read back against its own inputs. Pixels where the
+master departs from the smooth response around it by more than 10% are its
+features; a frame that disagrees with the master at more than a fifth of
+them was not looking at the same window. A dust shadow or a dead cluster is
+a feature too, but one every frame shows the same way, and it stays.
+
+- When the frames that disagree are a minority, the master is rebuilt from
+  the rest and the stack card says how many were left out.
+- When the set as a whole disagrees with itself, the next-nearest flat set
+  is built and used instead, and the card names both.
+- When there is no other set, the master is used and the card says the set
+  was unstable and should be retaken.
+
+The check runs once per build and is recorded with the master, so a cached
+master repeats its note. Flat masters built before this check rebuild once.
+
 ## Upgrades and backups
 
 PSF Guard keeps its own tables inside the scheduler catalog and upgrades them

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -35,6 +35,13 @@
 
 ## Fixed
 
+- A flat master is now checked against the flats that made it. Spots that
+  fade across the run (dew drying off the sensor window) used to survive
+  clipping and put a bright bead into every light wherever the sky is bright.
+  Frames that disagree with the rest of the set are left out; a set that
+  disagrees with itself gives way to the next one, or is used with a warning
+  when there is no other. Flat masters built before this rebuild once.
+
 - Sky-flat masters improve rejection of overlapping moving-star samples with
   robust median/MAD clipping after calibration and brightness normalization. Existing
   generated masters rebuild with the new algorithm when next needed. Stars

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -40,7 +40,8 @@
   clipping and put a bright bead into every light wherever the sky is bright.
   Frames that disagree with the rest of the set stay out; a set that disagrees
   with itself gives way to the next one, or serves with a warning when there
-  is no other. Flat masters built before this rebuild once.
+  is no other. Flat masters built before this rebuild once; bias and dark
+  masters do not.
 
 - Sky-flat masters improve rejection of overlapping moving-star samples with
   robust median/MAD clipping after calibration and brightness normalization. Existing

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -35,12 +35,12 @@
 
 ## Fixed
 
-- A flat master is now checked against the flats that made it. Spots that
-  fade across the run (dew drying off the sensor window) used to survive
+- PSF Guard now checks a flat master against the flats that made it. Spots
+  that fade across the run (dew drying off the sensor window) used to survive
   clipping and put a bright bead into every light wherever the sky is bright.
-  Frames that disagree with the rest of the set are left out; a set that
-  disagrees with itself gives way to the next one, or is used with a warning
-  when there is no other. Flat masters built before this rebuild once.
+  Frames that disagree with the rest of the set stay out; a set that disagrees
+  with itself gives way to the next one, or serves with a warning when there
+  is no other. Flat masters built before this rebuild once.
 
 - Sky-flat masters improve rejection of overlapping moving-star samples with
   robust median/MAD clipping after calibration and brightness normalization. Existing

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -43,11 +43,10 @@ pub const CALIBRATION_SCHEMA_VERSION: i64 = 8;
 /// metadata (seiza-stacking 0.11.1). Masters written before that carry no
 /// TELESCOP or FOCALLEN, which weakens validation and later matching to
 /// "nothing recorded, nothing to check" — so they rebuild once.
-/// Version 4: a flat master is checked against its own inputs, and frames
-/// that disagree about a feature the master kept (dew drying off the sensor
-/// window while the flats ran) are left out or the set is passed over. Flat
-/// masters built before the check rebuild once so it runs on them.
-pub const MASTER_CACHE_VERSION: u32 = 4;
+/// A flat master built before the flat-set check (see [`build_master`]) is
+/// invalidated by its record lacking a judgement rather than by this number,
+/// so bias and dark masters stay put when the check arrives.
+pub const MASTER_CACHE_VERSION: u32 = 3;
 const MIN_MASTER_FRAMES: usize = 2;
 const MAX_MASTER_FRAMES: usize = 64;
 
@@ -2417,6 +2416,7 @@ fn resolve_or_build_masters_pinned(
             inputs,
             master_recording_blocker.as_deref(),
             settings.flat_star_masking,
+            cancel,
         ) {
             // The integrator reads the headers, so it catches what selection
             // could not: a catalog holds only what it recorded at import.
@@ -3317,6 +3317,17 @@ struct BuiltAttempt {
     /// The master is a memo of a set this build once judged unstable: its
     /// record remains, its file does not, and it must not be served.
     memo: bool,
+    /// A master this build made and has not published: the file waits under
+    /// a staging name and no record exists until the caller decides. A cache
+    /// hit or a memo has nothing staged and is never this build's to remove.
+    staged: Option<StagedMaster>,
+}
+
+struct StagedMaster {
+    file: PathBuf,
+    source_hash: String,
+    exposure_seconds: Option<f64>,
+    statistics: serde_json::Value,
 }
 
 impl BuiltAttempt {
@@ -3379,8 +3390,7 @@ fn build_master_once(
     // every flat again only to reach the same replacement.
     if kind == CalibrationKind::Flat
         && allow_memo
-        && let Some(stability) = recorded_flat_stability(conn, &path, true)
-        && stability.disagreement.len() == frames.len()
+        && let Some(stability) = recorded_flat_stability(conn, &path, frames, true)
     {
         return Ok(Some(BuiltAttempt {
             master: BuiltMaster {
@@ -3393,6 +3403,7 @@ fn build_master_once(
             used: frames.to_vec(),
             stability: Some(stability),
             memo: true,
+            staged: None,
         }));
     }
     if path.exists() {
@@ -3415,7 +3426,13 @@ fn build_master_once(
         // recorded, nothing to check" for a week because reuse never asked.
         // The exception is a blocked recorder: it cannot rebuild, and an old
         // master under today's validation still beats no master at all.
-        let row_current = recorded_version == Some(i64::from(MASTER_CACHE_VERSION));
+        // A flat recorded before the flat-set check carries no judgement;
+        // it rebuilds once so the check runs, without disturbing the other
+        // kinds.
+        let judged = kind != CalibrationKind::Flat
+            || recorded_master_statistics(conn, &path)
+                .is_some_and(|statistics| statistics["flat_stability"].is_object());
+        let row_current = recorded_version == Some(i64::from(MASTER_CACHE_VERSION)) && judged;
         let file_valid = crate::image_io::open_linear_frame(&path)
             .and_then(|frame| frame.validate_master_kind(expected_kind))
             .is_ok();
@@ -3451,8 +3468,7 @@ fn build_master_once(
                     // A kept-but-unstable flat must not pass as a sound
                     // fallback for another set: its record says how its
                     // frames disagreed, and that judgement stands.
-                    let stability = recorded_flat_stability(conn, &path, false)
-                        .filter(|stability| stability.disagreement.len() == frames.len());
+                    let stability = recorded_flat_stability(conn, &path, frames, false);
                     return Ok(Some(BuiltAttempt {
                         master: BuiltMaster {
                             path,
@@ -3466,6 +3482,7 @@ fn build_master_once(
                         used: frames.to_vec(),
                         stability,
                         memo: false,
+                        staged: None,
                     }));
                 }
                 Err(error) => {
@@ -3574,18 +3591,10 @@ fn build_master_once(
             frame.defect_pixels_replaced
         );
     }
-    let used: Vec<CalibrationFrame> = frames
-        .iter()
-        .filter(|candidate| {
-            !skipped
-                .iter()
-                .any(|(path, _)| *path == candidate.source_path)
-        })
-        .cloned()
-        .collect();
     let stability = (kind == CalibrationKind::Flat).then(|| {
         let stability = flat_set_stability(
-            &used,
+            frames,
+            &skipped,
             &frame.image,
             frame.bayer,
             stability_calibration.as_ref(),
@@ -3600,42 +3609,24 @@ fn build_master_once(
         FLAT_STABILITY_CHECKED.lock().unwrap().push(path.clone());
         stability
     });
-    if !path.exists() {
-        let temporary = path.with_extension(format!("fits.tmp-{}", std::process::id()));
-        seiza_stacking::write_master_fits_f32(&temporary, &frame)
-            .with_context(|| format!("writing {}", temporary.display()))?;
-        std::fs::rename(&temporary, &path)
-            .with_context(|| format!("publishing {}", path.display()))?;
-    }
-    record_master(
-        conn,
-        kind,
-        frames,
-        &source_hash,
-        &path,
-        RecordedMaster {
-            exposure_seconds: frame.exposure_seconds,
-            statistics: serde_json::json!({
-                "rejection_method": frame.rejection_method.as_str(),
-                "accepted_samples": frame.accepted_samples,
-                "rejected_samples": frame.rejected_samples,
-                "fallback_pixels": frame.fallback_pixels,
-                "masked_samples": frame.masked_samples,
-                "flat_star_masking": frame.flat_star_masking,
-                "flat_stability": stability.as_ref().map(|stability| serde_json::json!({
-                    "feature_pixels": stability.feature_pixels,
-                    "drift_threshold": stability.drift_threshold,
-                    "disagreement": stability.disagreement,
-                })),
-            }),
-        },
-        MasterInputs {
-            bias: None,
-            dark: None,
-            bias_dependency,
-            dark_dependency,
-        },
-    )?;
+    // The file waits under a staging name and nothing is recorded until the
+    // caller has judged the set: a second process on the same cache must
+    // not take a master this build is about to set aside.
+    let staged = path.with_extension(format!(
+        "fits.tmp-{}-{}",
+        std::process::id(),
+        STAGED_MASTERS.fetch_add(1, Ordering::Relaxed)
+    ));
+    seiza_stacking::write_master_fits_f32(&staged, &frame)
+        .with_context(|| format!("writing {}", staged.display()))?;
+    let statistics = serde_json::json!({
+        "rejection_method": frame.rejection_method.as_str(),
+        "accepted_samples": frame.accepted_samples,
+        "rejected_samples": frame.rejected_samples,
+        "fallback_pixels": frame.fallback_pixels,
+        "masked_samples": frame.masked_samples,
+        "flat_star_masking": frame.flat_star_masking,
+    });
     Ok(Some(BuiltAttempt {
         master: BuiltMaster {
             path,
@@ -3644,11 +3635,20 @@ fn build_master_once(
             flat_star_masking: frame.flat_star_masking,
             stability_note: None,
         },
-        used,
+        used: frames.to_vec(),
         stability,
         memo: false,
+        staged: Some(StagedMaster {
+            file: staged,
+            source_hash,
+            exposure_seconds: frame.exposure_seconds,
+            statistics,
+        }),
     }))
 }
+
+/// Distinguishes the staging files of one process's concurrent builds.
+static STAGED_MASTERS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 /// Master paths whose flat set was checked, so a test can tell a memo hit
 /// from a rebuild.
@@ -3665,6 +3665,8 @@ static FLAT_STABILITY_CHECKED: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex
 /// frames disagree with the master about such features, the master rebuilds
 /// without them; when the set as a whole disagrees, the next set takes its
 /// place; when there is no next set the master stays and the card says so.
+/// Nothing is published until the judgement is made.
+#[allow(clippy::too_many_arguments)]
 fn build_master(
     conn: &Connection,
     root: &Path,
@@ -3673,6 +3675,7 @@ fn build_master(
     inputs: MasterInputs<'_>,
     recording_blocker: Option<&str>,
     flat_star_masking: bool,
+    cancel: Option<&AtomicBool>,
 ) -> Result<Option<BuiltMaster>> {
     let context = MasterBuildContext {
         conn,
@@ -3686,7 +3689,9 @@ fn build_master(
         build_master_once(&context, candidates, allow_memo)
     };
     if kind != CalibrationKind::Flat {
-        return Ok(build(frames, false)?.map(|attempt| attempt.master));
+        return build(frames, false)?
+            .map(|attempt| publish_master(&context, attempt, None))
+            .transpose();
     }
     let without = |excluded: &[CalibrationFrame]| -> Vec<CalibrationFrame> {
         frames
@@ -3713,7 +3718,7 @@ fn build_master(
     };
     let drifting = first.drifting();
     if drifting.is_empty() {
-        return Ok(Some(first.master));
+        return publish_master(&context, first, None).map(Some);
     }
     let feature_pixels = first
         .stability
@@ -3723,41 +3728,56 @@ fn build_master(
     let stable = used - drifting.len();
     let spots = "spots that come and go across the run: dew or frost on the sensor window?";
 
-    // A minority of odd frames: the rest still make an honest master.
-    if stable >= MIN_MASTER_FRAMES
-        && stable * 2 >= used
-        && let Some(trimmed) = retry(&without(&drifting))
-    {
-        if trimmed.drifting().is_empty() && !trimmed.memo {
-            set_aside_master(conn, &first.master);
-            let note = format!(
-                "Left out {} of {used} flats that disagreed with the rest of the set at \
-                 {feature_pixels} pixels ({spots})",
-                drifting.len()
-            );
-            return Ok(Some(with_stability_note(conn, trimmed.master, note)));
+    // A minority of odd frames: the rest of this set still make an honest
+    // master. Only this set's frames are offered, so the trim cannot slide
+    // onto another session while the card speaks of leaving frames out.
+    if stable >= MIN_MASTER_FRAMES && stable * 2 >= used {
+        stop_requested(cancel)?;
+        let rest: Vec<CalibrationFrame> = first
+            .used
+            .iter()
+            .filter(|frame| {
+                !drifting
+                    .iter()
+                    .any(|other| other.frame_uuid == frame.frame_uuid)
+            })
+            .cloned()
+            .collect();
+        if let Some(trimmed) = retry(&rest) {
+            if trimmed.drifting().is_empty() && !trimmed.memo {
+                set_aside_master(&context, first);
+                let note = format!(
+                    "Left out {} of {used} flats that disagreed with the rest of the set at \
+                     {feature_pixels} pixels ({spots})",
+                    drifting.len()
+                );
+                return publish_master(&context, trimmed, Some(note)).map(Some);
+            }
+            set_aside_master(&context, trimmed);
         }
-        set_aside_master(conn, &trimmed.master);
     }
 
     // The set disagrees with itself: the next set takes its place when
-    // there is one.
-    if let Some(other) = retry(&without(&first.used)) {
+    // there is one. Everything shot around this set goes with it: the
+    // frames the clusterer dropped from the same noon saw the same window.
+    stop_requested(cancel)?;
+    if let Some(other) = retry(&without(&same_session_as(&first.used, frames))) {
         if other.drifting().is_empty() && !other.memo {
-            set_aside_master(conn, &first.master);
             let note = format!(
                 "The nearest {} disagree with each other at {feature_pixels} pixels ({spots}); \
                  used {} instead",
                 flat_set_label(&first.used),
                 flat_set_label(&other.used)
             );
-            return Ok(Some(with_stability_note(conn, other.master, note)));
+            set_aside_master(&context, first);
+            return publish_master(&context, other, Some(note)).map(Some);
         }
-        set_aside_master(conn, &other.master);
+        set_aside_master(&context, other);
     }
     // Nothing better: the first master serves. A memo has no file, so the
     // set builds again for real.
     let first = if first.memo {
+        stop_requested(cancel)?;
         match build(frames, false)? {
             Some(rebuilt) => rebuilt,
             None => return Ok(None),
@@ -3770,7 +3790,156 @@ fn build_master(
          {feature_pixels} pixels ({spots}). Retake these flats",
         drifting.len()
     );
-    Ok(Some(with_stability_note(conn, first.master, note)))
+    publish_master(&context, first, Some(note)).map(Some)
+}
+
+/// The candidates shot within one flat session of `set`: the set itself and
+/// whatever the clusterer left out of it from the same run.
+fn same_session_as(
+    set: &[CalibrationFrame],
+    candidates: &[CalibrationFrame],
+) -> Vec<CalibrationFrame> {
+    let window = tolerances().flat_session_seconds as i64;
+    let first = set.iter().filter_map(|frame| frame.captured_at).min();
+    let last = set.iter().filter_map(|frame| frame.captured_at).max();
+    candidates
+        .iter()
+        .filter(|candidate| {
+            set.iter()
+                .any(|frame| frame.frame_uuid == candidate.frame_uuid)
+                || match (first, last, candidate.captured_at) {
+                    (Some(first), Some(last), Some(at)) => {
+                        at >= first - window && at <= last + window
+                    }
+                    _ => false,
+                }
+        })
+        .cloned()
+        .collect()
+}
+
+/// Make a built master real: move its staged file into place and record it,
+/// with the judgement and any note. A cache hit or memo is already real and
+/// only takes the note.
+fn publish_master(
+    context: &MasterBuildContext<'_, '_>,
+    attempt: BuiltAttempt,
+    note: Option<String>,
+) -> Result<BuiltMaster> {
+    let BuiltAttempt {
+        mut master,
+        used,
+        stability,
+        staged,
+        ..
+    } = attempt;
+    if let Some(note) = &note {
+        tracing::warn!("master flat {}: {note}", master.label());
+    }
+    if let Some(staged) = staged {
+        std::fs::rename(&staged.file, &master.path)
+            .with_context(|| format!("publishing {}", master.path.display()))?;
+        let mut statistics = staged.statistics;
+        if let Some(stability) = &stability {
+            statistics["flat_stability"] =
+                flat_stability_json(stability, &used, false, note.as_deref());
+        }
+        record_master(
+            context.conn,
+            context.kind,
+            &used,
+            &staged.source_hash,
+            &master.path,
+            RecordedMaster {
+                exposure_seconds: staged.exposure_seconds,
+                statistics,
+            },
+            MasterInputs {
+                bias: None,
+                dark: None,
+                bias_dependency: context.inputs.bias_dependency,
+                dark_dependency: context.inputs.dark_dependency,
+            },
+        )?;
+    } else if let Some(note) = &note {
+        patch_flat_stability(context.conn, &master.master_uuid, |stability| {
+            stability["note"] = serde_json::Value::String(note.clone());
+        });
+    }
+    master.stability_note = note;
+    Ok(master)
+}
+
+/// Drop a master this build made and judged against: its staged file goes,
+/// and its record stays as a memo of the judgement so the next selection of
+/// the same frames reaches the replacement without reading a flat. A cache
+/// hit or memo belongs to another selection and is left alone.
+fn set_aside_master(context: &MasterBuildContext<'_, '_>, attempt: BuiltAttempt) {
+    let BuiltAttempt {
+        master,
+        used,
+        stability,
+        staged,
+        ..
+    } = attempt;
+    let Some(staged) = staged else {
+        return;
+    };
+    if let Err(error) = std::fs::remove_file(&staged.file)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            "could not remove set-aside master {}: {error}",
+            staged.file.display()
+        );
+    }
+    let Some(stability) = stability else {
+        return;
+    };
+    let mut statistics = staged.statistics;
+    statistics["flat_stability"] = flat_stability_json(&stability, &used, true, None);
+    if let Err(error) = record_master(
+        context.conn,
+        context.kind,
+        &used,
+        &staged.source_hash,
+        &master.path,
+        RecordedMaster {
+            exposure_seconds: staged.exposure_seconds,
+            statistics,
+        },
+        MasterInputs {
+            bias: None,
+            dark: None,
+            bias_dependency: context.inputs.bias_dependency,
+            dark_dependency: context.inputs.dark_dependency,
+        },
+    ) {
+        tracing::warn!("could not record the flat-set judgement: {error:#}");
+    }
+}
+
+/// The judgement as recorded with a master, keyed by frame so a later
+/// selection lines it up by identity rather than by position.
+fn flat_stability_json(
+    stability: &FlatSetStability,
+    used: &[CalibrationFrame],
+    superseded: bool,
+    note: Option<&str>,
+) -> serde_json::Value {
+    let mut value = serde_json::json!({
+        "feature_pixels": stability.feature_pixels,
+        "drift_threshold": stability.drift_threshold,
+        "frames": used.iter().map(|frame| frame.frame_uuid.as_str()).collect::<Vec<_>>(),
+        "disagreement": stability.disagreement,
+    });
+    if superseded {
+        value["superseded"] = serde_json::Value::Bool(true);
+    }
+    if let Some(note) = note {
+        value["note"] = serde_json::Value::String(note.to_string());
+    }
+    value
 }
 
 /// Add one more sentence to the applied-calibration warning.
@@ -3804,34 +3973,6 @@ fn flat_set_label(frames: &[CalibrationFrame]) -> String {
         _ => String::new(),
     };
     format!("{} {filter}flats{when}", frames.len())
-}
-
-/// Set aside a master this build made and then decided against. The record
-/// stays, marked, as a memo of the judgement; the file goes, so nothing
-/// serves the master by mistake.
-fn set_aside_master(conn: &Connection, master: &BuiltMaster) {
-    patch_flat_stability(conn, &master.master_uuid, |stability| {
-        stability["superseded"] = serde_json::Value::Bool(true);
-    });
-    if let Err(error) = std::fs::remove_file(&master.path)
-        && error.kind() != std::io::ErrorKind::NotFound
-    {
-        tracing::warn!(
-            "could not remove set-aside master {}: {error}",
-            master.path.display()
-        );
-    }
-}
-
-/// Attach the stability note to the master and to its record, so a later
-/// cache hit on the same master repeats it.
-fn with_stability_note(conn: &Connection, mut master: BuiltMaster, note: String) -> BuiltMaster {
-    tracing::warn!("master flat {}: {note}", master.label());
-    patch_flat_stability(conn, &master.master_uuid, |stability| {
-        stability["note"] = serde_json::Value::String(note.clone());
-    });
-    master.stability_note = Some(note);
-    master
 }
 
 /// Edit the `flat_stability` object in a recorded master's statistics. A
@@ -3893,11 +4034,13 @@ fn cached_stability_note(conn: &Connection, path: &Path) -> Option<String> {
         .map(str::to_string)
 }
 
-/// The flat-set judgement recorded with the master at `path`. With
-/// `superseded_only`, only a memo of a set this build once set aside.
+/// The flat-set judgement recorded with the master at `path`, lined up with
+/// `frames` by identity; a frame the record never judged counts as agreeing.
+/// With `superseded_only`, only a memo of a set this build once set aside.
 fn recorded_flat_stability(
     conn: &Connection,
     path: &Path,
+    frames: &[CalibrationFrame],
     superseded_only: bool,
 ) -> Option<FlatSetStability> {
     let statistics = recorded_master_statistics(conn, path)?;
@@ -3905,15 +4048,24 @@ fn recorded_flat_stability(
     if superseded_only && stability["superseded"] != serde_json::Value::Bool(true) {
         return None;
     }
-    let disagreement = stability["disagreement"]
+    let by_frame: HashMap<&str, usize> = stability["frames"]
         .as_array()?
         .iter()
-        .map(|value| value.as_u64().map(|value| value as usize))
-        .collect::<Option<Vec<_>>>()?;
+        .zip(stability["disagreement"].as_array()?)
+        .map(|(uuid, count)| Some((uuid.as_str()?, count.as_u64()? as usize)))
+        .collect::<Option<_>>()?;
     Some(FlatSetStability {
         feature_pixels: stability["feature_pixels"].as_u64()? as usize,
         drift_threshold: stability["drift_threshold"].as_u64()? as usize,
-        disagreement,
+        disagreement: frames
+            .iter()
+            .map(|frame| {
+                by_frame
+                    .get(frame.frame_uuid.as_str())
+                    .copied()
+                    .unwrap_or(0)
+            })
+            .collect(),
     })
 }
 
@@ -4042,6 +4194,7 @@ impl SamplePlanes {
 
 fn flat_set_stability(
     frames: &[CalibrationFrame],
+    skipped: &[(PathBuf, String)],
     master: &seiza_stacking::LinearImage,
     bayer: Option<seiza_stacking::BayerLayout>,
     calibration: Option<&seiza_stacking::CalibrationMasters>,
@@ -4058,12 +4211,14 @@ fn flat_set_stability(
                 && (value - surround).abs() > FLAT_FEATURE_DEPTH * surround
         })
         .collect();
-    // Below this many pixels there is nothing to judge a set by: a handful
-    // of dead pixels, or a clean master. The same floor, doubled, is how
-    // many disagreeing pixels make a frame drift: far above what noise can
-    // reach, far below what a droplet run leaves.
+    // Below this many feature pixels there is nothing to judge a set by: a
+    // handful of dead pixels, or a clean master. A frame drifts once it
+    // disagrees at a fifth of the features, capped at one pixel in two
+    // hundred thousand of the sensor so a dusty optical path with many
+    // honest features cannot hide a droplet run, and never below sixteen so
+    // noise cannot reach it.
     let minimum = (pixels / 100_000).max(16);
-    let drift_threshold = (pixels / 50_000).max(16);
+    let drift_threshold = (pixels / 200_000).min(features.len() / 5).max(16);
     if features.len() < minimum {
         return FlatSetStability {
             feature_pixels: features.len(),
@@ -4075,9 +4230,15 @@ fn flat_set_stability(
     // samples to the master's, per plane, so a plane's own response does
     // not read as disagreement.
     let step = (master.data.len() / 200_000).max(1);
+    // A frame the integrator left out was never in the master and counts
+    // as agreeing; a frame the check cannot read back or calibrate is not
+    // trusted and counts as drifting.
     let disagreement = frames
         .iter()
         .map(|frame| {
+            if skipped.iter().any(|(path, _)| *path == frame.source_path) {
+                return 0;
+            }
             let mut opened = match crate::image_io::open_linear_frame(&frame.source_path) {
                 Ok(opened) => opened,
                 Err(error) => {
@@ -4085,24 +4246,26 @@ fn flat_set_stability(
                         "flat-set check could not read {}: {error}",
                         frame.source_path.display()
                     );
-                    return 0;
+                    return drift_threshold;
                 }
             };
             if opened.image.width != master.width
                 || opened.image.height != master.height
                 || opened.image.channels.max(1) != planes.channels
             {
-                return 0;
+                return drift_threshold;
             }
+            // The integrator scaled any dark by the catalog's exposure; do
+            // the same rather than trusting a header the catalog may not.
+            let exposure = frame.exposure_s.or(opened.exposure_seconds);
             if let Some(calibration) = calibration
-                && let Err(error) =
-                    calibration.apply(&mut opened.image, opened.exposure_seconds, opened.bayer)
+                && let Err(error) = calibration.apply(&mut opened.image, exposure, opened.bayer)
             {
                 tracing::warn!(
                     "flat-set check could not calibrate {}: {error}",
                     frame.source_path.display()
                 );
-                return 0;
+                return drift_threshold;
             }
             let data = &opened.image.data;
             let mut ratios: Vec<Vec<f32>> = vec![Vec::new(); planes.count()];

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -2648,10 +2648,7 @@ fn resolve_or_build_masters_pinned(
             "{} lacked enough matching coherent frames (each master needs at least {MIN_MASTER_FRAMES})",
             missing.join(", ")
         );
-        applied.warning = Some(match applied.warning.take() {
-            Some(previous) => format!("{previous}. {partial}"),
-            None => partial,
-        });
+        append_warning(&mut applied.warning, partial);
     }
     if !build_failures.is_empty() {
         let failed = format!(
@@ -2662,10 +2659,7 @@ fn resolve_or_build_masters_pinned(
                 .collect::<Vec<_>>()
                 .join("; ")
         );
-        applied.warning = Some(match applied.warning.take() {
-            Some(previous) => format!("{previous}. {failed}"),
-            None => failed,
-        });
+        append_warning(&mut applied.warning, failed);
     }
     if !set_aside.is_empty() {
         let note = format!(
@@ -2680,32 +2674,20 @@ fn resolve_or_build_masters_pinned(
                 .collect::<Vec<_>>()
                 .join("; ")
         );
-        applied.warning = Some(match applied.warning.take() {
-            Some(previous) => format!("{previous}. {note}"),
-            None => note,
-        });
+        append_warning(&mut applied.warning, note);
     }
     for note in stability_notes.into_inner() {
-        applied.warning = Some(match applied.warning.take() {
-            Some(previous) => format!("{previous}. {note}"),
-            None => note,
-        });
+        append_warning(&mut applied.warning, note);
     }
     if let Some(note) = flat_note {
-        applied.warning = Some(match applied.warning.take() {
-            Some(previous) => format!("{previous}. {note}"),
-            None => note,
-        });
+        append_warning(&mut applied.warning, note);
     }
     if let Some(note) = flat
         .as_ref()
         .and_then(|master| master.flat_star_masking.as_ref())
         .and_then(flat_masking_warning)
     {
-        applied.warning = Some(match applied.warning.take() {
-            Some(previous) => format!("{previous}. {note}"),
-            None => note,
-        });
+        append_warning(&mut applied.warning, note);
     }
     let external_used = external_used.into_inner();
     if !external_used.is_empty() {
@@ -2717,10 +2699,7 @@ fn resolve_or_build_masters_pinned(
                 .collect::<Vec<_>>()
                 .join("; ")
         );
-        applied.warning = Some(match applied.warning.take() {
-            Some(previous) => format!("{previous}. {note}"),
-            None => note,
-        });
+        append_warning(&mut applied.warning, note);
     }
     applied.masters_signature = masters_signature(&applied);
     applied.sessions = 1;
@@ -3521,23 +3500,10 @@ fn build_master_once(
     };
     // Only a build needs its own copies of the bias and dark; the cache hit
     // above returned without touching them.
-    let bias = inputs.bias.clone();
-    let dark = inputs.dark.clone();
-    // The check below calibrates each flat the way the integrator did, so
-    // it needs the same bias and dark once more.
-    let stability_calibration = (kind == CalibrationKind::Flat)
-        .then(|| seiza_stacking::CalibrationMasters::new(bias.clone(), dark.clone(), None))
-        .and_then(|masters| match masters {
-            Ok(masters) => Some(masters),
-            Err(error) => {
-                tracing::warn!("flat-set stability check skipped: {error}");
-                None
-            }
-        });
     let options = seiza_stacking::MasterBuildOptions {
         exposure_seconds: frames.first().and_then(|frame| frame.exposure_s),
-        bias,
-        dark,
+        bias: inputs.bias.clone(),
+        dark: inputs.dark.clone(),
         // A defective sensor pixel repeats in every flat, so across-frame
         // clipping keeps it and it would divide every light forever. The
         // flat's true response is smooth at pixel scale, so a spatial pass
@@ -3555,6 +3521,21 @@ fn build_master_once(
     let frame =
         seiza_stacking::build_master_from_fits_with_scratch(&paths, seiza_kind, &options, root)
             .with_context(|| format!("building master {}", kind.as_str()))?;
+    // The integrator's copies of the bias and dark go before the check
+    // below takes its own: it calibrates each flat the way the integrator
+    // did, and one full-frame copy at a time is enough.
+    drop(options);
+    let stability_calibration = (kind == CalibrationKind::Flat)
+        .then(|| {
+            seiza_stacking::CalibrationMasters::new(inputs.bias.clone(), inputs.dark.clone(), None)
+        })
+        .and_then(|masters| match masters {
+            Ok(masters) => Some(masters),
+            Err(error) => {
+                tracing::warn!("flat-set stability check skipped: {error}");
+                None
+            }
+        });
     tracing::info!(
         "master {} combined {} frame(s) with {} rejection: {} accepted, {} rejected samples, {} fallback pixels",
         kind.as_str(),
@@ -3790,6 +3771,15 @@ fn build_master(
         drifting.len()
     );
     Ok(Some(with_stability_note(conn, first.master, note)))
+}
+
+/// Add one more sentence to the applied-calibration warning.
+fn append_warning(warning: &mut Option<String>, note: impl Into<String>) {
+    let note = note.into();
+    *warning = Some(match warning.take() {
+        Some(previous) => format!("{previous}. {note}"),
+        None => note,
+    });
 }
 
 /// "20 G flats from 2026-09-10", for a note about one flat set.

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -3332,14 +3332,17 @@ struct BuiltAttempt {
     master: BuiltMaster,
     /// The frames the integrator combined, in the order they were offered.
     used: Vec<CalibrationFrame>,
-    /// Present when the master is a freshly built flat; a cached master was
-    /// checked when it was built.
+    /// How the frames agreed with the master: measured on a fresh flat
+    /// build, read back from the record on a cache hit, absent otherwise.
     stability: Option<FlatSetStability>,
+    /// The master is a memo of a set this build once judged unstable: its
+    /// record remains, its file does not, and it must not be served.
+    memo: bool,
 }
 
 impl BuiltAttempt {
-    /// Frames that disagree with the master at more than
-    /// [`FLAT_DRIFT_SHARE`] of its feature pixels.
+    /// Frames that disagree with the master at enough of its feature pixels
+    /// to have been looking at a different sensor window.
     fn drifting(&self) -> Vec<CalibrationFrame> {
         let Some(stability) = &self.stability else {
             return Vec::new();
@@ -3347,21 +3350,37 @@ impl BuiltAttempt {
         self.used
             .iter()
             .zip(&stability.disagreement)
-            .filter(|(_, share)| **share > FLAT_DRIFT_SHARE)
+            .filter(|(_, disagree)| **disagree >= stability.drift_threshold)
             .map(|(frame, _)| frame.clone())
             .collect()
     }
 }
 
-fn build_master_once(
-    conn: &Connection,
-    root: &Path,
+/// What every attempt at one master shares: where it goes, what it is, and
+/// what it subtracts.
+#[derive(Clone, Copy)]
+struct MasterBuildContext<'a, 'b> {
+    conn: &'a Connection,
+    root: &'a Path,
     kind: CalibrationKind,
-    frames: &[CalibrationFrame],
-    inputs: MasterInputs<'_>,
-    recording_blocker: Option<&str>,
+    inputs: &'a MasterInputs<'b>,
+    recording_blocker: Option<&'a str>,
     flat_star_masking: bool,
+}
+
+fn build_master_once(
+    context: &MasterBuildContext<'_, '_>,
+    frames: &[CalibrationFrame],
+    allow_memo: bool,
 ) -> Result<Option<BuiltAttempt>> {
+    let MasterBuildContext {
+        conn,
+        root,
+        kind,
+        inputs,
+        recording_blocker,
+        flat_star_masking,
+    } = *context;
     // Reduce to the frames that can actually combine (one temperature, one
     // flat session). The master's content hash below covers exactly this
     // subset, so a subset change re-keys the cache.
@@ -3370,16 +3389,33 @@ fn build_master_once(
     if frames.len() < MIN_MASTER_FRAMES {
         return Ok(None);
     }
-    let MasterInputs {
-        bias,
-        dark,
-        bias_dependency,
-        dark_dependency,
-    } = inputs;
+    let bias_dependency = inputs.bias_dependency;
+    let dark_dependency = inputs.dark_dependency;
     let flat_star_masking = kind == CalibrationKind::Flat && flat_star_masking;
     let source_hash = source_set_hash(frames, bias_dependency, dark_dependency, flat_star_masking);
     let master_uuid = stable_uuid(&format!("{}:{source_hash}", kind.as_str()));
     let path = root.join(format!("{}-{source_hash}.fits", kind.as_str()));
+    // A flat set this build once judged unstable keeps its record as a memo
+    // of that judgement, file gone. Serving the judgement spares reading
+    // every flat again only to reach the same replacement.
+    if kind == CalibrationKind::Flat
+        && allow_memo
+        && let Some(stability) = recorded_flat_stability(conn, &path, true)
+        && stability.disagreement.len() == frames.len()
+    {
+        return Ok(Some(BuiltAttempt {
+            master: BuiltMaster {
+                path,
+                master_uuid,
+                skipped: Vec::new(),
+                flat_star_masking: None,
+                stability_note: None,
+            },
+            used: frames.to_vec(),
+            stability: Some(stability),
+            memo: true,
+        }));
+    }
     if path.exists() {
         let expected_kind = match kind {
             CalibrationKind::Bias => "BIAS",
@@ -3433,6 +3469,11 @@ fn build_master_once(
             match masking_statistics {
                 Ok(statistics) => {
                     let stability_note = cached_stability_note(conn, &path);
+                    // A kept-but-unstable flat must not pass as a sound
+                    // fallback for another set: its record says how its
+                    // frames disagreed, and that judgement stands.
+                    let stability = recorded_flat_stability(conn, &path, false)
+                        .filter(|stability| stability.disagreement.len() == frames.len());
                     return Ok(Some(BuiltAttempt {
                         master: BuiltMaster {
                             path,
@@ -3444,7 +3485,8 @@ fn build_master_once(
                             stability_note,
                         },
                         used: frames.to_vec(),
-                        stability: None,
+                        stability,
+                        memo: false,
                     }));
                 }
                 Err(error) => {
@@ -3477,6 +3519,10 @@ fn build_master_once(
         CalibrationKind::Dark | CalibrationKind::DarkFlat => seiza_stacking::MasterFrameKind::Dark,
         CalibrationKind::Flat => seiza_stacking::MasterFrameKind::Flat,
     };
+    // Only a build needs its own copies of the bias and dark; the cache hit
+    // above returned without touching them.
+    let bias = inputs.bias.clone();
+    let dark = inputs.dark.clone();
     // The check below calibrates each flat the way the integrator did, so
     // it needs the same bias and dark once more.
     let stability_calibration = (kind == CalibrationKind::Flat)
@@ -3557,16 +3603,20 @@ fn build_master_once(
         .cloned()
         .collect();
     let stability = (kind == CalibrationKind::Flat).then(|| {
-        let stability = flat_set_stability(&used, &frame.image, stability_calibration.as_ref());
-        tracing::info!(
-            "master flat kept {} feature pixel(s); per-frame disagreement {:?}",
-            stability.feature_pixels,
-            stability
-                .disagreement
-                .iter()
-                .map(|share| (share * 100.0).round() / 100.0)
-                .collect::<Vec<_>>()
+        let stability = flat_set_stability(
+            &used,
+            &frame.image,
+            frame.bayer,
+            stability_calibration.as_ref(),
         );
+        tracing::info!(
+            "master flat kept {} feature pixel(s); frames disagree at {:?} of them (drift from {})",
+            stability.feature_pixels,
+            stability.disagreement,
+            stability.drift_threshold
+        );
+        #[cfg(test)]
+        FLAT_STABILITY_CHECKED.lock().unwrap().push(path.clone());
         stability
     });
     if !path.exists() {
@@ -3593,6 +3643,7 @@ fn build_master_once(
                 "flat_star_masking": frame.flat_star_masking,
                 "flat_stability": stability.as_ref().map(|stability| serde_json::json!({
                     "feature_pixels": stability.feature_pixels,
+                    "drift_threshold": stability.drift_threshold,
                     "disagreement": stability.disagreement,
                 })),
             }),
@@ -3614,8 +3665,14 @@ fn build_master_once(
         },
         used,
         stability,
+        memo: false,
     }))
 }
+
+/// Master paths whose flat set was checked, so a test can tell a memo hit
+/// from a rebuild.
+#[cfg(test)]
+static FLAT_STABILITY_CHECKED: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(Vec::new());
 
 /// Build one master from nearest-first candidates.
 ///
@@ -3623,10 +3680,10 @@ fn build_master_once(
 /// the frames that fed it: dew or frost drying off the sensor window while
 /// the flats ran leaves spots that fade frame by frame, the across-frame
 /// median keeps a middling copy of each spot, and every light divided by that
-/// master gets a bright bead wherever the sky is bright. Frames that disagree
-/// with the master about such features are left out when they are a
-/// minority; when the set as a whole disagrees, the next set is preferred;
-/// when there is no next set the master is kept and the card says so.
+/// master gets a bright bead wherever the sky is bright. When a minority of
+/// frames disagree with the master about such features, the master rebuilds
+/// without them; when the set as a whole disagrees, the next set takes its
+/// place; when there is no next set the master stays and the card says so.
 fn build_master(
     conn: &Connection,
     root: &Path,
@@ -3636,17 +3693,19 @@ fn build_master(
     recording_blocker: Option<&str>,
     flat_star_masking: bool,
 ) -> Result<Option<BuiltMaster>> {
+    let context = MasterBuildContext {
+        conn,
+        root,
+        kind,
+        inputs: &inputs,
+        recording_blocker,
+        flat_star_masking,
+    };
+    let build = |candidates: &[CalibrationFrame], allow_memo: bool| {
+        build_master_once(&context, candidates, allow_memo)
+    };
     if kind != CalibrationKind::Flat {
-        return Ok(build_master_once(
-            conn,
-            root,
-            kind,
-            frames,
-            inputs,
-            recording_blocker,
-            flat_star_masking,
-        )?
-        .map(|attempt| attempt.master));
+        return Ok(build(frames, false)?.map(|attempt| attempt.master));
     }
     let without = |excluded: &[CalibrationFrame]| -> Vec<CalibrationFrame> {
         frames
@@ -3659,16 +3718,16 @@ fn build_master(
             .cloned()
             .collect()
     };
-    let Some(first) = build_master_once(
-        conn,
-        root,
-        kind,
-        frames,
-        inputs.clone(),
-        recording_blocker,
-        flat_star_masking,
-    )?
-    else {
+    // A retry that fails must not fail the build: the first master exists
+    // and is the honest fallback, named as such below.
+    let retry = |candidates: &[CalibrationFrame]| match build(candidates, true) {
+        Ok(attempt) => attempt,
+        Err(error) => {
+            tracing::warn!("flat master retry failed; keeping the first build: {error:#}");
+            None
+        }
+    };
+    let Some(first) = build(frames, true)? else {
         return Ok(None);
     };
     let drifting = first.drifting();
@@ -3684,43 +3743,27 @@ fn build_master(
     let spots = "spots that come and go across the run: dew or frost on the sensor window?";
 
     // A minority of odd frames: the rest still make an honest master.
-    if stable >= MIN_MASTER_FRAMES && stable * 2 >= used {
-        let candidates = without(&drifting);
-        if let Some(trimmed) = build_master_once(
-            conn,
-            root,
-            kind,
-            &candidates,
-            inputs.clone(),
-            recording_blocker,
-            flat_star_masking,
-        )? {
-            if trimmed.drifting().is_empty() {
-                discard_master(conn, &first.master);
-                let note = format!(
-                    "Left out {} of {used} flats that disagreed with the rest of the set at \
-                     {feature_pixels} pixels ({spots})",
-                    drifting.len()
-                );
-                return Ok(Some(with_stability_note(conn, trimmed.master, note)));
-            }
-            discard_master(conn, &trimmed.master);
+    if stable >= MIN_MASTER_FRAMES
+        && stable * 2 >= used
+        && let Some(trimmed) = retry(&without(&drifting))
+    {
+        if trimmed.drifting().is_empty() && !trimmed.memo {
+            set_aside_master(conn, &first.master);
+            let note = format!(
+                "Left out {} of {used} flats that disagreed with the rest of the set at \
+                 {feature_pixels} pixels ({spots})",
+                drifting.len()
+            );
+            return Ok(Some(with_stability_note(conn, trimmed.master, note)));
         }
+        set_aside_master(conn, &trimmed.master);
     }
 
-    // The set disagrees with itself: prefer the next one when there is one.
-    let candidates = without(&first.used);
-    if let Some(other) = build_master_once(
-        conn,
-        root,
-        kind,
-        &candidates,
-        inputs,
-        recording_blocker,
-        flat_star_masking,
-    )? {
-        if other.drifting().is_empty() {
-            discard_master(conn, &first.master);
+    // The set disagrees with itself: the next set takes its place when
+    // there is one.
+    if let Some(other) = retry(&without(&first.used)) {
+        if other.drifting().is_empty() && !other.memo {
+            set_aside_master(conn, &first.master);
             let note = format!(
                 "The nearest {} disagree with each other at {feature_pixels} pixels ({spots}); \
                  used {} instead",
@@ -3729,8 +3772,18 @@ fn build_master(
             );
             return Ok(Some(with_stability_note(conn, other.master, note)));
         }
-        discard_master(conn, &other.master);
+        set_aside_master(conn, &other.master);
     }
+    // Nothing better: the first master serves. A memo has no file, so the
+    // set builds again for real.
+    let first = if first.memo {
+        match build(frames, false)? {
+            Some(rebuilt) => rebuilt,
+            None => return Ok(None),
+        }
+    } else {
+        first
+    };
     let note = format!(
         "Built from an unstable flat set: {} of {used} frames disagree with the master at \
          {feature_pixels} pixels ({spots}). Retake these flats",
@@ -3763,18 +3816,13 @@ fn flat_set_label(frames: &[CalibrationFrame]) -> String {
     format!("{} {filter}flats{when}", frames.len())
 }
 
-/// Forget a master this build made and then decided against, so no later
-/// selection of the same frames serves it as a cache hit.
-fn discard_master(conn: &Connection, master: &BuiltMaster) {
-    if let Err(error) = conn.execute(
-        "DELETE FROM psf_guard_calibration_master WHERE master_uuid = ?1",
-        [&master.master_uuid],
-    ) {
-        tracing::warn!(
-            "could not forget set-aside master {}: {error}",
-            master.label()
-        );
-    }
+/// Set aside a master this build made and then decided against. The record
+/// stays, marked, as a memo of the judgement; the file goes, so nothing
+/// serves the master by mistake.
+fn set_aside_master(conn: &Connection, master: &BuiltMaster) {
+    patch_flat_stability(conn, &master.master_uuid, |stability| {
+        stability["superseded"] = serde_json::Value::Bool(true);
+    });
     if let Err(error) = std::fs::remove_file(&master.path)
         && error.kind() != std::io::ErrorKind::NotFound
     {
@@ -3789,66 +3837,106 @@ fn discard_master(conn: &Connection, master: &BuiltMaster) {
 /// cache hit on the same master repeats it.
 fn with_stability_note(conn: &Connection, mut master: BuiltMaster, note: String) -> BuiltMaster {
     tracing::warn!("master flat {}: {note}", master.label());
+    patch_flat_stability(conn, &master.master_uuid, |stability| {
+        stability["note"] = serde_json::Value::String(note.clone());
+    });
+    master.stability_note = Some(note);
+    master
+}
+
+/// Edit the `flat_stability` object in a recorded master's statistics. A
+/// master without a record (recording blocked) is left alone.
+fn patch_flat_stability(
+    conn: &Connection,
+    master_uuid: &str,
+    edit: impl FnOnce(&mut serde_json::Value),
+) {
     let recorded: Option<String> = conn
         .query_row(
             "SELECT statistics_json FROM psf_guard_calibration_master WHERE master_uuid = ?1",
-            [&master.master_uuid],
+            [master_uuid],
             |row| row.get(0),
         )
         .optional()
         .ok()
         .flatten();
-    if let Some(recorded) = recorded {
-        let mut statistics: serde_json::Value =
-            serde_json::from_str(&recorded).unwrap_or(serde_json::Value::Null);
-        if !statistics.is_object() {
-            statistics = serde_json::json!({});
-        }
-        let stability = statistics["flat_stability"].take();
-        let mut stability = if stability.is_object() {
-            stability
-        } else {
-            serde_json::json!({})
-        };
-        stability["note"] = serde_json::Value::String(note.clone());
-        statistics["flat_stability"] = stability;
-        if let Err(error) = conn.execute(
-            "UPDATE psf_guard_calibration_master SET statistics_json = ?1 WHERE master_uuid = ?2",
-            params![statistics.to_string(), master.master_uuid],
-        ) {
-            tracing::warn!("could not record the flat stability note: {error}");
-        }
+    let Some(recorded) = recorded else {
+        return;
+    };
+    let mut statistics: serde_json::Value =
+        serde_json::from_str(&recorded).unwrap_or(serde_json::Value::Null);
+    if !statistics.is_object() {
+        statistics = serde_json::json!({});
     }
-    master.stability_note = Some(note);
-    master
+    if !statistics["flat_stability"].is_object() {
+        statistics["flat_stability"] = serde_json::json!({});
+    }
+    edit(&mut statistics["flat_stability"]);
+    if let Err(error) = conn.execute(
+        "UPDATE psf_guard_calibration_master SET statistics_json = ?1 WHERE master_uuid = ?2",
+        params![statistics.to_string(), master_uuid],
+    ) {
+        tracing::warn!("could not record the flat stability judgement: {error}");
+    }
 }
 
-/// The stability note recorded with a cached master, if it has one.
-fn cached_stability_note(conn: &Connection, path: &Path) -> Option<String> {
+/// The statistics recorded with the master at `path` by this generation of
+/// the cache, if any.
+fn recorded_master_statistics(conn: &Connection, path: &Path) -> Option<serde_json::Value> {
     let recorded: String = conn
         .query_row(
-            "SELECT statistics_json FROM psf_guard_calibration_master WHERE cache_path = ?1",
-            [path.to_string_lossy().as_ref()],
+            "SELECT statistics_json FROM psf_guard_calibration_master
+             WHERE cache_path = ?1 AND cache_version = ?2",
+            params![path.to_string_lossy().as_ref(), MASTER_CACHE_VERSION],
             |row| row.get(0),
         )
         .optional()
         .ok()
         .flatten()?;
-    let statistics: serde_json::Value = serde_json::from_str(&recorded).ok()?;
-    statistics["flat_stability"]["note"]
+    serde_json::from_str(&recorded).ok()
+}
+
+/// The stability note recorded with a cached master, if it has one.
+fn cached_stability_note(conn: &Connection, path: &Path) -> Option<String> {
+    recorded_master_statistics(conn, path)?["flat_stability"]["note"]
         .as_str()
         .map(str::to_string)
 }
 
+/// The flat-set judgement recorded with the master at `path`. With
+/// `superseded_only`, only a memo of a set this build once set aside.
+fn recorded_flat_stability(
+    conn: &Connection,
+    path: &Path,
+    superseded_only: bool,
+) -> Option<FlatSetStability> {
+    let statistics = recorded_master_statistics(conn, path)?;
+    let stability = &statistics["flat_stability"];
+    if superseded_only && stability["superseded"] != serde_json::Value::Bool(true) {
+        return None;
+    }
+    let disagreement = stability["disagreement"]
+        .as_array()?
+        .iter()
+        .map(|value| value.as_u64().map(|value| value as usize))
+        .collect::<Option<Vec<_>>>()?;
+    Some(FlatSetStability {
+        feature_pixels: stability["feature_pixels"].as_u64()? as usize,
+        drift_threshold: stability["drift_threshold"].as_u64()? as usize,
+        disagreement,
+    })
+}
+
 /// A master pixel counts as a feature when it departs from the smooth
-/// response around it by more than this fraction, and a frame disagrees with
-/// the master at a feature when its own value departs from the master's by
-/// more than the same fraction. Dust shadows sit at a few percent; a drying
-/// droplet reads at 3 to 70 percent of its surround.
+/// response around it by more than this fraction. Dust shadows sit at a few
+/// percent; a drying droplet reads at 3 to 70 percent of its surround.
 const FLAT_FEATURE_DEPTH: f32 = 0.10;
-/// A frame that disagrees at more than this share of the feature pixels is
-/// not looking at the same sensor window as the master.
-const FLAT_DRIFT_SHARE: f64 = 0.20;
+/// A frame disagrees with the master at a feature when its own value departs
+/// from the master's by more than this fraction of the local response. Half
+/// the feature depth, so a spot that only drifts slowly across the run still
+/// shows up in the frames on either side of the median. Photon noise in a
+/// flat sits near one percent.
+const FLAT_AGREEMENT_DEPTH: f32 = 0.05;
 /// Half-width of the box that estimates the smooth response. Wider than any
 /// droplet, narrower than a dust donut, which the frames all agree on anyway.
 const FLAT_SMOOTH_RADIUS: usize = 16;
@@ -3861,37 +3949,116 @@ const FLAT_SMOOTH_RADIUS: usize = 16;
 struct FlatSetStability {
     /// Master pixels that depart from the smooth response around them.
     feature_pixels: usize,
-    /// Per input frame, in `frames` order: the share of feature pixels at
-    /// which the frame disagrees with the master. `NaN` for a frame that
-    /// could not be read back or calibrated.
-    disagreement: Vec<f64>,
+    /// Disagreeing pixels at or above which a frame counts as drifting: a
+    /// share of the sensor rather than of the features, so a dusty optical
+    /// path with many honest features cannot hide a droplet run.
+    drift_threshold: usize,
+    /// Per input frame, in `frames` order: feature pixels at which the frame
+    /// disagrees with the master. Zero for a frame that could not be read
+    /// back or calibrated.
+    disagreement: Vec<usize>,
+}
+
+/// The sample grids a flat master is smooth on: one per colour channel of an
+/// RGB image, one per CFA phase of a raw colour frame (each phase has its
+/// own response, and a box mean across phases would call every pixel a
+/// feature), and one for a mono frame.
+struct SamplePlanes {
+    width: usize,
+    height: usize,
+    channels: usize,
+    cfa: bool,
+}
+
+impl SamplePlanes {
+    fn new(
+        image: &seiza_stacking::LinearImage,
+        bayer: Option<seiza_stacking::BayerLayout>,
+    ) -> Self {
+        let channels = image.channels.max(1);
+        Self {
+            width: image.width,
+            height: image.height,
+            channels,
+            cfa: channels == 1 && bayer.is_some(),
+        }
+    }
+
+    fn count(&self) -> usize {
+        if self.cfa {
+            4
+        } else {
+            self.channels
+        }
+    }
+
+    /// Which plane a sample index belongs to.
+    fn plane_of(&self, index: usize) -> usize {
+        if self.cfa {
+            let (x, y) = (index % self.width, index / self.width);
+            (y & 1) * 2 + (x & 1)
+        } else {
+            index % self.channels
+        }
+    }
+
+    /// The plane's own grid size.
+    fn size(&self, plane: usize) -> (usize, usize) {
+        if self.cfa {
+            let (ox, oy) = (plane & 1, plane >> 1);
+            (
+                (self.width + 1 - ox.min(self.width)) / 2,
+                (self.height + 1 - oy.min(self.height)) / 2,
+            )
+        } else {
+            (self.width, self.height)
+        }
+    }
+
+    /// Sample index of a plane-grid position.
+    fn index(&self, plane: usize, x: usize, y: usize) -> usize {
+        if self.cfa {
+            let (ox, oy) = (plane & 1, plane >> 1);
+            (2 * y + oy) * self.width + 2 * x + ox
+        } else {
+            (y * self.width + x) * self.channels + plane
+        }
+    }
+
+    /// The smooth response under every sample: a box mean on each plane.
+    fn smooth(&self, data: &[f32]) -> Vec<f32> {
+        let mut smooth = vec![0f32; data.len()];
+        let radius = if self.cfa {
+            FLAT_SMOOTH_RADIUS / 2
+        } else {
+            FLAT_SMOOTH_RADIUS
+        };
+        for plane in 0..self.count() {
+            let (width, height) = self.size(plane);
+            let values: Vec<f32> = (0..height)
+                .flat_map(|y| (0..width).map(move |x| (x, y)))
+                .map(|(x, y)| data[self.index(plane, x, y)])
+                .collect();
+            let blurred = box_mean_plane(&values, width, height, radius);
+            for y in 0..height {
+                for x in 0..width {
+                    smooth[self.index(plane, x, y)] = blurred[y * width + x];
+                }
+            }
+        }
+        smooth
+    }
 }
 
 fn flat_set_stability(
     frames: &[CalibrationFrame],
     master: &seiza_stacking::LinearImage,
+    bayer: Option<seiza_stacking::BayerLayout>,
     calibration: Option<&seiza_stacking::CalibrationMasters>,
 ) -> FlatSetStability {
-    let channels = master.channels.max(1);
-    let (width, height) = (master.width, master.height);
-    let pixels = width * height;
-    let smooth: Vec<f32> = if channels == 1 {
-        box_mean_plane(&master.data, width, height, FLAT_SMOOTH_RADIUS)
-    } else {
-        let mut smooth = vec![0f32; master.data.len()];
-        for channel in 0..channels {
-            let plane: Vec<f32> = (0..pixels)
-                .map(|pixel| master.data[pixel * channels + channel])
-                .collect();
-            for (pixel, value) in box_mean_plane(&plane, width, height, FLAT_SMOOTH_RADIUS)
-                .into_iter()
-                .enumerate()
-            {
-                smooth[pixel * channels + channel] = value;
-            }
-        }
-        smooth
-    };
+    let planes = SamplePlanes::new(master, bayer);
+    let pixels = master.width * master.height;
+    let smooth = planes.smooth(&master.data);
     let features: Vec<usize> = (0..master.data.len())
         .filter(|&index| {
             let value = master.data[index];
@@ -3901,27 +4068,22 @@ fn flat_set_stability(
                 && (value - surround).abs() > FLAT_FEATURE_DEPTH * surround
         })
         .collect();
-    // Too few features to judge a set by: a handful of dead pixels, or a
-    // clean master.
+    // Below this many pixels there is nothing to judge a set by: a handful
+    // of dead pixels, or a clean master. The same floor, doubled, is how
+    // many disagreeing pixels make a frame drift: far above what noise can
+    // reach, far below what a droplet run leaves.
     let minimum = (pixels / 100_000).max(16);
+    let drift_threshold = (pixels / 50_000).max(16);
     if features.len() < minimum {
         return FlatSetStability {
             feature_pixels: features.len(),
-            disagreement: vec![0.0; frames.len()],
+            drift_threshold,
+            disagreement: vec![0; frames.len()],
         };
     }
     // Each frame is put on the master's scale by the median ratio of its
-    // samples to the master's, per CFA phase for a raw colour flat so the
-    // channels' different responses do not read as disagreement.
-    let phases = if channels == 1 { 4 } else { channels };
-    let phase_of = |index: usize| -> usize {
-        if channels == 1 {
-            let (x, y) = (index % width, index / width);
-            (y & 1) * 2 + (x & 1)
-        } else {
-            index % channels
-        }
-    };
+    // samples to the master's, per plane, so a plane's own response does
+    // not read as disagreement.
     let step = (master.data.len() / 200_000).max(1);
     let disagreement = frames
         .iter()
@@ -3933,14 +4095,14 @@ fn flat_set_stability(
                         "flat-set check could not read {}: {error}",
                         frame.source_path.display()
                     );
-                    return f64::NAN;
+                    return 0;
                 }
             };
-            if opened.image.width != width
-                || opened.image.height != height
-                || opened.image.channels.max(1) != channels
+            if opened.image.width != master.width
+                || opened.image.height != master.height
+                || opened.image.channels.max(1) != planes.channels
             {
-                return f64::NAN;
+                return 0;
             }
             if let Some(calibration) = calibration
                 && let Err(error) =
@@ -3950,42 +4112,32 @@ fn flat_set_stability(
                     "flat-set check could not calibrate {}: {error}",
                     frame.source_path.display()
                 );
-                return f64::NAN;
+                return 0;
             }
             let data = &opened.image.data;
-            let mut ratios: Vec<Vec<f32>> = vec![Vec::new(); phases];
+            let mut ratios: Vec<Vec<f32>> = vec![Vec::new(); planes.count()];
             for index in (0..data.len()).step_by(step) {
                 let (value, reference) = (data[index], master.data[index]);
                 if reference > 0.05 && reference.is_finite() && value.is_finite() {
-                    ratios[phase_of(index)].push(value / reference);
+                    ratios[planes.plane_of(index)].push(value / reference);
                 }
             }
-            let overall = median_f32(ratios.iter().flatten().copied().collect());
-            let gains: Vec<f32> = ratios
-                .into_iter()
-                .map(|ratios| {
-                    if ratios.len() >= 16 {
-                        median_f32(ratios)
-                    } else {
-                        overall
-                    }
-                })
-                .collect();
-            let disagree = features
+            let gains: Vec<f32> = ratios.into_iter().map(median_f32).collect();
+            features
                 .iter()
                 .filter(|&&index| {
-                    let gain = gains[phase_of(index)];
+                    let gain = gains[planes.plane_of(index)];
                     gain.is_finite()
                         && gain > 0.0
                         && (data[index] / gain - master.data[index]).abs()
-                            > FLAT_FEATURE_DEPTH * smooth[index]
+                            > FLAT_AGREEMENT_DEPTH * smooth[index]
                 })
-                .count();
-            disagree as f64 / features.len() as f64
+                .count()
         })
         .collect();
     FlatSetStability {
         feature_pixels: features.len(),
+        drift_threshold,
         disagreement,
     }
 }
@@ -8000,13 +8152,26 @@ mod tests {
         master.image.data[34 * 64 + 24] / master.image.data[45 * 64 + 24]
     }
 
+    /// Flat masters that can be served: a set-aside one keeps its record
+    /// as a memo but is not counted.
     fn flat_master_count(conn: &Connection) -> i64 {
         conn.query_row(
-            "SELECT count(*) FROM psf_guard_calibration_master WHERE kind = 'flat'",
+            "SELECT count(*) FROM psf_guard_calibration_master WHERE kind = 'flat'
+             AND json_extract(statistics_json, '$.flat_stability.superseded') IS NOT 1",
             [],
             |row| row.get(0),
         )
         .unwrap()
+    }
+
+    /// How many flat sets under `cache` have been read back and checked.
+    fn stability_checks(cache: &Path) -> usize {
+        FLAT_STABILITY_CHECKED
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|path| path.starts_with(cache))
+            .count()
     }
 
     #[test]
@@ -8046,7 +8211,60 @@ mod tests {
         assert_eq!(
             flat_master_count(&conn),
             1,
-            "the unstable master must not stay recorded"
+            "the set-aside master must not be served again"
+        );
+        // The same selection again: the judgement is remembered, so no flat
+        // is read back and the same master and note come out.
+        let checks = stability_checks(&cache);
+        let (_, again) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        assert_eq!(again.flat_master.as_deref(), Some(label.as_str()));
+        assert!(
+            again
+                .warning
+                .as_deref()
+                .unwrap_or_default()
+                .contains("instead"),
+            "the note repeats: {:?}",
+            again.warning
+        );
+        assert_eq!(
+            stability_checks(&cache),
+            checks,
+            "a remembered judgement must not read the flats again"
+        );
+    }
+
+    #[test]
+    fn a_spot_that_drifts_slowly_still_marks_the_set_unstable() {
+        // The spot deepens gently: 60% of its surround in the first frame,
+        // 100% in the last. Only the frames at either end sit far from the
+        // median; the ones beside it are within a tenth. Judged at half the
+        // feature depth they still disagree, so the set is unstable rather
+        // than trimmed to a master with a shallow spot.
+        let temp = tempfile::tempdir().unwrap();
+        let (conn, cache, light) =
+            spotted_flat_library(&temp, 5, |index| 0.6 + 0.1 * index as f64, 0);
+        let (_, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        let warning = applied.warning.as_deref().unwrap_or_default();
+        assert!(
+            warning.contains("unstable flat set"),
+            "a slow drift must not pass as a trimmed set: {warning}"
         );
     }
 
@@ -8081,7 +8299,7 @@ mod tests {
         assert_eq!(
             flat_master_count(&conn),
             1,
-            "the first attempt must be forgotten"
+            "the first attempt must be set aside"
         );
     }
 
@@ -8105,11 +8323,12 @@ mod tests {
         assert!(applied.flat_master.is_some(), "the master is still used");
         let warning = applied.warning.as_deref().unwrap_or_default();
         assert!(
-            warning.contains("unstable flat set") && warning.contains("4 of 6 frames disagree"),
+            warning.contains("unstable flat set") && warning.contains("of 6 frames disagree"),
             "the card must name the problem: {warning}"
         );
         // A second selection of the same frames is a cache hit and must
         // repeat the note.
+        let checks = stability_checks(&cache);
         let (_, again) = resolve_or_build_masters(
             &conn,
             &cache,
@@ -8127,6 +8346,11 @@ mod tests {
                 .contains("unstable flat set"),
             "a cached master repeats its note: {:?}",
             again.warning
+        );
+        assert_eq!(
+            stability_checks(&cache),
+            checks,
+            "a cache hit must not read the flats again"
         );
     }
 

--- a/src/calibration.rs
+++ b/src/calibration.rs
@@ -43,7 +43,11 @@ pub const CALIBRATION_SCHEMA_VERSION: i64 = 8;
 /// metadata (seiza-stacking 0.11.1). Masters written before that carry no
 /// TELESCOP or FOCALLEN, which weakens validation and later matching to
 /// "nothing recorded, nothing to check" — so they rebuild once.
-pub const MASTER_CACHE_VERSION: u32 = 3;
+/// Version 4: a flat master is checked against its own inputs, and frames
+/// that disagree about a feature the master kept (dew drying off the sensor
+/// window while the flats ran) are left out or the set is passed over. Flat
+/// masters built before the check rebuild once so it runs on them.
+pub const MASTER_CACHE_VERSION: u32 = 4;
 const MIN_MASTER_FRAMES: usize = 2;
 const MAX_MASTER_FRAMES: usize = 64;
 
@@ -2320,6 +2324,8 @@ fn resolve_or_build_masters_pinned(
     let mut build_failures: Vec<(CalibrationKind, String)> = Vec::new();
     // Masters taken from other software as they were, with what each match
     // had to take on trust; reported so the operator knows what calibrated.
+    // What the flat-set stability check did, for the card.
+    let stability_notes: std::cell::RefCell<Vec<String>> = std::cell::RefCell::new(Vec::new());
     let external_used: std::cell::RefCell<Vec<(CalibrationKind, String)>> =
         std::cell::RefCell::new(Vec::new());
     // Frames that clustered but that the integrator would have refused. The
@@ -2417,6 +2423,9 @@ fn resolve_or_build_masters_pinned(
             Ok(Some(master)) => {
                 if let Some((path, _)) = master.skipped.first() {
                     set_aside.push((kind, master.skipped.len(), path.display().to_string()));
+                }
+                if let Some(note) = &master.stability_note {
+                    stability_notes.borrow_mut().push(note.clone());
                 }
                 Some(master)
             }
@@ -2671,6 +2680,12 @@ fn resolve_or_build_masters_pinned(
                 .collect::<Vec<_>>()
                 .join("; ")
         );
+        applied.warning = Some(match applied.warning.take() {
+            Some(previous) => format!("{previous}. {note}"),
+            None => note,
+        });
+    }
+    for note in stability_notes.into_inner() {
         applied.warning = Some(match applied.warning.take() {
             Some(previous) => format!("{previous}. {note}"),
             None => note,
@@ -3042,6 +3057,9 @@ struct BuiltMaster {
     /// headers, while selection has only what the catalog recorded.
     skipped: Vec<(PathBuf, String)>,
     flat_star_masking: Option<seiza_stacking::FlatStarMaskingStatistics>,
+    /// What the flat-set stability check did or found, for the stack card.
+    /// Recorded with the master so a cache hit repeats it.
+    stability_note: Option<String>,
 }
 
 impl BuiltMaster {
@@ -3082,7 +3100,7 @@ fn flat_masking_warning(statistics: &seiza_stacking::FlatStarMaskingStatistics) 
     (!notes.is_empty()).then(|| format!("Star-masked flat: {}", notes.join(". ")))
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct MasterInputs<'a> {
     bias: Option<seiza_stacking::LinearImage>,
     dark: Option<seiza_stacking::MasterDark>,
@@ -3169,6 +3187,7 @@ fn adopt_external_master(
                     master_uuid,
                     skipped: Vec::new(),
                     flat_star_masking: None,
+                    stability_note: None,
                 },
                 note: format!("{source_name}{trust_note}"),
             });
@@ -3257,6 +3276,7 @@ fn adopt_external_master(
             master_uuid,
             skipped: Vec::new(),
             flat_star_masking: None,
+            stability_note: None,
         },
         note: format!("{source_name}{trust_note}{scale_note}"),
     })
@@ -3306,7 +3326,34 @@ fn place_unit_range_float_on_adu_scale(frame: &mut seiza_stacking::FitsFrame) ->
     true
 }
 
-fn build_master(
+/// One master build: what it made, which frames fed it and, for a flat, how
+/// well those frames agreed about the features it kept.
+struct BuiltAttempt {
+    master: BuiltMaster,
+    /// The frames the integrator combined, in the order they were offered.
+    used: Vec<CalibrationFrame>,
+    /// Present when the master is a freshly built flat; a cached master was
+    /// checked when it was built.
+    stability: Option<FlatSetStability>,
+}
+
+impl BuiltAttempt {
+    /// Frames that disagree with the master at more than
+    /// [`FLAT_DRIFT_SHARE`] of its feature pixels.
+    fn drifting(&self) -> Vec<CalibrationFrame> {
+        let Some(stability) = &self.stability else {
+            return Vec::new();
+        };
+        self.used
+            .iter()
+            .zip(&stability.disagreement)
+            .filter(|(_, share)| **share > FLAT_DRIFT_SHARE)
+            .map(|(frame, _)| frame.clone())
+            .collect()
+    }
+}
+
+fn build_master_once(
     conn: &Connection,
     root: &Path,
     kind: CalibrationKind,
@@ -3314,7 +3361,7 @@ fn build_master(
     inputs: MasterInputs<'_>,
     recording_blocker: Option<&str>,
     flat_star_masking: bool,
-) -> Result<Option<BuiltMaster>> {
+) -> Result<Option<BuiltAttempt>> {
     // Reduce to the frames that can actually combine (one temperature, one
     // flat session). The master's content hash below covers exactly this
     // subset, so a subset change re-keys the cache.
@@ -3385,13 +3432,19 @@ fn build_master(
             };
             match masking_statistics {
                 Ok(statistics) => {
-                    return Ok(Some(BuiltMaster {
-                        path,
-                        master_uuid,
-                        // A cached master is served without rebuilding, so there is
-                        // no fresh refusal to report.
-                        skipped: Vec::new(),
-                        flat_star_masking: statistics,
+                    let stability_note = cached_stability_note(conn, &path);
+                    return Ok(Some(BuiltAttempt {
+                        master: BuiltMaster {
+                            path,
+                            master_uuid,
+                            // A cached master is served without rebuilding, so there is
+                            // no fresh refusal to report.
+                            skipped: Vec::new(),
+                            flat_star_masking: statistics,
+                            stability_note,
+                        },
+                        used: frames.to_vec(),
+                        stability: None,
                     }));
                 }
                 Err(error) => {
@@ -3424,6 +3477,17 @@ fn build_master(
         CalibrationKind::Dark | CalibrationKind::DarkFlat => seiza_stacking::MasterFrameKind::Dark,
         CalibrationKind::Flat => seiza_stacking::MasterFrameKind::Flat,
     };
+    // The check below calibrates each flat the way the integrator did, so
+    // it needs the same bias and dark once more.
+    let stability_calibration = (kind == CalibrationKind::Flat)
+        .then(|| seiza_stacking::CalibrationMasters::new(bias.clone(), dark.clone(), None))
+        .and_then(|masters| match masters {
+            Ok(masters) => Some(masters),
+            Err(error) => {
+                tracing::warn!("flat-set stability check skipped: {error}");
+                None
+            }
+        });
     let options = seiza_stacking::MasterBuildOptions {
         exposure_seconds: frames.first().and_then(|frame| frame.exposure_s),
         bias,
@@ -3483,6 +3547,28 @@ fn build_master(
             frame.defect_pixels_replaced
         );
     }
+    let used: Vec<CalibrationFrame> = frames
+        .iter()
+        .filter(|candidate| {
+            !skipped
+                .iter()
+                .any(|(path, _)| *path == candidate.source_path)
+        })
+        .cloned()
+        .collect();
+    let stability = (kind == CalibrationKind::Flat).then(|| {
+        let stability = flat_set_stability(&used, &frame.image, stability_calibration.as_ref());
+        tracing::info!(
+            "master flat kept {} feature pixel(s); per-frame disagreement {:?}",
+            stability.feature_pixels,
+            stability
+                .disagreement
+                .iter()
+                .map(|share| (share * 100.0).round() / 100.0)
+                .collect::<Vec<_>>()
+        );
+        stability
+    });
     if !path.exists() {
         let temporary = path.with_extension(format!("fits.tmp-{}", std::process::id()));
         seiza_stacking::write_master_fits_f32(&temporary, &frame)
@@ -3505,6 +3591,10 @@ fn build_master(
                 "fallback_pixels": frame.fallback_pixels,
                 "masked_samples": frame.masked_samples,
                 "flat_star_masking": frame.flat_star_masking,
+                "flat_stability": stability.as_ref().map(|stability| serde_json::json!({
+                    "feature_pixels": stability.feature_pixels,
+                    "disagreement": stability.disagreement,
+                })),
             }),
         },
         MasterInputs {
@@ -3514,12 +3604,435 @@ fn build_master(
             dark_dependency,
         },
     )?;
-    Ok(Some(BuiltMaster {
-        path,
-        master_uuid,
-        skipped,
-        flat_star_masking: frame.flat_star_masking,
+    Ok(Some(BuiltAttempt {
+        master: BuiltMaster {
+            path,
+            master_uuid,
+            skipped,
+            flat_star_masking: frame.flat_star_masking,
+            stability_note: None,
+        },
+        used,
+        stability,
     }))
+}
+
+/// Build one master from nearest-first candidates.
+///
+/// Bias and dark masters build once. A flat master is also checked against
+/// the frames that fed it: dew or frost drying off the sensor window while
+/// the flats ran leaves spots that fade frame by frame, the across-frame
+/// median keeps a middling copy of each spot, and every light divided by that
+/// master gets a bright bead wherever the sky is bright. Frames that disagree
+/// with the master about such features are left out when they are a
+/// minority; when the set as a whole disagrees, the next set is preferred;
+/// when there is no next set the master is kept and the card says so.
+fn build_master(
+    conn: &Connection,
+    root: &Path,
+    kind: CalibrationKind,
+    frames: &[CalibrationFrame],
+    inputs: MasterInputs<'_>,
+    recording_blocker: Option<&str>,
+    flat_star_masking: bool,
+) -> Result<Option<BuiltMaster>> {
+    if kind != CalibrationKind::Flat {
+        return Ok(build_master_once(
+            conn,
+            root,
+            kind,
+            frames,
+            inputs,
+            recording_blocker,
+            flat_star_masking,
+        )?
+        .map(|attempt| attempt.master));
+    }
+    let without = |excluded: &[CalibrationFrame]| -> Vec<CalibrationFrame> {
+        frames
+            .iter()
+            .filter(|frame| {
+                !excluded
+                    .iter()
+                    .any(|other| other.frame_uuid == frame.frame_uuid)
+            })
+            .cloned()
+            .collect()
+    };
+    let Some(first) = build_master_once(
+        conn,
+        root,
+        kind,
+        frames,
+        inputs.clone(),
+        recording_blocker,
+        flat_star_masking,
+    )?
+    else {
+        return Ok(None);
+    };
+    let drifting = first.drifting();
+    if drifting.is_empty() {
+        return Ok(Some(first.master));
+    }
+    let feature_pixels = first
+        .stability
+        .as_ref()
+        .map_or(0, |stability| stability.feature_pixels);
+    let used = first.used.len();
+    let stable = used - drifting.len();
+    let spots = "spots that come and go across the run: dew or frost on the sensor window?";
+
+    // A minority of odd frames: the rest still make an honest master.
+    if stable >= MIN_MASTER_FRAMES && stable * 2 >= used {
+        let candidates = without(&drifting);
+        if let Some(trimmed) = build_master_once(
+            conn,
+            root,
+            kind,
+            &candidates,
+            inputs.clone(),
+            recording_blocker,
+            flat_star_masking,
+        )? {
+            if trimmed.drifting().is_empty() {
+                discard_master(conn, &first.master);
+                let note = format!(
+                    "Left out {} of {used} flats that disagreed with the rest of the set at \
+                     {feature_pixels} pixels ({spots})",
+                    drifting.len()
+                );
+                return Ok(Some(with_stability_note(conn, trimmed.master, note)));
+            }
+            discard_master(conn, &trimmed.master);
+        }
+    }
+
+    // The set disagrees with itself: prefer the next one when there is one.
+    let candidates = without(&first.used);
+    if let Some(other) = build_master_once(
+        conn,
+        root,
+        kind,
+        &candidates,
+        inputs,
+        recording_blocker,
+        flat_star_masking,
+    )? {
+        if other.drifting().is_empty() {
+            discard_master(conn, &first.master);
+            let note = format!(
+                "The nearest {} disagree with each other at {feature_pixels} pixels ({spots}); \
+                 used {} instead",
+                flat_set_label(&first.used),
+                flat_set_label(&other.used)
+            );
+            return Ok(Some(with_stability_note(conn, other.master, note)));
+        }
+        discard_master(conn, &other.master);
+    }
+    let note = format!(
+        "Built from an unstable flat set: {} of {used} frames disagree with the master at \
+         {feature_pixels} pixels ({spots}). Retake these flats",
+        drifting.len()
+    );
+    Ok(Some(with_stability_note(conn, first.master, note)))
+}
+
+/// "20 G flats from 2026-09-10", for a note about one flat set.
+fn flat_set_label(frames: &[CalibrationFrame]) -> String {
+    let filter = frames
+        .iter()
+        .find_map(|frame| frame.filter.as_deref())
+        .map(|name| format!("{name} "))
+        .unwrap_or_default();
+    let day = |timestamp: i64| {
+        chrono::DateTime::from_timestamp(timestamp, 0)
+            .map(|at| at.format("%Y-%m-%d").to_string())
+            .unwrap_or_else(|| timestamp.to_string())
+    };
+    let first = frames.iter().filter_map(|frame| frame.captured_at).min();
+    let last = frames.iter().filter_map(|frame| frame.captured_at).max();
+    let when = match (first, last) {
+        (Some(first), Some(last)) if day(first) != day(last) => {
+            format!(" from {} to {}", day(first), day(last))
+        }
+        (Some(first), _) => format!(" from {}", day(first)),
+        _ => String::new(),
+    };
+    format!("{} {filter}flats{when}", frames.len())
+}
+
+/// Forget a master this build made and then decided against, so no later
+/// selection of the same frames serves it as a cache hit.
+fn discard_master(conn: &Connection, master: &BuiltMaster) {
+    if let Err(error) = conn.execute(
+        "DELETE FROM psf_guard_calibration_master WHERE master_uuid = ?1",
+        [&master.master_uuid],
+    ) {
+        tracing::warn!(
+            "could not forget set-aside master {}: {error}",
+            master.label()
+        );
+    }
+    if let Err(error) = std::fs::remove_file(&master.path)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            "could not remove set-aside master {}: {error}",
+            master.path.display()
+        );
+    }
+}
+
+/// Attach the stability note to the master and to its record, so a later
+/// cache hit on the same master repeats it.
+fn with_stability_note(conn: &Connection, mut master: BuiltMaster, note: String) -> BuiltMaster {
+    tracing::warn!("master flat {}: {note}", master.label());
+    let recorded: Option<String> = conn
+        .query_row(
+            "SELECT statistics_json FROM psf_guard_calibration_master WHERE master_uuid = ?1",
+            [&master.master_uuid],
+            |row| row.get(0),
+        )
+        .optional()
+        .ok()
+        .flatten();
+    if let Some(recorded) = recorded {
+        let mut statistics: serde_json::Value =
+            serde_json::from_str(&recorded).unwrap_or(serde_json::Value::Null);
+        if !statistics.is_object() {
+            statistics = serde_json::json!({});
+        }
+        let stability = statistics["flat_stability"].take();
+        let mut stability = if stability.is_object() {
+            stability
+        } else {
+            serde_json::json!({})
+        };
+        stability["note"] = serde_json::Value::String(note.clone());
+        statistics["flat_stability"] = stability;
+        if let Err(error) = conn.execute(
+            "UPDATE psf_guard_calibration_master SET statistics_json = ?1 WHERE master_uuid = ?2",
+            params![statistics.to_string(), master.master_uuid],
+        ) {
+            tracing::warn!("could not record the flat stability note: {error}");
+        }
+    }
+    master.stability_note = Some(note);
+    master
+}
+
+/// The stability note recorded with a cached master, if it has one.
+fn cached_stability_note(conn: &Connection, path: &Path) -> Option<String> {
+    let recorded: String = conn
+        .query_row(
+            "SELECT statistics_json FROM psf_guard_calibration_master WHERE cache_path = ?1",
+            [path.to_string_lossy().as_ref()],
+            |row| row.get(0),
+        )
+        .optional()
+        .ok()
+        .flatten()?;
+    let statistics: serde_json::Value = serde_json::from_str(&recorded).ok()?;
+    statistics["flat_stability"]["note"]
+        .as_str()
+        .map(str::to_string)
+}
+
+/// A master pixel counts as a feature when it departs from the smooth
+/// response around it by more than this fraction, and a frame disagrees with
+/// the master at a feature when its own value departs from the master's by
+/// more than the same fraction. Dust shadows sit at a few percent; a drying
+/// droplet reads at 3 to 70 percent of its surround.
+const FLAT_FEATURE_DEPTH: f32 = 0.10;
+/// A frame that disagrees at more than this share of the feature pixels is
+/// not looking at the same sensor window as the master.
+const FLAT_DRIFT_SHARE: f64 = 0.20;
+/// Half-width of the box that estimates the smooth response. Wider than any
+/// droplet, narrower than a dust donut, which the frames all agree on anyway.
+const FLAT_SMOOTH_RADIUS: usize = 16;
+
+/// How the frames of one flat set agree about the features their master
+/// kept. A feature every frame shows the same way is a real property of the
+/// optical path (a dust shadow, a dead cluster) and corrects the lights. A
+/// feature the frames disagree about was changing while they were shot, and
+/// the master's copy of it corrects nothing.
+struct FlatSetStability {
+    /// Master pixels that depart from the smooth response around them.
+    feature_pixels: usize,
+    /// Per input frame, in `frames` order: the share of feature pixels at
+    /// which the frame disagrees with the master. `NaN` for a frame that
+    /// could not be read back or calibrated.
+    disagreement: Vec<f64>,
+}
+
+fn flat_set_stability(
+    frames: &[CalibrationFrame],
+    master: &seiza_stacking::LinearImage,
+    calibration: Option<&seiza_stacking::CalibrationMasters>,
+) -> FlatSetStability {
+    let channels = master.channels.max(1);
+    let (width, height) = (master.width, master.height);
+    let pixels = width * height;
+    let smooth: Vec<f32> = if channels == 1 {
+        box_mean_plane(&master.data, width, height, FLAT_SMOOTH_RADIUS)
+    } else {
+        let mut smooth = vec![0f32; master.data.len()];
+        for channel in 0..channels {
+            let plane: Vec<f32> = (0..pixels)
+                .map(|pixel| master.data[pixel * channels + channel])
+                .collect();
+            for (pixel, value) in box_mean_plane(&plane, width, height, FLAT_SMOOTH_RADIUS)
+                .into_iter()
+                .enumerate()
+            {
+                smooth[pixel * channels + channel] = value;
+            }
+        }
+        smooth
+    };
+    let features: Vec<usize> = (0..master.data.len())
+        .filter(|&index| {
+            let value = master.data[index];
+            let surround = smooth[index];
+            value.is_finite()
+                && surround > 0.0
+                && (value - surround).abs() > FLAT_FEATURE_DEPTH * surround
+        })
+        .collect();
+    // Too few features to judge a set by: a handful of dead pixels, or a
+    // clean master.
+    let minimum = (pixels / 100_000).max(16);
+    if features.len() < minimum {
+        return FlatSetStability {
+            feature_pixels: features.len(),
+            disagreement: vec![0.0; frames.len()],
+        };
+    }
+    // Each frame is put on the master's scale by the median ratio of its
+    // samples to the master's, per CFA phase for a raw colour flat so the
+    // channels' different responses do not read as disagreement.
+    let phases = if channels == 1 { 4 } else { channels };
+    let phase_of = |index: usize| -> usize {
+        if channels == 1 {
+            let (x, y) = (index % width, index / width);
+            (y & 1) * 2 + (x & 1)
+        } else {
+            index % channels
+        }
+    };
+    let step = (master.data.len() / 200_000).max(1);
+    let disagreement = frames
+        .iter()
+        .map(|frame| {
+            let mut opened = match crate::image_io::open_linear_frame(&frame.source_path) {
+                Ok(opened) => opened,
+                Err(error) => {
+                    tracing::warn!(
+                        "flat-set check could not read {}: {error}",
+                        frame.source_path.display()
+                    );
+                    return f64::NAN;
+                }
+            };
+            if opened.image.width != width
+                || opened.image.height != height
+                || opened.image.channels.max(1) != channels
+            {
+                return f64::NAN;
+            }
+            if let Some(calibration) = calibration
+                && let Err(error) =
+                    calibration.apply(&mut opened.image, opened.exposure_seconds, opened.bayer)
+            {
+                tracing::warn!(
+                    "flat-set check could not calibrate {}: {error}",
+                    frame.source_path.display()
+                );
+                return f64::NAN;
+            }
+            let data = &opened.image.data;
+            let mut ratios: Vec<Vec<f32>> = vec![Vec::new(); phases];
+            for index in (0..data.len()).step_by(step) {
+                let (value, reference) = (data[index], master.data[index]);
+                if reference > 0.05 && reference.is_finite() && value.is_finite() {
+                    ratios[phase_of(index)].push(value / reference);
+                }
+            }
+            let overall = median_f32(ratios.iter().flatten().copied().collect());
+            let gains: Vec<f32> = ratios
+                .into_iter()
+                .map(|ratios| {
+                    if ratios.len() >= 16 {
+                        median_f32(ratios)
+                    } else {
+                        overall
+                    }
+                })
+                .collect();
+            let disagree = features
+                .iter()
+                .filter(|&&index| {
+                    let gain = gains[phase_of(index)];
+                    gain.is_finite()
+                        && gain > 0.0
+                        && (data[index] / gain - master.data[index]).abs()
+                            > FLAT_FEATURE_DEPTH * smooth[index]
+                })
+                .count();
+            disagree as f64 / features.len() as f64
+        })
+        .collect();
+    FlatSetStability {
+        feature_pixels: features.len(),
+        disagreement,
+    }
+}
+
+fn median_f32(mut values: Vec<f32>) -> f32 {
+    if values.is_empty() {
+        return f32::NAN;
+    }
+    let middle = values.len() / 2;
+    let (_, median, _) = values.select_nth_unstable_by(middle, |a, b| a.total_cmp(b));
+    *median
+}
+
+/// Mean over a (2r+1)-square box clamped at the edges, in two separable
+/// passes. Non-finite samples count as zero.
+fn box_mean_plane(plane: &[f32], width: usize, height: usize, radius: usize) -> Vec<f32> {
+    let mut rows = vec![0f32; plane.len()];
+    let mut prefix = vec![0f64; width.max(height) + 1];
+    for y in 0..height {
+        let row = &plane[y * width..(y + 1) * width];
+        for x in 0..width {
+            let value = row[x];
+            prefix[x + 1] = prefix[x]
+                + if value.is_finite() {
+                    f64::from(value)
+                } else {
+                    0.0
+                };
+        }
+        for x in 0..width {
+            let low = x.saturating_sub(radius);
+            let high = (x + radius + 1).min(width);
+            rows[y * width + x] = ((prefix[high] - prefix[low]) / (high - low) as f64) as f32;
+        }
+    }
+    let mut out = vec![0f32; plane.len()];
+    for x in 0..width {
+        for y in 0..height {
+            prefix[y + 1] = prefix[y] + f64::from(rows[y * width + x]);
+        }
+        for y in 0..height {
+            let low = y.saturating_sub(radius);
+            let high = (y + radius + 1).min(height);
+            out[y * width + x] = ((prefix[high] - prefix[low]) / (high - low) as f64) as f32;
+        }
+    }
+    out
 }
 
 fn cached_flat_masking_statistics(
@@ -7406,6 +7919,214 @@ mod tests {
         assert!(
             (value - neighbor).abs() < 0.05,
             "the defect must sit on the smooth response: {value} vs neighbor {neighbor}"
+        );
+        assert!(
+            applied.warning.as_deref().is_none_or(
+                |warning| !warning.contains("disagree") && !warning.contains("Left out")
+            ),
+            "a set that agrees with itself draws no stability note: {:?}",
+            applied.warning
+        );
+    }
+
+    /// A flat library with a bias pair, `wet` flats whose 8x8 spot at
+    /// (20..28, 30..38) reads `factor(index)` of its surround, optional clean
+    /// flats from three nights earlier, and one light. Returns the connection,
+    /// cache root, and light path, ready for `resolve_or_build_masters`.
+    fn spotted_flat_library(
+        temp: &tempfile::TempDir,
+        wet: usize,
+        factor: impl Fn(usize) -> f64,
+        dry_earlier: usize,
+    ) -> (Connection, PathBuf, PathBuf) {
+        const SIZE: usize = 64;
+        let night = 1_750_000_000i64;
+        let vignette = |x: usize| 0.7 + 0.6 * x as f64 / (SIZE - 1) as f64;
+        let in_spot = |x: usize, y: usize| (20..28).contains(&x) && (30..38).contains(&y);
+        let mut calibration_meta = Vec::new();
+        for index in 0..2 {
+            let path = temp.path().join(format!("bias-{index}.fits"));
+            write_gradient_fits(&path, "BIAS", SIZE, SIZE, "Camera", 30, |x, y| {
+                100.0 + ((x * 31 + y * 17 + index) % 13) as f64 / 13.0
+            });
+            let mut meta = crate::commands::import::headers::read_frame_meta(&path);
+            meta.timestamp = Some(night);
+            calibration_meta.push(meta);
+        }
+        for index in 0..wet {
+            let factor = factor(index);
+            let path = temp.path().join(format!("flat-wet-{index}.fits"));
+            write_gradient_fits(&path, "FLAT", SIZE, SIZE, "Camera", 30, move |x, y| {
+                let response =
+                    100.0 + 20_000.0 * vignette(x) + ((x * 7 + y * 3 + index) % 11) as f64;
+                if in_spot(x, y) {
+                    100.0 + (response - 100.0) * factor
+                } else {
+                    response
+                }
+            });
+            let mut meta = crate::commands::import::headers::read_frame_meta(&path);
+            meta.timestamp = Some(night + 60 + index as i64 * 5);
+            calibration_meta.push(meta);
+        }
+        for index in 0..dry_earlier {
+            let path = temp.path().join(format!("flat-dry-{index}.fits"));
+            write_gradient_fits(&path, "FLAT", SIZE, SIZE, "Camera", 30, move |x, y| {
+                100.0 + 20_000.0 * vignette(x) + ((x * 7 + y * 3 + index) % 11) as f64
+            });
+            let mut meta = crate::commands::import::headers::read_frame_meta(&path);
+            meta.timestamp = Some(night - 3 * 86_400 + index as i64 * 5);
+            calibration_meta.push(meta);
+        }
+        let light_path = temp.path().join("light.fits");
+        write_gradient_fits(&light_path, "LIGHT", SIZE, SIZE, "Camera", 30, |x, _| {
+            400.0 + 100.0 * vignette(x)
+        });
+        let mut conn = Connection::open_in_memory().unwrap();
+        {
+            let tx = conn.transaction().unwrap();
+            import_calibration_frames(&tx, &calibration_meta, Some("profile")).unwrap();
+            tx.commit().unwrap();
+        }
+        (conn, temp.path().join("cache"), light_path)
+    }
+
+    /// The master's response at the spot relative to the same column outside
+    /// it, so the vignette cancels.
+    fn spot_response(cache: &Path, label: &str) -> f32 {
+        let master =
+            crate::image_io::open_linear_frame(cache.join("calibration-masters").join(label))
+                .unwrap();
+        master.image.data[34 * 64 + 24] / master.image.data[45 * 64 + 24]
+    }
+
+    fn flat_master_count(conn: &Connection) -> i64 {
+        conn.query_row(
+            "SELECT count(*) FROM psf_guard_calibration_master WHERE kind = 'flat'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn an_unstable_flat_set_gives_way_to_the_next_one() {
+        // Six flats shot while a droplet dried off the sensor window: the
+        // spot reads 10% of its surround in the first frame and 85% in the
+        // last. The median keeps a middling copy that matches no frame. With
+        // four clean flats from three nights earlier on offer, those must be
+        // used instead, and the card must say so.
+        let temp = tempfile::tempdir().unwrap();
+        let (conn, cache, light) =
+            spotted_flat_library(&temp, 6, |index| 0.10 + 0.15 * index as f64, 4);
+        let (_, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        let label = applied.flat_master.expect("a flat master");
+        let response = spot_response(&cache, &label);
+        assert!(
+            (response - 1.0).abs() < 0.05,
+            "the master must come from the clean set; spot response {response}"
+        );
+        let warning = applied.warning.as_deref().unwrap_or_default();
+        assert!(
+            warning.contains("6 Ha flats") && warning.contains("disagree with each other"),
+            "the card must say the nearest set was passed over: {warning}"
+        );
+        assert!(
+            warning.contains("used 4 Ha flats") && warning.contains("instead"),
+            "the card must say what was used: {warning}"
+        );
+        assert_eq!(
+            flat_master_count(&conn),
+            1,
+            "the unstable master must not stay recorded"
+        );
+    }
+
+    #[test]
+    fn a_few_flats_that_disagree_with_the_set_are_left_out() {
+        // Four flats share a spot at half response and two show none: the
+        // spot appeared or cleared partway through the run. The four that
+        // agree make the master, the two are left out, and the card says so.
+        let temp = tempfile::tempdir().unwrap();
+        let (conn, cache, light) =
+            spotted_flat_library(&temp, 6, |index| if index < 4 { 0.5 } else { 1.0 }, 0);
+        let (_, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        let label = applied.flat_master.expect("a flat master");
+        let response = spot_response(&cache, &label);
+        assert!(
+            (response - 0.5).abs() < 0.05,
+            "the master must keep the feature the majority shows; spot response {response}"
+        );
+        let warning = applied.warning.as_deref().unwrap_or_default();
+        assert!(
+            warning.contains("Left out 2 of 6 flats that disagreed"),
+            "the card must say which frames were left out: {warning}"
+        );
+        assert_eq!(
+            flat_master_count(&conn),
+            1,
+            "the first attempt must be forgotten"
+        );
+    }
+
+    #[test]
+    fn an_unstable_flat_set_with_no_alternative_is_kept_and_named() {
+        // The same drying droplet, but no other flats to fall back to. Auto
+        // mode never hard-fails: the master is used and the card says the set
+        // was unstable.
+        let temp = tempfile::tempdir().unwrap();
+        let (conn, cache, light) =
+            spotted_flat_library(&temp, 6, |index| 0.10 + 0.15 * index as f64, 0);
+        let (_, applied) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        assert!(applied.flat_master.is_some(), "the master is still used");
+        let warning = applied.warning.as_deref().unwrap_or_default();
+        assert!(
+            warning.contains("unstable flat set") && warning.contains("4 of 6 frames disagree"),
+            "the card must name the problem: {warning}"
+        );
+        // A second selection of the same frames is a cache hit and must
+        // repeat the note.
+        let (_, again) = resolve_or_build_masters(
+            &conn,
+            &cache,
+            std::slice::from_ref(&light),
+            None,
+            None,
+            CalibrationMode::Auto,
+        )
+        .unwrap();
+        assert!(
+            again
+                .warning
+                .as_deref()
+                .unwrap_or_default()
+                .contains("unstable flat set"),
+            "a cached master repeats its note: {:?}",
+            again.warning
         );
     }
 


### PR DESCRIPTION
Seen on starfront-ultracat131: the NGC 7023 green stack carried clusters of bright beads wherever the nebula was bright. The green flats had been shot at noon with the sensor at +4.5 °C a day after it sat at +31 °C, and condensation on the sensor window was drying off while they ran. Every frame had the spots, each shallower than the last; the across-frame median kept a middling copy of each, and dividing the lights by that master brightened those pixels 2 to 28 times. The raw lights were clean at every one of them. The R and B stacks were fine only by luck: R used an older flat set, and enough B frames were dry that clipping threw the spots out.

**Change.** A freshly built flat master is read back against its own inputs (`flat_set_stability` in `src/calibration.rs`). Master pixels that depart from a 33-px box mean of the master by more than 10% are its features; on a raw colour flat the box mean runs per CFA phase, on RGB per channel. Each input flat is re-read, calibrated with the same bias and dark the integrator used, put on the master's scale by the median ratio per plane, and counted at the feature pixels where it departs from the master by more than 5% of the local response (half the feature depth, so a spot that drifts slowly still shows in the frames beside the median). A frame is drifting at a fifth of the feature pixels, capped at one pixel per two hundred thousand of the sensor and never below sixteen, so a dusty optical path with many honest features cannot hide a droplet run and a few small droplets on a large sensor still count.

- Drifting frames a minority, and at least two frames left: the first master is forgotten (row and file) and rebuilt from the rest. Card: "Left out 2 of 6 flats that disagreed with the rest of the set at N pixels (spots that come and go across the run: dew or frost on the sensor window?)".
- The set as a whole drifting: the next coherent set among the remaining candidates is built; if it holds together, it is used and the first is forgotten. Card names both sets ("The nearest 20 G flats from 2026-09-10 disagree with each other at N pixels (…); used 20 G flats from 2026-08-26 instead").
- No other set: the master is used and the card says the set was unstable and should be retaken. Auto mode never hard-fails.

Features every frame shows the same way (dust shadows, dead clusters) score zero disagreement and stay, so a normal master is untouched. Stars in sky flats are not master features (clipping or native masking removes them), so they do not count.

A built master waits under a staging name with no record until the set is judged, so a second process on the same cache cannot take a master this build is about to set aside, and only what this build staged is ever set aside (a retry that cache-hits another selection's kept master is left alone). The judgement is recorded in the master's `statistics_json` keyed by frame: a kept master repeats its note on a cache hit and still reports its drift, so it cannot pass as a sound fallback for another set; a set-aside master leaves a record without a file as a memo, so the next selection of the same frames reaches the replacement without reading a flat. The trim retries from this set's own frames; the next-set retry excludes everything shot within a flat session of the first. A frame the check cannot read or calibrate counts as drifting. A failed retry logs and the first master serves with its note; cancellation is honoured between attempts. The bias and dark are cloned only when a master is actually built, after the integrator's copies are dropped. A flat recorded without a judgement rebuilds once; `MASTER_CACHE_VERSION` stays at 3, so bias and dark masters are not rebuilt.

Cost: one extra read of each input flat when a flat master is built, and nothing on a cache hit or a remembered judgement.

Reviewed with /code-review; its findings on the first cut (rebuild on every selection after a set-aside, a cache hit forgetting a kept master's drift, a retry error propagating, a slow drift trimming to a shallow spot, OSC masters counting every pixel as a feature, publish-before-judge and set-aside of another selection's master, a wet next set from the same noon, the version bump rebuilding every kind, small droplets under an absolute threshold, three live copies of the bias) are all addressed in the follow-up commits. Not addressed: the candidate list is capped at 64 nearest flats, so a wet session of 64 or more frames leaves no older set to fall back to (pre-existing limit); the read-back loop is serial.

Docs: a "Flats that changed while they were shot" section in `CALIBRATION_LIBRARY.md`; release note.

Tests: a six-frame drying-droplet set with a clean older set on offer gives way to the older set, names both, leaves one servable flat master, and on a second selection reads no flat back; a set with four spotted and two clean frames keeps the majority's feature and says two were left out; the same droplet set with no alternative serves with an "unstable flat set" note that a second, cached selection repeats without a re-check; a spot drifting from 60% to 100% across five frames is unstable rather than trimmed; the existing shared-defect test now also asserts no note.

Checks run locally: `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, `cargo test --locked` (1045 passed, 0 failed, after rebasing onto #424 and #426), `git diff --check`. No frontend change; the browser suite is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018evEp8YHi33wHfrnupSycv
