### PR TITLE
Review and invalidate Target Scheduler flat coverage

### DIFF
--- a/docs/CALIBRATION_LIBRARY.md
+++ b/docs/CALIBRATION_LIBRARY.md
@@ -53,6 +53,39 @@ Forgetting a frame also drops every master record that used it, including
 downstream masters that used one of those masters. Clearing masters waits for
 any active stack preview and rebuilds them on demand later.
 
+## Scheduler flat coverage
+
+The NINA plugin sends Target Scheduler's `flathistory` coverage records during
+grade pulls and applied reconciles. In **Settings > Databases**, open the
+database's calibration library and choose **Scheduler flats**. Filter by target,
+source, filter, or status, then select the suspect coverage records and choose
+**Invalidate coverage** with a reason. This requires database management access.
+
+The next plugin grade pull or applied reconcile removes those exact, unchanged
+history rows from the source scheduler database and reports the result here.
+Preview-only reconcile does not apply invalidations. A full database round trip
+is not required. Run this sync before the next Target Scheduler flats action:
+an action already in progress has already loaded its coverage. The next action
+reads fresh history and can request replacement flats, subject to its current
+profile, target, cadence, and light-frame eligibility. Target Scheduler normally
+considers lights from the last 45 days; older runs can require manual flats.
+
+Coverage is not a list of flat files. Target Scheduler may record coverage after
+reusing an existing flat set, and duplicate coverage can satisfy the same run.
+Select every suspect record for the intended run, including duplicates and any
+other sessions known to have reused the bad set. PSF Guard does not guess these
+relationships from filenames or capture times. Invalidating coverage does not
+reject or delete calibration files or masters, and forgetting a calibration
+frame does not invalidate scheduler coverage automatically.
+
+Each source database has a plugin-owned origin UUID. Every decision also binds
+the original row ID, exact target GUID, and complete source-row fingerprint.
+Newly taken flats, changed rows, and reused IDs are preserved; **Changed in
+NINA** records require review. Decisions and acknowledgements remain in PSF
+Guard, so stale snapshots cannot revive invalid coverage. The plugin keeps its
+origin identity outside the scheduler database; moving the database or replacing
+that identity starts a new source and does not apply old-source decisions.
+
 ## Masters from other software
 
 A master dark, bias, or flat integrated by PixInsight's WBPP, Siril, or

--- a/docs/design/data-transfer.md
+++ b/docs/design/data-transfer.md
@@ -327,6 +327,50 @@ Each database opts into this protocol on its own. Holding a valid key is not
 enough: the operator ticks **Accept remote scheduler sync** for that database,
 separately from **Accept remote image uploads**.
 
+### Scheduler flat coverage
+
+`flat_history_v1` advertises a separate typed exchange for the NINA plugin.
+Native `flathistory` has no GUID and is deliberately not added to merge or
+grade bundles. These bearer-authenticated endpoints require the paired
+catalog's existing scheduler-sync grant:
+
+```
+POST /api/sync/v1/flat-history/snapshot
+POST /api/sync/v1/flat-history/pending
+POST /api/sync/v1/flat-history/acknowledge
+```
+
+Every request carries `protocol_version: 1`, `catalog_id`, and the plugin's
+persistent per-source-database `origin_id` UUID. Every response echoes the
+catalog and origin, which the plugin checks before applying local changes.
+Snapshots add `source_name` and up to 1000 typed `records`. Each record carries
+`source_row_id`, `fingerprint`, resolved `target_guid` (null only for profile
+coverage), `target_name`, `profile_id`, exact native session/capture timestamps,
+`light_session_id`, flats type, filter, and acquisition settings. The SHA-256
+fingerprint is computed and checked by the plugin over every native row value,
+schema metadata, and resolved target GUID. The server treats it as opaque; it
+does not try to reproduce another implementation's JSON serialization.
+
+PSF-owned `psf_guard_scheduler_flat_history` records bind origin, row ID, and
+fingerprint to a server UUID. Replayed snapshots update display metadata but
+cannot clear invalidations. A new row generation can supersede an undecided
+record, never a pending or acknowledged decision. Missing snapshot rows have
+no meaning: a chunk or target-scoped snapshot is not a deletion request.
+
+`GET /api/db/{id}/flat-history` supports `limit`, `offset`, `state`, and literal
+substring `q` filters. It performs no schema writes. The editor- and
+database-management-gated `POST /api/db/{id}/flat-history/invalidate` accepts
+explicit `record_ids` and a nonempty `reason`, atomically marking recorded
+coverage pending. This is a reviewed coverage operation, not image grading.
+
+The plugin requests pending decisions, optionally restricted to an exact target
+GUID, and applies them in batches of at most 1000. Local deletion requires an
+unchanged row fingerprint and target identity inside a short transaction.
+Acknowledgements carry the full decision identity and `removed`, `absent`, or
+`conflict`. Compatible removed/absent retries retain the first audit result;
+changed coverage is never deleted. See [calibration libraries](../CALIBRATION_LIBRARY.md#scheduler-flat-coverage)
+for scheduler timing, duplicate coverage, and recapture eligibility.
+
 ### Speaking the protocol, not only answering it
 
 `server/remote_sync.rs` answers `/api/sync/v1`; `sync_client.rs` speaks it.

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,11 @@
 
 ## Added
 
+- Review Target Scheduler flat coverage in the calibration library and invalidate
+  suspect runs with a reason. The NINA plugin applies these requests on grade
+  pulls and applied reconciles, preserving changed or newly taken coverage and
+  leaving calibration files untouched.
+
 - Inspect the calibration masters used by a mono or color stack from its
   **Masters** action, with session/channel provenance, display stretch,
   native-size zoom, rejection statistics, and unchanged FITS downloads.

--- a/src/server/flat_history.rs
+++ b/src/server/flat_history.rs
@@ -1,0 +1,785 @@
+//! Explicit Target Scheduler flat-coverage invalidation, not calibration grading.
+//!
+//! Scheduler history rows have no GUID. Their origin, local row ID and capture
+//! fingerprint identify one observed generation; PSF Guard never matches files
+//! to it or edits the scheduler's native table on the server.
+
+use std::{collections::HashSet, sync::Arc};
+
+use axum::{
+    extract::{Query, State},
+    http::HeaderMap,
+    Json,
+};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::{
+    api::ApiResponse,
+    database_context::{open_scheduler_connection_with_flags, DatabaseContext},
+    extract::DbContext,
+    handlers::{require_database_management_allowed, AppError},
+    remote_audit::{AuditAction, AuditOutcome, AuditRecord},
+    remote_sync::{authenticated_catalog, require_catalog},
+    state::AppState,
+};
+
+pub const MAX_BODY_BYTES: usize = 4 * 1024 * 1024;
+const MAX_RECORDS: usize = 1_000;
+const TABLE: &str = "psf_guard_scheduler_flat_history";
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Scope {
+    pub protocol_version: u32,
+    pub catalog_id: String,
+    pub origin_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct CaptureRecord {
+    pub source_row_id: i64,
+    pub fingerprint: String,
+    pub target_guid: Option<String>,
+    pub target_name: Option<String>,
+    pub profile_id: String,
+    pub light_session_date: Option<i64>,
+    #[serde(default)]
+    pub light_session_id: i64,
+    pub flats_taken_date: Option<i64>,
+    pub flats_type: Option<String>,
+    pub filter_name: Option<String>,
+    pub gain: Option<i64>,
+    pub offset: Option<i64>,
+    pub bin: Option<i64>,
+    pub readout_mode: Option<i64>,
+    pub rotation: Option<f64>,
+    pub roi: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SnapshotRequest {
+    #[serde(flatten)]
+    pub scope: Scope,
+    pub source_name: String,
+    pub records: Vec<CaptureRecord>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SnapshotResponse {
+    pub catalog_id: String,
+    pub origin_id: String,
+    pub received: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PendingRequest {
+    #[serde(flatten)]
+    pub scope: Scope,
+    pub target_guid: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Decision {
+    pub record_id: String,
+    pub source_row_id: i64,
+    pub fingerprint: String,
+    pub target_guid: Option<String>,
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PendingResponse {
+    pub catalog_id: String,
+    pub origin_id: String,
+    pub decisions: Vec<Decision>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryState {
+    Recorded,
+    Pending,
+    Removed,
+    Absent,
+    Conflict,
+    Superseded,
+}
+
+impl HistoryState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Recorded => "recorded",
+            Self::Pending => "pending",
+            Self::Removed => "removed",
+            Self::Absent => "absent",
+            Self::Conflict => "conflict",
+            Self::Superseded => "superseded",
+        }
+    }
+    fn parse(value: &str) -> Result<Self, AppError> {
+        match value {
+            "recorded" => Ok(Self::Recorded),
+            "pending" => Ok(Self::Pending),
+            "removed" => Ok(Self::Removed),
+            "absent" => Ok(Self::Absent),
+            "conflict" => Ok(Self::Conflict),
+            "superseded" => Ok(Self::Superseded),
+            _ => Err(AppError::DatabaseError(
+                "invalid stored flat-history state".into(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcknowledgeStatus {
+    Removed,
+    Absent,
+    Conflict,
+}
+
+impl AcknowledgeStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Removed => "removed",
+            Self::Absent => "absent",
+            Self::Conflict => "conflict",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AcknowledgeResult {
+    pub record_id: String,
+    pub source_row_id: i64,
+    pub fingerprint: String,
+    pub status: AcknowledgeStatus,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AcknowledgeRequest {
+    #[serde(flatten)]
+    pub scope: Scope,
+    pub results: Vec<AcknowledgeResult>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AcknowledgeResponse {
+    pub catalog_id: String,
+    pub origin_id: String,
+    pub acknowledged: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HistoryRecord {
+    pub record_id: String,
+    pub origin_id: String,
+    pub source_name: String,
+    #[serde(flatten)]
+    pub capture: CaptureRecord,
+    pub state: HistoryState,
+    pub reason: Option<String>,
+    pub invalidated_at: Option<i64>,
+    pub last_seen: i64,
+    pub acknowledged_at: Option<i64>,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ListQuery {
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+    pub state: Option<HistoryState>,
+    pub q: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HistoryList {
+    pub records: Vec<HistoryRecord>,
+    pub total: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct InvalidateRequest {
+    pub record_ids: Vec<String>,
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InvalidateResponse {
+    pub invalidated: usize,
+}
+
+fn bad(message: &str) -> AppError {
+    AppError::BadRequest(message.into())
+}
+
+fn uuid(value: &str, field: &str) -> Result<(), AppError> {
+    let parsed = Uuid::parse_str(value).map_err(|_| bad(&format!("{field} must be a UUID")))?;
+    if parsed.is_nil() || value != parsed.hyphenated().to_string() {
+        return Err(bad(&format!(
+            "{field} must be a nonzero lowercase hyphenated UUID"
+        )));
+    }
+    Ok(())
+}
+
+fn text(value: &str, field: &str, max: usize, required: bool) -> Result<(), AppError> {
+    if value.len() > max || value.contains('\0') || (required && value.trim().is_empty()) {
+        return Err(bad(&format!("{field} is empty or too long")));
+    }
+    Ok(())
+}
+
+fn optional_text(value: &Option<String>, field: &str, max: usize) -> Result<(), AppError> {
+    if let Some(value) = value {
+        text(value, field, max, false)?;
+    }
+    Ok(())
+}
+
+fn identity(source_row_id: i64, fingerprint: &str) -> Result<(), AppError> {
+    if source_row_id <= 0 {
+        return Err(bad("source_row_id must be positive"));
+    }
+    if fingerprint.len() != 64
+        || !fingerprint
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return Err(bad("fingerprint must be lowercase SHA-256 hex"));
+    }
+    Ok(())
+}
+
+fn validate_scope(scope: &Scope, ctx: &DatabaseContext) -> Result<(), AppError> {
+    require_catalog(ctx, &scope.catalog_id)?;
+    if scope.protocol_version != 1 {
+        return Err(bad("unsupported flat-history protocol version"));
+    }
+    uuid(&scope.origin_id, "origin_id")
+}
+
+fn validate_capture(record: &CaptureRecord) -> Result<(), AppError> {
+    identity(record.source_row_id, &record.fingerprint)?;
+    if let Some(guid) = &record.target_guid {
+        uuid(guid, "target_guid")?;
+    }
+    optional_text(&record.target_name, "target_name", 512)?;
+    text(&record.profile_id, "profile_id", 128, true)?;
+    optional_text(&record.flats_type, "flats_type", 64)?;
+    optional_text(&record.filter_name, "filter_name", 128)?;
+    if record.rotation.is_some_and(|value| !value.is_finite())
+        || record.roi.is_some_and(|value| !value.is_finite())
+    {
+        return Err(bad("rotation and roi must be finite"));
+    }
+    Ok(())
+}
+
+fn bounded_count(count: usize) -> Result<(), AppError> {
+    if count > MAX_RECORDS {
+        return Err(bad(
+            "at most 1000 flat-history records are allowed per request",
+        ));
+    }
+    Ok(())
+}
+
+fn schema_exists(conn: &Connection) -> Result<bool, AppError> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1)",
+        [TABLE],
+        |row| row.get(0),
+    )
+    .map_err(AppError::db)
+}
+
+fn ensure_schema(conn: &Connection) -> Result<(), AppError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS psf_guard_scheduler_flat_history (
+            record_id TEXT PRIMARY KEY,
+            origin_id TEXT NOT NULL,
+            source_row_id INTEGER NOT NULL,
+            fingerprint TEXT NOT NULL,
+            target_guid TEXT,
+            source_name TEXT NOT NULL,
+            record_json TEXT NOT NULL,
+            state TEXT NOT NULL CHECK(state IN ('recorded','pending','removed','absent','conflict','superseded')),
+            reason TEXT,
+            invalidated_at INTEGER,
+            last_seen INTEGER NOT NULL,
+            acknowledged_at INTEGER,
+            detail TEXT,
+            UNIQUE(origin_id, source_row_id, fingerprint)
+        );
+        CREATE INDEX IF NOT EXISTS idx_psf_guard_flat_history_pending
+            ON psf_guard_scheduler_flat_history(origin_id, state, target_guid, invalidated_at, record_id);
+        CREATE INDEX IF NOT EXISTS idx_psf_guard_flat_history_state
+            ON psf_guard_scheduler_flat_history(state, last_seen);"
+    ).map_err(AppError::db)
+}
+
+fn read_capture(value: &str) -> Result<CaptureRecord, AppError> {
+    serde_json::from_str(value)
+        .map_err(|_| AppError::DatabaseError("invalid stored flat-history capture".into()))
+}
+
+fn same_capture(left: &CaptureRecord, right: &CaptureRecord) -> bool {
+    // A target rename is presentation metadata, not a new capture generation.
+    let mut left = left.clone();
+    let mut right = right.clone();
+    left.target_name = None;
+    right.target_name = None;
+    left == right
+}
+
+fn store_snapshot(
+    conn: &mut Connection,
+    request: &SnapshotRequest,
+    now: i64,
+) -> Result<usize, AppError> {
+    bounded_count(request.records.len())?;
+    text(&request.source_name, "source_name", 256, true)?;
+    let mut ids = HashSet::new();
+    for record in &request.records {
+        validate_capture(record)?;
+        if !ids.insert(record.source_row_id) {
+            return Err(bad("snapshot contains duplicate source row IDs"));
+        }
+    }
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(AppError::db)?;
+    ensure_schema(&tx)?;
+    for record in &request.records {
+        let stored: Option<String> = tx.query_row(
+            "SELECT record_json FROM psf_guard_scheduler_flat_history WHERE origin_id=?1 AND source_row_id=?2 AND fingerprint=?3",
+            params![request.scope.origin_id, record.source_row_id, record.fingerprint], |row| row.get(0),
+        ).optional().map_err(AppError::db)?;
+        let record_json = serde_json::to_string(record).map_err(AppError::db)?;
+        if let Some(stored) = stored {
+            if !same_capture(&read_capture(&stored)?, record) {
+                return Err(AppError::Conflict(
+                    "flat-history fingerprint was reused for different capture metadata".into(),
+                ));
+            }
+            // Replayed old generations remain terminal or superseded. Decisions
+            // never inherit the telescope's view of whether flats are still good.
+            tx.execute(
+                "UPDATE psf_guard_scheduler_flat_history SET source_name=?1, record_json=?2, last_seen=?3
+                 WHERE origin_id=?4 AND source_row_id=?5 AND fingerprint=?6",
+                params![request.source_name, record_json, now, request.scope.origin_id, record.source_row_id, record.fingerprint],
+            ).map_err(AppError::db)?;
+        } else {
+            tx.execute(
+                "UPDATE psf_guard_scheduler_flat_history SET state='superseded'
+                 WHERE origin_id=?1 AND source_row_id=?2 AND state='recorded'",
+                params![request.scope.origin_id, record.source_row_id],
+            )
+            .map_err(AppError::db)?;
+            tx.execute(
+                "INSERT INTO psf_guard_scheduler_flat_history
+                 (record_id,origin_id,source_row_id,fingerprint,target_guid,source_name,record_json,state,last_seen)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,'recorded',?8)",
+                params![Uuid::new_v4().to_string(), request.scope.origin_id, record.source_row_id, record.fingerprint,
+                    record.target_guid, request.source_name, record_json, now],
+            ).map_err(AppError::db)?;
+        }
+    }
+    tx.commit().map_err(AppError::db)?;
+    Ok(request.records.len())
+}
+
+fn pending_decisions(
+    conn: &Connection,
+    request: &PendingRequest,
+) -> Result<Vec<Decision>, AppError> {
+    if let Some(guid) = &request.target_guid {
+        uuid(guid, "target_guid")?;
+    }
+    if !schema_exists(conn)? {
+        return Ok(Vec::new());
+    }
+    let mut statement = conn.prepare(
+        "SELECT record_id,source_row_id,fingerprint,target_guid,reason FROM psf_guard_scheduler_flat_history
+         WHERE origin_id=?1 AND state='pending' AND (?2 IS NULL OR target_guid=?2)
+         ORDER BY invalidated_at,record_id LIMIT 1000"
+    ).map_err(AppError::db)?;
+    statement
+        .query_map(
+            params![request.scope.origin_id, request.target_guid],
+            |row| {
+                Ok(Decision {
+                    record_id: row.get(0)?,
+                    source_row_id: row.get(1)?,
+                    fingerprint: row.get(2)?,
+                    target_guid: row.get(3)?,
+                    reason: row.get(4)?,
+                })
+            },
+        )
+        .map_err(AppError::db)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(AppError::db)
+}
+
+fn acknowledge_records(
+    conn: &mut Connection,
+    request: &AcknowledgeRequest,
+    now: i64,
+) -> Result<usize, AppError> {
+    bounded_count(request.results.len())?;
+    let mut ids = HashSet::new();
+    for result in &request.results {
+        uuid(&result.record_id, "record_id")?;
+        identity(result.source_row_id, &result.fingerprint)?;
+        optional_text(&result.detail, "detail", 1024)?;
+        if !ids.insert(&result.record_id) {
+            return Err(bad("acknowledgement contains duplicate record IDs"));
+        }
+    }
+    if request.results.is_empty() {
+        return Ok(0);
+    }
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(AppError::db)?;
+    if !schema_exists(&tx)? {
+        return Err(AppError::NotFound);
+    }
+    for result in &request.results {
+        let stored: Option<(String, i64, String, String)> = tx.query_row(
+            "SELECT origin_id,source_row_id,fingerprint,state FROM psf_guard_scheduler_flat_history WHERE record_id=?1",
+            [&result.record_id], |row| Ok((row.get(0)?,row.get(1)?,row.get(2)?,row.get(3)?)),
+        ).optional().map_err(AppError::db)?;
+        let (origin, row_id, fingerprint, state) = stored.ok_or(AppError::NotFound)?;
+        if origin != request.scope.origin_id {
+            return Err(AppError::Forbidden(
+                "flat-history record belongs to a different origin".into(),
+            ));
+        }
+        if row_id != result.source_row_id || fingerprint != result.fingerprint {
+            return Err(AppError::Conflict(
+                "flat-history acknowledgement identity does not match".into(),
+            ));
+        }
+        if state == result.status.as_str()
+            || (matches!(state.as_str(), "removed" | "absent")
+                && matches!(
+                    result.status,
+                    AcknowledgeStatus::Removed | AcknowledgeStatus::Absent
+                ))
+        {
+            // A replay after deletion observes absence. Keep the first audit
+            // result instead of failing this otherwise successful batch.
+            continue;
+        }
+        if state != "pending" {
+            return Err(AppError::Conflict(
+                "flat-history decision is not pending".into(),
+            ));
+        }
+        tx.execute(
+            "UPDATE psf_guard_scheduler_flat_history SET state=?1,acknowledged_at=?2,detail=?3 WHERE record_id=?4",
+            params![result.status.as_str(), now, result.detail, result.record_id],
+        ).map_err(AppError::db)?;
+    }
+    tx.commit().map_err(AppError::db)?;
+    Ok(request.results.len())
+}
+
+fn list_records(conn: &Connection, query: &ListQuery) -> Result<HistoryList, AppError> {
+    let limit = query.limit.unwrap_or(100);
+    let offset = query.offset.unwrap_or(0);
+    if !(1..=1000).contains(&limit) || offset > i64::MAX as usize {
+        return Err(bad("invalid flat-history pagination"));
+    }
+    optional_text(&query.q, "q", 200)?;
+    if !schema_exists(conn)? {
+        return Ok(HistoryList {
+            records: Vec::new(),
+            total: 0,
+        });
+    }
+    let search = query
+        .q
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            format!(
+                "%{}%",
+                value
+                    .replace('\\', "\\\\")
+                    .replace('%', "\\%")
+                    .replace('_', "\\_")
+            )
+        });
+    let state = query.state.map(HistoryState::as_str);
+    let filter = "WHERE (?1 IS NULL OR state=?1) AND (?2 IS NULL
+        OR source_name LIKE ?2 ESCAPE '\\'
+        OR json_extract(record_json,'$.target_name') LIKE ?2 ESCAPE '\\'
+        OR json_extract(record_json,'$.filter_name') LIKE ?2 ESCAPE '\\'
+        OR json_extract(record_json,'$.profile_id') LIKE ?2 ESCAPE '\\')";
+    // Read the total and page from one snapshot while a remote snapshot arrives.
+    let tx = conn.unchecked_transaction().map_err(AppError::db)?;
+    let total: i64 = tx
+        .query_row(
+            &format!("SELECT COUNT(*) FROM {TABLE} {filter}"),
+            params![state, search],
+            |row| row.get(0),
+        )
+        .map_err(AppError::db)?;
+    let total = usize::try_from(total)
+        .map_err(|_| AppError::DatabaseError("invalid flat-history record count".into()))?;
+    let records = {
+        let mut statement = tx.prepare(&format!(
+            "SELECT record_id,origin_id,source_name,record_json,state,reason,invalidated_at,last_seen,acknowledged_at,detail
+             FROM {TABLE} {filter} ORDER BY json_extract(record_json,'$.flats_taken_date') DESC,record_id LIMIT ?3 OFFSET ?4"
+        )).map_err(AppError::db)?;
+        let mut rows = statement
+            .query(params![state, search, limit as i64, offset as i64])
+            .map_err(AppError::db)?;
+        let mut records = Vec::new();
+        while let Some(row) = rows.next().map_err(AppError::db)? {
+            records.push(HistoryRecord {
+                record_id: row.get(0).map_err(AppError::db)?,
+                origin_id: row.get(1).map_err(AppError::db)?,
+                source_name: row.get(2).map_err(AppError::db)?,
+                capture: read_capture(&row.get::<_, String>(3).map_err(AppError::db)?)?,
+                state: HistoryState::parse(&row.get::<_, String>(4).map_err(AppError::db)?)?,
+                reason: row.get(5).map_err(AppError::db)?,
+                invalidated_at: row.get(6).map_err(AppError::db)?,
+                last_seen: row.get(7).map_err(AppError::db)?,
+                acknowledged_at: row.get(8).map_err(AppError::db)?,
+                detail: row.get(9).map_err(AppError::db)?,
+            });
+        }
+        records
+    };
+    tx.commit().map_err(AppError::db)?;
+    Ok(HistoryList { records, total })
+}
+
+fn invalidate_records(
+    conn: &mut Connection,
+    request: &InvalidateRequest,
+    now: i64,
+) -> Result<usize, AppError> {
+    bounded_count(request.record_ids.len())?;
+    if request.record_ids.is_empty() {
+        return Err(bad("no flat-history records selected"));
+    }
+    text(&request.reason, "reason", 1024, true)?;
+    let mut ids = HashSet::new();
+    for id in &request.record_ids {
+        uuid(id, "record_id")?;
+        if !ids.insert(id) {
+            return Err(bad("duplicate flat-history record IDs"));
+        }
+    }
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(AppError::db)?;
+    if !schema_exists(&tx)? {
+        return Err(AppError::NotFound);
+    }
+    let mut invalidated = 0;
+    for id in &request.record_ids {
+        let state: Option<String> = tx
+            .query_row(
+                "SELECT state FROM psf_guard_scheduler_flat_history WHERE record_id=?1",
+                [id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(AppError::db)?;
+        match state.as_deref() {
+            None => return Err(AppError::NotFound),
+            Some("pending") => continue,
+            Some("recorded") => {}
+            _ => {
+                return Err(AppError::Conflict(
+                    "only currently recorded flat history can be invalidated".into(),
+                ))
+            }
+        }
+        invalidated += tx.execute(
+            "UPDATE psf_guard_scheduler_flat_history SET state='pending',reason=?1,invalidated_at=?2 WHERE record_id=?3",
+            params![request.reason.trim(),now,id],
+        ).map_err(AppError::db)?;
+    }
+    tx.commit().map_err(AppError::db)?;
+    Ok(invalidated)
+}
+
+async fn database_task<T: Send + 'static>(
+    ctx: Arc<DatabaseContext>,
+    write: bool,
+    task: impl FnOnce(&mut Connection) -> Result<T, AppError> + Send + 'static,
+) -> Result<T, AppError> {
+    tokio::task::spawn_blocking(move || {
+        let flags = if write {
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+        } else {
+            OpenFlags::SQLITE_OPEN_READ_ONLY
+        };
+        let mut conn = open_scheduler_connection_with_flags(&ctx.database_path, flags)
+            .map_err(AppError::db)?;
+        task(&mut conn)
+    })
+    .await
+    .map_err(|_| AppError::InternalError("flat-history database task failed".into()))?
+}
+
+fn audit<T>(
+    state: &AppState,
+    catalog_id: &str,
+    scope: &Scope,
+    action: AuditAction,
+    operation: &str,
+    result: &Result<T, AppError>,
+) {
+    let outcome = match result {
+        Ok(_) => AuditOutcome::Ok,
+        Err(AppError::DatabaseError(_) | AppError::InternalError(_)) => AuditOutcome::Failed,
+        Err(_) => AuditOutcome::Refused,
+    };
+    state.remote_audit.record(
+        catalog_id,
+        action,
+        outcome,
+        AuditRecord {
+            operation: Some(operation),
+            source_id: Some(&scope.origin_id),
+            ..Default::default()
+        },
+    );
+    tracing::info!(catalog=catalog_id,origin=%scope.origin_id,operation,?outcome,"flat-history sync");
+}
+
+pub async fn snapshot(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<SnapshotRequest>,
+) -> Result<Json<ApiResponse<SnapshotResponse>>, AppError> {
+    let ctx = authenticated_catalog(&state, &headers, AuditAction::FlatHistorySnapshot)?;
+    let catalog_id = ctx.id.clone();
+    let scope = request.scope.clone();
+    let result = async {
+        validate_scope(&scope, &ctx)?;
+        let received = database_task(ctx, true, move |conn| {
+            store_snapshot(conn, &request, chrono::Utc::now().timestamp())
+        })
+        .await?;
+        Ok(Json(ApiResponse::success(SnapshotResponse {
+            catalog_id: scope.catalog_id.clone(),
+            origin_id: scope.origin_id.clone(),
+            received,
+        })))
+    }
+    .await;
+    audit(
+        &state,
+        &catalog_id,
+        &scope,
+        AuditAction::FlatHistorySnapshot,
+        "flat_history_snapshot",
+        &result,
+    );
+    result
+}
+
+pub async fn pending(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<PendingRequest>,
+) -> Result<Json<ApiResponse<PendingResponse>>, AppError> {
+    let ctx = authenticated_catalog(&state, &headers, AuditAction::FlatHistoryPending)?;
+    let catalog_id = ctx.id.clone();
+    let scope = request.scope.clone();
+    let result = async {
+        validate_scope(&scope, &ctx)?;
+        let decisions =
+            database_task(ctx, false, move |conn| pending_decisions(conn, &request)).await?;
+        Ok(Json(ApiResponse::success(PendingResponse {
+            catalog_id: scope.catalog_id.clone(),
+            origin_id: scope.origin_id.clone(),
+            decisions,
+        })))
+    }
+    .await;
+    audit(
+        &state,
+        &catalog_id,
+        &scope,
+        AuditAction::FlatHistoryPending,
+        "flat_history_pending",
+        &result,
+    );
+    result
+}
+
+pub async fn acknowledge(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<AcknowledgeRequest>,
+) -> Result<Json<ApiResponse<AcknowledgeResponse>>, AppError> {
+    let ctx = authenticated_catalog(&state, &headers, AuditAction::FlatHistoryAcknowledge)?;
+    let catalog_id = ctx.id.clone();
+    let scope = request.scope.clone();
+    let result = async {
+        validate_scope(&scope, &ctx)?;
+        let acknowledged = database_task(ctx, true, move |conn| {
+            acknowledge_records(conn, &request, chrono::Utc::now().timestamp())
+        })
+        .await?;
+        Ok(Json(ApiResponse::success(AcknowledgeResponse {
+            catalog_id: scope.catalog_id.clone(),
+            origin_id: scope.origin_id.clone(),
+            acknowledged,
+        })))
+    }
+    .await;
+    audit(
+        &state,
+        &catalog_id,
+        &scope,
+        AuditAction::FlatHistoryAcknowledge,
+        "flat_history_acknowledge",
+        &result,
+    );
+    result
+}
+
+pub async fn list(
+    ctx: DbContext,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<ApiResponse<HistoryList>>, AppError> {
+    database_task(ctx.0, false, move |conn| list_records(conn, &query))
+        .await
+        .map(ApiResponse::success)
+        .map(Json)
+}
+
+pub async fn invalidate(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Json(request): Json<InvalidateRequest>,
+) -> Result<Json<ApiResponse<InvalidateResponse>>, AppError> {
+    require_database_management_allowed(&state)?;
+    let invalidated = database_task(ctx.0, true, move |conn| {
+        invalidate_records(conn, &request, chrono::Utc::now().timestamp())
+    })
+    .await?;
+    Ok(Json(ApiResponse::success(InvalidateResponse {
+        invalidated,
+    })))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/server/flat_history/tests.rs
+++ b/src/server/flat_history/tests.rs
@@ -1,0 +1,692 @@
+use super::*;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+const ORIGIN: &str = "11111111-1111-4111-8111-111111111111";
+const OTHER_ORIGIN: &str = "22222222-2222-4222-8222-222222222222";
+const TARGET: &str = "33333333-3333-4333-8333-333333333333";
+const TOKEN: &str = "flat-history-test-token-1234567890";
+
+fn scope() -> Scope {
+    Scope {
+        protocol_version: 1,
+        catalog_id: "test".into(),
+        origin_id: ORIGIN.into(),
+    }
+}
+
+fn capture(id: i64) -> CaptureRecord {
+    CaptureRecord {
+        source_row_id: id,
+        fingerprint: format!("{id:064x}"),
+        target_guid: Some(TARGET.into()),
+        target_name: Some("M31".into()),
+        profile_id: "profile-one".into(),
+        light_session_date: Some(100),
+        light_session_id: 42,
+        flats_taken_date: Some(200 + id),
+        flats_type: Some("AFTER".into()),
+        filter_name: Some("L".into()),
+        gain: Some(100),
+        offset: Some(50),
+        bin: Some(1),
+        readout_mode: Some(0),
+        rotation: Some(0.0),
+        roi: Some(1.0),
+    }
+}
+
+fn snapshot_request(records: Vec<CaptureRecord>) -> SnapshotRequest {
+    SnapshotRequest {
+        scope: scope(),
+        source_name: "C925".into(),
+        records,
+    }
+}
+
+fn records(conn: &Connection) -> Vec<HistoryRecord> {
+    list_records(conn, &ListQuery::default()).unwrap().records
+}
+
+fn invalidate_one(conn: &mut Connection, record_id: &str) {
+    assert_eq!(
+        invalidate_records(
+            conn,
+            &InvalidateRequest {
+                record_ids: vec![record_id.into()],
+                reason: "Bad illumination".into()
+            },
+            300
+        )
+        .unwrap(),
+        1
+    );
+}
+
+fn acknowledgement(record: &HistoryRecord, status: AcknowledgeStatus) -> AcknowledgeRequest {
+    AcknowledgeRequest {
+        scope: scope(),
+        results: vec![AcknowledgeResult {
+            record_id: record.record_id.clone(),
+            source_row_id: record.capture.source_row_id,
+            fingerprint: record.capture.fingerprint.clone(),
+            status,
+            detail: Some("Native coverage row removed".into()),
+        }],
+    }
+}
+
+#[test]
+fn reads_of_an_uninitialized_catalog_do_not_create_tables() {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.pragma_update(None, "query_only", true).unwrap();
+    assert_eq!(list_records(&conn, &ListQuery::default()).unwrap().total, 0);
+    assert!(pending_decisions(
+        &conn,
+        &PendingRequest {
+            scope: scope(),
+            target_guid: None
+        }
+    )
+    .unwrap()
+    .is_empty());
+    assert!(!schema_exists(&conn).unwrap());
+}
+
+#[test]
+fn snapshot_replay_and_target_rename_preserve_identity_and_decisions() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    let mut request = snapshot_request(vec![capture(1)]);
+    store_snapshot(&mut conn, &request, 100).unwrap();
+    let id = records(&conn)[0].record_id.clone();
+    invalidate_one(&mut conn, &id);
+    request.source_name = "Renamed telescope".into();
+    request.records[0].target_name = Some("Andromeda".into());
+    store_snapshot(&mut conn, &request, 500).unwrap();
+    let current = records(&conn).remove(0);
+    assert_eq!(current.record_id, id);
+    assert_eq!(current.state, HistoryState::Pending);
+    assert_eq!(current.reason.as_deref(), Some("Bad illumination"));
+    assert_eq!(current.invalidated_at, Some(300));
+    assert_eq!(current.capture.target_name.as_deref(), Some("Andromeda"));
+    assert_eq!(current.source_name, "Renamed telescope");
+    assert_eq!(current.last_seen, 500);
+    assert_eq!(
+        invalidate_records(
+            &mut conn,
+            &InvalidateRequest {
+                record_ids: vec![id],
+                reason: "Changed reason".into()
+            },
+            600
+        )
+        .unwrap(),
+        0
+    );
+    assert_eq!(
+        records(&conn)[0].reason.as_deref(),
+        Some("Bad illumination")
+    );
+}
+
+#[test]
+fn reused_ids_never_erase_pending_decisions_or_revive_superseded_generations() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    let old = snapshot_request(vec![capture(1), capture(2)]);
+    store_snapshot(&mut conn, &old, 100).unwrap();
+    let first_id = records(&conn)
+        .iter()
+        .find(|r| r.capture.source_row_id == 1)
+        .unwrap()
+        .record_id
+        .clone();
+    invalidate_one(&mut conn, &first_id);
+    let mut new = snapshot_request(vec![capture(1), capture(2)]);
+    for record in &mut new.records {
+        record.fingerprint = "a".repeat(64);
+        record.flats_taken_date = Some(900);
+    }
+    store_snapshot(&mut conn, &new, 400).unwrap();
+    store_snapshot(&mut conn, &old, 500).unwrap();
+    let all = records(&conn);
+    assert_eq!(all.len(), 4);
+    assert_eq!(
+        all.iter()
+            .filter(|r| r.state == HistoryState::Recorded)
+            .count(),
+        2
+    );
+    assert_eq!(
+        all.iter()
+            .filter(|r| r.state == HistoryState::Superseded)
+            .count(),
+        1
+    );
+    let pending = pending_decisions(
+        &conn,
+        &PendingRequest {
+            scope: scope(),
+            target_guid: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].record_id, first_id);
+    assert_eq!(pending[0].fingerprint, format!("{:064x}", 1));
+}
+
+#[test]
+fn capture_metadata_cannot_change_under_an_existing_fingerprint_and_batch_rolls_back() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    let initial = snapshot_request(vec![capture(1)]);
+    store_snapshot(&mut conn, &initial, 100).unwrap();
+    let mut changed = capture(1);
+    changed.gain = Some(200);
+    assert!(matches!(
+        store_snapshot(&mut conn, &snapshot_request(vec![capture(2), changed]), 200),
+        Err(AppError::Conflict(_))
+    ));
+    assert_eq!(records(&conn).len(), 1);
+    assert_eq!(records(&conn)[0].last_seen, 100);
+    assert!(matches!(
+        store_snapshot(
+            &mut conn,
+            &snapshot_request(vec![capture(2), capture(2)]),
+            300
+        ),
+        Err(AppError::BadRequest(_))
+    ));
+    assert_eq!(records(&conn).len(), 1);
+}
+
+#[test]
+fn missing_rows_are_not_treated_as_invalidations() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    store_snapshot(&mut conn, &snapshot_request(vec![capture(1)]), 100).unwrap();
+    store_snapshot(&mut conn, &snapshot_request(Vec::new()), 200).unwrap();
+    assert_eq!(records(&conn)[0].state, HistoryState::Recorded);
+    assert!(pending_decisions(
+        &conn,
+        &PendingRequest {
+            scope: scope(),
+            target_guid: None
+        }
+    )
+    .unwrap()
+    .is_empty());
+}
+
+#[test]
+fn pending_is_scoped_to_origin_and_exact_target_but_includes_profile_coverage() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    let mut profile = capture(2);
+    profile.target_guid = None;
+    profile.target_name = None;
+    store_snapshot(&mut conn, &snapshot_request(vec![capture(1), profile]), 100).unwrap();
+    let mut other = snapshot_request(vec![capture(1)]);
+    other.scope.origin_id = OTHER_ORIGIN.into();
+    store_snapshot(&mut conn, &other, 100).unwrap();
+    for record in records(&conn) {
+        invalidate_one(&mut conn, &record.record_id);
+    }
+    let all = pending_decisions(
+        &conn,
+        &PendingRequest {
+            scope: scope(),
+            target_guid: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(all.len(), 2);
+    let selected = pending_decisions(
+        &conn,
+        &PendingRequest {
+            scope: scope(),
+            target_guid: Some(TARGET.into()),
+        },
+    )
+    .unwrap();
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].source_row_id, 1);
+    let other = pending_decisions(
+        &conn,
+        &PendingRequest {
+            scope: other.scope,
+            target_guid: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(other.len(), 1);
+    assert_ne!(selected[0].record_id, other[0].record_id);
+}
+
+#[test]
+fn acknowledgement_is_idempotent_and_preserves_first_audit_details() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    store_snapshot(&mut conn, &snapshot_request(vec![capture(1)]), 100).unwrap();
+    let record = records(&conn).remove(0);
+    invalidate_one(&mut conn, &record.record_id);
+    let mut ack = acknowledgement(&record, AcknowledgeStatus::Removed);
+    assert_eq!(acknowledge_records(&mut conn, &ack, 400).unwrap(), 1);
+    ack.results[0].detail = Some("Retry".into());
+    assert_eq!(acknowledge_records(&mut conn, &ack, 500).unwrap(), 1);
+    store_snapshot(&mut conn, &snapshot_request(vec![capture(1)]), 600).unwrap();
+    let result = records(&conn).remove(0);
+    assert_eq!(result.state, HistoryState::Removed);
+    assert_eq!(result.acknowledged_at, Some(400));
+    assert_eq!(
+        result.detail.as_deref(),
+        Some("Native coverage row removed")
+    );
+    assert_eq!(result.reason.as_deref(), Some("Bad illumination"));
+    assert!(pending_decisions(
+        &conn,
+        &PendingRequest {
+            scope: scope(),
+            target_guid: None
+        }
+    )
+    .unwrap()
+    .is_empty());
+    ack.results[0].status = AcknowledgeStatus::Absent;
+    assert_eq!(acknowledge_records(&mut conn, &ack, 700).unwrap(), 1);
+    assert_eq!(records(&conn)[0].state, HistoryState::Removed);
+    assert_eq!(records(&conn)[0].acknowledged_at, Some(400));
+    ack.results[0].status = AcknowledgeStatus::Conflict;
+    assert!(matches!(
+        acknowledge_records(&mut conn, &ack, 700),
+        Err(AppError::Conflict(_))
+    ));
+}
+
+#[test]
+fn acknowledgement_refuses_wrong_origin_mismatched_identity_and_unrequested_rows() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    store_snapshot(&mut conn, &snapshot_request(vec![capture(1)]), 100).unwrap();
+    let record = records(&conn).remove(0);
+    let mut ack = acknowledgement(&record, AcknowledgeStatus::Conflict);
+    assert!(matches!(
+        acknowledge_records(&mut conn, &ack, 200),
+        Err(AppError::Conflict(_))
+    ));
+    invalidate_one(&mut conn, &record.record_id);
+    ack.scope.origin_id = OTHER_ORIGIN.into();
+    assert!(matches!(
+        acknowledge_records(&mut conn, &ack, 400),
+        Err(AppError::Forbidden(_))
+    ));
+    ack.scope.origin_id = ORIGIN.into();
+    ack.results[0].fingerprint = "f".repeat(64);
+    assert!(matches!(
+        acknowledge_records(&mut conn, &ack, 400),
+        Err(AppError::Conflict(_))
+    ));
+    ack.results[0].fingerprint = record.capture.fingerprint;
+    ack.results[0].source_row_id = 3;
+    assert!(matches!(
+        acknowledge_records(&mut conn, &ack, 400),
+        Err(AppError::Conflict(_))
+    ));
+    assert_eq!(records(&conn)[0].state, HistoryState::Pending);
+}
+
+#[test]
+fn invalidation_and_acknowledgement_batches_are_atomic() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    store_snapshot(
+        &mut conn,
+        &snapshot_request(vec![capture(1), capture(2)]),
+        100,
+    )
+    .unwrap();
+    let all = records(&conn);
+    assert!(matches!(
+        invalidate_records(
+            &mut conn,
+            &InvalidateRequest {
+                record_ids: vec![all[0].record_id.clone(), Uuid::new_v4().to_string()],
+                reason: "Bad flats".into(),
+            },
+            200
+        ),
+        Err(AppError::NotFound)
+    ));
+    assert!(records(&conn)
+        .iter()
+        .all(|r| r.state == HistoryState::Recorded));
+    for record in &all {
+        invalidate_one(&mut conn, &record.record_id);
+    }
+    let mut ack = acknowledgement(&all[0], AcknowledgeStatus::Removed);
+    ack.results
+        .extend(acknowledgement(&all[1], AcknowledgeStatus::Absent).results);
+    ack.results[1].fingerprint = "f".repeat(64);
+    assert!(acknowledge_records(&mut conn, &ack, 400).is_err());
+    assert!(records(&conn)
+        .iter()
+        .all(|r| r.state == HistoryState::Pending));
+}
+
+#[test]
+fn pagination_filters_totals_and_treats_search_wildcards_literally() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    let mut literal = capture(1);
+    literal.target_name = Some("100%_Target".into());
+    let mut null_date = capture(3);
+    null_date.flats_taken_date = None;
+    store_snapshot(
+        &mut conn,
+        &snapshot_request(vec![literal, capture(2), null_date]),
+        100,
+    )
+    .unwrap();
+    let first = list_records(
+        &conn,
+        &ListQuery {
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(first.total, 3);
+    assert_eq!(first.records[0].capture.source_row_id, 2);
+    let last = list_records(
+        &conn,
+        &ListQuery {
+            limit: Some(1),
+            offset: Some(2),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(last.records[0].capture.source_row_id, 3);
+    let literal = list_records(
+        &conn,
+        &ListQuery {
+            q: Some("%_".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(literal.total, 1);
+    invalidate_one(&mut conn, &literal.records[0].record_id);
+    let filtered = list_records(
+        &conn,
+        &ListQuery {
+            state: Some(HistoryState::Pending),
+            q: Some("c925".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(filtered.total, 1);
+    assert_eq!(filtered.records[0].capture.source_row_id, 1);
+    assert!(list_records(
+        &conn,
+        &ListQuery {
+            limit: Some(0),
+            ..Default::default()
+        }
+    )
+    .is_err());
+    assert!(list_records(
+        &conn,
+        &ListQuery {
+            q: Some("x".repeat(201)),
+            ..Default::default()
+        }
+    )
+    .is_err());
+}
+
+#[test]
+fn request_validation_bounds_strings_counts_ids_and_finite_values() {
+    let mut conn = Connection::open_in_memory().unwrap();
+    assert!(store_snapshot(
+        &mut conn,
+        &snapshot_request((1..=1001).map(capture).collect()),
+        100
+    )
+    .is_err());
+    let mut record = capture(1);
+    record.rotation = Some(f64::INFINITY);
+    assert!(validate_capture(&record).is_err());
+    record.rotation = Some(0.0);
+    record.fingerprint = "A".repeat(64);
+    assert!(validate_capture(&record).is_err());
+    record.fingerprint = "a".repeat(64);
+    record.source_row_id = 0;
+    assert!(validate_capture(&record).is_err());
+    assert!(!schema_exists(&conn).unwrap());
+    let legacy = json!({"source_row_id":1,"fingerprint":"a".repeat(64),"target_guid":null,"profile_id":"profile"});
+    let legacy: CaptureRecord = serde_json::from_value(legacy).unwrap();
+    assert_eq!(legacy.light_session_id, 0);
+    assert_eq!(legacy.flats_taken_date, None);
+    assert!(validate_capture(&legacy).is_ok());
+}
+
+fn http_fixture() -> (tempfile::TempDir, Arc<AppState>, Router) {
+    let directory = tempfile::tempdir().unwrap();
+    let state = AppState::new_for_test(Connection::open_in_memory().unwrap());
+    let mut state = state;
+    state.remote_audit = super::super::remote_audit::RemoteAuditLog::new(directory.path());
+    let state = Arc::new(state);
+    let mut databases = state.databases.write().unwrap();
+    databases.clear();
+    for (id, token, sync_enabled) in [
+        ("test", TOKEN, true),
+        ("other", "other-flat-history-token-1234567890", true),
+        ("disabled", "disabled-flat-history-token-1234567890", false),
+    ] {
+        let path = directory.path().join(format!("{id}.sqlite"));
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch("CREATE TABLE flathistory (Id INTEGER PRIMARY KEY); INSERT INTO flathistory VALUES (1);").unwrap();
+        let mut ctx = DatabaseContext::new_for_test(conn);
+        ctx.id = id.into();
+        ctx.database_path = path.to_string_lossy().into_owned();
+        let mut config = crate::db_registry::RemoteImageUploadConfig {
+            sync_enabled,
+            ..Default::default()
+        };
+        config.set_token(token).unwrap();
+        ctx.remote_image_upload = Some(config);
+        databases.insert(id.into(), Arc::new(ctx));
+    }
+    drop(databases);
+    let router = Router::new()
+        .route(
+            "/api/sync/v1/capabilities",
+            get(super::super::remote_sync::capabilities),
+        )
+        .route("/api/sync/v1/flat-history/snapshot", post(snapshot))
+        .route("/api/sync/v1/flat-history/pending", post(pending))
+        .route("/api/sync/v1/flat-history/acknowledge", post(acknowledge))
+        .route("/api/db/{db_id}/flat-history", get(list))
+        .route("/api/db/{db_id}/flat-history/invalidate", post(invalidate))
+        .with_state(Arc::clone(&state));
+    (directory, state, router)
+}
+
+async fn call(
+    router: &Router,
+    method: &str,
+    url: &str,
+    token: Option<&str>,
+    body: Option<Value>,
+) -> (StatusCode, Value) {
+    let mut request = Request::builder().method(method).uri(url);
+    if let Some(token) = token {
+        request = request.header("authorization", format!("Bearer {token}"));
+    }
+    let request = if let Some(body) = body {
+        request
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    } else {
+        request.body(Body::empty()).unwrap()
+    };
+    let response = router.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+fn snapshot_json() -> Value {
+    json!({"protocol_version":1,"catalog_id":"test","origin_id":ORIGIN,"source_name":"C925","records":[capture(1)]})
+}
+
+#[tokio::test]
+async fn http_routes_enforce_token_scope_sync_grant_management_and_echo_origin() {
+    let (_directory, state, router) = http_fixture();
+    let snapshot_url = "/api/sync/v1/flat-history/snapshot";
+    assert_eq!(
+        call(&router, "POST", snapshot_url, None, Some(snapshot_json()))
+            .await
+            .0,
+        StatusCode::FORBIDDEN
+    );
+    assert_eq!(
+        call(
+            &router,
+            "POST",
+            snapshot_url,
+            Some("bad-token"),
+            Some(snapshot_json())
+        )
+        .await
+        .0,
+        StatusCode::FORBIDDEN
+    );
+    assert_eq!(
+        call(
+            &router,
+            "POST",
+            snapshot_url,
+            Some("other-flat-history-token-1234567890"),
+            Some(snapshot_json())
+        )
+        .await
+        .0,
+        StatusCode::FORBIDDEN
+    );
+    assert_eq!(
+        call(
+            &router,
+            "POST",
+            snapshot_url,
+            Some("disabled-flat-history-token-1234567890"),
+            Some(snapshot_json())
+        )
+        .await
+        .0,
+        StatusCode::FORBIDDEN
+    );
+    let (_, capabilities) = call(
+        &router,
+        "GET",
+        "/api/sync/v1/capabilities",
+        Some(TOKEN),
+        None,
+    )
+    .await;
+    assert!(capabilities["data"]["capabilities"]
+        .as_array()
+        .unwrap()
+        .contains(&json!("flat_history_v1")));
+    let (status, result) = call(
+        &router,
+        "POST",
+        snapshot_url,
+        Some(TOKEN),
+        Some(snapshot_json()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(result["data"]["origin_id"], ORIGIN);
+    assert_eq!(result["data"]["catalog_id"], "test");
+    assert_eq!(result["data"]["received"], 1);
+    let (status, page) = call(
+        &router,
+        "GET",
+        "/api/db/test/flat-history?state=recorded&limit=1&offset=0&q=M31",
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{page}");
+    assert_eq!(page["data"]["total"], 1);
+    assert_eq!(page["data"]["records"][0]["target_guid"], TARGET);
+    let record_id = page["data"]["records"][0]["record_id"].as_str().unwrap();
+    let invalidation = json!({"record_ids":[record_id],"reason":"Flat panel reflection"});
+    assert_eq!(
+        call(
+            &router,
+            "POST",
+            "/api/db/test/flat-history/invalidate",
+            None,
+            Some(invalidation.clone())
+        )
+        .await
+        .0,
+        StatusCode::FORBIDDEN
+    );
+    state.set_allow_database_management(true);
+    assert_eq!(
+        call(
+            &router,
+            "POST",
+            "/api/db/test/flat-history/invalidate",
+            None,
+            Some(invalidation)
+        )
+        .await
+        .0,
+        StatusCode::OK
+    );
+    let pending = json!({"protocol_version":1,"catalog_id":"test","origin_id":ORIGIN});
+    let (status, result) = call(
+        &router,
+        "POST",
+        "/api/sync/v1/flat-history/pending",
+        Some(TOKEN),
+        Some(pending),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(result["data"]["decisions"][0]["record_id"], record_id);
+    let ack = json!({"protocol_version":1,"catalog_id":"test","origin_id":ORIGIN,"results":[{
+        "record_id":record_id,"source_row_id":1,"fingerprint":capture(1).fingerprint,"status":"removed","detail":"Removed native coverage"
+    }]});
+    let (status, result) = call(
+        &router,
+        "POST",
+        "/api/sync/v1/flat-history/acknowledge",
+        Some(TOKEN),
+        Some(ack),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{result}");
+    assert_eq!(result["data"]["acknowledged"], 1);
+    let conn = state.get_database("test").unwrap().db();
+    let conn = conn.lock().unwrap();
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM flathistory", [], |row| row
+            .get::<_, i64>(0))
+            .unwrap(),
+        1,
+        "server must not delete native history"
+    );
+    let other = state.get_database("other").unwrap().db();
+    assert!(!schema_exists(&other.lock().unwrap()).unwrap());
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -8,6 +8,7 @@ pub mod embedded_static;
 pub mod export_job;
 pub mod export_settings;
 pub mod extract;
+pub mod flat_history;
 pub mod handlers;
 pub mod import_job;
 pub mod organization;
@@ -378,6 +379,8 @@ async fn run_server_internal(
             get(organization::destinations),
         )
         .route("/calibrations", get(handlers::get_calibration_library))
+        .route("/flat-history", get(flat_history::list))
+        .route("/flat-history/invalidate", post(flat_history::invalidate))
         .route(
             "/calibrations/details",
             get(handlers::get_calibration_library_details),
@@ -724,6 +727,19 @@ async fn run_server_internal(
             post(peers::sync_with_peer),
         )
         .route("/sync/v1/capabilities", get(remote_sync::capabilities))
+        .route(
+            "/sync/v1/flat-history/snapshot",
+            post(flat_history::snapshot).layer(DefaultBodyLimit::max(flat_history::MAX_BODY_BYTES)),
+        )
+        .route(
+            "/sync/v1/flat-history/pending",
+            post(flat_history::pending).layer(DefaultBodyLimit::max(flat_history::MAX_BODY_BYTES)),
+        )
+        .route(
+            "/sync/v1/flat-history/acknowledge",
+            post(flat_history::acknowledge)
+                .layer(DefaultBodyLimit::max(flat_history::MAX_BODY_BYTES)),
+        )
         .route("/sync/v1/pair", post(pairing::pair_route))
         .route(
             "/sync/v1/previews",

--- a/src/server/remote_audit.rs
+++ b/src/server/remote_audit.rs
@@ -34,6 +34,9 @@ pub enum AuditAction {
     PreviewRefresh,
     Apply,
     Pair,
+    FlatHistorySnapshot,
+    FlatHistoryPending,
+    FlatHistoryAcknowledge,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/src/server/remote_sync.rs
+++ b/src/server/remote_sync.rs
@@ -433,6 +433,7 @@ pub async fn capabilities(
         "preview_refresh",
         "async_preview_jobs",
         "exports",
+        "flat_history_v1",
     ];
     if catalog
         .remote_image_upload
@@ -972,7 +973,7 @@ pub async fn get_export(
     export_response(export)
 }
 
-fn authenticated_catalog(
+pub(super) fn authenticated_catalog(
     state: &AppState,
     headers: &HeaderMap,
     action: AuditAction,
@@ -1040,7 +1041,7 @@ fn require_protocol(version: u32) -> Result<(), AppError> {
     }
 }
 
-fn require_catalog(catalog: &DatabaseContext, requested: &str) -> Result<(), AppError> {
+pub(super) fn require_catalog(catalog: &DatabaseContext, requested: &str) -> Result<(), AppError> {
     if catalog.id == requested {
         Ok(())
     } else {

--- a/static/e2e/flat-history.spec.ts
+++ b/static/e2e/flat-history.spec.ts
@@ -1,0 +1,80 @@
+import { expect, request as playwrightRequest, test, type APIRequestContext } from '@playwright/test';
+import { randomUUID, createHash } from 'node:crypto';
+import { REVIEW_DB, REVIEW_TOKEN } from './fixtures/sync';
+
+let review: APIRequestContext;
+const headers = { Authorization: `Bearer ${REVIEW_TOKEN}` };
+
+test.beforeAll(async () => {
+  review = await playwrightRequest.newContext({ baseURL: process.env.PSF_GUARD_E2E_REVIEW_URL });
+});
+test.afterAll(async () => { await review.dispose(); });
+
+test('invalidates selected flat coverage, retains decisions across stale snapshots and shows acknowledgements', async ({ page }, testInfo) => {
+  const origin = randomUUID();
+  const target = randomUUID();
+  const profile = randomUUID();
+  const source = `C925-${origin.slice(0, 8)}`;
+  const scope = { protocol_version: 1, catalog_id: REVIEW_DB, origin_id: origin };
+  const records = [1, 2, 3].map((id) => ({
+    source_row_id: id,
+    fingerprint: createHash('sha256').update(`${origin}:${id}`).digest('hex'),
+    target_guid: target, target_name: 'NGC 7331', profile_id: profile,
+    light_session_date: 1788998400, light_session_id: 3,
+    flats_taken_date: 1789023600, flats_type: 'sky', filter_name: id === 3 ? 'Ha' : 'L',
+    gain: 100, offset: 30, bin: 1, readout_mode: 0, rotation: 90, roi: 1,
+  }));
+  const snapshot = { ...scope, source_name: source, records };
+  const posted = await review.post('/api/sync/v1/flat-history/snapshot', { headers, data: snapshot });
+  expect(posted.status(), await posted.text()).toBe(200);
+  const listed = await review.get(`/api/db/${REVIEW_DB}/flat-history`, { params: { q: source } });
+  expect((await listed.json()).data.total).toBe(3);
+
+  await page.goto(`${process.env.PSF_GUARD_E2E_REVIEW_URL}/`);
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  await page.getByRole('tab', { name: 'Databases', exact: true }).click();
+  await page.locator('.db-entry').filter({ has: page.locator('.db-row-slug', { hasText: REVIEW_DB }) })
+    .getByRole('button', { name: 'Manage', exact: true }).click();
+  const dialog = page.getByRole('dialog', { name: 'Calibration library' });
+  await dialog.getByRole('tab', { name: 'Scheduler flats', exact: true }).click();
+  await dialog.getByLabel('Target, source or filter').fill(source);
+  await dialog.getByRole('button', { name: 'Search', exact: true }).click();
+  await expect(dialog.locator('tbody tr')).toHaveCount(3);
+  await dialog.getByRole('checkbox', { name: 'Select coverage 1 for NGC 7331', exact: true }).check();
+  await dialog.getByRole('checkbox', { name: 'Select coverage 2 for NGC 7331', exact: true }).check();
+  await expect(dialog.getByRole('button', { name: 'Invalidate coverage', exact: true })).toBeDisabled();
+  await dialog.getByLabel('Reason', { exact: true }).fill('Bright-star artifacts in the luminance sky flats');
+  expect(await dialog.getByRole('button', { name: 'Refresh coverage', exact: true }).locator('svg')
+    .evaluate((el) => el.getBoundingClientRect().width)).toBeGreaterThanOrEqual(16);
+  await dialog.screenshot({ path: testInfo.outputPath('flat-history-desktop.png') });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(dialog.getByRole('button', { name: 'Invalidate coverage', exact: true })).toBeVisible();
+  expect(await dialog.evaluate((el) => el.scrollWidth <= el.clientWidth)).toBe(true);
+  await dialog.screenshot({ path: testInfo.outputPath('flat-history-mobile.png') });
+  await dialog.getByRole('button', { name: 'Invalidate coverage', exact: true }).click();
+  await expect(dialog.getByRole('status')).toHaveText('2 coverage records awaiting sync.');
+  await expect(dialog.locator('tbody tr')).toHaveCount(1);
+
+  // A stale plugin snapshot must not revive the explicitly invalidated coverage.
+  expect((await review.post('/api/sync/v1/flat-history/snapshot', { headers, data: snapshot })).ok()).toBe(true);
+  const pending = await review.post('/api/sync/v1/flat-history/pending', { headers, data: scope });
+  const decisions = (await pending.json()).data.decisions as Array<{
+    record_id: string; source_row_id: number; fingerprint: string;
+  }>;
+  expect(decisions.map((d) => d.source_row_id).sort()).toEqual([1, 2]);
+  const ack = await review.post('/api/sync/v1/flat-history/acknowledge', {
+    headers, data: { ...scope, results: decisions.map((d) => ({
+      ...d, status: d.source_row_id === 1 ? 'removed' : 'conflict',
+      detail: d.source_row_id === 1 ? null : 'Source coverage changed; new flats preserved.',
+    })) },
+  });
+  expect(ack.status(), await ack.text()).toBe(200);
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await dialog.getByLabel('Coverage status', { exact: true }).selectOption('all');
+  await expect(dialog.locator('tbody tr')).toHaveCount(3);
+  await expect(dialog.locator('tbody').getByText('Coverage removed', { exact: true })).toBeVisible();
+  await expect(dialog.locator('tbody').getByText('Changed in NINA', { exact: true })).toBeVisible();
+  await expect(dialog.getByText('Source coverage changed; new flats preserved.', { exact: true })).toBeVisible();
+  const remaining = await review.post('/api/sync/v1/flat-history/pending', { headers, data: scope });
+  expect((await remaining.json()).data.decisions).toEqual([]);
+});

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -3,6 +3,8 @@ import type { AxiosInstance } from 'axios';
 import { AUTH_REQUIRED_EVENT } from '../auth/events';
 import { getServerUrl } from '../utils/tauri';
 import type {
+  FlatHistoryState,
+  SchedulerFlatHistoryPage,
   CalibrationSettings,
   CalibrationMasterSource,
   StackCalibrationMasters,
@@ -662,6 +664,29 @@ export const apiClient = {
       dbPath(dbId, '/calibrations/details')
     );
     if (!data.data) throw new Error(data.error || 'Failed to read calibration frames');
+    return data.data;
+  },
+
+  getSchedulerFlatHistory: async (
+    dbId: string,
+    params: { limit: number; offset: number; state?: FlatHistoryState; q?: string }
+  ): Promise<SchedulerFlatHistoryPage> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<SchedulerFlatHistoryPage>>(
+      dbPath(dbId, '/flat-history'), { params }
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to read scheduler flat coverage');
+    return data.data;
+  },
+
+  invalidateSchedulerFlatHistory: async (
+    dbId: string, recordIds: string[], reason: string
+  ): Promise<{ invalidated: number }> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.post<ApiResponse<{ invalidated: number }>>(
+      dbPath(dbId, '/flat-history/invalidate'), { record_ids: recordIds, reason }
+    );
+    if (!data.data) throw new Error(data.error || 'Failed to invalidate flat coverage');
     return data.data;
   },
 

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -2252,3 +2252,38 @@ export interface RemoteSyncResult {
   peer_catalog: string;
   summary: Record<string, number>;
 }
+export type FlatHistoryState =
+  | 'recorded' | 'pending' | 'removed' | 'absent' | 'conflict' | 'superseded';
+
+export interface SchedulerFlatHistoryRecord {
+  record_id: string;
+  origin_id: string;
+  source_name: string;
+  source_row_id: number;
+  fingerprint: string;
+  target_guid: string | null;
+  target_name: string | null;
+  profile_id: string;
+  light_session_date: number | null;
+  light_session_id: number;
+  flats_taken_date: number | null;
+  flats_type: string | null;
+  filter_name: string | null;
+  gain: number | null;
+  offset: number | null;
+  bin: number | null;
+  readout_mode: number | null;
+  rotation: number | null;
+  roi: number | null;
+  state: FlatHistoryState;
+  reason: string | null;
+  invalidated_at: number | null;
+  last_seen: number;
+  acknowledged_at: number | null;
+  detail: string | null;
+}
+
+export interface SchedulerFlatHistoryPage {
+  records: SchedulerFlatHistoryRecord[];
+  total: number;
+}

--- a/static/src/components/CalibrationLibraryDialog.tsx
+++ b/static/src/components/CalibrationLibraryDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import type { CalibrationFrameSummary } from '../api/types';
+import SchedulerFlatHistory from './SchedulerFlatHistory';
 
 interface CalibrationLibraryDialogProps {
   dbId: string;
@@ -128,6 +129,7 @@ export default function CalibrationLibraryDialog({
   onImport,
 }: CalibrationLibraryDialogProps) {
   const queryClient = useQueryClient();
+  const [view, setView] = useState<'frames' | 'scheduler'>('frames');
   const [kind, setKind] = useState<'all' | CalibrationFrameSummary['kind']>('all');
   const [rig, setRig] = useState('all');
   const [missingOnly, setMissingOnly] = useState(false);
@@ -297,6 +299,11 @@ export default function CalibrationLibraryDialog({
           </button>
         </header>
 
+        <div className="calibration-library-tabs" role="tablist" aria-label="Calibration views">
+          <button role="tab" aria-selected={view === 'frames'} onClick={() => setView('frames')}>Frames</button>
+          <button role="tab" aria-selected={view === 'scheduler'} onClick={() => setView('scheduler')}>Scheduler flats</button>
+        </div>
+        {view === 'scheduler' ? <SchedulerFlatHistory key={dbId} dbId={dbId} canManage={canManage} /> : <>
         <div className="calibration-library-toolbar">
           <label>
             Rig
@@ -575,6 +582,7 @@ export default function CalibrationLibraryDialog({
             </div>
           )}
         </div>
+        </>}
       </section>
     </div>
   );

--- a/static/src/components/SchedulerFlatHistory.css
+++ b/static/src/components/SchedulerFlatHistory.css
@@ -1,0 +1,92 @@
+.tauri-settings .calibration-library-tabs {
+  display: flex;
+  gap: 20px;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--color-border-primary);
+  flex-shrink: 0;
+}
+
+.tauri-settings .calibration-library-tabs button {
+  padding: 12px 0;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  color: var(--color-text-muted);
+  background: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+.tauri-settings .calibration-library-tabs button[aria-selected='true'] {
+  color: var(--color-text-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.scheduler-flat-history {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+  font-size: 13px;
+  letter-spacing: 0;
+}
+
+.flat-history-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: end;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border-primary);
+}
+
+.flat-history-toolbar label,
+.flat-history-invalidate label {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  color: var(--color-text-secondary);
+}
+
+.flat-history-search { flex: 1 1 230px; }
+.flat-history-toolbar input,
+.flat-history-toolbar select,
+.flat-history-invalidate input {
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 34px;
+  padding: 6px 8px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: 4px;
+  background: var(--color-bg-input);
+  color: var(--color-text-primary);
+}
+
+.flat-history-table-scroll { overflow: auto; min-height: 120px; }
+.flat-history-table { width: 100%; border-collapse: collapse; text-align: left; }
+.flat-history-table th { background: var(--color-bg-secondary); font-weight: 600; position: sticky; top: 0; z-index: 1; }
+.flat-history-table td,
+.flat-history-table th { padding: 12px; vertical-align: top; border-bottom: 1px solid var(--color-border-primary); }
+.flat-history-table td { overflow-wrap: anywhere; min-width: 100px; max-width: 280px; }
+.flat-history-table td:first-child { min-width: 20px; }
+.flat-history-table small { display: block; color: var(--color-text-muted); margin-top: 5px; }
+.flat-history-state { font-weight: 600; }
+.flat-history-state-pending { color: var(--color-warning); }
+.flat-history-state-conflict { color: var(--color-error); }
+.flat-history-state-removed, .flat-history-state-absent { color: var(--color-success); }
+.flat-history-invalidate { padding: 16px 24px; background: var(--color-bg-secondary); border-bottom: 1px solid var(--color-border-primary); }
+.flat-history-invalidate p { margin: 8px 0; line-height: 1.5; }
+.flat-history-invalidate > div { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+.flat-history-invalidate button { display: inline-flex; align-items: center; gap: 7px; }
+.flat-history-footer { display: flex; align-items: center; gap: 10px; padding: 12px 24px; }
+.flat-history-footer > span { margin-right: auto; }
+.flat-history-message { padding: 0 24px; color: var(--color-success); }
+.tauri-settings .scheduler-flat-history .flat-history-icon { display: inline-flex; align-items: center; justify-content: center; width: 34px; height: 34px; padding: 0; flex-shrink: 0; }
+.flat-history-icon svg { flex-shrink: 0; }
+
+@media (max-width: 600px) {
+  .flat-history-toolbar, .flat-history-invalidate, .flat-history-footer { padding: 12px; }
+  .flat-history-table { font-size: 12px; }
+  .flat-history-table td, .flat-history-table th { padding: 8px; }
+}

--- a/static/src/components/SchedulerFlatHistory.tsx
+++ b/static/src/components/SchedulerFlatHistory.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronLeft, ChevronRight, RefreshCw, ShieldOff } from 'lucide-react';
+import { apiClient } from '../api/client';
+import type { FlatHistoryState, SchedulerFlatHistoryRecord } from '../api/types';
+import './SchedulerFlatHistory.css';
+
+const PAGE_SIZE = 100;
+const STATES: Record<FlatHistoryState, string> = {
+  recorded: 'Recorded', pending: 'Awaiting sync', removed: 'Coverage removed',
+  absent: 'Already absent', conflict: 'Changed in NINA', superseded: 'Replaced',
+};
+
+function timestamp(value: number | null): string {
+  return value === null ? 'Unknown' : new Date(value * 1000).toLocaleString();
+}
+
+function settings(row: SchedulerFlatHistoryRecord): string {
+  return [
+    row.gain !== null ? `Gain ${row.gain}` : null,
+    row.offset !== null ? `offset ${row.offset}` : null,
+    row.bin !== null ? `bin ${row.bin}` : null,
+    row.readout_mode !== null ? `readout ${row.readout_mode}` : null,
+    row.roi !== null ? `ROI ${row.roi}` : null,
+    row.rotation !== null ? `rotation ${row.rotation}` : null,
+  ].filter(Boolean).join(' / ') || 'Settings not recorded';
+}
+
+export default function SchedulerFlatHistory({ dbId, canManage }: {
+  dbId: string; canManage: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<FlatHistoryState | 'all'>('recorded');
+  const [query, setQuery] = useState('');
+  const [search, setSearch] = useState('');
+  const [offset, setOffset] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [reason, setReason] = useState('');
+  const [message, setMessage] = useState('');
+  const history = useQuery({
+    queryKey: ['db', dbId, 'flat-history', state, search, offset],
+    queryFn: () => apiClient.getSchedulerFlatHistory(dbId, {
+      limit: PAGE_SIZE, offset, state: state === 'all' ? undefined : state,
+      q: search || undefined,
+    }),
+  });
+  const rows = history.data?.records ?? [];
+  const eligible = rows.filter((row) => row.state === 'recorded');
+  // A refresh can replace a selected row. Only the current immutable records
+  // still eligible for invalidation may be submitted.
+  const selectedIds = eligible.filter((row) => selected.has(row.record_id))
+    .map((row) => row.record_id);
+  const invalidate = useMutation({
+    mutationFn: (input: { ids: string[]; reason: string }) =>
+      apiClient.invalidateSchedulerFlatHistory(dbId, input.ids, input.reason),
+    onSuccess: async ({ invalidated }) => {
+      setSelected(new Set());
+      setReason('');
+      setOffset(0);
+      setMessage(`${invalidated} coverage record${invalidated === 1 ? '' : 's'} awaiting sync.`);
+      await queryClient.invalidateQueries({ queryKey: ['db', dbId, 'flat-history'] });
+    },
+  });
+  const resetSelection = () => {
+    setSelected(new Set());
+    setMessage('');
+    invalidate.reset();
+  };
+  const changePage = (next: number) => {
+    resetSelection();
+    setOffset(next);
+  };
+  const total = history.data?.total ?? 0;
+  useEffect(() => {
+    if (history.data && !history.isFetching && !history.error && offset > 0 && offset >= history.data.total) {
+      setSelected(new Set());
+      setOffset(Math.max(0, Math.floor((history.data.total - 1) / PAGE_SIZE) * PAGE_SIZE));
+    }
+  }, [history.data, history.isFetching, history.error, offset]);
+  return (
+    <div className="scheduler-flat-history" role="tabpanel" aria-label="Scheduler flats">
+      <form className="flat-history-toolbar" onSubmit={(event) => {
+        event.preventDefault();
+        resetSelection();
+        setSearch(query.trim());
+        setOffset(0);
+      }}>
+        <label className="flat-history-search">Target, source or filter
+          <input type="search" value={query} maxLength={200}
+            onChange={(event) => setQuery(event.target.value)} />
+        </label>
+        <button className="browse-button" type="submit" disabled={invalidate.isPending}>Search</button>
+        <label>Status
+          <select aria-label="Coverage status" value={state} disabled={invalidate.isPending} onChange={(event) => {
+            resetSelection(); setOffset(0); setState(event.target.value as typeof state);
+          }}>
+            <option value="all">All statuses</option>
+            {Object.entries(STATES).map(([value, label]) =>
+              <option key={value} value={value}>{label}</option>)}
+          </select>
+        </label>
+        <button type="button" className="browse-button flat-history-icon"
+          title="Refresh coverage" aria-label="Refresh coverage"
+          disabled={history.isFetching || invalidate.isPending}
+          onClick={() => { void history.refetch(); }}><RefreshCw size={16} /></button>
+      </form>
+      {message && <p className="flat-history-message" role="status">{message}</p>}
+      {history.error && <p className="calibration-library-error" role="alert">
+        Could not load scheduler flat coverage: {history.error.message}
+      </p>}
+      {invalidate.error && <p className="calibration-library-error" role="alert">
+        {invalidate.error.message}
+      </p>}
+      {canManage && selectedIds.length > 0 && (
+        <form className="flat-history-invalidate" onSubmit={(event) => {
+          event.preventDefault();
+          if (reason.trim() && !history.isFetching && !history.error && !invalidate.isPending) {
+            invalidate.mutate({ ids: selectedIds, reason: reason.trim() });
+          }
+        }}>
+          <strong>Invalidate {selectedIds.length} coverage record{selectedIds.length === 1 ? '' : 's'}?</strong>
+          <p>This removes the selected coverage from Target Scheduler on the next grade pull or
+            applied reconcile. Sync before the next flats action. New flats remain subject to
+            scheduler eligibility. Files and calibration masters are unchanged.</p>
+          <p>Duplicate coverage can still satisfy the scheduler. Include all suspect records for the run.</p>
+          <label>Reason
+            <input value={reason} required maxLength={1000} disabled={invalidate.isPending}
+              onChange={(event) => setReason(event.target.value)} />
+          </label>
+          <div>
+            <button className="remove-button" type="submit"
+              disabled={!reason.trim() || history.isFetching || !!history.error || invalidate.isPending}>
+              <ShieldOff size={16} /> {invalidate.isPending ? 'Invalidating...' : 'Invalidate coverage'}
+            </button>
+            <button className="browse-button" type="button" disabled={invalidate.isPending}
+              onClick={resetSelection}>Cancel</button>
+          </div>
+        </form>
+      )}
+      <div className="flat-history-table-scroll" aria-busy={history.isFetching}>
+        {history.isLoading && <p className="calibration-library-empty">Loading scheduler flat coverage...</p>}
+        {!history.isLoading && !history.error && rows.length === 0 && (
+          <p className="calibration-library-empty">No scheduler flat coverage matches these filters.</p>
+        )}
+        {rows.length > 0 && <table className="flat-history-table">
+          <thead><tr>
+            {canManage && <th><input type="checkbox" aria-label="Select recorded coverage on this page"
+              disabled={eligible.length === 0 || invalidate.isPending || history.isFetching}
+              checked={eligible.length > 0 && selectedIds.length === eligible.length}
+              onChange={(event) => setSelected(new Set(event.target.checked ? eligible.map((r) => r.record_id) : []))} /></th>}
+            <th>Target / source</th><th>Light session</th><th>Flat coverage</th><th>Status</th>
+          </tr></thead>
+          <tbody>{rows.map((row) => <tr key={row.record_id}>
+            {canManage && <td>{row.state === 'recorded' && <input type="checkbox"
+              aria-label={`Select coverage ${row.source_row_id} for ${row.target_name || 'profile flats'}`}
+              checked={selectedIds.includes(row.record_id)} disabled={invalidate.isPending || history.isFetching}
+              onChange={(event) => setSelected((current) => {
+                const next = new Set(current);
+                if (event.target.checked) next.add(row.record_id); else next.delete(row.record_id);
+                return next;
+              })} />}</td>}
+            <td><strong title={row.target_guid ?? undefined}>{row.target_name || 'Profile flats'}</strong>
+              <small title={row.origin_id}>{row.source_name} / #{row.source_row_id}</small>
+              <small title={row.origin_id}>Source: {row.origin_id.slice(0, 8)}</small>
+              <small>Profile: {row.profile_id}</small></td>
+            <td>{timestamp(row.light_session_date)}<small>Session {row.light_session_id}</small></td>
+            <td><strong>{row.filter_name || 'No filter'}{row.flats_type ? ` / ${row.flats_type}` : ''}</strong>
+              <small>{timestamp(row.flats_taken_date)}</small><small>{settings(row)}</small></td>
+            <td><span className={`flat-history-state flat-history-state-${row.state}`}>{STATES[row.state]}</span>
+              {row.reason && <small>{row.reason}</small>}
+              {row.detail && <small>{row.detail}</small>}
+              <small>Last seen: {timestamp(row.last_seen)}</small>
+              {row.invalidated_at !== null && <small>Invalidated: {timestamp(row.invalidated_at)}</small>}
+              {row.acknowledged_at !== null && <small>Synced: {timestamp(row.acknowledged_at)}</small>}
+            </td>
+          </tr>)}</tbody>
+        </table>}
+      </div>
+      <footer className="flat-history-footer">
+        <span>{total === 0 ? '0 records' : rows.length === 0 ? `${total} records` : `${offset + 1}-${offset + rows.length} of ${total} records`}</span>
+        <button type="button" className="browse-button flat-history-icon" title="Previous page"
+          aria-label="Previous coverage page" disabled={offset === 0 || history.isFetching || invalidate.isPending}
+          onClick={() => changePage(Math.max(0, offset - PAGE_SIZE))}><ChevronLeft size={16} /></button>
+        <button type="button" className="browse-button flat-history-icon" title="Next page"
+          aria-label="Next coverage page" disabled={offset + PAGE_SIZE >= total || history.isFetching || invalidate.isPending}
+          onClick={() => changePage(offset + PAGE_SIZE)}><ChevronRight size={16} /></button>
+      </footer>
+    </div>
+  );
+}

--- a/static/src/components/__tests__/SchedulerFlatHistory.test.tsx
+++ b/static/src/components/__tests__/SchedulerFlatHistory.test.tsx
@@ -1,0 +1,118 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server } from '../../test/msw-server';
+import type { SchedulerFlatHistoryRecord } from '../../api/types';
+import SchedulerFlatHistory from '../SchedulerFlatHistory';
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+const row: SchedulerFlatHistoryRecord = {
+  record_id: 'record-a', origin_id: 'origin', source_name: 'C925', source_row_id: 1,
+  fingerprint: 'a'.repeat(64), target_guid: 'target', target_name: 'M31', profile_id: 'profile',
+  light_session_date: 1789000000, light_session_id: 2, flats_taken_date: 1789040000,
+  flats_type: 'sky', filter_name: 'L', gain: 100, offset: 30, bin: 1, readout_mode: 0,
+  rotation: 90, roi: 1, state: 'recorded', reason: null, invalidated_at: null,
+  last_seen: 1789041000, acknowledged_at: null, detail: null,
+};
+
+function serve(rows: SchedulerFlatHistoryRecord[], total = rows.length) {
+  server.use(http.get('/api/db/demo/flat-history', () =>
+    HttpResponse.json({ success: true, data: { records: rows, total } })));
+}
+
+describe('scheduler flat coverage', () => {
+  it('requires a reason and submits exact selected records, including duplicates', async () => {
+    serve([row, { ...row, record_id: 'record-b', source_row_id: 2 }]);
+    let received: unknown;
+    server.use(http.post('/api/db/demo/flat-history/invalidate', async ({ request }) => {
+      received = await request.json();
+      return HttpResponse.json({ success: true, data: { invalidated: 2 } });
+    }));
+    render(<SchedulerFlatHistory dbId="demo" canManage />, { wrapper: wrapper() });
+    await screen.findAllByText('M31');
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select recorded coverage on this page' }));
+    const submit = screen.getByRole('button', { name: 'Invalidate coverage' });
+    expect(submit).toBeDisabled();
+    expect(screen.getByText(/Files and calibration masters are unchanged/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Reason'), { target: { value: '  Bright-star artifacts  ' } });
+    fireEvent.click(submit);
+    await waitFor(() => expect(received).toEqual({
+      record_ids: ['record-a', 'record-b'], reason: 'Bright-star artifacts',
+    }));
+    expect(await screen.findByRole('status')).toHaveTextContent('2 coverage records awaiting sync.');
+    expect(screen.queryByLabelText('Reason')).not.toBeInTheDocument();
+  });
+
+  it('shows failed invalidation and preserves the selection and reason for retry', async () => {
+    serve([row]);
+    server.use(http.post('/api/db/demo/flat-history/invalidate', () =>
+      HttpResponse.json({ success: false, error: 'Coverage changed; refresh the list.' })));
+    render(<SchedulerFlatHistory dbId="demo" canManage />, { wrapper: wrapper() });
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Select coverage 1 for M31' }));
+    fireEvent.change(screen.getByLabelText('Reason'), { target: { value: 'Bad flats' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Invalidate coverage' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Coverage changed; refresh the list.');
+    expect(screen.getByLabelText('Reason')).toHaveValue('Bad flats');
+    expect(screen.getByRole('checkbox', { name: 'Select coverage 1 for M31' })).toBeChecked();
+  });
+
+  it('does not offer mutation controls to read-only users or already invalidated records', async () => {
+    serve([{ ...row, state: 'conflict', reason: 'Artifacts', detail: 'Source row changed' }]);
+    render(<SchedulerFlatHistory dbId="demo" canManage={false} />, { wrapper: wrapper() });
+    expect(await screen.findByText('Source row changed')).toBeInTheDocument();
+    expect(screen.getAllByText('Changed in NINA')).toHaveLength(2);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('clears selection when searching or changing pages and passes server filters', async () => {
+    const requests: URL[] = [];
+    server.use(http.get('/api/db/demo/flat-history', ({ request }) => {
+      requests.push(new URL(request.url));
+      return HttpResponse.json({ success: true, data: { records: [row], total: 201 } });
+    }));
+    render(<SchedulerFlatHistory dbId="demo" canManage />, { wrapper: wrapper() });
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Select coverage 1 for M31' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next coverage page' }));
+    await waitFor(() => expect(requests.at(-1)?.searchParams.get('offset')).toBe('100'));
+    expect(screen.queryByLabelText('Reason')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Target, source or filter'), { target: { value: 'M31' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await waitFor(() => expect(requests.at(-1)?.searchParams.get('q')).toBe('M31'));
+    expect(requests.at(-1)?.searchParams.get('offset')).toBe('0');
+    expect(requests.at(-1)?.searchParams.get('state')).toBe('recorded');
+  });
+
+  it('does not submit a stale selected row after refresh changes its status', async () => {
+    serve([row]);
+    render(<SchedulerFlatHistory dbId="demo" canManage />, { wrapper: wrapper() });
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Select coverage 1 for M31' }));
+    serve([{ ...row, state: 'superseded' }]);
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh coverage' }));
+    await waitFor(() => expect(screen.getAllByText('Replaced')).toHaveLength(2));
+    expect(screen.queryByRole('button', { name: 'Invalidate coverage' })).not.toBeInTheDocument();
+  });
+
+  it('returns to a valid page when a concurrent sync shrinks the result set', async () => {
+    let shrunk = false;
+    server.use(http.get('/api/db/demo/flat-history', ({ request }) => {
+      const offset = new URL(request.url).searchParams.get('offset');
+      if (offset === '100') shrunk = true;
+      return HttpResponse.json({ success: true, data: {
+        records: offset === '100' ? [] : [row], total: shrunk ? 1 : 101,
+      } });
+    }));
+    render(<SchedulerFlatHistory dbId="demo" canManage />, { wrapper: wrapper() });
+    await screen.findByText('1-1 of 101 records');
+    fireEvent.click(screen.getByRole('button', { name: 'Next coverage page' }));
+    expect(await screen.findByText('1-1 of 1 records')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Previous coverage page' })).toBeDisabled();
+  });
+});

--- a/tests/integration_server_auth.rs
+++ b/tests/integration_server_auth.rs
@@ -14,7 +14,7 @@ use psf_guard::{
     config::ServerAuthConfig,
     server::{
         auth::{self, ServerAuth},
-        handlers, organization,
+        flat_history, handlers, organization,
         stack_preview::calibration_masters,
         state::AppState,
         user_admin,
@@ -79,6 +79,10 @@ fn app_with_management(config: ServerAuthConfig, allow_management: bool) -> Rout
             post(organization::preview),
         )
         .route("/db/{db_id}/organization/apply", post(organization::apply))
+        .route(
+            "/db/{db_id}/flat-history/invalidate",
+            post(flat_history::invalidate),
+        )
         .route(
             "/db/{db_id}/stack-previews/calibration-masters/generation-status",
             post(calibration_masters::post_generation_status),
@@ -204,6 +208,34 @@ async fn organization_requires_an_editor_and_database_management() {
                 StatusCode::FORBIDDEN
             );
         }
+    }
+}
+
+#[tokio::test]
+async fn flat_history_invalidation_requires_an_editor_and_database_management() {
+    for (allow_management, username, password) in [
+        (true, "viewer", "viewer-secret"),
+        (false, "editor", "editor-secret"),
+    ] {
+        let app = app_with_management(auth_config(), allow_management);
+        let (_, cookie, _) = login(&app, username, password).await;
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/api/db/test/flat-history/invalidate")
+            .header(COOKIE, &cookie)
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "record_ids": ["11111111-1111-4111-8111-111111111111"],
+                    "reason": "Flat panel reflection",
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::FORBIDDEN
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a Scheduler flats tab in each database's calibration library to review and explicitly invalidate suspect Target Scheduler coverage with a reason.
- Add catalog-authenticated flat_history_v1 snapshot, pending-decision, and acknowledgement endpoints, separate from normal GUID-keyed catalog bundles.
- Preserve invalidation decisions across stale snapshots and ID reuse; retain acknowledgements and report changed/new coverage without deleting it.

## Behavior and Safety
The companion NINA plugin publishes coverage during grade pulls and applied reconciles, then removes only explicitly invalidated, unchanged native history rows. Sync before the next Target Scheduler flats action; cadence, active profile/target and recent-light eligibility still apply. Duplicate coverage must be explicitly selected. Calibration files and generated masters are unchanged; there is no inferred association between files and history rows.

The API uses the existing per-database scheduler-sync grant. UI invalidation requires an editor and database management. Read-only listing creates no tables. Requests and acknowledgements are bounded and transactional; compatible removed/absent retries preserve the first audit result.

Companion plugin PR: https://github.com/theatrus/psf-guard-nina-plugin/pull/19 . Older clients are unaffected; the new plugin detects this capability.

## Review
Independent reviews covered the backend, plugin exchange, and UI. Fixed acknowledgement replay races, malformed/empty GUID validation, stale-page pagination, and icon sizing during desktop/mobile inspection.

## Validation Performed Locally
- cargo fmt -- --check
- cargo test --locked -j 2: 905 unit and 128 integration tests passed; 5 existing tests ignored
- cargo clippy --locked --all-targets --all-features -j 2 -- -D warnings
- cargo build --locked --bin psf-guard -j 2
- npm run lint
- npx vitest run: 395 tests passed
- npm run build
- Playwright flat-history.spec.ts, sync-api.spec.ts, calibration-settings.spec.ts: 10 passed, using isolated registries/catalogs; desktop and mobile screenshots visually inspected
- Actual C# plugin -> local Rust server conformance: snapshots, UI invalidation, duplicate deletion, preservation of changed/new rows, acknowledgement, and applied reconcile without full pull-back
- git diff --check

No live user catalog, original image, NINA installation, release, or registry was modified. Hosted CI is separate from these local results.