### PR TITLE
Separate exposure groups with a per-project setting

### DIFF
--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -24,6 +24,36 @@ only that channel's remembered result; the other channel cards remain intact.
 - **Accepted only** removes Pending frames. By default both Accepted and usable
   Pending frames are eligible.
 
+### Separate exposure lengths
+
+Enable **Separate exposure groups** in a project's image grid to keep short
+exposures apart from substantially longer ones. The setting is saved for that
+project in this database and is off by default. It does not change Target
+Scheduler templates or exposure plans.
+
+PSF Guard uses each image's recorded exposure, not the template's current
+default. Within each exact target and filter, it sorts known exposure lengths
+and starts a new group when an exposure is at least twice the shortest one in
+the current group. Small timing differences remain together, and intermediate
+lengths cannot bridge a short group into a long one. For example, 10, 10.1, and
+19 seconds share a group; 30 seconds and 300 seconds each start another.
+Missing, zero, negative, or invalid exposure values form **Unknown exposure**.
+
+Groups are calculated from the complete project catalog, before status, date,
+target, or selection filters. Grid headings and stack cards show the exposure
+length or range. Each group has its own calibration override, latest result,
+and resume checkpoint. Changing the setting, or adding an exposure that changes
+group membership, prevents incompatible remembered stacks from being reused.
+
+When a color role has more than one mono stack, select the desired input for
+that role. Different exposure combinations retain separate color previews;
+rebuilding one does not replace another. This is explicit channel selection,
+not automatic HDR blending or saturated-pixel replacement.
+
+Sequence grading already compares matching capture profiles, including exposure
+length. This setting changes presentation and stacking boundaries, not those
+grading cohorts or existing grades.
+
 The build runs in the background and the panel polls its status. Different
 target/channel groups are processed sequentially. Only one stacking job runs
 in the PSF Guard process at a time, even when the server hosts multiple
@@ -956,6 +986,8 @@ immutable cached response for the rebuilt output.
 The grid uses these per-database endpoints:
 
 ```text
+GET  /api/db/{db}/projects/{project}/processing-settings
+PUT  /api/db/{db}/projects/{project}/processing-settings
 POST /api/db/{db}/projects/{project}/stack-previews
 GET  /api/db/{db}/projects/{project}/stack-previews/latest
 GET  /api/db/{db}/projects/{project}/stack-previews/{job}
@@ -985,6 +1017,32 @@ GET  /api/db/{db}/stack-previews/stretch/{stretch}/preview[?size=screen|original
 GET  /api/db/{db}/stack-previews/stretch/{stretch}/fits
 GET  /api/db/{db}/stack-previews/rc-astro/{id}/fits[?stars=true]
 ```
+
+Project processing settings use `{ "split_exposure_groups": false }`. Writes
+require editor access and the database-management gate. This is a catalog
+setting, not a per-build request flag. Image and mono stack-group responses
+include nullable `exposure_group` metadata with an opaque `key`, a display
+`label`, and `min_seconds`/`max_seconds`. Unknown exposure has null bounds.
+
+The color catalog's `source_candidates` lists every usable mono input with
+its role, exposure group, and exact artifact reference. Color build requests
+may specify `input_sources`, keyed by role:
+
+```json
+{
+  "target_id": 42,
+  "kind": "rgb",
+  "input_sources": {
+    "red": { "job_id": "<mono-job>", "group_index": 0, "artifact_revision": "<revision>" }
+  }
+}
+```
+
+An omitted role resolves automatically only when it has one usable candidate.
+Selected sources must belong to the same project and target, match the role,
+and still have the selected revision. The worker checks again after waiting
+in the queue. Color latest results have a `source_family_key` so distinct
+exposure combinations remain separate when individual mono stacks rebuild.
 
 Master previews return `202` while queued and use the shared generation-status
 poller. They accept `size=screen|original`, `midtone=0.01..0.99` (default `0.2`),

--- a/docs/STACKING_PREVIEWS.md
+++ b/docs/STACKING_PREVIEWS.md
@@ -45,10 +45,14 @@ length or range. Each group has its own calibration override, latest result,
 and resume checkpoint. Changing the setting, or adding an exposure that changes
 group membership, prevents incompatible remembered stacks from being reused.
 
-When a color role has more than one mono stack, select the desired input for
-that role. Different exposure combinations retain separate color previews;
-rebuilding one does not replace another. This is explicit channel selection,
-not automatic HDR blending or saturated-pixel replacement.
+Color previews offer separate RGB, LRGB, and narrowband cards for matching
+exposure bands. For example, 30-second and 300-second RGB inputs produce two
+cards, each ready to build without selecting its channels by hand. A band
+without every required channel stays visible but disabled, with its missing
+roles named. Different exposure combinations retain separate color previews;
+rebuilding one does not replace another. **Custom combination** exposes manual
+source selection for deliberately mixed exposures or ambiguous channels. This
+is not automatic HDR blending or saturated-pixel replacement.
 
 Sequence grading already compares matching capture profiles, including exposure
 length. This setting changes presentation and stacking boundaries, not those
@@ -737,8 +741,8 @@ the grid adds a **Combine channel stacks** section. Color generation is a
 separate on-demand job: rebuilding or changing a color palette never changes
 the mono integrations or their admission evidence.
 
-- **RGB** requires one unambiguous Red, Green, and Blue stack.
-- **LRGB** requires one unambiguous Luminance, Red, Green, and Blue stack.
+- **RGB** requires one Red, Green, and Blue stack in its exposure band.
+- **LRGB** requires one Luminance, Red, Green, and Blue stack in its exposure band.
   Luminance supplies the output luminance while Seiza retains the RGB
   chromaticity.
 - **Narrowband** requires H-alpha and OIII. HOO and Foraxx HOO are then
@@ -747,12 +751,30 @@ the mono integrations or their admission evidence.
   remain available, and selecting another palette builds or restores its own
   artifact.
 
+With exposure grouping enabled, the default cards match channels by their
+recorded duration ranges, not their filter-specific group identifiers. Starting
+with the shortest range, a band accepts another channel only while its longest
+exposure remains less than twice its shortest. The whole range must fit, so
+small timing differences can match without chaining short and long exposures
+together. RGB and LRGB use their required channels. Narrowband bands include
+the available H-alpha, OIII, and SII stacks so palette changes stay within the
+same exposure band; each palette still requires only its own channels.
+
+Incomplete bands show their missing roles and cannot build. Multiple candidates
+for the same role remain ambiguous rather than choosing one arbitrarily.
+Unknown durations and ranges already spanning a factor of two or more require
+manual selection. Open **Custom combination** for the target and composition
+to choose those inputs, deliberately mix short and long exposures, or inspect
+a saved custom combination. A source that disappears or changes revision must
+be chosen again; PSF Guard never silently substitutes another stack.
+
 PSF Guard recognizes the ordinary short and long filter names (`L`, `Red`,
 `Ha`, `H-alpha`, `OIII`, `SII`, `O3`, and `S2`) plus descriptive names such as
 `Red`, `H-alpha`, and `OIII` as distinct tokens in vendor labels. It
-deliberately does not guess when two stacks map to the same role or when a
-multi-band filter name is ambiguous. Rename the Target Scheduler filters to
-make those roles explicit before building color.
+deliberately does not guess when two stacks in a band map to the same role or
+when a multi-band filter name is ambiguous. Choose a known-role stack under
+**Custom combination**, or rename ambiguous Target Scheduler filters to make
+their roles explicit before building color.
 
 Before registration, PSF Guard uses `seiza-background` to fit and correct each
 linear channel independently. Background extraction is enabled for new UI
@@ -1039,6 +1061,8 @@ may specify `input_sources`, keyed by role:
 ```
 
 An omitted role resolves automatically only when it has one usable candidate.
+The UI supplies exact `input_sources` for each automatic exposure-band card;
+the API does not infer an exposure band from the target and role alone.
 Selected sources must belong to the same project and target, match the role,
 and still have the selected revision. The worker checks again after waiting
 in the queue. Color latest results have a `source_family_key` so distinct

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -8,8 +8,10 @@
 
 - A per-project **Separate exposure groups** option keeps substantially different
   exposure lengths apart in the image grid and stack previews. Short and long
-  integrations retain independent stack results and calibration choices, with
-  explicit mono-input selection and separate saved combinations for color.
+  integrations retain independent stack results and calibration choices.
+  RGB, LRGB, and narrowband cards pair matching exposure bands automatically;
+  incomplete bands show their missing channels. **Custom combination** keeps
+  manual source selection available for mixed exposures and saved variants.
 
 - Review Target Scheduler flat coverage in the calibration library and invalidate
   suspect runs with a reason. The NINA plugin applies these requests on grade

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,6 +6,11 @@
 
 ## Added
 
+- A per-project **Separate exposure groups** option keeps substantially different
+  exposure lengths apart in the image grid and stack previews. Short and long
+  integrations retain independent stack results and calibration choices, with
+  explicit mono-input selection and separate saved combinations for color.
+
 - Review Target Scheduler flat coverage in the calibration library and invalidate
   suspect runs with a reason. The NINA plugin applies these requests on grade
   pulls and applied reconciles, preserving changed or newly taken coverage and

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -187,6 +187,7 @@ pub struct RecentActivity {
 #[derive(Debug, Serialize)]
 pub struct ImageResponse {
     pub id: i32,
+    pub exposure_group: Option<crate::server::exposure_groups::ExposureGroup>,
     pub project_id: i32,
     pub project_name: String,
     pub project_display_name: String,

--- a/src/server/database_context.rs
+++ b/src/server/database_context.rs
@@ -393,6 +393,8 @@ pub struct DatabaseContext {
     pub cache_dir: String,
     pub cache_dir_path: PathBuf,
     db_connection: Arc<Mutex<Connection>>,
+    pub(crate) exposure_groups_cache:
+        Arc<Mutex<crate::server::exposure_groups::ProjectExposureGroupsCache>>,
     /// File identity of `database_path` as of the currently open connection.
     /// Compared on every `db()` to detect an external replace.
     db_fingerprint: Arc<Mutex<Option<DbFingerprint>>>,
@@ -753,6 +755,7 @@ impl DatabaseContext {
             cache_dir,
             cache_dir_path,
             db_connection: Arc::new(Mutex::new(conn)),
+            exposure_groups_cache: Arc::new(Mutex::new(Default::default())),
             db_fingerprint: Arc::new(Mutex::new(fingerprint)),
             reopen_lock: Arc::new(Mutex::new(())),
             organization_mutex: Arc::new(Mutex::new(())),
@@ -858,7 +861,11 @@ impl DatabaseContext {
         // block queries.
         match open_scheduler_connection(&self.database_path) {
             Ok(new_conn) => {
-                *lock_recover(&self.db_connection) = new_conn;
+                {
+                    let mut conn = lock_recover(&self.db_connection);
+                    *conn = new_conn;
+                    lock_recover(&self.exposure_groups_cache).clear();
+                }
                 *lock_recover(&self.db_fingerprint) = Some(new_fp);
                 lock_recover(&self.remote_image_verifications).clear();
                 lock_recover(&self.remote_file_verifications).clear();
@@ -887,7 +894,11 @@ impl DatabaseContext {
         let _reopen = lock_recover(&self.reopen_lock);
         match open_scheduler_connection(&self.database_path) {
             Ok(new_conn) => {
-                *lock_recover(&self.db_connection) = new_conn;
+                {
+                    let mut conn = lock_recover(&self.db_connection);
+                    *conn = new_conn;
+                    lock_recover(&self.exposure_groups_cache).clear();
+                }
                 *lock_recover(&self.db_fingerprint) = fingerprint_path(&self.database_path);
                 lock_recover(&self.remote_image_verifications).clear();
                 lock_recover(&self.remote_file_verifications).clear();
@@ -1934,6 +1945,7 @@ impl DatabaseContext {
             cache_dir: "/tmp/psf-guard-test".to_string(),
             cache_dir_path: PathBuf::from("/tmp/psf-guard-test"),
             db_connection: Arc::new(Mutex::new(conn)),
+            exposure_groups_cache: Arc::new(Mutex::new(Default::default())),
             db_fingerprint: Arc::new(Mutex::new(None)),
             reopen_lock: Arc::new(Mutex::new(())),
             organization_mutex: Arc::new(Mutex::new(())),
@@ -1973,6 +1985,7 @@ impl Clone for DatabaseContext {
             cache_dir: self.cache_dir.clone(),
             cache_dir_path: self.cache_dir_path.clone(),
             db_connection: self.db_connection.clone(),
+            exposure_groups_cache: self.exposure_groups_cache.clone(),
             db_fingerprint: self.db_fingerprint.clone(),
             reopen_lock: self.reopen_lock.clone(),
             organization_mutex: self.organization_mutex.clone(),
@@ -2002,6 +2015,28 @@ impl Clone for DatabaseContext {
 mod tests {
     use super::*;
     use rusqlite::Connection;
+
+    #[test]
+    fn connection_reopen_invalidates_shared_project_exposure_cache() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("catalog.sqlite");
+        make_db(&path, "Project");
+        let mut ctx = DatabaseContext::new_for_test(Connection::open(&path).unwrap());
+        ctx.database_path = path.to_string_lossy().into_owned();
+        let before = {
+            let db = ctx.db();
+            let conn = db.lock().unwrap();
+            crate::server::exposure_groups::cached_project_groups(&ctx, &conn, 1).unwrap()
+        };
+        let shared = ctx.clone();
+        ctx.force_reopen();
+        let after = {
+            let db = shared.db();
+            let conn = db.lock().unwrap();
+            crate::server::exposure_groups::cached_project_groups(&shared, &conn, 1).unwrap()
+        };
+        assert!(!Arc::ptr_eq(&before, &after));
+    }
 
     /// Write a tiny standalone SQLite DB holding one project row.
     fn make_db(path: &std::path::Path, project_name: &str) {

--- a/src/server/exposure_groups.rs
+++ b/src/server/exposure_groups.rs
@@ -1,0 +1,641 @@
+//! Project-local exposure families shared by the image grid and stack builders.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+
+use super::{
+    api::ApiResponse,
+    extract::DbContext,
+    handlers::{require_database_management_allowed, AppError},
+    state::AppState,
+};
+
+const SETTINGS_TABLE: &str = "psf_guard_project_processing";
+const EXPOSURE_SPLIT_RATIO: f64 = 2.0;
+
+type ExposureStream = Vec<(i32, Option<f64>)>;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectProcessingSettings {
+    pub split_exposure_groups: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExposureGroup {
+    pub key: String,
+    pub label: String,
+    pub min_seconds: Option<f64>,
+    pub max_seconds: Option<f64>,
+}
+
+pub struct ProjectExposureGroups {
+    pub settings: ProjectProcessingSettings,
+    pub by_image: HashMap<i32, ExposureGroup>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct CatalogRevision {
+    data_version: i64,
+    total_changes: u64,
+}
+
+impl CatalogRevision {
+    fn read(conn: &Connection) -> Result<Self, AppError> {
+        Ok(Self {
+            data_version: conn
+                .query_row("PRAGMA data_version", [], |row| row.get(0))
+                .map_err(AppError::db)?,
+            total_changes: conn.total_changes(),
+        })
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ProjectExposureGroupsCache {
+    entries: HashMap<i32, (CatalogRevision, Arc<ProjectExposureGroups>)>,
+}
+
+impl ProjectExposureGroupsCache {
+    /// A connection reopen starts a new data-version namespace. The caller
+    /// holds the connection mutex while clearing, before another read can run.
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+    }
+}
+
+/// The caller already owns this context's connection mutex. Always take it
+/// before the cache mutex, including during connection replacement.
+pub fn cached_project_groups(
+    ctx: &super::database_context::DatabaseContext,
+    conn: &Connection,
+    project_id: i32,
+) -> Result<Arc<ProjectExposureGroups>, AppError> {
+    let revision = CatalogRevision::read(conn)?;
+    let mut cache = ctx
+        .exposure_groups_cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some((cached_revision, groups)) = cache.entries.get(&project_id)
+        && *cached_revision == revision
+    {
+        return Ok(Arc::clone(groups));
+    }
+    let groups = Arc::new(load_project_groups(conn, project_id)?);
+    // A second connection may commit while the two read queries run. Do not
+    // retain that raced result under a revision which never described it.
+    if CatalogRevision::read(conn)? == revision {
+        cache
+            .entries
+            .insert(project_id, (revision, Arc::clone(&groups)));
+    } else {
+        cache.entries.remove(&project_id);
+    }
+    Ok(groups)
+}
+
+fn project_key(conn: &Connection, project_id: i32) -> Result<String, AppError> {
+    let mut statement = conn
+        .prepare("PRAGMA table_info(project)")
+        .map_err(AppError::db)?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(AppError::db)?;
+    let has_guid = columns
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(AppError::db)?
+        .iter()
+        .any(|name| name.eq_ignore_ascii_case("guid"));
+    let sql = if has_guid {
+        "SELECT guid FROM project WHERE Id=?1"
+    } else {
+        "SELECT NULL FROM project WHERE Id=?1"
+    };
+    let guid: Option<String> = conn
+        .query_row(sql, [project_id], |row| row.get(0))
+        .optional()
+        .map_err(AppError::db)?
+        .ok_or(AppError::NotFound)?;
+    if let Some(guid) = guid
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM project WHERE lower(trim(guid))=lower(?1)",
+                [guid],
+                |row| row.get(0),
+            )
+            .map_err(AppError::db)?;
+        if count == 1 {
+            Ok(format!("guid:{}", guid.to_ascii_lowercase()))
+        } else {
+            // Corrupt duplicate GUIDs must not couple two projects' settings.
+            Ok(format!("local-id:{project_id}"))
+        }
+    } else {
+        // Legacy catalogs without GUIDs retain explicitly local settings.
+        Ok(format!("local-id:{project_id}"))
+    }
+}
+
+pub fn load_settings(
+    conn: &Connection,
+    project_id: i32,
+) -> Result<ProjectProcessingSettings, AppError> {
+    let key = project_key(conn, project_id)?;
+    let exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1)",
+            [SETTINGS_TABLE],
+            |row| row.get(0),
+        )
+        .map_err(AppError::db)?;
+    if !exists {
+        return Ok(ProjectProcessingSettings::default());
+    }
+    let split_exposure_groups = conn
+        .query_row(
+            "SELECT split_exposure_groups FROM psf_guard_project_processing WHERE project_key=?1",
+            [key],
+            |row| row.get::<_, bool>(0),
+        )
+        .optional()
+        .map_err(AppError::db)?
+        .unwrap_or(false);
+    Ok(ProjectProcessingSettings {
+        split_exposure_groups,
+    })
+}
+
+fn save_settings(
+    conn: &mut Connection,
+    project_id: i32,
+    settings: ProjectProcessingSettings,
+) -> Result<(), AppError> {
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(AppError::db)?;
+    let key = project_key(&tx, project_id)?;
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS psf_guard_project_processing (
+            project_key TEXT PRIMARY KEY,
+            split_exposure_groups INTEGER NOT NULL CHECK(split_exposure_groups IN (0,1))
+        )",
+    )
+    .map_err(AppError::db)?;
+    tx.execute(
+        "INSERT INTO psf_guard_project_processing(project_key,split_exposure_groups)
+         VALUES (?1,?2) ON CONFLICT(project_key) DO UPDATE
+         SET split_exposure_groups=excluded.split_exposure_groups",
+        params![key, settings.split_exposure_groups],
+    )
+    .map_err(AppError::db)?;
+    tx.commit().map_err(AppError::db)
+}
+
+pub fn exposure_seconds_from_metadata(metadata_json: &str) -> Option<f64> {
+    let metadata: serde_json::Value = serde_json::from_str(metadata_json).ok()?;
+    ["ExposureDuration", "ExposureTime", "EXPTIME"]
+        .iter()
+        .find_map(|key| {
+            let value = &metadata[key];
+            value
+                .as_f64()
+                .or_else(|| value.as_str()?.trim().parse().ok())
+                .filter(|value| value.is_finite() && *value > 0.0)
+        })
+}
+
+fn seconds_label(seconds: f64) -> String {
+    if seconds < 0.001 {
+        return format!("{seconds} s");
+    }
+    let value = format!("{seconds:.3}");
+    format!("{} s", value.trim_end_matches('0').trim_end_matches('.'))
+}
+
+fn assign_stream(values: &mut [(i32, Option<f64>)], result: &mut HashMap<i32, ExposureGroup>) {
+    values.sort_by(|a, b| {
+        a.1.unwrap_or(0.0)
+            .total_cmp(&b.1.unwrap_or(0.0))
+            .then(a.0.cmp(&b.0))
+    });
+    let mut start = 0;
+    while start < values.len() {
+        let minimum = values[start].1;
+        let mut end = start + 1;
+        // Bound the complete family, not adjacent gaps: intermediate exposures
+        // must not bridge short and long integrations into one family.
+        while end < values.len()
+            && match (minimum, values[end].1) {
+                (Some(min), Some(value)) => value / min < EXPOSURE_SPLIT_RATIO,
+                (None, None) => true,
+                _ => false,
+            }
+        {
+            end += 1;
+        }
+        let maximum = values[end - 1].1;
+        // A newly arrived frame with slightly less exposure must not rename
+        // an existing family and discard its resumable integration history.
+        let anchor_id = values[start..end].iter().map(|(id, _)| *id).min().unwrap();
+        let (key, label) = match (minimum, maximum) {
+            (Some(min), Some(max)) => (
+                format!("exposure-{anchor_id}"),
+                if min == max {
+                    seconds_label(min)
+                } else {
+                    format!("{} - {}", seconds_label(min), seconds_label(max))
+                },
+            ),
+            _ => ("unknown".into(), "Unknown exposure".into()),
+        };
+        let group = ExposureGroup {
+            key,
+            label,
+            min_seconds: minimum,
+            max_seconds: maximum,
+        };
+        for (id, _) in &values[start..end] {
+            result.insert(*id, group.clone());
+        }
+        start = end;
+    }
+}
+
+/// Resolve against the full catalog population, before status/date/selection
+/// filters. A one-channel rebuild therefore cannot change a frame's identity.
+pub fn load_project_groups(
+    conn: &Connection,
+    project_id: i32,
+) -> Result<ProjectExposureGroups, AppError> {
+    let settings = load_settings(conn, project_id)?;
+    let mut by_image = HashMap::new();
+    if settings.split_exposure_groups {
+        let mut statement = conn.prepare(
+            "SELECT Id,targetid,COALESCE(filtername,''),metadata FROM acquiredimage WHERE projectid=?1",
+        ).map_err(AppError::db)?;
+        let rows = statement
+            .query_map([project_id], |row| {
+                Ok((
+                    row.get::<_, i32>(0)?,
+                    row.get::<_, i32>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            })
+            .map_err(AppError::db)?;
+        let mut streams: BTreeMap<(i32, String), ExposureStream> = BTreeMap::new();
+        for row in rows {
+            let (id, target, filter, metadata) = row.map_err(AppError::db)?;
+            streams.entry((target, filter)).or_default().push((
+                id,
+                metadata.as_deref().and_then(exposure_seconds_from_metadata),
+            ));
+        }
+        for stream in streams.values_mut() {
+            assign_stream(stream, &mut by_image);
+        }
+    }
+    Ok(ProjectExposureGroups { settings, by_image })
+}
+
+pub async fn get_project_settings(
+    ctx: DbContext,
+    Path((_db, project_id)): Path<(String, i32)>,
+) -> Result<Json<ApiResponse<ProjectProcessingSettings>>, AppError> {
+    let conn = ctx.db();
+    let conn = conn.lock().map_err(AppError::db)?;
+    Ok(Json(ApiResponse::success(load_settings(
+        &conn, project_id,
+    )?)))
+}
+
+pub async fn update_project_settings(
+    State(state): State<Arc<AppState>>,
+    ctx: DbContext,
+    Path((_db, project_id)): Path<(String, i32)>,
+    Json(settings): Json<ProjectProcessingSettings>,
+) -> Result<Json<ApiResponse<ProjectProcessingSettings>>, AppError> {
+    require_database_management_allowed(&state)?;
+    let conn = ctx.db();
+    let mut conn = conn.lock().map_err(AppError::db)?;
+    save_settings(&mut conn, project_id, settings)?;
+    Ok(Json(ApiResponse::success(settings)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE project(Id INTEGER PRIMARY KEY,guid TEXT);
+            INSERT INTO project VALUES(1,'project-one'),(2,'project-two');
+            CREATE TABLE acquiredimage(Id INTEGER PRIMARY KEY,projectid INTEGER,targetid INTEGER,filtername TEXT,metadata TEXT);
+            INSERT INTO acquiredimage VALUES
+            (1,1,10,'R','{\"ExposureDuration\":10}'),
+            (2,1,10,'R','{\"ExposureDuration\":10.01}'),
+            (3,1,10,'R','{\"ExposureDuration\":19}'),
+            (4,1,10,'R','{\"ExposureDuration\":30}'),
+            (5,1,10,'R','{\"ExposureDuration\":300}'),
+            (6,1,10,'R','{\"ExposureDuration\":0}'),
+            (7,1,10,'R','bad-json'),
+            (8,1,11,'R','{\"ExposureDuration\":12}'),
+            (9,1,10,'G','{\"ExposureDuration\":12}'),
+            (10,2,20,'R','{\"ExposureDuration\":10}');").unwrap();
+        conn
+    }
+
+    #[test]
+    fn reads_default_off_without_writing_schema() {
+        let conn = fixture();
+        let groups = load_project_groups(&conn, 1).unwrap();
+        assert!(!groups.settings.split_exposure_groups);
+        assert!(groups.by_image.is_empty());
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name=?1",
+                [SETTINGS_TABLE],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+        assert!(matches!(load_settings(&conn, 999), Err(AppError::NotFound)));
+    }
+
+    #[test]
+    fn cached_groups_reuse_maps_and_refresh_after_local_changes() {
+        let ctx = super::super::database_context::DatabaseContext::new_for_test(fixture());
+        let db = ctx.db();
+        let mut conn = db.lock().unwrap();
+        let disabled = cached_project_groups(&ctx, &conn, 1).unwrap();
+        assert!(Arc::ptr_eq(
+            &disabled,
+            &cached_project_groups(&ctx.clone(), &conn, 1).unwrap()
+        ));
+        save_settings(
+            &mut conn,
+            1,
+            ProjectProcessingSettings {
+                split_exposure_groups: true,
+            },
+        )
+        .unwrap();
+        let first = cached_project_groups(&ctx, &conn, 1).unwrap();
+        assert!(!Arc::ptr_eq(&disabled, &first));
+        assert_eq!(first.by_image[&5].min_seconds, Some(300.0));
+        assert!(Arc::ptr_eq(
+            &first,
+            &cached_project_groups(&ctx, &conn, 1).unwrap()
+        ));
+        conn.execute(
+            "UPDATE acquiredimage SET metadata='{\"ExposureDuration\":600}' WHERE Id=5",
+            [],
+        )
+        .unwrap();
+        let updated = cached_project_groups(&ctx, &conn, 1).unwrap();
+        assert!(!Arc::ptr_eq(&first, &updated));
+        assert_eq!(updated.by_image[&5].min_seconds, Some(600.0));
+        save_settings(&mut conn, 1, ProjectProcessingSettings::default()).unwrap();
+        assert!(cached_project_groups(&ctx, &conn, 1)
+            .unwrap()
+            .by_image
+            .is_empty());
+    }
+
+    #[test]
+    fn cached_groups_refresh_after_an_external_writer_commits() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("catalog.sqlite");
+        let mut writer = Connection::open(&path).unwrap();
+        writer.execute_batch("CREATE TABLE project(Id INTEGER PRIMARY KEY,guid TEXT);
+            INSERT INTO project VALUES(1,'one');
+            CREATE TABLE acquiredimage(Id INTEGER PRIMARY KEY,projectid INTEGER,targetid INTEGER,filtername TEXT,metadata TEXT);
+            INSERT INTO acquiredimage VALUES(1,1,10,'R','{\"ExposureDuration\":30}');").unwrap();
+        save_settings(
+            &mut writer,
+            1,
+            ProjectProcessingSettings {
+                split_exposure_groups: true,
+            },
+        )
+        .unwrap();
+        let ctx = super::super::database_context::DatabaseContext::new_for_test(
+            Connection::open(&path).unwrap(),
+        );
+        let db = ctx.db();
+        let conn = db.lock().unwrap();
+        let first = cached_project_groups(&ctx, &conn, 1).unwrap();
+        writer
+            .execute(
+                "UPDATE acquiredimage SET metadata='{\"ExposureDuration\":300}' WHERE Id=1",
+                [],
+            )
+            .unwrap();
+        let updated = cached_project_groups(&ctx, &conn, 1).unwrap();
+        assert!(!Arc::ptr_eq(&first, &updated));
+        assert_eq!(updated.by_image[&1].min_seconds, Some(300.0));
+        assert!(Arc::ptr_eq(
+            &updated,
+            &cached_project_groups(&ctx, &conn, 1).unwrap()
+        ));
+    }
+
+    #[test]
+    fn bounds_families_and_isolates_unknowns_targets_filters_and_projects() {
+        let mut conn = fixture();
+        save_settings(
+            &mut conn,
+            1,
+            ProjectProcessingSettings {
+                split_exposure_groups: true,
+            },
+        )
+        .unwrap();
+        let groups = load_project_groups(&conn, 1).unwrap().by_image;
+        assert_eq!(groups[&1], groups[&2]);
+        assert_eq!(groups[&1], groups[&3]);
+        assert_ne!(groups[&1].key, groups[&4].key);
+        assert_ne!(groups[&4].key, groups[&5].key);
+        assert_eq!(groups[&6].key, "unknown");
+        assert_eq!(groups[&6], groups[&7]);
+        assert_eq!(groups[&8].min_seconds, Some(12.0));
+        assert_eq!(groups[&9].min_seconds, Some(12.0));
+        assert!(!groups.contains_key(&10));
+        assert!(load_project_groups(&conn, 2).unwrap().by_image.is_empty());
+        save_settings(&mut conn, 1, ProjectProcessingSettings::default()).unwrap();
+        assert!(load_project_groups(&conn, 1).unwrap().by_image.is_empty());
+    }
+
+    #[test]
+    fn exact_twofold_difference_starts_a_new_family() {
+        let mut groups = HashMap::new();
+        assign_stream(
+            &mut [
+                (1, Some(0.1)),
+                (2, Some(0.2)),
+                (3, Some(0.399)),
+                (4, Some(0.4)),
+            ],
+            &mut groups,
+        );
+        assert_ne!(groups[&1].key, groups[&2].key);
+        assert_eq!(groups[&2].key, groups[&3].key);
+        assert_ne!(groups[&3].key, groups[&4].key);
+    }
+
+    #[test]
+    fn grouping_is_deterministic_and_keeps_key_when_a_family_grows() {
+        let mut first = HashMap::new();
+        let mut second = HashMap::new();
+        assign_stream(
+            &mut [(2, Some(300.0)), (1, Some(10.0)), (3, Some(11.0))],
+            &mut first,
+        );
+        assign_stream(
+            &mut [
+                (3, Some(11.0)),
+                (1, Some(10.0)),
+                (4, Some(12.0)),
+                (2, Some(300.0)),
+            ],
+            &mut second,
+        );
+        for id in [1, 2, 3] {
+            assert_eq!(first[&id].key, second[&id].key);
+        }
+    }
+
+    #[test]
+    fn settings_follow_guid_and_do_not_leak_to_reused_ids() {
+        let mut conn = fixture();
+        save_settings(
+            &mut conn,
+            1,
+            ProjectProcessingSettings {
+                split_exposure_groups: true,
+            },
+        )
+        .unwrap();
+        conn.execute("UPDATE project SET Id=3 WHERE Id=1", [])
+            .unwrap();
+        assert!(load_settings(&conn, 3).unwrap().split_exposure_groups);
+        conn.execute("INSERT INTO project VALUES(1,'replacement')", [])
+            .unwrap();
+        assert!(!load_settings(&conn, 1).unwrap().split_exposure_groups);
+    }
+
+    #[test]
+    fn small_new_exposure_variations_preserve_existing_family_identity() {
+        let mut before = HashMap::new();
+        let mut after = HashMap::new();
+        assign_stream(
+            &mut [(1, Some(30.0)), (2, Some(30.1)), (3, Some(300.0))],
+            &mut before,
+        );
+        assign_stream(
+            &mut [
+                (1, Some(30.0)),
+                (2, Some(30.1)),
+                (3, Some(300.0)),
+                (4, Some(29.9)),
+                (5, Some(299.9)),
+            ],
+            &mut after,
+        );
+        for id in [1, 2, 3] {
+            assert_eq!(before[&id].key, after[&id].key);
+        }
+        assert_eq!(after[&1].min_seconds, Some(29.9));
+        assert_eq!(after[&3].min_seconds, Some(299.9));
+    }
+
+    #[test]
+    fn legacy_project_schema_supports_local_settings() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE project(Id INTEGER PRIMARY KEY); INSERT INTO project VALUES(1);",
+        )
+        .unwrap();
+        save_settings(
+            &mut conn,
+            1,
+            ProjectProcessingSettings {
+                split_exposure_groups: true,
+            },
+        )
+        .unwrap();
+        assert!(load_settings(&conn, 1).unwrap().split_exposure_groups);
+    }
+
+    #[test]
+    fn ambiguous_guids_keep_settings_local() {
+        let mut conn = fixture();
+        conn.execute("UPDATE project SET guid='project-one' WHERE Id=2", [])
+            .unwrap();
+        save_settings(
+            &mut conn,
+            1,
+            ProjectProcessingSettings {
+                split_exposure_groups: true,
+            },
+        )
+        .unwrap();
+        assert!(load_settings(&conn, 1).unwrap().split_exposure_groups);
+        assert!(!load_settings(&conn, 2).unwrap().split_exposure_groups);
+    }
+
+    #[test]
+    fn saved_settings_survive_reopen_and_read_only_access() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("catalog.sqlite");
+        {
+            let mut conn = Connection::open(&path).unwrap();
+            conn.execute_batch("CREATE TABLE project(Id INTEGER PRIMARY KEY,guid TEXT); INSERT INTO project VALUES(1,'one');").unwrap();
+            save_settings(
+                &mut conn,
+                1,
+                ProjectProcessingSettings {
+                    split_exposure_groups: true,
+                },
+            )
+            .unwrap();
+        }
+        let conn =
+            Connection::open_with_flags(&path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).unwrap();
+        assert!(load_settings(&conn, 1).unwrap().split_exposure_groups);
+        assert!(matches!(load_settings(&conn, 999), Err(AppError::NotFound)));
+    }
+
+    #[test]
+    fn exposures_accept_recorded_aliases_and_reject_invalid_values() {
+        for json in [
+            r#"{"ExposureDuration":30}"#,
+            r#"{"ExposureTime":"30"}"#,
+            r#"{"EXPTIME":30}"#,
+            r#"{"ExposureDuration":-1,"ExposureTime":30}"#,
+        ] {
+            assert_eq!(exposure_seconds_from_metadata(json), Some(30.0));
+        }
+        for json in [
+            "broken",
+            "{}",
+            r#"{"ExposureDuration":"NaN"}"#,
+            r#"{"ExposureDuration":0}"#,
+            r#"{"ExposureDuration":"inf"}"#,
+        ] {
+            assert_eq!(exposure_seconds_from_metadata(json), None);
+        }
+        assert!(serde_json::from_str::<ProjectProcessingSettings>("{}").is_err());
+    }
+}

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -3672,6 +3672,18 @@ pub async fn get_images(
         )
         .map_err(AppError::db)?;
 
+    let mut exposure_groups = std::collections::HashMap::new();
+    let projects: std::collections::HashSet<_> = images
+        .iter()
+        .map(|(image, _, _)| image.project_id)
+        .collect();
+    for project_id in projects {
+        exposure_groups.insert(
+            project_id,
+            crate::server::exposure_groups::cached_project_groups(&ctx, &conn, project_id)?,
+        );
+    }
+
     let response: Vec<ImageResponse> = images
         .into_iter()
         .map(|(img, proj_name, target_name)| {
@@ -3685,6 +3697,10 @@ pub async fn get_images(
 
             ImageResponse {
                 id: img.id,
+                exposure_group: exposure_groups
+                    .get(&img.project_id)
+                    .and_then(|groups| groups.by_image.get(&img.id))
+                    .cloned(),
                 project_id: img.project_id,
                 project_name: proj_name,
                 project_display_name,
@@ -3711,7 +3727,7 @@ pub async fn get_image(
     use crate::image_analysis::FitsImage;
 
     // Get image data from database first (before any async operations)
-    let (image, proj_name, target_name, mut metadata, ambiguous_names) = {
+    let (image, proj_name, target_name, mut metadata, ambiguous_names, exposure_group) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
@@ -3735,7 +3751,19 @@ pub async fn get_image(
         let metadata: serde_json::Value = serde_json::from_str(&image.metadata)
             .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
 
-        (image, proj_name, target_name, metadata, ambiguous_names)
+        let exposure_group =
+            crate::server::exposure_groups::cached_project_groups(&ctx, &conn, image.project_id)?
+                .by_image
+                .get(&image.id)
+                .cloned();
+        (
+            image,
+            proj_name,
+            target_name,
+            metadata,
+            ambiguous_names,
+            exposure_group,
+        )
     }; // Database connection is dropped here
 
     // Try to resolve the filesystem path for the FITS file
@@ -3867,6 +3895,7 @@ pub async fn get_image(
     };
 
     let response = ImageResponse {
+        exposure_group,
         id: image.id,
         project_id: image.project_id,
         project_name: proj_name,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,6 +7,7 @@ pub mod database_context;
 pub mod embedded_static;
 pub mod export_job;
 pub mod export_settings;
+pub mod exposure_groups;
 pub mod extract;
 pub mod flat_history;
 pub mod handlers;
@@ -372,6 +373,11 @@ async fn run_server_internal(
             put(handlers::refresh_directory_tree_cache),
         )
         .route("/projects", get(handlers::list_projects))
+        .route(
+            "/projects/{project_id}/processing-settings",
+            get(exposure_groups::get_project_settings)
+                .put(exposure_groups::update_project_settings),
+        )
         .route("/organization/preview", post(organization::preview))
         .route("/organization/apply", post(organization::apply))
         .route(

--- a/src/server/stack_preview.rs
+++ b/src/server/stack_preview.rs
@@ -46,6 +46,7 @@ use crate::sequence_analysis::{
 };
 use crate::server::api::ApiResponse;
 use crate::server::database_context::DatabaseContext;
+use crate::server::exposure_groups::{ExposureGroup, ProjectExposureGroups};
 use crate::server::extract::DbContext;
 use crate::server::handlers::AppError;
 use crate::server::state::AppState;
@@ -188,6 +189,8 @@ pub struct CalibrationOverride {
     pub target_id: i32,
     #[serde(default)]
     pub filter_name: String,
+    #[serde(default)]
+    pub exposure_group_key: Option<String>,
     pub calibration: crate::calibration::CalibrationMode,
 }
 
@@ -198,10 +201,15 @@ impl StackPreviewRequest {
         &self,
         target_id: i32,
         filter_name: &str,
+        exposure_group_key: Option<&str>,
     ) -> crate::calibration::CalibrationMode {
         self.calibration_overrides
             .iter()
-            .find(|entry| entry.target_id == target_id && entry.filter_name == filter_name)
+            .find(|entry| {
+                entry.target_id == target_id
+                    && entry.filter_name == filter_name
+                    && entry.exposure_group_key.as_deref() == exposure_group_key
+            })
             .map(|entry| entry.calibration)
             .unwrap_or(self.calibration)
     }
@@ -327,6 +335,8 @@ pub struct StackGroupStatus {
     pub target_id: i32,
     pub target_name: String,
     pub filter_name: String,
+    #[serde(default)]
+    pub exposure_group: Option<ExposureGroup>,
     pub state: StackGroupState,
     #[serde(default)]
     pub phase: String,
@@ -520,7 +530,11 @@ fn mono_activity(job: &StackPreviewJob) -> StackActivityEntry {
     });
     let label = match pending {
         Some(group) => {
-            let base = channel_label(&group.target_name, &group.filter_name);
+            let mut base = channel_label(&group.target_name, &group.filter_name);
+            if let Some(exposure_group) = &group.exposure_group {
+                base.push_str(" · ");
+                base.push_str(&exposure_group.label);
+            }
             let remaining = job
                 .groups
                 .iter()
@@ -774,9 +788,15 @@ impl StackPreviewManager {
         }
     }
 
-    fn persist_latest(&self, cache_root: &FsPath, job: &StackPreviewJob) -> Result<(), String> {
+    fn persist_latest(&self, ctx: &DatabaseContext, job: &StackPreviewJob) -> Result<(), String> {
+        let current = {
+            let db = ctx.db();
+            let conn = db.lock().map_err(|error| error.to_string())?;
+            crate::server::exposure_groups::cached_project_groups(ctx, &conn, job.project_id)
+                .map_err(|error| format!("Failed to load project exposure groups: {error:?}"))?
+        };
         let _guard = self.latest_write.lock().unwrap();
-        persist_latest_groups(cache_root, job)
+        persist_latest_groups_with_exposures(&ctx.cache_dir_path, job, Some(&current))
     }
 }
 
@@ -810,19 +830,7 @@ struct PreparedFrame {
 /// can arrive as a number or as text, so take the first that reads as a finite
 /// positive number.
 fn exposure_seconds_from_metadata(metadata_json: &str) -> f64 {
-    let Ok(metadata) = serde_json::from_str::<serde_json::Value>(metadata_json) else {
-        return 0.0;
-    };
-    ["ExposureDuration", "ExposureTime", "EXPTIME"]
-        .iter()
-        .find_map(|key| {
-            let value = &metadata[*key];
-            value
-                .as_f64()
-                .or_else(|| value.as_str().and_then(|text| text.trim().parse().ok()))
-        })
-        .filter(|value: &f64| value.is_finite() && *value > 0.0)
-        .unwrap_or(0.0)
+    crate::server::exposure_groups::exposure_seconds_from_metadata(metadata_json).unwrap_or(0.0)
 }
 
 /// The decision recorded for a frame that did not reach the accumulator,
@@ -1111,9 +1119,7 @@ pub async fn start_stack_previews(
         ) || (!request.force && existing.state == StackJobState::Completed))
     {
         if existing.state == StackJobState::Completed
-            && let Err(error) = state
-                .stack_previews
-                .persist_latest(&prepared.cache_root, &existing)
+            && let Err(error) = state.stack_previews.persist_latest(&ctx, &existing)
         {
             tracing::warn!("Failed to refresh latest stack preview index: {error}");
         }
@@ -1124,10 +1130,7 @@ pub async fn start_stack_previews(
         && let Ok(existing) = serde_json::from_slice::<StackPreviewJob>(&bytes)
         && existing.state == StackJobState::Completed
     {
-        if let Err(error) = state
-            .stack_previews
-            .persist_latest(&prepared.cache_root, &existing)
-        {
+        if let Err(error) = state.stack_previews.persist_latest(&ctx, &existing) {
             tracing::warn!("Failed to refresh latest stack preview index: {error}");
         }
         let _ = state.stack_previews.insert(existing.clone());
@@ -1205,10 +1208,10 @@ pub async fn get_latest_stack_previews(
             )))
         }
     };
-    let latest = current_latest_stacks(latest);
     if latest.database_id != ctx.id || latest.project_id != project_id {
         return Err(AppError::NotFound);
     }
+    let latest = current_project_latest_stacks(&ctx, project_id, latest)?;
     Ok(Json(ApiResponse::success(latest)))
 }
 
@@ -1462,10 +1465,12 @@ fn prepare_job(
     let flat_star_masking = crate::calibration::flat_star_masking_enabled();
     let scoring = StackScoringSettings::from_overrides(&request.scoring);
     let requested = request.image_ids.iter().copied().collect::<HashSet<_>>();
-    let (project_images, expected_by_image, mapped_sources) = {
+    let (project_images, expected_by_image, mapped_sources, exposure_groups) = {
         let conn = ctx.db();
         let conn = conn.lock().map_err(AppError::db)?;
         let db = Database::new(&conn);
+        let exposure_groups =
+            crate::server::exposure_groups::cached_project_groups(ctx, &conn, project_id)?;
         let images = db
             .get_images_by_project_id(project_id)
             .map_err(AppError::db)?;
@@ -1509,7 +1514,7 @@ fn prepare_job(
             &ctx.image_dir_paths,
             relevant.iter().map(|(image, _, _)| image),
         )?;
-        (relevant, expected, mapped_sources)
+        (relevant, expected, mapped_sources, exposure_groups)
     };
 
     let quality = quality_results(
@@ -1524,8 +1529,9 @@ fn prepare_job(
         .map(|result| (result.image_id, result))
         .collect::<HashMap<_, _>>();
 
-    let mut grouped: BTreeMap<(i32, String, String), Vec<(AcquiredImage, ImageQualityResult)>> =
-        BTreeMap::new();
+    type StackGroupKey = (i32, String, String, Option<String>);
+    type ScoredImages = Vec<(AcquiredImage, ImageQualityResult)>;
+    let mut grouped: BTreeMap<StackGroupKey, ScoredImages> = BTreeMap::new();
     for (image, _project_name, target_name) in project_images {
         if !requested.contains(&image.id) {
             continue;
@@ -1535,7 +1541,15 @@ fn prepare_job(
             .cloned()
             .unwrap_or_else(|| fallback_quality(image.id));
         grouped
-            .entry((image.target_id, target_name, image.filter_name.clone()))
+            .entry((
+                image.target_id,
+                target_name,
+                image.filter_name.clone(),
+                exposure_groups
+                    .by_image
+                    .get(&image.id)
+                    .map(|group| group.key.clone()),
+            ))
             .or_default()
             .push((image, scored));
     }
@@ -1544,6 +1558,9 @@ fn prepare_job(
     let mut prepared_groups = Vec::new();
     let artifact_revision = new_artifact_revision();
     let mut hasher = Sha256::new();
+    if exposure_groups.settings.split_exposure_groups {
+        hasher.update(b"exposure-groups-v1\0");
+    }
     hasher.update(ctx.id.as_bytes());
     hasher.update(project_id.to_le_bytes());
     hasher.update([request.accepted_only as u8]);
@@ -1571,17 +1588,26 @@ fn prepare_job(
         }
     }
 
-    for (index, ((target_id, target_name, filter_name), mut entries)) in
+    for (index, ((target_id, target_name, filter_name, exposure_group_key), mut entries)) in
         grouped.into_iter().enumerate()
     {
         // Hash the mode each channel actually stacks under, so the same
         // effective configuration lands on the same job whether it came from
         // the request-wide mode or an override.
-        let group_calibration = request.calibration_for(target_id, &filter_name);
+        let group_calibration =
+            request.calibration_for(target_id, &filter_name, exposure_group_key.as_deref());
+        let exposure_group = entries
+            .first()
+            .and_then(|(image, _)| exposure_groups.by_image.get(&image.id))
+            .cloned();
         hasher.update(target_id.to_le_bytes());
         hasher.update(target_name.as_bytes());
         hasher.update(filter_name.as_bytes());
         hasher.update(group_calibration.as_str().as_bytes());
+        if let Some(key) = &exposure_group_key {
+            hasher.update(b"\0exposure-group\0");
+            hasher.update(key.as_bytes());
+        }
         entries.sort_by_key(|(image, _)| (image.acquired_date.unwrap_or(0), image.id));
         let total_candidates = entries.len();
         let input_images = entries
@@ -1687,6 +1713,7 @@ fn prepare_job(
             target_id,
             target_name,
             filter_name,
+            exposure_group,
             state: if eligible_frames >= 2 {
                 StackGroupState::Queued
             } else {
@@ -2134,7 +2161,8 @@ fn run_job(state: &Arc<AppState>, prepared: PreparedJob, cancel: &Arc<AtomicBool
             job.state,
             StackJobState::Completed | StackJobState::Cancelled
         )
-        && let Err(error) = state.stack_previews.persist_latest(&cache_root, &job)
+        && let Some(ctx) = state.get_database(&database_id)
+        && let Err(error) = state.stack_previews.persist_latest(&ctx, &job)
     {
         tracing::warn!("Failed to persist latest stack preview index: {error}");
     }
@@ -2314,12 +2342,16 @@ fn run_group(
         status.calibration = applied_calibration;
         status.phase = "stacking".into();
     });
-    let (group_target_id, group_filter_name) = state
+    let (group_target_id, group_filter_name, group_exposure_key) = state
         .stack_previews
         .get(job_id)
         .map(|job| {
             let status = &job.groups[group.index];
-            (status.target_id, status.filter_name.clone())
+            (
+                status.target_id,
+                status.filter_name.clone(),
+                exposure_group_key(status).map(str::to_owned),
+            )
         })
         .ok_or_else(|| "Stack job disappeared while running".to_string())?;
     let requested = group
@@ -2338,6 +2370,7 @@ fn run_group(
         database_id,
         group_target_id,
         &group_filter_name,
+        group_exposure_key.as_deref(),
         accepted_only,
         scoring,
         SEIZA_STACKING_VERSION,
@@ -2401,7 +2434,7 @@ fn run_group(
                     tracing::warn!(
                         "Stack checkpoint context and manifest did not match; rebuilding from scratch"
                     );
-                    resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
+                    resume::discard(cache_root, database_id, group_target_id, &group_filter_name, group_exposure_key.as_deref());
                     state.stack_previews.update(job_id, |job| {
                         job.groups[group.index].resume_note =
                             Some("Full restack: the checkpoint files did not match".into());
@@ -2412,7 +2445,7 @@ fn run_group(
                     tracing::warn!(
                         "Stack checkpoint could not be reopened ({error}); rebuilding from scratch"
                     );
-                    resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
+                    resume::discard(cache_root, database_id, group_target_id, &group_filter_name, group_exposure_key.as_deref());
                     state.stack_previews.update(job_id, |job| {
                         job.groups[group.index].resume_note =
                             Some("Full restack: the checkpoint could not be reopened".into());
@@ -2572,64 +2605,82 @@ fn run_group(
     {
         points.push(snr::point(sample, integrated_exposure(&ledger)));
     }
-    let save_checkpoint = |stacker: &LiveStacker,
-                           ledger: &[resume::ResumeFrame],
-                           points: &[snr::SnrPoint]| {
-        pool.install(|| {
-            // A quality-ordered build is a full restack by nature. Writing its
-            // accumulator here would leave a checkpoint no later build can
-            // extend, in place of the capture-order one that can be.
-            if !order.resumable() {
-                return;
-            }
-            if ledger.iter().any(|frame| frame.retryable_failure) {
-                resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
-                return;
-            }
-            let context_path =
-                resume::context_path(cache_root, database_id, group_target_id, &group_filter_name);
-            let manifest = resume::ResumeManifest {
-                schema_version: resume::RESUME_SCHEMA_VERSION,
-                stacking_version: SEIZA_STACKING_VERSION.into(),
-                target_id: group_target_id,
-                filter_name: group_filter_name.clone(),
-                accepted_only,
-                scoring,
-                calibration_fingerprint: calibration_fingerprint.clone(),
-                order,
-                snr_points: points.to_vec(),
-                frames: ledger.to_vec(),
-            };
-            let saved = context_path
-                .parent()
-                .ok_or_else(|| "checkpoint path has no parent".to_string())
-                .and_then(|parent| {
-                    std::fs::create_dir_all(parent).map_err(|error| error.to_string())
-                })
-                .and_then(|()| {
-                    stacker
-                        .save_context(&context_path)
-                        .map_err(|error| error.to_string())
-                })
-                .and_then(|()| {
-                    resume::store_manifest(
-                        &resume::manifest_path(
-                            cache_root,
-                            database_id,
-                            group_target_id,
-                            &group_filter_name,
-                        ),
-                        &manifest,
-                    )
-                });
-            if let Err(error) = saved {
-                // A checkpoint is an optimization; a build never fails over
-                // it. Discard the pair so nothing resumes from half a save.
-                tracing::warn!("Failed to save stack checkpoint: {error}");
-                resume::discard(cache_root, database_id, group_target_id, &group_filter_name);
-            }
-        })
-    };
+    let save_checkpoint =
+        |stacker: &LiveStacker, ledger: &[resume::ResumeFrame], points: &[snr::SnrPoint]| {
+            pool.install(|| {
+                // A quality-ordered build is a full restack by nature. Writing its
+                // accumulator here would leave a checkpoint no later build can
+                // extend, in place of the capture-order one that can be.
+                if !order.resumable() {
+                    return;
+                }
+                if ledger.iter().any(|frame| frame.retryable_failure) {
+                    resume::discard(
+                        cache_root,
+                        database_id,
+                        group_target_id,
+                        &group_filter_name,
+                        group_exposure_key.as_deref(),
+                    );
+                    return;
+                }
+                let context_path = resume::context_path(
+                    cache_root,
+                    database_id,
+                    group_target_id,
+                    &group_filter_name,
+                    group_exposure_key.as_deref(),
+                );
+                let manifest = resume::ResumeManifest {
+                    schema_version: resume::RESUME_SCHEMA_VERSION,
+                    stacking_version: SEIZA_STACKING_VERSION.into(),
+                    target_id: group_target_id,
+                    filter_name: group_filter_name.clone(),
+                    exposure_group_key: group_exposure_key.clone(),
+                    accepted_only,
+                    scoring,
+                    calibration_fingerprint: calibration_fingerprint.clone(),
+                    order,
+                    snr_points: points.to_vec(),
+                    frames: ledger.to_vec(),
+                };
+                let saved = context_path
+                    .parent()
+                    .ok_or_else(|| "checkpoint path has no parent".to_string())
+                    .and_then(|parent| {
+                        std::fs::create_dir_all(parent).map_err(|error| error.to_string())
+                    })
+                    .and_then(|()| {
+                        stacker
+                            .save_context(&context_path)
+                            .map_err(|error| error.to_string())
+                    })
+                    .and_then(|()| {
+                        resume::store_manifest(
+                            &resume::manifest_path(
+                                cache_root,
+                                database_id,
+                                group_target_id,
+                                &group_filter_name,
+                                group_exposure_key.as_deref(),
+                            ),
+                            &manifest,
+                        )
+                    });
+                if let Err(error) = saved {
+                    // A checkpoint is an optimization; a build never fails over
+                    // it. Discard the pair so nothing resumes from half a save.
+                    tracing::warn!("Failed to save stack checkpoint: {error}");
+                    resume::discard(
+                        cache_root,
+                        database_id,
+                        group_target_id,
+                        &group_filter_name,
+                        group_exposure_key.as_deref(),
+                    );
+                }
+            })
+        };
 
     // Pending frames keep their index into `group.frames`, which is what
     // the calibration plan's session assignments are aligned with.
@@ -3215,11 +3266,23 @@ fn persist_manifest(cache_root: &FsPath, job: &StackPreviewJob) -> Result<(), St
     std::fs::rename(&temporary, path).map_err(|error| error.to_string())
 }
 
+#[cfg(test)]
 fn persist_latest_groups(cache_root: &FsPath, job: &StackPreviewJob) -> Result<(), String> {
+    persist_latest_groups_with_exposures(cache_root, job, None)
+}
+
+fn persist_latest_groups_with_exposures(
+    cache_root: &FsPath,
+    job: &StackPreviewJob,
+    current: Option<&ProjectExposureGroups>,
+) -> Result<(), String> {
     let ready = job
         .groups
         .iter()
         .filter(|group| group.state == StackGroupState::Ready)
+        .filter(|group| {
+            current.is_none_or(|current| group_matches_project_exposures(group, current))
+        })
         .cloned()
         .collect::<Vec<_>>();
     if ready.is_empty() {
@@ -3240,6 +3303,21 @@ fn persist_latest_groups(cache_root: &FsPath, job: &StackPreviewJob) -> Result<(
             groups: Vec::new(),
         });
 
+    // Only successful current split builds retire obsolete split identities.
+    // A toggle, failed build, or cached old request never discards another
+    // family's remembered result. Keep the unsplit result for switching back.
+    if let Some(current) = current
+        && current.settings.split_exposure_groups
+        && ready
+            .iter()
+            .any(|group| group_matches_project_exposures(group, current))
+    {
+        latest.groups.retain(|entry| {
+            entry.group.exposure_group.is_none()
+                || group_matches_project_exposures(&entry.group, current)
+        });
+    }
+
     for group in ready {
         let replacement = LatestStackPreviewGroup {
             job_id: job.job_id.clone(),
@@ -3254,6 +3332,7 @@ fn persist_latest_groups(cache_root: &FsPath, job: &StackPreviewJob) -> Result<(
         if let Some(existing) = latest.groups.iter_mut().find(|existing| {
             existing.group.target_id == replacement.group.target_id
                 && existing.group.filter_name == replacement.group.filter_name
+                && exposure_group_key(&existing.group) == exposure_group_key(&replacement.group)
         }) {
             *existing = replacement;
         } else {
@@ -3266,6 +3345,7 @@ fn persist_latest_groups(cache_root: &FsPath, job: &StackPreviewJob) -> Result<(
             .cmp(&right.group.target_name)
             .then_with(|| left.group.filter_name.cmp(&right.group.filter_name))
             .then_with(|| left.group.target_id.cmp(&right.group.target_id))
+            .then_with(|| exposure_group_key(&left.group).cmp(&exposure_group_key(&right.group)))
     });
     latest.updated_unix_seconds = chrono::Utc::now().timestamp();
 
@@ -3289,6 +3369,47 @@ pub(super) fn current_latest_stacks(mut latest: LatestStackPreviews) -> LatestSt
                 .is_some_and(StackSkyOrientation::is_current)
     });
     latest
+}
+
+fn exposure_group_key(group: &StackGroupStatus) -> Option<&str> {
+    group
+        .exposure_group
+        .as_ref()
+        .map(|group| group.key.as_str())
+}
+
+fn group_matches_project_exposures(
+    group: &StackGroupStatus,
+    current: &ProjectExposureGroups,
+) -> bool {
+    if !current.settings.split_exposure_groups {
+        return group.exposure_group.is_none();
+    }
+    let Some(key) = exposure_group_key(group) else {
+        return false;
+    };
+    !group.input_images.is_empty()
+        && group.input_images.iter().all(|image| {
+            current
+                .by_image
+                .get(&image.image_id)
+                .is_some_and(|group| group.key == key)
+        })
+}
+
+pub(super) fn current_project_latest_stacks(
+    ctx: &DatabaseContext,
+    project_id: i32,
+    latest: LatestStackPreviews,
+) -> Result<LatestStackPreviews, AppError> {
+    let mut latest = current_latest_stacks(latest);
+    let conn = ctx.db();
+    let conn = conn.lock().map_err(AppError::db)?;
+    let current = crate::server::exposure_groups::cached_project_groups(ctx, &conn, project_id)?;
+    latest
+        .groups
+        .retain(|entry| group_matches_project_exposures(&entry.group, &current));
+    Ok(latest)
 }
 
 fn stack_dir(cache_root: &FsPath, job_id: &str) -> PathBuf {
@@ -3502,6 +3623,7 @@ mod tests {
             target_id,
             target_name: format!("Target {target_id}"),
             filter_name: filter_name.into(),
+            exposure_group: None,
             state: StackGroupState::Ready,
             phase: "ready".into(),
             total_candidates: 2,
@@ -3548,6 +3670,189 @@ mod tests {
             groups,
             error: None,
         }
+    }
+
+    fn exposure_group(key: &str, seconds: f64) -> ExposureGroup {
+        ExposureGroup {
+            key: key.into(),
+            label: format!("{seconds} s"),
+            min_seconds: Some(seconds),
+            max_seconds: Some(seconds),
+        }
+    }
+
+    #[test]
+    fn latest_exposure_groups_are_independent_and_replace_only_their_own_family() {
+        let cache = tempfile::tempdir().unwrap();
+        let mut short = ready_group(42, "Ha", 1);
+        short.exposure_group = Some(exposure_group("short", 10.0));
+        let mut long = ready_group(42, "Ha", 2);
+        long.exposure_group = Some(exposure_group("long", 300.0));
+        persist_latest_groups(
+            cache.path(),
+            &completed_job("first", vec![short.clone(), long]),
+        )
+        .unwrap();
+        persist_latest_groups(cache.path(), &completed_job("second", vec![short])).unwrap();
+        let latest: LatestStackPreviews =
+            serde_json::from_slice(&std::fs::read(latest_path(cache.path(), 7)).unwrap()).unwrap();
+        assert_eq!(latest.groups.len(), 2);
+        assert_eq!(
+            latest
+                .groups
+                .iter()
+                .find(|entry| exposure_group_key(&entry.group) == Some("short"))
+                .unwrap()
+                .job_id,
+            "second"
+        );
+        assert_eq!(
+            latest
+                .groups
+                .iter()
+                .find(|entry| exposure_group_key(&entry.group) == Some("long"))
+                .unwrap()
+                .job_id,
+            "first"
+        );
+    }
+
+    #[test]
+    fn latest_group_must_match_the_current_project_setting_and_every_input() {
+        use crate::server::exposure_groups::ProjectProcessingSettings;
+        let short = exposure_group("short", 10.0);
+        let mut current = ProjectExposureGroups {
+            settings: ProjectProcessingSettings {
+                split_exposure_groups: true,
+            },
+            by_image: HashMap::from([(1, short.clone()), (2, exposure_group("long", 300.0))]),
+        };
+        let mut group = ready_group(42, "Ha", 1);
+        assert!(!group_matches_project_exposures(&group, &current));
+        group.exposure_group = Some(short);
+        assert!(group_matches_project_exposures(&group, &current));
+        group.input_images.push(StackInputImage {
+            image_id: 2,
+            grading_status: 1,
+        });
+        assert!(!group_matches_project_exposures(&group, &current));
+        group.input_images.pop();
+        current.by_image.remove(&1);
+        assert!(!group_matches_project_exposures(&group, &current));
+        current.settings.split_exposure_groups = false;
+        assert!(!group_matches_project_exposures(&group, &current));
+        group.exposure_group = None;
+        assert!(group_matches_project_exposures(&group, &current));
+    }
+
+    #[test]
+    fn old_stack_groups_without_exposure_metadata_remain_readable() {
+        let mut value = serde_json::to_value(ready_group(42, "Ha", 1)).unwrap();
+        value.as_object_mut().unwrap().remove("exposure_group");
+        let group: StackGroupStatus = serde_json::from_value(value).unwrap();
+        assert!(group.exposure_group.is_none());
+    }
+
+    #[test]
+    fn successful_split_publish_retires_only_obsolete_split_families() {
+        use crate::server::exposure_groups::ProjectProcessingSettings;
+        let cache = tempfile::tempdir().unwrap();
+        let unsplit = ready_group(42, "Ha", 1);
+        let mut old_short = ready_group(42, "Ha", 1);
+        old_short.exposure_group = Some(exposure_group("old-short", 11.0));
+        let mut long = ready_group(42, "Ha", 2);
+        long.exposure_group = Some(exposure_group("long", 300.0));
+        persist_latest_groups(
+            cache.path(),
+            &completed_job("previous", vec![unsplit, old_short, long]),
+        )
+        .unwrap();
+        let short = exposure_group("new-short", 10.0);
+        let current = ProjectExposureGroups {
+            settings: ProjectProcessingSettings {
+                split_exposure_groups: true,
+            },
+            by_image: HashMap::from([(1, short.clone()), (2, exposure_group("long", 300.0))]),
+        };
+        let mut replacement = ready_group(42, "Ha", 1);
+        replacement.exposure_group = Some(short);
+        persist_latest_groups_with_exposures(
+            cache.path(),
+            &completed_job("current", vec![replacement]),
+            Some(&current),
+        )
+        .unwrap();
+        let mut queued_before_regroup = ready_group(42, "Ha", 1);
+        queued_before_regroup.exposure_group = Some(exposure_group("old-short", 11.0));
+        persist_latest_groups_with_exposures(
+            cache.path(),
+            &completed_job("stale-queued", vec![queued_before_regroup]),
+            Some(&current),
+        )
+        .unwrap();
+        let latest: LatestStackPreviews =
+            serde_json::from_slice(&std::fs::read(latest_path(cache.path(), 7)).unwrap()).unwrap();
+        let keys: HashSet<_> = latest
+            .groups
+            .iter()
+            .map(|entry| exposure_group_key(&entry.group))
+            .collect();
+        assert_eq!(keys, HashSet::from([None, Some("new-short"), Some("long")]));
+    }
+
+    #[test]
+    fn prepare_job_uses_persisted_full_project_exposure_groups_for_subsets() {
+        let directory = tempfile::tempdir().unwrap();
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::ts_schema::apply_schema(&conn).unwrap();
+        conn.execute_batch("INSERT INTO project(Id,name,profileId,guid) VALUES(1,'Project','profile','project-one');
+            INSERT INTO target(Id,name,projectId,active,ra,dec,epochcode,rotation,roi,guid)
+                VALUES(1,'Target',1,1,10,20,0,0,100,'target-one');
+            CREATE TABLE psf_guard_project_processing(project_key TEXT PRIMARY KEY,split_exposure_groups INTEGER NOT NULL);
+            INSERT INTO psf_guard_project_processing VALUES('guid:project-one',1);").unwrap();
+        for (id, exposure) in [(1, 10.0), (2, 11.0), (3, 300.0), (4, 310.0)] {
+            conn.execute("INSERT INTO acquiredimage(Id,projectId,targetId,gradingStatus,metadata,acquireddate,filtername)
+                VALUES(?1,1,1,1,?2,?1,'Ha')", rusqlite::params![id, serde_json::json!({"ExposureDuration":exposure}).to_string()]).unwrap();
+        }
+        let mut ctx = DatabaseContext::new_for_test(conn);
+        ctx.cache_dir_path = directory.path().to_path_buf();
+        ctx.cache_dir = directory.path().to_string_lossy().into_owned();
+        let ctx = Arc::new(ctx);
+        let request = |ids: Vec<i32>| {
+            serde_json::from_value::<StackPreviewRequest>(
+                serde_json::json!({"image_ids":ids,"calibration":"off"}),
+            )
+            .unwrap()
+        };
+        let full = prepare_job(&ctx, 1, &request(vec![1, 2, 3, 4])).unwrap();
+        let subset = prepare_job(&ctx, 1, &request(vec![2, 4])).unwrap();
+        assert_eq!(full.public.groups.len(), 2);
+        assert_eq!(subset.public.groups.len(), 2);
+        for group in &subset.public.groups {
+            assert_eq!(group.total_candidates, 1);
+            let whole_group = full
+                .public
+                .groups
+                .iter()
+                .find(|candidate| exposure_group_key(candidate) == exposure_group_key(group))
+                .unwrap();
+            assert_eq!(whole_group.exposure_group, group.exposure_group);
+            assert_eq!(whole_group.total_candidates, 2);
+        }
+        {
+            let db = ctx.db();
+            db.lock()
+                .unwrap()
+                .execute(
+                    "UPDATE psf_guard_project_processing SET split_exposure_groups=0",
+                    [],
+                )
+                .unwrap();
+        }
+        let unsplit = prepare_job(&ctx, 1, &request(vec![2, 4])).unwrap();
+        assert_eq!(unsplit.public.groups.len(), 1);
+        assert!(unsplit.public.groups[0].exposure_group.is_none());
+        assert_ne!(unsplit.public.job_id, subset.public.job_id);
     }
 
     #[test]
@@ -3737,7 +4042,7 @@ mod tests {
     #[test]
     fn a_channel_override_wins_over_the_request_mode() {
         use crate::calibration::CalibrationMode;
-        let request = StackPreviewRequest {
+        let mut request = StackPreviewRequest {
             image_ids: vec![1, 2],
             accepted_only: false,
             force: false,
@@ -3748,12 +4053,36 @@ mod tests {
             calibration_overrides: vec![CalibrationOverride {
                 target_id: 7,
                 filter_name: "Ha".into(),
+                exposure_group_key: None,
                 calibration: CalibrationMode::Off,
             }],
         };
-        assert_eq!(request.calibration_for(7, "Ha"), CalibrationMode::Off);
-        assert_eq!(request.calibration_for(7, "OIII"), CalibrationMode::Auto);
-        assert_eq!(request.calibration_for(8, "Ha"), CalibrationMode::Auto);
+        assert_eq!(request.calibration_for(7, "Ha", None), CalibrationMode::Off);
+        assert_eq!(
+            request.calibration_for(7, "OIII", None),
+            CalibrationMode::Auto
+        );
+        assert_eq!(
+            request.calibration_for(8, "Ha", None),
+            CalibrationMode::Auto
+        );
+        assert_eq!(
+            request.calibration_for(7, "Ha", Some("short")),
+            CalibrationMode::Auto
+        );
+        request.calibration_overrides[0].exposure_group_key = Some("short".into());
+        assert_eq!(
+            request.calibration_for(7, "Ha", Some("short")),
+            CalibrationMode::Off
+        );
+        assert_eq!(
+            request.calibration_for(7, "Ha", Some("long")),
+            CalibrationMode::Auto
+        );
+        assert_eq!(
+            request.calibration_for(7, "Ha", None),
+            CalibrationMode::Auto
+        );
     }
 
     #[test]

--- a/src/server/stack_preview/artifact.rs
+++ b/src/server/stack_preview/artifact.rs
@@ -1442,6 +1442,7 @@ mod tests {
         std::fs::create_dir_all(preview_path.parent().unwrap()).unwrap();
         image::GrayImage::new(16, 16).save(preview_path).unwrap();
         let group = StackGroupStatus {
+            exposure_group: None,
             index: 0,
             target_id: 1,
             target_name: "Target".into(),

--- a/src/server/stack_preview/color.rs
+++ b/src/server/stack_preview/color.rs
@@ -249,6 +249,17 @@ pub struct StackColorRequest {
     /// original quick-look behavior for API compatibility.
     #[serde(default)]
     pub processing: Option<StackColorProcessing>,
+    /// Exact current mono artifacts to use when a role has multiple stacks.
+    /// Omitted roles are resolved only when there is one usable candidate.
+    #[serde(default)]
+    pub input_sources: BTreeMap<StackColorRole, StackColorSourceRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StackColorSourceRef {
+    pub job_id: String,
+    pub group_index: usize,
+    pub artifact_revision: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -348,6 +359,10 @@ pub struct StackColorProgress {
 pub struct StackColorSource {
     pub role: StackColorRole,
     pub filter_name: String,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub exposure_group: Option<crate::server::exposure_groups::ExposureGroup>,
     pub job_id: String,
     pub group_index: usize,
     pub artifact_revision: String,
@@ -390,6 +405,9 @@ pub struct StackColorJob {
     pub kind: StackColorKind,
     pub palette: Option<StackNarrowbandPalette>,
     pub label: String,
+    /// Stable channel-family identity, independent of artifact revisions.
+    #[serde(default)]
+    pub source_family_key: String,
     pub state: StackJobState,
     pub phase: String,
     pub processed_channels: usize,
@@ -463,6 +481,7 @@ pub struct StackColorTargetAvailability {
     pub target_id: i32,
     pub target_name: String,
     pub available_roles: Vec<StackColorAvailableRole>,
+    pub source_candidates: Vec<StackColorSource>,
     pub ambiguous_roles: Vec<StackColorRole>,
     pub unmapped_filters: Vec<String>,
     pub rgb_available: bool,
@@ -1038,10 +1057,21 @@ fn validate_request(request: &StackColorRequest) -> Result<(), AppError> {
             "Narrowband color previews require a palette".into(),
         )),
         _ => {
+            let required = required_roles(request.kind, request.palette);
+            if let Some(role) = request
+                .input_sources
+                .keys()
+                .find(|role| !required.contains(role))
+            {
+                return Err(AppError::BadRequest(format!(
+                    "{} is not an input to {}",
+                    role.label(),
+                    composition_label(request.kind, request.palette)
+                )));
+            }
             let Some(processing) = &request.processing else {
                 return Ok(());
             };
-            let required = required_roles(request.kind, request.palette);
             if let Some(role) = processing
                 .input_stretches
                 .keys()
@@ -1140,28 +1170,8 @@ fn prepare_color_job(
     let target = targets.get(&request.target_id).ok_or_else(|| {
         AppError::BadRequest("No completed channel stacks are available for that target".into())
     })?;
-    let roles = required_roles(request.kind, request.palette);
-    let mut sources = Vec::with_capacity(roles.len());
-    for role in roles {
-        let candidates = target.by_role.get(&role).map(Vec::as_slice).unwrap_or(&[]);
-        match candidates {
-            [source] => sources.push(source.clone()),
-            [] => {
-                return Err(AppError::BadRequest(format!(
-                    "{} requires a {} channel stack",
-                    composition_label(request.kind, request.palette),
-                    role.label()
-                )))
-            }
-            _ => {
-                return Err(AppError::BadRequest(format!(
-                    "{} has multiple channel stacks that map to {}; rename filters to make the role unambiguous",
-                    target.target_name,
-                    role.label()
-                )))
-            }
-        }
-    }
+    let sources = select_sources(target, &request)?;
+    let source_family_key = source_family_key(&sources);
 
     let resolved_background_protection = if request.processing.as_ref().is_some_and(|processing| {
         processing
@@ -1265,6 +1275,7 @@ fn prepare_color_job(
             kind: request.kind,
             palette: request.palette,
             label,
+            source_family_key,
             state: StackJobState::Queued,
             phase: "Waiting for color processor".into(),
             processed_channels: 0,
@@ -1314,6 +1325,78 @@ fn prepare_color_job(
         rc_astro_schemas,
         rc_astro_chains,
     })
+}
+
+fn select_sources(
+    target: &TargetSources,
+    request: &StackColorRequest,
+) -> Result<Vec<StackColorSource>, AppError> {
+    let roles = required_roles(request.kind, request.palette);
+    let mut sources = Vec::with_capacity(roles.len());
+    for role in roles {
+        let candidates = target.by_role.get(&role).map(Vec::as_slice).unwrap_or(&[]);
+        if let Some(selected) = request.input_sources.get(&role) {
+            let source = candidates.iter().find(|source| {
+                source.job_id == selected.job_id
+                    && source.group_index == selected.group_index
+                    && source.artifact_revision == selected.artifact_revision
+            });
+            let Some(source) = source else {
+                return Err(AppError::BadRequest(format!(
+                    "The selected {} stack is not a current source for this target; refresh the channel selection",
+                    role.label()
+                )));
+            };
+            sources.push(source.clone());
+            continue;
+        }
+        match candidates {
+            [source] => sources.push(source.clone()),
+            [] => {
+                return Err(AppError::BadRequest(format!(
+                    "{} requires a {} channel stack",
+                    composition_label(request.kind, request.palette),
+                    role.label()
+                )))
+            }
+            _ => {
+                return Err(AppError::BadRequest(format!(
+                "{} has multiple {} channel stacks; select the source exposure group explicitly",
+                target.target_name,
+                role.label()
+            )))
+            }
+        }
+    }
+    Ok(sources)
+}
+
+fn source_family_key(sources: &[StackColorSource]) -> String {
+    // Preserve the pre-grouping latest identity for legacy unsplit projects.
+    if sources.iter().all(|source| source.exposure_group.is_none()) {
+        return String::new();
+    }
+    let families = sources
+        .iter()
+        .map(|source| {
+            (
+                source.role,
+                (
+                    source.filter_name.as_str(),
+                    source
+                        .exposure_group
+                        .as_ref()
+                        .map(|group| group.key.as_str()),
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let bytes = serde_json::to_vec(&families).expect("color source families are serializable");
+    let mut key = String::with_capacity(64);
+    for byte in Sha256::digest(bytes) {
+        write!(&mut key, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    key
 }
 
 fn color_rc_astro_chains(
@@ -1595,6 +1678,14 @@ fn run_color_job(state: &Arc<AppState>, prepared: PreparedColorJob) {
         job.phase = "Loading channel stacks".into();
     });
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // A mono rebuild ahead in the shared queue may have replaced a
+        // selected revision while this color job waited for the permit.
+        let ctx = state
+            .get_database(&prepared.public.database_id)
+            .ok_or_else(|| "The color source database is no longer available".to_string())?;
+        let latest = load_latest_stacks(&ctx, prepared.public.project_id)
+            .map_err(|error| format!("Failed to validate color sources: {error:?}"))?;
+        validate_current_color_sources(&prepared.public, &latest)?;
         compose_color(
             state,
             &prepared.public,
@@ -2727,7 +2818,7 @@ fn load_latest_stacks(
             if latest.database_id != ctx.id || latest.project_id != project_id {
                 return Err(AppError::NotFound);
             }
-            Ok(super::current_latest_stacks(latest))
+            super::current_project_latest_stacks(ctx, project_id, latest)
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(LatestStackPreviews {
             schema_version: 1,
@@ -2796,7 +2887,10 @@ fn collect_sources(
 ) -> BTreeMap<i32, TargetSources> {
     let mut targets = BTreeMap::<i32, TargetSources>::new();
     for entry in &latest.groups {
-        if super::validate_job_id(&entry.job_id).is_err() {
+        if super::validate_job_id(&entry.job_id).is_err()
+            || entry.group.state != super::StackGroupState::Ready
+            || entry.group.output_channels != 1
+        {
             continue;
         }
         if !super::fits_path(cache_root, &entry.job_id, entry.group.index).is_file() {
@@ -2817,6 +2911,11 @@ fn collect_sources(
             .push(StackColorSource {
                 role,
                 filter_name: entry.group.filter_name.clone(),
+                label: entry.group.exposure_group.as_ref().map_or_else(
+                    || entry.group.filter_name.clone(),
+                    |group| format!("{} ({})", entry.group.filter_name, group.label),
+                ),
+                exposure_group: entry.group.exposure_group.clone(),
                 job_id: entry.job_id.clone(),
                 group_index: entry.group.index,
                 artifact_revision: entry.artifact_revision.clone(),
@@ -2829,6 +2928,16 @@ fn collect_sources(
     for target in targets.values_mut() {
         target.unmapped_filters.sort();
         target.unmapped_filters.dedup();
+        for candidates in target.by_role.values_mut() {
+            candidates.sort_by(|left, right| {
+                left.filter_name.cmp(&right.filter_name).then_with(|| {
+                    left.exposure_group
+                        .as_ref()
+                        .map(|group| &group.key)
+                        .cmp(&right.exposure_group.as_ref().map(|group| &group.key))
+                })
+            });
+        }
     }
     targets
 }
@@ -2848,22 +2957,19 @@ fn availability(sources: &BTreeMap<i32, TargetSources>) -> Vec<StackColorTargetA
                     _ => ambiguous_roles.push(*role),
                 }
             }
-            let unique = available_roles
-                .iter()
-                .map(|available| available.role)
-                .collect::<HashSet<_>>();
+            let present = target.by_role.keys().copied().collect::<HashSet<_>>();
             let rgb_available = [
                 StackColorRole::Red,
                 StackColorRole::Green,
                 StackColorRole::Blue,
             ]
             .iter()
-            .all(|role| unique.contains(role));
-            let lrgb_available = rgb_available && unique.contains(&StackColorRole::Luminance);
+            .all(|role| present.contains(role));
+            let lrgb_available = rgb_available && present.contains(&StackColorRole::Luminance);
             let has_ha_oiii =
-                unique.contains(&StackColorRole::Ha) && unique.contains(&StackColorRole::Oiii);
+                present.contains(&StackColorRole::Ha) && present.contains(&StackColorRole::Oiii);
             let narrowband_palettes = if has_ha_oiii {
-                StackNarrowbandPalette::all(unique.contains(&StackColorRole::Sii))
+                StackNarrowbandPalette::all(present.contains(&StackColorRole::Sii))
             } else {
                 Vec::new()
             };
@@ -2871,6 +2977,7 @@ fn availability(sources: &BTreeMap<i32, TargetSources>) -> Vec<StackColorTargetA
                 target_id: *target_id,
                 target_name: target.target_name.clone(),
                 available_roles,
+                source_candidates: target.by_role.values().flatten().cloned().collect(),
                 ambiguous_roles,
                 unmapped_filters: target.unmapped_filters.clone(),
                 rgb_available,
@@ -2960,13 +3067,37 @@ fn classify_filter(filter_name: &str) -> Option<StackColorRole> {
     }
 }
 
-fn source_is_current(source: &StackColorSource, latest: &LatestStackPreviews) -> bool {
+fn source_is_current(
+    source: &StackColorSource,
+    target_id: i32,
+    latest: &LatestStackPreviews,
+) -> bool {
     latest.groups.iter().any(|entry| {
         entry.job_id == source.job_id
             && entry.artifact_revision == source.artifact_revision
             && entry.group.index == source.group_index
+            && entry.group.target_id == target_id
             && entry.group.filter_name == source.filter_name
+            && entry.group.exposure_group == source.exposure_group
+            && classify_filter(&entry.group.filter_name) == Some(source.role)
     })
+}
+
+fn validate_current_color_sources(
+    job: &StackColorJob,
+    latest: &LatestStackPreviews,
+) -> Result<(), String> {
+    if latest.database_id != job.database_id || latest.project_id != job.project_id {
+        return Err("The color source project changed while the build was queued".into());
+    }
+    if !job
+        .sources
+        .iter()
+        .all(|source| source_is_current(source, job.target_id, latest))
+    {
+        return Err("A selected channel stack changed while the color build was queued; refresh the channel selection and build again".into());
+    }
+    Ok(())
 }
 
 fn color_artifacts_exist(cache_root: &FsPath, job_id: &str) -> bool {
@@ -2992,7 +3123,7 @@ fn color_job_outdated_reason(
         return Ok(Some("the color processing version changed".into()));
     }
     if !job.sources.iter().all(|source| {
-        source_is_current(source, latest)
+        source_is_current(source, job.target_id, latest)
             && super::fits_path(&ctx.cache_dir_path, &source.job_id, source.group_index).is_file()
     }) {
         return Ok(Some("one or more source channel stacks changed".into()));
@@ -3039,6 +3170,7 @@ fn persist_latest_color(cache_root: &FsPath, job: &StackColorJob) -> Result<(), 
         existing.target_id == job.target_id
             && existing.kind == job.kind
             && existing.palette == job.palette
+            && existing.source_family_key == job.source_family_key
     }) {
         *existing = job.clone();
     } else {
@@ -3247,6 +3379,7 @@ mod tests {
                 target_id: 7,
                 target_name: "Color target".into(),
                 filter_name: filter_name.into(),
+                exposure_group: None,
                 state: StackGroupState::Ready,
                 phase: "ready".into(),
                 total_candidates: 3,
@@ -3341,6 +3474,7 @@ mod tests {
             crop: StackColorCrop::None,
             crop_report: None,
             label: "SHO".into(),
+            source_family_key: String::new(),
             state,
             phase: "Registering source channels".into(),
             processed_channels: 1,
@@ -3594,6 +3728,177 @@ mod tests {
     }
 
     #[test]
+    fn exposure_candidates_require_an_explicit_current_source() {
+        let cache = tempfile::tempdir().unwrap();
+        let mut groups = vec![
+            source_group("R", 0),
+            source_group("R", 1),
+            source_group("G", 2),
+            source_group("B", 3),
+        ];
+        for (index, group) in groups.iter_mut().enumerate() {
+            let seconds = if index == 1 { 300.0 } else { 30.0 };
+            group.group.exposure_group = Some(crate::server::exposure_groups::ExposureGroup {
+                key: format!("{seconds}"),
+                label: format!("{seconds} s"),
+                min_seconds: Some(seconds),
+                max_seconds: Some(seconds),
+            });
+            let path = super::super::fits_path(cache.path(), &group.job_id, group.group.index);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"fixture").unwrap();
+        }
+        let latest = LatestStackPreviews {
+            schema_version: 1,
+            database_id: "db".into(),
+            project_id: 1,
+            updated_unix_seconds: 1,
+            groups,
+        };
+        let targets = collect_sources(cache.path(), &latest);
+        let target = targets.get(&7).unwrap();
+        let catalog = availability(&targets);
+        assert!(catalog[0].rgb_available);
+        assert_eq!(catalog[0].source_candidates.len(), 4);
+        assert_eq!(catalog[0].ambiguous_roles, [StackColorRole::Red]);
+        assert_eq!(catalog[0].source_candidates[0].label, "R (30 s)");
+        let mut request: StackColorRequest = serde_json::from_value(serde_json::json!({
+            "target_id": 7, "kind": "rgb"
+        }))
+        .unwrap();
+        assert!(select_sources(target, &request).is_err());
+        let selected = &target.by_role[&StackColorRole::Red][0];
+        request.input_sources.insert(
+            StackColorRole::Red,
+            StackColorSourceRef {
+                job_id: selected.job_id.clone(),
+                group_index: selected.group_index,
+                artifact_revision: selected.artifact_revision.clone(),
+            },
+        );
+        let sources = select_sources(target, &request).unwrap();
+        assert_eq!(sources.len(), 3);
+        assert_eq!(sources[0].job_id, selected.job_id);
+        let mut queued = running_color_job(&"a".repeat(64), StackJobState::Queued);
+        queued.database_id = latest.database_id.clone();
+        queued.project_id = latest.project_id;
+        queued.target_id = request.target_id;
+        queued.sources = sources.clone();
+        assert!(validate_current_color_sources(&queued, &latest).is_ok());
+        let mut rebuilt = latest.clone();
+        rebuilt.groups[0].artifact_revision = "rebuilt-while-queued".into();
+        assert!(validate_current_color_sources(&queued, &rebuilt).is_err());
+        let mut regrouped = latest.clone();
+        regrouped.groups.clear();
+        assert!(validate_current_color_sources(&queued, &regrouped).is_err());
+        let mut other_target = latest.clone();
+        other_target.groups[0].group.target_id += 1;
+        assert!(validate_current_color_sources(&queued, &other_target).is_err());
+        let mut other_project = latest.clone();
+        other_project.project_id += 1;
+        assert!(validate_current_color_sources(&queued, &other_project).is_err());
+        let mut stale = request.clone();
+        stale
+            .input_sources
+            .get_mut(&StackColorRole::Red)
+            .unwrap()
+            .artifact_revision = "old".into();
+        assert!(select_sources(target, &stale).is_err());
+        let mut wrong_role = request.clone();
+        let green = &target.by_role[&StackColorRole::Green][0];
+        wrong_role.input_sources.insert(
+            StackColorRole::Red,
+            StackColorSourceRef {
+                job_id: green.job_id.clone(),
+                group_index: green.group_index,
+                artifact_revision: green.artifact_revision.clone(),
+            },
+        );
+        assert!(select_sources(target, &wrong_role).is_err());
+        let mut foreign_target = request.clone();
+        foreign_target
+            .input_sources
+            .get_mut(&StackColorRole::Red)
+            .unwrap()
+            .job_id = "f".repeat(64);
+        assert!(select_sources(target, &foreign_target).is_err());
+        request.input_sources.insert(
+            StackColorRole::Ha,
+            StackColorSourceRef {
+                job_id: selected.job_id.clone(),
+                group_index: selected.group_index,
+                artifact_revision: selected.artifact_revision.clone(),
+            },
+        );
+        assert!(validate_request(&request).is_err());
+
+        let mut variant = sources.clone();
+        variant[0] = target.by_role[&StackColorRole::Red][1].clone();
+        assert_ne!(source_family_key(&sources), source_family_key(&variant));
+        let original_key = source_family_key(&variant);
+        variant.reverse();
+        for source in &mut variant {
+            source.job_id = "new".into();
+            source.artifact_revision = "new".into();
+            source.group_index += 3;
+        }
+        assert_eq!(original_key, source_family_key(&variant));
+    }
+
+    #[test]
+    fn single_sources_remain_automatic_and_non_mono_artifacts_are_excluded() {
+        let cache = tempfile::tempdir().unwrap();
+        let mut groups = vec![
+            source_group("R", 0),
+            source_group("G", 1),
+            source_group("B", 2),
+            source_group("R", 3),
+        ];
+        groups[3].group.output_channels = 3;
+        for group in &groups {
+            let path = super::super::fits_path(cache.path(), &group.job_id, group.group.index);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"fixture").unwrap();
+        }
+        let latest = LatestStackPreviews {
+            schema_version: 1,
+            database_id: "db".into(),
+            project_id: 1,
+            updated_unix_seconds: 1,
+            groups,
+        };
+        let targets = collect_sources(cache.path(), &latest);
+        let request: StackColorRequest = serde_json::from_value(serde_json::json!({
+            "target_id": 7, "kind": "rgb"
+        }))
+        .unwrap();
+        let sources = select_sources(&targets[&7], &request).unwrap();
+        assert_eq!(sources.len(), 3);
+        assert_eq!(source_family_key(&sources), "");
+    }
+
+    #[test]
+    fn latest_color_index_keeps_exposure_variants_and_replaces_only_the_same_family() {
+        let cache = tempfile::tempdir().unwrap();
+        let mut short = running_color_job(&"a".repeat(64), StackJobState::Completed);
+        short.source_family_key = "short-family".into();
+        let mut long = short.clone();
+        long.job_id = "b".repeat(64);
+        long.source_family_key = "long-family".into();
+        persist_latest_color(cache.path(), &short).unwrap();
+        persist_latest_color(cache.path(), &long).unwrap();
+        short.job_id = "c".repeat(64);
+        persist_latest_color(cache.path(), &short).unwrap();
+        let latest: LatestStackColorPreviews = serde_json::from_slice(
+            &std::fs::read(latest_color_path(cache.path(), short.project_id)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(latest.jobs.len(), 2);
+        assert_eq!(latest.jobs[0].job_id, short.job_id);
+        assert_eq!(latest.jobs[1].job_id, long.job_id);
+    }
+
+    #[test]
     fn color_artifact_paths_are_separate_from_mono_groups() {
         let root = FsPath::new("/cache/db");
         assert_eq!(
@@ -3699,6 +4004,7 @@ mod tests {
             force: false,
             crop: StackColorCrop::None,
             processing: None,
+            input_sources: BTreeMap::new(),
         })
         .is_err());
         assert!(validate_request(&StackColorRequest {
@@ -3708,6 +4014,7 @@ mod tests {
             force: false,
             crop: StackColorCrop::None,
             processing: None,
+            input_sources: BTreeMap::new(),
         })
         .is_err());
         assert!(validate_request(&StackColorRequest {
@@ -3717,6 +4024,7 @@ mod tests {
             force: false,
             crop: StackColorCrop::None,
             processing: None,
+            input_sources: BTreeMap::new(),
         })
         .is_err());
     }
@@ -3729,6 +4037,7 @@ mod tests {
             palette: None,
             force: false,
             crop: StackColorCrop::None,
+            input_sources: BTreeMap::new(),
             processing: Some(StackColorProcessing {
                 background_extraction: Some(extraction),
                 ..StackColorProcessing::default()
@@ -3903,6 +4212,8 @@ mod tests {
         .map(|(index, role)| StackColorSource {
             role,
             filter_name: role.label().into(),
+            label: role.label().into(),
+            exposure_group: None,
             job_id: format!("{index:064x}"),
             group_index: 0,
             artifact_revision: format!("revision-{index}"),

--- a/src/server/stack_preview/resume.rs
+++ b/src/server/stack_preview/resume.rs
@@ -50,6 +50,8 @@ pub(super) struct ResumeManifest {
     pub stacking_version: String,
     pub target_id: i32,
     pub filter_name: String,
+    #[serde(default)]
+    pub exposure_group_key: Option<String>,
     pub accepted_only: bool,
     /// The scoring policy that decided which frames reached this accumulator.
     /// Checkpoints from before this field existed used calibrated defaults.
@@ -119,11 +121,23 @@ impl ResumeDecision {
 
 /// One group identity has one checkpoint, replaced on every settle. The key
 /// hashes the identity so filter names never reach the filesystem.
-fn group_key(database_id: &str, target_id: i32, filter_name: &str) -> String {
+fn group_key(
+    database_id: &str,
+    target_id: i32,
+    filter_name: &str,
+    exposure_group_key: Option<&str>,
+) -> String {
     let mut hasher = Sha256::new();
+    if exposure_group_key.is_some() {
+        hasher.update(b"exposure-groups-v1\0");
+    }
     hasher.update(database_id.as_bytes());
     hasher.update(target_id.to_le_bytes());
     hasher.update(filter_name.as_bytes());
+    if let Some(key) = exposure_group_key {
+        hasher.update(b"\0exposure-group\0");
+        hasher.update(key.as_bytes());
+    }
     let mut output = String::with_capacity(64);
     for byte in hasher.finalize() {
         write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
@@ -140,10 +154,11 @@ pub(super) fn context_path(
     database_id: &str,
     target_id: i32,
     filter_name: &str,
+    exposure_group_key: Option<&str>,
 ) -> PathBuf {
     resume_dir(cache_root).join(format!(
         "{}.seiza-stack",
-        group_key(database_id, target_id, filter_name)
+        group_key(database_id, target_id, filter_name, exposure_group_key)
     ))
 }
 
@@ -152,10 +167,11 @@ pub(super) fn manifest_path(
     database_id: &str,
     target_id: i32,
     filter_name: &str,
+    exposure_group_key: Option<&str>,
 ) -> PathBuf {
     resume_dir(cache_root).join(format!(
         "{}.json",
-        group_key(database_id, target_id, filter_name)
+        group_key(database_id, target_id, filter_name, exposure_group_key)
     ))
 }
 
@@ -168,6 +184,7 @@ pub(super) fn load(
     database_id: &str,
     target_id: i32,
     filter_name: &str,
+    exposure_group_key: Option<&str>,
     accepted_only: bool,
     scoring: StackScoringSettings,
     stacking_version: &str,
@@ -175,8 +192,20 @@ pub(super) fn load(
     order: snr::StackFrameOrder,
     requested: &[(i32, &str, f64)],
 ) -> ResumeDecision {
-    let manifest_path = manifest_path(cache_root, database_id, target_id, filter_name);
-    let context_path = context_path(cache_root, database_id, target_id, filter_name);
+    let manifest_path = manifest_path(
+        cache_root,
+        database_id,
+        target_id,
+        filter_name,
+        exposure_group_key,
+    );
+    let context_path = context_path(
+        cache_root,
+        database_id,
+        target_id,
+        filter_name,
+        exposure_group_key,
+    );
     if !context_path.exists() {
         return ResumeDecision::Fresh(None);
     }
@@ -196,6 +225,7 @@ pub(super) fn load(
         || manifest.stacking_version != stacking_version
         || manifest.target_id != target_id
         || manifest.filter_name != filter_name
+        || manifest.exposure_group_key.as_deref() != exposure_group_key
     {
         return ResumeDecision::Fresh(Some("the stacking pipeline changed"));
     }
@@ -250,18 +280,26 @@ pub(super) fn store_manifest(path: &Path, manifest: &ResumeManifest) -> Result<(
 
 /// Drop a group's checkpoint. Used when a fresh build replaces it and fails
 /// to save its own, so a later build cannot resume from the wrong ancestor.
-pub(super) fn discard(cache_root: &Path, database_id: &str, target_id: i32, filter_name: &str) {
+pub(super) fn discard(
+    cache_root: &Path,
+    database_id: &str,
+    target_id: i32,
+    filter_name: &str,
+    exposure_group_key: Option<&str>,
+) {
     let _ = std::fs::remove_file(manifest_path(
         cache_root,
         database_id,
         target_id,
         filter_name,
+        exposure_group_key,
     ));
     let _ = std::fs::remove_file(context_path(
         cache_root,
         database_id,
         target_id,
         filter_name,
+        exposure_group_key,
     ));
 }
 
@@ -295,6 +333,7 @@ mod tests {
             stacking_version: "test".into(),
             target_id: 7,
             filter_name: "Ha".into(),
+            exposure_group_key: None,
             accepted_only: false,
             scoring: StackScoringSettings::default(),
             calibration_fingerprint: "cal-1".into(),
@@ -314,13 +353,25 @@ mod tests {
 
     fn store(cache_root: &Path, manifest: &ResumeManifest) {
         store_manifest(
-            &manifest_path(cache_root, "db", manifest.target_id, &manifest.filter_name),
+            &manifest_path(
+                cache_root,
+                "db",
+                manifest.target_id,
+                &manifest.filter_name,
+                manifest.exposure_group_key.as_deref(),
+            ),
             manifest,
         )
         .unwrap();
         // The context itself is Seiza's; its presence is what load checks.
         std::fs::write(
-            context_path(cache_root, "db", manifest.target_id, &manifest.filter_name),
+            context_path(
+                cache_root,
+                "db",
+                manifest.target_id,
+                &manifest.filter_name,
+                manifest.exposure_group_key.as_deref(),
+            ),
             b"context",
         )
         .unwrap();
@@ -353,6 +404,7 @@ mod tests {
             "db",
             7,
             "Ha",
+            None,
             false,
             StackScoringSettings::default(),
             "test",
@@ -432,6 +484,7 @@ mod tests {
             "db",
             7,
             "Ha",
+            None,
             false,
             StackScoringSettings::default(),
             "test",
@@ -500,6 +553,7 @@ mod tests {
             "db",
             7,
             "Ha",
+            None,
             false,
             StackScoringSettings::default(),
             "test",
@@ -524,6 +578,7 @@ mod tests {
             "db",
             7,
             "Ha",
+            None,
             false,
             StackScoringSettings::default(),
             "test",
@@ -563,6 +618,7 @@ mod tests {
             "db",
             7,
             "Ha",
+            None,
             false,
             StackScoringSettings::default(),
             "test",
@@ -586,6 +642,7 @@ mod tests {
             "db",
             7,
             "Ha",
+            None,
             false,
             changed,
             "test",
@@ -606,6 +663,7 @@ mod tests {
             "db",
             recorded.target_id,
             &recorded.filter_name,
+            None,
         );
         let mut legacy = serde_json::to_value(&recorded).unwrap();
         legacy.as_object_mut().unwrap().remove("scoring");
@@ -617,6 +675,7 @@ mod tests {
                 "db",
                 recorded.target_id,
                 &recorded.filter_name,
+                None,
             ),
             b"legacy context",
         )
@@ -634,6 +693,7 @@ mod tests {
             "db",
             7,
             "Ha",
+            None,
             false,
             StackScoringSettings::default(),
             "newer",
@@ -656,6 +716,7 @@ mod tests {
             "db",
             recorded.target_id,
             &recorded.filter_name,
+            None,
         );
         let mut legacy = serde_json::to_value(&recorded).unwrap();
         legacy["schema_version"] = serde_json::Value::from(1);
@@ -668,6 +729,7 @@ mod tests {
                 "db",
                 recorded.target_id,
                 &recorded.filter_name,
+                None,
             ),
             b"legacy context",
         )
@@ -678,6 +740,7 @@ mod tests {
             "db",
             7,
             "Ha",
+            None,
             false,
             StackScoringSettings::default(),
             "test",
@@ -700,6 +763,7 @@ mod tests {
             "db",
             7,
             "Ha",
+            None,
             true,
             StackScoringSettings::default(),
             "test",
@@ -717,7 +781,11 @@ mod tests {
     fn a_missing_context_never_resumes_even_with_a_manifest() {
         let cache = tempfile::tempdir().unwrap();
         let manifest_value = manifest(vec![frame(1, "f1")]);
-        store_manifest(&manifest_path(cache.path(), "db", 7, "Ha"), &manifest_value).unwrap();
+        store_manifest(
+            &manifest_path(cache.path(), "db", 7, "Ha", None),
+            &manifest_value,
+        )
+        .unwrap();
         assert!(try_load(cache.path(), &[(1, "f1"), (2, "f2")]).is_none());
     }
 
@@ -725,20 +793,70 @@ mod tests {
     fn discard_removes_both_files() {
         let cache = tempfile::tempdir().unwrap();
         store(cache.path(), &manifest(vec![frame(1, "f1")]));
-        discard(cache.path(), "db", 7, "Ha");
+        discard(cache.path(), "db", 7, "Ha", None);
         assert!(try_load(cache.path(), &[(1, "f1"), (2, "f2")]).is_none());
-        assert!(!manifest_path(cache.path(), "db", 7, "Ha").exists());
+        assert!(!manifest_path(cache.path(), "db", 7, "Ha", None).exists());
     }
 
     #[test]
     fn group_keys_separate_databases_targets_and_filters() {
         let keys = [
-            group_key("db-a", 7, "Ha"),
-            group_key("db-b", 7, "Ha"),
-            group_key("db-a", 8, "Ha"),
-            group_key("db-a", 7, "OIII"),
+            group_key("db-a", 7, "Ha", None),
+            group_key("db-b", 7, "Ha", None),
+            group_key("db-a", 8, "Ha", None),
+            group_key("db-a", 7, "OIII", None),
+            group_key("db-a", 7, "Ha", Some("short")),
+            group_key("db-a", 7, "Ha", Some("long")),
         ];
         let unique: std::collections::HashSet<_> = keys.iter().collect();
         assert_eq!(unique.len(), keys.len());
+    }
+
+    #[test]
+    fn exposure_families_keep_independent_checkpoints_and_validate_their_identity() {
+        let cache = tempfile::tempdir().unwrap();
+        let legacy = manifest(vec![frame(1, "f1")]);
+        let mut short = legacy.clone();
+        short.exposure_group_key = Some("short".into());
+        let mut long = legacy.clone();
+        long.exposure_group_key = Some("long".into());
+        for checkpoint in [&legacy, &short, &long] {
+            store(cache.path(), checkpoint);
+        }
+        let load_family = |key| {
+            load(
+                cache.path(),
+                "db",
+                7,
+                "Ha",
+                key,
+                false,
+                StackScoringSettings::default(),
+                "test",
+                "cal-1",
+                snr::StackFrameOrder::Capture,
+                &[(1, "f1", 300.0)],
+            )
+        };
+        assert!(load_family(None).state().is_some());
+        assert!(load_family(Some("short")).state().is_some());
+        assert!(load_family(Some("long")).state().is_some());
+        store_manifest(
+            &manifest_path(cache.path(), "db", 7, "Ha", Some("short")),
+            &long,
+        )
+        .unwrap();
+        assert!(load_family(Some("short")).state().is_none());
+        discard(cache.path(), "db", 7, "Ha", Some("short"));
+        assert!(load_family(None).state().is_some());
+        assert!(load_family(Some("long")).state().is_some());
+    }
+
+    #[test]
+    fn checkpoints_without_exposure_group_metadata_remain_readable() {
+        let mut value = serde_json::to_value(manifest(vec![])).unwrap();
+        value.as_object_mut().unwrap().remove("exposure_group_key");
+        let restored: ResumeManifest = serde_json::from_value(value).unwrap();
+        assert!(restored.exposure_group_key.is_none());
     }
 }

--- a/static/e2e/exposure-groups.spec.ts
+++ b/static/e2e/exposure-groups.spec.ts
@@ -151,14 +151,26 @@ test('persists project exposure grouping and separates mono and color choices', 
   await expect(page.locator('.stack-preview-card img').first()).toBeVisible();
   await expect(page.getByText('Loading saved processing...', { exact: true })).toHaveCount(0);
   await expect(page.getByText(/Saved processing could not be loaded:/)).toHaveCount(0);
-  const rgb = page.locator('.stack-color-card[data-color-kind="rgb"]');
-  await expect(rgb.getByRole('button', { name: 'Build RGB color preview' })).toBeDisabled();
+  const rgb = page.locator('.stack-color-card[data-color-kind="rgb"][data-exposure-set]');
+  await expect(rgb).toHaveCount(2);
+  const shortRgb = rgb.filter({ has: page.getByRole('button', { name: 'Build RGB 30 s color preview', exact: true }) });
+  const longRgb = rgb.filter({ has: page.getByRole('button', { name: 'Build RGB 300 s color preview', exact: true }) });
+  await expect(shortRgb.getByRole('button', { name: 'Build RGB 30 s color preview', exact: true })).toBeEnabled();
+  await expect(longRgb.getByRole('button', { name: 'Build RGB 300 s color preview', exact: true })).toBeEnabled();
+  await expect(rgb.locator('.stack-color-source-selectors')).toHaveCount(0);
+  await expect(page.getByRole('combobox', { name: 'Beta Field rgb R source stack' })).toHaveCount(0);
+  const custom = page.locator('details[data-color-kind="rgb"][data-target-id="2"]');
+  const customSummary = custom.getByText('Custom combination', { exact: true });
+  await customSummary.click();
+  const customRgb = custom.locator('.stack-color-card[data-color-kind="rgb"]');
+  await expect(customRgb.getByRole('button', { name: 'Build RGB custom color preview', exact: true })).toBeDisabled();
   for (const role of ['R', 'G', 'B']) {
-    const selector = rgb.getByRole('combobox', { name: `Beta Field rgb ${role} source stack` });
+    const selector = customRgb.getByRole('combobox', { name: `Beta Field rgb ${role} source stack` });
     await expect(selector.locator('option')).toHaveCount(3);
-    await selector.selectOption({ label: `${role} (300 s) · 2 frames` });
+    await selector.selectOption({ label: `${role} (${role === 'R' ? 30 : 300} s) · 2 frames` });
   }
-  await expect(rgb.getByRole('button', { name: 'Build RGB color preview' })).toBeEnabled();
+  await expect(customRgb.getByRole('button', { name: 'Build RGB custom color preview', exact: true })).toBeEnabled();
+  await customSummary.click();
   await page.locator('.app-main').evaluate((element) => { element.scrollTop = 0; });
   expect(await page.locator('.project-exposure-grouping label').evaluate((element) => element.getBoundingClientRect().height)).toBeLessThan(28);
   await page.screenshot({ path: testInfo.outputPath('exposure-groups-desktop.png'), fullPage: false });
@@ -176,9 +188,26 @@ test('persists project exposure grouping and separates mono and color choices', 
   for (const header of await page.locator('.stack-preview-card > header').all()) {
     expect(await header.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
   }
-  await positionBelowToolbar(rgb);
-  await rgb.screenshot({ path: testInfo.outputPath('exposure-color-sources-mobile.png') });
-  expect(await rgb.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+  for (const [card, duration] of [[shortRgb, 30], [longRgb, 300]] as const) {
+    await positionBelowToolbar(card);
+    await card.screenshot({ path: testInfo.outputPath(`exposure-color-${duration}-mobile.png`) });
+    expect(await card.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+  }
+  await customSummary.click();
+  await positionBelowToolbar(customRgb);
+  await customRgb.screenshot({ path: testInfo.outputPath('exposure-color-sources-mobile.png') });
+  expect(await customRgb.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+
+  // Leave the short RGB set complete while removing only the remembered long B stack.
+  const indexPath = path.join(tmpBase(), 'cache', dbId, 'stack-previews', 'latest-project-2.json');
+  const remembered = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+  fs.writeFileSync(indexPath, JSON.stringify({ ...remembered, groups: savedStacks.filter((stack) =>
+    !(stack.group.filter_name === 'B' && stack.group.exposure_group?.min_seconds === 300)) }));
+  await page.reload();
+  await expect(rgb).toHaveCount(2);
+  await expect(shortRgb.getByRole('button', { name: 'Build RGB 30 s color preview', exact: true })).toBeEnabled();
+  await expect(longRgb.getByRole('button', { name: 'Build RGB 300 s color preview', exact: true })).toBeDisabled();
+  await expect(longRgb).toContainText('Missing B');
   await toggle.click();
   await expect(toggle).not.toBeChecked();
   await expect(page.locator('.stack-preview-card')).toHaveCount(3);

--- a/static/e2e/exposure-groups.spec.ts
+++ b/static/e2e/exposure-groups.spec.ts
@@ -1,0 +1,188 @@
+import { expect, test, type Locator } from '@playwright/test';
+import Database from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Image } from '../src/api/types';
+import { fixtureDbPath, fixtureImageDir, resetDatabases, tmpBase, waitForCacheReady } from './helpers';
+
+function syntheticFits(): Buffer {
+  const cards = ['SIMPLE  =                    T', 'BITPIX  =                  -32',
+    'NAXIS   =                    2', 'NAXIS1  =                   32',
+    'NAXIS2  =                   24', 'END'];
+  const header = Buffer.from(cards.map((card) => card.padEnd(80)).join('').padEnd(2880), 'ascii');
+  const pixels = Buffer.alloc(5760);
+  for (let index = 0; index < 32 * 24; index++) pixels.writeFloatBE(1 + index / 768, index * 4);
+  return Buffer.concat([header, pixels]);
+}
+
+async function positionBelowToolbar(locator: Locator) {
+  await locator.evaluate((element) => {
+    const scroller = element.closest('.app-main');
+    if (!scroller) return;
+    const toolbar = scroller.querySelector('.image-controls');
+    const stickyHeight = toolbar && getComputedStyle(toolbar).position === 'sticky'
+      ? toolbar.getBoundingClientRect().height : 0;
+    scroller.scrollTop += element.getBoundingClientRect().top
+      - scroller.getBoundingClientRect().top - stickyHeight - 12;
+  });
+}
+
+function seedExposureStacks(databaseId: string, images: Image[]) {
+  const root = path.join(tmpBase(), 'cache', databaseId, 'stack-previews');
+  const partitions = new Map<string, Image[]>();
+  for (const image of images) {
+    const key = JSON.stringify([image.target_id, image.filter_name, image.exposure_group?.key]);
+    partitions.set(key, [...(partitions.get(key) ?? []), image]);
+  }
+  const groups = [...partitions.values()].map((frames, index) => {
+    const first = frames[0];
+    const jobId = (index + 100).toString(16).padStart(64, '0');
+    fs.mkdirSync(path.join(root, jobId), { recursive: true });
+    fs.writeFileSync(path.join(root, jobId, 'group-0.fits'), syntheticFits());
+    const remembered = {
+      job_id: jobId, artifact_revision: `exposure-fixture-${index}`, accepted_only: false,
+      created_unix_seconds: 1_760_000_000 + index, cache_version: 15,
+      group: {
+        index: 0, target_id: first.target_id, target_name: first.target_name,
+        filter_name: first.filter_name, exposure_group: first.exposure_group,
+        state: 'ready', phase: 'ready', total_candidates: frames.length, eligible_frames: frames.length,
+        quality_excluded: 0, missing_files: 0, processed_frames: frames.length,
+        accepted_frames: frames.length, rejected_frames: 0, output_channels: 1,
+        sky_orientation: { convention: 'source_frame', version: 1, source: 'sky_anchor',
+          output_width: 32, output_height: 24,
+          source_to_output: { matrix: [[1, 0], [0, 1]], translation_x: 0, translation_y: 0 } },
+        reference_image_id: first.id, total_exposure_seconds: frames.reduce((sum, image) => sum + Number(image.metadata.ExposureDuration), 0),
+        preview_url: null, fits_url: null, error: null,
+        input_images: frames.map((image) => ({ image_id: image.id, grading_status: image.grading_status })), frames: [],
+      },
+    };
+    fs.writeFileSync(path.join(root, jobId, 'manifest.json'), JSON.stringify({
+      schema_version: 2, database_id: databaseId, project_id: 2,
+      job_id: jobId, artifact_revision: remembered.artifact_revision,
+      state: 'completed', accepted_only: remembered.accepted_only,
+      created_unix_seconds: remembered.created_unix_seconds,
+      cache_version: remembered.cache_version, stacking_version: '0.14.0',
+      order: 'capture', groups: [remembered.group], error: null,
+    }));
+    return remembered;
+  });
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(path.join(root, 'latest-project-2.json'), JSON.stringify({
+    schema_version: 1, database_id: databaseId, project_id: 2, updated_unix_seconds: 1_760_000_100, groups,
+  }));
+  return groups;
+}
+
+test('persists project exposure grouping and separates mono and color choices', async ({ page, request }, testInfo) => {
+  test.setTimeout(120_000);
+  await resetDatabases(request);
+  const databasePath = path.join(tmpBase(), `exposure-groups-${testInfo.repeatEachIndex}-${testInfo.retry}.sqlite`);
+  fs.copyFileSync(fixtureDbPath(), databasePath);
+  const database = new Database(databasePath);
+  try {
+    const existing = database.prepare('SELECT * FROM acquiredimage WHERE projectId=2 LIMIT 1').get() as {
+      acquireddate: number; metadata: string;
+    };
+    database.exec('DELETE FROM acquiredimage');
+    const insert = database.prepare('INSERT INTO acquiredimage(Id,projectId,targetId,acquireddate,filtername,gradingStatus,metadata) VALUES(?,2,2,?,?,1,?)');
+    let id = 100;
+    for (const filter of ['R', 'G', 'B']) for (const exposure of [30, 300]) for (let repeat = 0; repeat < 2; repeat++) {
+      insert.run(id++, existing.acquireddate + id, filter, JSON.stringify({
+        ...JSON.parse(existing.metadata), ExposureDuration: exposure, ExposureTime: exposure, Filter: filter,
+      }));
+    }
+  } finally {
+    database.close();
+  }
+  const registered = await request.post('/api/databases', { data: {
+    name: 'Exposure groups fixture', db_path: databasePath, image_dirs: [fixtureImageDir()],
+    slug: `exposure-groups-${testInfo.repeatEachIndex}-${testInfo.retry}`,
+  } });
+  expect(registered.ok()).toBe(true);
+  const dbId = (await registered.json()).data.id as string;
+  await waitForCacheReady(request, dbId);
+  const settingsPath = `/api/db/${encodeURIComponent(dbId)}/projects/2/processing-settings`;
+  const initial = await request.get(settingsPath);
+  expect((await initial.json()).data.split_exposure_groups).toBe(false);
+  await page.setViewportSize({ width: 1440, height: 1050 });
+  await page.goto(`/#/grid?db=${encodeURIComponent(dbId)}&project=2&groupingMode=filter`);
+  const toggle = page.getByRole('checkbox', { name: 'Separate exposure groups' });
+  await expect(toggle).toBeEnabled();
+  await expect(toggle).not.toBeChecked();
+  await expect(page.locator('.stack-preview-card')).toHaveCount(3);
+  await toggle.click();
+  await expect(toggle).toBeChecked();
+  await expect(page.locator('.stack-preview-card')).toHaveCount(6);
+  const images = (await (await request.get(`/api/db/${dbId}/images?project_id=2&limit=1000`)).json()).data as Image[];
+  expect(images).toHaveLength(12);
+  expect(images.every((image) => image.exposure_group)).toBe(true);
+  const savedStacks = seedExposureStacks(dbId, images);
+  for (const stack of savedStacks) {
+    const processing = await request.get(`/api/db/${dbId}/stack-previews/${stack.job_id}/0/stretch?v=${stack.artifact_revision}`);
+    expect(processing.status()).toBe(200);
+    expect((await processing.json()).data).toBeNull();
+  }
+
+  // Synthetic preview pixels isolate the UI contract from expensive image processing.
+  const preview = await page.evaluate(() => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 512; canvas.height = 320;
+    const context = canvas.getContext('2d')!;
+    const bitmap = context.createImageData(canvas.width, canvas.height);
+    for (let y = 0; y < canvas.height; y++) for (let x = 0; x < canvas.width; x++) {
+      const radius = ((x - 240) / 130) ** 2 + ((y - 165) / 65) ** 2;
+      const brightness = 15 + 90 * Math.exp(-radius) + ((x * 37 + y * 13) % 11);
+      const index = (y * canvas.width + x) * 4;
+      bitmap.data.set([brightness, brightness, brightness, 255], index);
+    }
+    context.putImageData(bitmap, 0, 0);
+    context.fillStyle = '#ddd';
+    for (let star = 0; star < 60; star++) {
+      context.beginPath(); context.arc((star * 83 + 13) % 512, (star * 47 + 11) % 320, 0.8 + star % 2, 0, Math.PI * 2); context.fill();
+    }
+    return canvas.toDataURL('image/png').split(',')[1];
+  });
+  await page.route('**/stack-previews/*/*/preview?*', (route) => route.fulfill({
+    status: 200, contentType: 'image/png', body: Buffer.from(preview, 'base64'),
+  }));
+  await page.reload();
+  await expect(toggle).toBeChecked();
+  await expect(page.locator('.stack-preview-card')).toHaveCount(6);
+  await expect(page.locator('.stack-preview-card img').first()).toBeVisible();
+  await expect(page.getByText('Loading saved processing...', { exact: true })).toHaveCount(0);
+  await expect(page.getByText(/Saved processing could not be loaded:/)).toHaveCount(0);
+  const rgb = page.locator('.stack-color-card[data-color-kind="rgb"]');
+  await expect(rgb.getByRole('button', { name: 'Build RGB color preview' })).toBeDisabled();
+  for (const role of ['R', 'G', 'B']) {
+    const selector = rgb.getByRole('combobox', { name: `Beta Field rgb ${role} source stack` });
+    await expect(selector.locator('option')).toHaveCount(3);
+    await selector.selectOption({ label: `${role} (300 s) · 2 frames` });
+  }
+  await expect(rgb.getByRole('button', { name: 'Build RGB color preview' })).toBeEnabled();
+  await page.locator('.app-main').evaluate((element) => { element.scrollTop = 0; });
+  expect(await page.locator('.project-exposure-grouping label').evaluate((element) => element.getBoundingClientRect().height)).toBeLessThan(28);
+  await page.screenshot({ path: testInfo.outputPath('exposure-groups-desktop.png'), fullPage: false });
+  await positionBelowToolbar(page.locator('.stack-preview-card').first());
+  await page.screenshot({ path: testInfo.outputPath('exposure-stack-cards-desktop.png'), fullPage: false });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.locator('.app-main').evaluate((element) => { element.scrollTop = 0; });
+  await expect(page.locator('.grid-stats')).toContainText('6 groups');
+  expect(await page.locator('.grid-stats').evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+  await page.screenshot({ path: testInfo.outputPath('exposure-groups-mobile.png'), fullPage: false });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  expect(await page.locator('.app-main').evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+  await positionBelowToolbar(page.locator('.stack-preview-card').first());
+  await page.screenshot({ path: testInfo.outputPath('exposure-stack-cards-mobile.png'), fullPage: false });
+  for (const header of await page.locator('.stack-preview-card > header').all()) {
+    expect(await header.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+  }
+  await positionBelowToolbar(rgb);
+  await rgb.screenshot({ path: testInfo.outputPath('exposure-color-sources-mobile.png') });
+  expect(await rgb.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
+  await toggle.click();
+  await expect(toggle).not.toBeChecked();
+  await expect(page.locator('.stack-preview-card')).toHaveCount(3);
+  expect((await (await request.get(settingsPath)).json()).data.split_exposure_groups).toBe(false);
+  const unsplit = (await (await request.get(`/api/db/${dbId}/images?project_id=2&limit=1000`)).json()).data as Image[];
+  expect(unsplit.every((image) => !image.exposure_group)).toBe(true);
+});

--- a/static/src/App.css
+++ b/static/src/App.css
@@ -3063,7 +3063,9 @@
   grid-area: view;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 1rem;
+  min-width: 0;
 }
 
 .toolbar-section {
@@ -3108,7 +3110,7 @@
   font-size: 0.8rem;
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1500px) {
   .controls-row-combined {
     grid-template-columns: minmax(0, 1fr) auto;
     grid-template-areas:
@@ -3139,11 +3141,18 @@
   }
   
   .controls-row-combined > .stats-section {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.25rem;
     font-size: 0.8rem;
     min-height: 2rem;
     margin: 0;
     padding: 0;
     text-align: left;
+  }
+
+  .controls-row-combined .grid-stats {
+    white-space: normal;
   }
 
   .size-control.compact input[type="range"] {
@@ -3390,7 +3399,8 @@
   }
 
   .controls-row-combined .selection-action-bar {
-    min-width: 19rem;
+    min-width: 0;
+    max-width: 100%;
     overflow-x: auto;
   }
 }
@@ -5611,21 +5621,80 @@
 }
 
 @media (max-width: 760px) {
+  .app-main:has(.grouped-image-container) {
+    padding-inline: 0.5rem;
+  }
+
+  .grouped-image-container > .image-controls.sticky {
+    position: static;
+  }
+
+  .stack-preview-panel {
+    margin: 0.75rem 0;
+    padding: 0.65rem;
+  }
+
   .stack-preview-heading {
     flex-direction: column;
+    gap: 0.75rem;
   }
 
   .stack-preview-actions {
     justify-content: flex-start;
   }
 
+  .stack-preview-statusline {
+    flex-wrap: wrap;
+    gap: 0.4rem 0.65rem;
+  }
+
+  .stack-preview-card > header,
+  .stack-color-card > header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .stack-preview-card-title,
+  .stack-color-card > header > div:first-child {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .stack-preview-card-title h3 {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .stack-preview-card-actions {
+    flex-wrap: wrap;
+    flex-shrink: 1;
+    justify-content: flex-start;
+    max-width: 100%;
+  }
+
+  .stack-color-section {
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+
   .stack-color-heading {
     flex-direction: column;
   }
 
-  .stack-color-card > header {
-    align-items: flex-start;
-    flex-direction: column;
+  .stack-color-palette,
+  .stack-color-crop {
+    max-width: 100%;
+  }
+
+  .stack-color-palette select,
+  .stack-color-crop select {
+    max-width: 100%;
+  }
+
+  .stack-color-processing > summary small {
+    min-width: 0;
   }
 
   .stack-preview-metrics {
@@ -6501,13 +6570,15 @@
 
 @media (max-width: 620px) {
   .controls-section {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 0.5rem 0.75rem;
   }
 
   .size-control.compact {
     min-width: 0;
+    flex: 0 0 auto;
     gap: 0.3rem;
   }
 

--- a/static/src/api/client.ts
+++ b/static/src/api/client.ts
@@ -3,6 +3,8 @@ import type { AxiosInstance } from 'axios';
 import { AUTH_REQUIRED_EVENT } from '../auth/events';
 import { getServerUrl } from '../utils/tauri';
 import type {
+  ProjectProcessingSettings,
+  StackColorInputSources,
   FlatHistoryState,
   SchedulerFlatHistoryPage,
   CalibrationSettings,
@@ -997,6 +999,28 @@ export const apiClient = {
     return data.data;
   },
 
+  getProjectProcessingSettings: async (
+    dbId: string, projectId: number, signal?: AbortSignal
+  ): Promise<ProjectProcessingSettings> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.get<ApiResponse<ProjectProcessingSettings>>(
+      dbPath(dbId, `/projects/${projectId}/processing-settings`), { signal }
+    );
+    if (!data.data) throw new Error(data.error || 'Project processing settings could not be loaded');
+    return data.data;
+  },
+
+  updateProjectProcessingSettings: async (
+    dbId: string, projectId: number, settings: ProjectProcessingSettings
+  ): Promise<ProjectProcessingSettings> => {
+    const apiInstance = await getApi();
+    const { data } = await apiInstance.put<ApiResponse<ProjectProcessingSettings>>(
+      dbPath(dbId, `/projects/${projectId}/processing-settings`), settings
+    );
+    if (!data.data) throw new Error(data.error || 'Project processing settings could not be saved');
+    return data.data;
+  },
+
   startStackPreviews: async (
     dbId: string,
     projectId: number,
@@ -1023,6 +1047,7 @@ export const apiClient = {
       calibration_overrides?: Array<{
         target_id: number;
         filter_name: string;
+        exposure_group_key?: string;
         calibration: CalibrationMode;
       }>;
     }
@@ -1276,6 +1301,7 @@ export const apiClient = {
       force?: boolean;
       crop?: StackColorCrop;
       processing?: StackColorProcessing;
+      input_sources?: StackColorInputSources;
     }
   ): Promise<StackColorJob> => {
     const apiInstance = await getApi();

--- a/static/src/api/types.ts
+++ b/static/src/api/types.ts
@@ -70,7 +70,19 @@ export interface OrganizationDestinations {
   targets: { id: number; name: string; project_id: number }[];
 }
 
+export interface ExposureGroup {
+  key: string;
+  label: string;
+  min_seconds: number | null;
+  max_seconds: number | null;
+}
+
+export interface ProjectProcessingSettings {
+  split_exposure_groups: boolean;
+}
+
 export interface Image {
+  exposure_group?: ExposureGroup | null;
   id: number;
   project_id: number;
   project_name: string;
@@ -623,6 +635,7 @@ export interface ProgressiveSnr {
 }
 
 export interface StackGroupStatus {
+  exposure_group?: ExposureGroup | null;
   index: number;
   target_id: number;
   target_name: string;
@@ -932,6 +945,8 @@ export type StackNarrowbandPalette =
   | 'foraxx-hoo';
 
 export interface StackColorSource {
+  label?: string;
+  exposure_group?: ExposureGroup | null;
   role: StackColorRole;
   filter_name: string;
   job_id: string;
@@ -942,6 +957,14 @@ export interface StackColorSource {
   sky_orientation: StackSkyOrientation | null;
   registration_transform: SimilarityTransform | null;
 }
+
+export interface StackColorSourceReference {
+  job_id: string;
+  group_index: number;
+  artifact_revision: string;
+}
+
+export type StackColorInputSources = Partial<Record<StackColorRole, StackColorSourceReference>>;
 
 export interface StackColorProcessing {
   background_extraction: StackBackgroundExtraction | null;
@@ -1117,6 +1140,7 @@ export interface StackColorCropReport {
 }
 
 export interface StackColorJob {
+  source_family_key?: string;
   schema_version: number;
   job_id: string;
   database_id: string;
@@ -1165,6 +1189,7 @@ export interface StackColorAvailableRole {
 }
 
 export interface StackColorTargetAvailability {
+  source_candidates?: StackColorSource[];
   target_id: number;
   target_name: string;
   available_roles: StackColorAvailableRole[];

--- a/static/src/components/GroupedImageGrid.tsx
+++ b/static/src/components/GroupedImageGrid.tsx
@@ -16,6 +16,7 @@ import FilterControls, { type FilterOptions } from './FilterControls';
 import StatsDashboard from './StatsDashboard';
 import UndoRedoToolbar from './UndoRedoToolbar';
 import StackPreviewPanel from './StackPreviewPanel';
+import ProjectExposureGrouping from './ProjectExposureGrouping';
 import ThumbnailSizeControl from './ThumbnailSizeControl';
 import { QualityScanButton } from './QualityScanControl';
 import { 
@@ -33,6 +34,7 @@ import {
   imageGroupKey,
   NO_EXPANDED_GROUPS,
   resolveExpandedGroups,
+  splitImageGroupsByExposure,
 } from '../utils/imageGrouping';
 import { imageDetailPath } from '../utils/imageDetailRoutes';
 import {
@@ -239,7 +241,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
   // Group images based on selected mode
   const imageGroups = useMemo(() => {
     if (groupingMode === 'session') {
-      return groupImagesBySession(filteredImages);
+      return splitImageGroupsByExposure(groupImagesBySession(filteredImages));
     }
 
     const groups = new Map<string, Image[]>();
@@ -312,7 +314,7 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
       sorted.sort((a, b) => a.filterName.localeCompare(b.filterName));
     }
     
-    return sorted;
+    return splitImageGroupsByExposure(sorted);
   }, [filteredImages, groupingMode]);
 
   const visibleExpandedGroups = useMemo(
@@ -847,6 +849,12 @@ export default function GroupedImageGrid({ useLazyImages = false }: GroupedImage
               </div>
 
               <SecondaryScoreToggle className="compact" />
+              {dbId && projectId != null && <ProjectExposureGrouping
+                key={`${dbId}:${projectId}`}
+                dbId={dbId}
+                projectId={projectId}
+                canManage={grading.canWrite && !!serverInfo?.allow_database_management}
+              />}
             </div>
             
             {/* Undo/Redo Toolbar */}

--- a/static/src/components/ProjectExposureGrouping.css
+++ b/static/src/components/ProjectExposureGrouping.css
@@ -1,0 +1,21 @@
+.project-exposure-grouping {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+  min-width: 0;
+  flex: 0 0 auto;
+  font-size: 0.8rem;
+}
+
+.project-exposure-grouping label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+}
+
+.project-exposure-grouping .error {
+  color: var(--error-color, #c84f4f);
+  overflow-wrap: anywhere;
+}

--- a/static/src/components/ProjectExposureGrouping.tsx
+++ b/static/src/components/ProjectExposureGrouping.tsx
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import './ProjectExposureGrouping.css';
+
+export default function ProjectExposureGrouping({ dbId, projectId, canManage }: {
+  dbId: string;
+  projectId: number;
+  canManage: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const queryKey = ['db', dbId, 'project', projectId, 'processing-settings'];
+  const settings = useQuery({
+    queryKey,
+    queryFn: ({ signal }) => apiClient.getProjectProcessingSettings(dbId, projectId, signal),
+  });
+  const save = useMutation({
+    mutationFn: (enabled: boolean) => apiClient.updateProjectProcessingSettings(
+      dbId, projectId, { split_exposure_groups: enabled }
+    ),
+    onSuccess: async (result) => {
+      queryClient.setQueryData(queryKey, result);
+      await queryClient.invalidateQueries({
+        predicate: (query) => query.queryKey[0] === 'db' && query.queryKey[1] === dbId
+          && (query.queryKey.includes('images') || query.queryKey.includes('all-images')
+            || (query.queryKey[2] === 'image' && query.queryKey.length === 4)
+            || (query.queryKey[2] === 'project' && query.queryKey[3] === projectId
+              && !query.queryKey.includes('processing-settings'))),
+      });
+    },
+  });
+  const error = save.error ?? settings.error;
+  return (
+    <div className="project-exposure-grouping" aria-busy={settings.isPending || save.isPending}>
+      <label title={canManage ? 'Project processing setting' : 'Database management access required'}>
+        <input
+          type="checkbox"
+          checked={settings.data?.split_exposure_groups ?? false}
+          disabled={!canManage || settings.isPending || settings.isError || save.isPending}
+          onChange={(event) => save.mutate(event.target.checked)}
+        />
+        Separate exposure groups
+      </label>
+      {(settings.isPending || save.isPending) && (
+        <span role="status">{save.isPending ? 'Saving...' : 'Loading...'}</span>
+      )}
+      {error && <span className="error" role="alert">
+        {error instanceof Error ? error.message : 'Exposure grouping could not be saved.'}
+      </span>}
+    </div>
+  );
+}

--- a/static/src/components/StackColorPreviewPanel.tsx
+++ b/static/src/components/StackColorPreviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import type {
@@ -7,6 +7,7 @@ import type {
   StackColorKind,
   StackColorProcessing,
   StackColorRole,
+  StackColorInputSources,
   StackColorTargetAvailability,
   StackNarrowbandPalette,
 } from '../api/types';
@@ -19,6 +20,8 @@ import {
 import { isColorStackSkyOriented } from './stackOrientation';
 import { cropLabels, cropOrder, describeCrop, offCenterChannels } from './stackColorCrop';
 import { STACK_ACTIVITY_QUERY_KEY, useStackActivity } from '../hooks/useStackActivity';
+import { colorSourceKey, colorSourcesLabel, completedColorArtifact, resolveColorSources, sameColorSourceFamily } from './stackColorSources';
+import './StackColorSources.css';
 
 interface StackColorPreviewPanelProps {
   dbId: string;
@@ -38,6 +41,7 @@ interface ColorOperation {
   operationKey: string;
   crop: StackColorCrop;
   processing: StackColorProcessing;
+  inputSources?: StackColorInputSources;
 }
 
 const terminalStates = new Set(['completed', 'failed']);
@@ -128,6 +132,7 @@ function ColorCard({
   onBuild,
   onInspect,
   onProcessingApply,
+  sourceControls,
 }: {
   dbId: string;
   target: StackColorTargetAvailability;
@@ -147,6 +152,7 @@ function ColorCard({
   onBuild: () => void;
   onInspect: (job: StackColorJob) => void;
   onProcessingApply: (processing: StackColorProcessing) => void;
+  sourceControls?: ReactNode;
 }) {
   const current = activeJob ?? artifact;
   const state = activeJob?.state ?? (artifact ? 'completed' : 'not-built');
@@ -177,6 +183,7 @@ function ColorCard({
       className={`stack-color-card ${artifact?.outdated || sourceStacksOutdated ? 'outdated' : ''}`}
       data-color-kind={kind}
       data-target-id={target.target_id}
+      data-source-family={artifact?.source_family_key ?? ''}
     >
       <header>
         <div>
@@ -246,6 +253,7 @@ function ColorCard({
           </button>
         </div>
       </header>
+      {sourceControls}
 
       {(artifact?.outdated || sourceStacksOutdated) && (
         <div className="stack-preview-outdated">
@@ -352,7 +360,7 @@ function ColorCard({
           {current.sources.map((source) => (
             <span key={`${source.role}:${source.job_id}:${source.group_index}`}>
               <strong>{roleLabels[source.role]}</strong>
-              {source.filter_name}
+              {colorSourcesLabel([source])}
               <small>{source.accepted_frames} frames</small>
             </span>
           ))}
@@ -386,6 +394,8 @@ export default function StackColorPreviewPanel({
   const [watchedJobIds, setWatchedJobIds] = useState<string[]>([]);
   const [paletteByTarget, setPaletteByTarget] = useState<Record<number, StackNarrowbandPalette>>({});
   const [cropByCard, setCropByCard] = useState<Record<string, StackColorCrop>>({});
+  const [sourcesByCard, setSourcesByCard] = useState<Record<string, Partial<Record<StackColorRole, string>>>>({});
+  const [savedByCard, setSavedByCard] = useState<Record<string, string>>({});
   const [inspector, setInspector] = useState<StackColorJob | null>(null);
 
   const catalog = useQuery({
@@ -407,8 +417,14 @@ export default function StackColorPreviewPanel({
       force: operation.force,
       crop: operation.crop,
       processing: operation.processing,
+      ...(operation.inputSources ? { input_sources: operation.inputSources } : {}),
     }),
-    onSuccess: (job) => {
+    onSuccess: (job, operation) => {
+      setSavedByCard((current) => {
+        const next = { ...current };
+        delete next[operationKey(operation.targetId, operation.kind, operation.palette)];
+        return next;
+      });
       queryClient.setQueryData(jobQueryKey(dbId, projectId, job.job_id), job);
       setWatchedJobIds((current) =>
         current.includes(job.job_id) ? current : [...current, job.job_id]
@@ -453,6 +469,8 @@ export default function StackColorPreviewPanel({
     setWatchedJobIds([]);
     setPaletteByTarget({});
     setCropByCard({});
+    setSourcesByCard({});
+    setSavedByCard({});
     setInspector(null);
     resetStart();
   }, [dbId, projectId, resetStart]);
@@ -512,10 +530,90 @@ export default function StackColorPreviewPanel({
   const newestWatched = (
     targetId: number,
     kind: StackColorKind,
-    palette?: StackNarrowbandPalette
+    palette?: StackNarrowbandPalette,
+    matchesFamily: (job: StackColorJob) => boolean = () => true,
   ) => {
-    const mine = watchedJobs.filter((job) => jobMatches(job, targetId, kind, palette));
+    const mine = watchedJobs.filter((job) => jobMatches(job, targetId, kind, palette) && matchesFamily(job));
     return mine[mine.length - 1];
+  };
+
+  const sourceSelection = (target: StackColorTargetAvailability, kind: StackColorKind, palette?: StackNarrowbandPalette) => {
+    const key = operationKey(target.target_id, kind, palette);
+    const roles = requiredRoles(kind, palette);
+    const candidates = target.source_candidates ?? [];
+    const aware = target.source_candidates !== undefined;
+    const resolved = resolveColorSources(candidates, roles, sourcesByCard[key] ?? {});
+    const saved = (catalog.data?.jobs ?? []).filter((job) => jobMatches(job, target.target_id, kind, palette));
+    const selectedSaved = saved.find((job) => job.job_id === savedByCard[key]);
+    const matchesFamily = (job: StackColorJob) => !aware || (resolved.complete
+      && job.sources.length === roles.length
+      && resolved.sources.every((source) => job.sources.some((previous) => sameColorSourceFamily(source, previous))));
+    const showChoices = candidates.some((source) => source.exposure_group)
+      || target.ambiguous_roles.some((role) => roles.includes(role))
+      || (!resolved.complete && roles.some((role) => sourcesByCard[key]?.[role] !== undefined))
+      || saved.length > 1;
+    const resetCrop = () => setCropByCard((current) => {
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+    const controls = showChoices ? (
+      <div className="stack-color-source-selectors">
+        {saved.length > 0 && <label>
+          <span>Saved preview</span>
+          <select
+            aria-label={`${target.target_name} ${palette ?? kind} saved preview`}
+            value={selectedSaved?.job_id ?? ''}
+            onChange={(event) => {
+              resetCrop();
+              const job = saved.find((entry) => entry.job_id === event.target.value);
+              setSavedByCard((current) => ({ ...current, [key]: event.target.value }));
+              if (job) setSourcesByCard((current) => ({
+                ...current,
+                [key]: Object.fromEntries(roles.map((role) => {
+                  const previous = job.sources.find((source) => source.role === role);
+                  const current = previous && candidates.find((source) => sameColorSourceFamily(source, previous));
+                  return [role, current ? colorSourceKey(current) : ''];
+                })),
+              }));
+            }}
+          >
+            <option value="">Current source selection</option>
+            {saved.map((job) => <option key={job.job_id} value={job.job_id}>{colorSourcesLabel(job.sources)}</option>)}
+          </select>
+        </label>}
+        {roles.map((role) => {
+          const choices = candidates.filter((source) => source.role === role);
+          const chosen = resolved.sources.find((source) => source.role === role);
+          return <label key={role}>
+            <span>{roleLabels[role]}</span>
+            <select
+              aria-label={`${target.target_name} ${palette ?? kind} ${roleLabels[role]} source stack`}
+              value={chosen ? colorSourceKey(chosen) : ''}
+              disabled={choices.length === 0}
+              onChange={(event) => {
+                resetCrop();
+                setSourcesByCard((current) => ({ ...current, [key]: { ...current[key], [role]: event.target.value } }));
+                setSavedByCard((current) => ({ ...current, [key]: '' }));
+              }}
+            >
+              <option value="">{choices.length ? 'Choose stack' : 'Unavailable'}</option>
+              {choices.map((source) => <option key={colorSourceKey(source)} value={colorSourceKey(source)}>
+                {colorSourcesLabel([source])} · {source.accepted_frames} frames
+              </option>)}
+            </select>
+          </label>;
+        })}
+      </div>
+    ) : undefined;
+    return {
+      complete: !aware || resolved.complete,
+      inputSources: showChoices && resolved.complete ? resolved.inputSources : undefined,
+      matchesFamily,
+      remembered: selectedSaved ?? saved.find(matchesFamily)
+        ?? (candidates.length === 0 ? saved[0] : undefined),
+      controls,
+    };
   };
 
   return (
@@ -542,11 +640,10 @@ export default function StackColorPreviewPanel({
             { kind: 'lrgb', available: target.lrgb_available },
           ];
           for (const { kind, available } of broadbandKinds) {
-            const watched = newestWatched(target.target_id, kind);
-            const artifact = watched?.state === 'completed'
-              ? watched
-              : targetJobs.find((job) => jobMatches(job, target.target_id, kind));
-            const cardActive = watched;
+            const sources = sourceSelection(target, kind);
+            const watched = newestWatched(target.target_id, kind, undefined, sources.matchesFamily);
+            const artifact = completedColorArtifact(watched, catalog.data?.jobs ?? [], sources.remembered);
+            const cardActive = watched?.state === 'completed' ? undefined : watched;
             if (available || artifact) {
               const key = operationKey(target.target_id, kind);
               const crop = cropByCard[key] ?? artifact?.crop ?? 'none';
@@ -567,7 +664,8 @@ export default function StackColorPreviewPanel({
                   activeJob={cardActive}
                   busy={cardBusy}
                   operationPending={operationPending}
-                  unavailable={!available}
+                  unavailable={!available || !sources.complete}
+                  sourceControls={sources.controls}
                   sourceStacksOutdated={outdatedTargetIds.has(target.target_id)}
                   canCompute={canCompute}
                   onCropChange={(next) => setCropByCard((current) => ({
@@ -580,6 +678,7 @@ export default function StackColorPreviewPanel({
                     operationKey: key,
                     crop,
                     processing: processingForColorBuild(artifact, requiredRoles(kind)),
+                    inputSources: sources.inputSources,
                   })}
                   onInspect={setInspector}
                   onProcessingApply={(processing) => startColor({
@@ -589,6 +688,7 @@ export default function StackColorPreviewPanel({
                     operationKey: `${key}:processing`,
                     crop,
                     processing,
+                    inputSources: sources.inputSources,
                   })}
                 />
               );
@@ -601,11 +701,10 @@ export default function StackColorPreviewPanel({
           );
           const palette = paletteByTarget[target.target_id] ?? defaultPalette(paletteChoices);
           if (palette) {
-            const watched = newestWatched(target.target_id, 'narrowband', palette);
-            const artifact = watched?.state === 'completed'
-              ? watched
-              : targetJobs.find((job) => jobMatches(job, target.target_id, 'narrowband', palette));
-            const cardActive = watched;
+            const sources = sourceSelection(target, 'narrowband', palette);
+            const watched = newestWatched(target.target_id, 'narrowband', palette, sources.matchesFamily);
+            const artifact = completedColorArtifact(watched, catalog.data?.jobs ?? [], sources.remembered);
+            const cardActive = watched?.state === 'completed' ? undefined : watched;
             const key = operationKey(target.target_id, 'narrowband', palette);
             const crop = cropByCard[key] ?? artifact?.crop ?? 'none';
             const operationPending = startPending &&
@@ -626,7 +725,8 @@ export default function StackColorPreviewPanel({
                 activeJob={cardActive}
                 busy={cardBusy}
                 operationPending={operationPending}
-                unavailable={!target.narrowband_palettes.includes(palette)}
+                unavailable={!target.narrowband_palettes.includes(palette) || !sources.complete}
+                sourceControls={sources.controls}
                 sourceStacksOutdated={outdatedTargetIds.has(target.target_id)}
                 canCompute={canCompute}
                 onPaletteChange={(next) => setPaletteByTarget((current) => ({
@@ -645,6 +745,7 @@ export default function StackColorPreviewPanel({
                   processing: processingForColorBuild(
                     artifact, requiredRoles('narrowband', palette)
                   ),
+                  inputSources: sources.inputSources,
                 })}
                 onInspect={setInspector}
                 onProcessingApply={(processing) => startColor({
@@ -655,6 +756,7 @@ export default function StackColorPreviewPanel({
                   operationKey: `${key}:processing`,
                   crop,
                   processing,
+                  inputSources: sources.inputSources,
                 })}
               />
             );
@@ -668,6 +770,7 @@ export default function StackColorPreviewPanel({
           title={inspector.target_name}
           label={inspector.label}
           summary={[
+            colorSourcesLabel(inspector.sources),
             `${inspector.sources.length} channel stacks`,
             `${inspector.sources.reduce((sum, source) => sum + source.accepted_frames, 0)} integrated inputs`,
             ...(isColorStackSkyOriented(inspector) ? ['North up · East left'] : []),

--- a/static/src/components/StackColorPreviewPanel.tsx
+++ b/static/src/components/StackColorPreviewPanel.tsx
@@ -20,7 +20,8 @@ import {
 import { isColorStackSkyOriented } from './stackOrientation';
 import { cropLabels, cropOrder, describeCrop, offCenterChannels } from './stackColorCrop';
 import { STACK_ACTIVITY_QUERY_KEY, useStackActivity } from '../hooks/useStackActivity';
-import { colorSourceKey, colorSourcesLabel, completedColorArtifact, resolveColorSources, sameColorSourceFamily } from './stackColorSources';
+import { buildColorExposureSets, colorSourceKey, colorSourcesLabel, completedColorArtifact, resolveColorSources, sameColorSourceFamily, type ColorExposureSet } from './stackColorSources';
+import { withRetainedColorExposureSets } from './colorExposureCards';
 import './StackColorSources.css';
 
 interface StackColorPreviewPanelProps {
@@ -28,21 +29,26 @@ interface StackColorPreviewPanelProps {
   projectId: number;
   sourceRevision: string;
   channelBuildRunning: boolean;
-  outdatedTargetIds: ReadonlySet<number>;
+  outdatedSourceKeys: ReadonlySet<string>;
   canCompute: boolean;
   onOpenImage: (imageId: number) => void;
 }
 
 interface ColorOperation {
+  dbId: string;
+  projectId: number;
   targetId: number;
   kind: StackColorKind;
   palette?: StackNarrowbandPalette;
   force: boolean;
   operationKey: string;
+  cardKey: string;
   crop: StackColorCrop;
   processing: StackColorProcessing;
   inputSources?: StackColorInputSources;
 }
+
+type ExposureCardSet = ColorExposureSet & { retained?: boolean };
 
 const terminalStates = new Set(['completed', 'failed']);
 const paletteOrder: StackNarrowbandPalette[] = [
@@ -133,6 +139,10 @@ function ColorCard({
   onInspect,
   onProcessingApply,
   sourceControls,
+  exposureSetKey,
+  exposureLabel,
+  custom,
+  unavailableReason,
 }: {
   dbId: string;
   target: StackColorTargetAvailability;
@@ -153,16 +163,21 @@ function ColorCard({
   onInspect: (job: StackColorJob) => void;
   onProcessingApply: (processing: StackColorProcessing) => void;
   sourceControls?: ReactNode;
+  exposureSetKey?: string;
+  exposureLabel?: string;
+  custom?: boolean;
+  unavailableReason?: string;
 }) {
   const current = activeJob ?? artifact;
   const state = activeJob?.state ?? (artifact ? 'completed' : 'not-built');
-  const label = kind === 'rgb'
+  const baseLabel = kind === 'rgb'
     ? 'RGB'
     : kind === 'lrgb'
       ? 'LRGB'
       : palette
         ? paletteLabels[palette].split(' · ')[0]
         : 'Narrowband';
+  const label = [baseLabel, exposureLabel, custom ? 'custom' : undefined].filter(Boolean).join(' ');
   const detailedProgress = activeJob?.progress ?? artifact?.progress;
   const processed = detailedProgress?.total_units
     ? detailedProgress.completed_units
@@ -184,6 +199,8 @@ function ColorCard({
       data-color-kind={kind}
       data-target-id={target.target_id}
       data-source-family={artifact?.source_family_key ?? ''}
+      data-exposure-set={exposureSetKey}
+      data-custom-combination={custom ? 'true' : undefined}
     >
       <header>
         <div>
@@ -192,7 +209,7 @@ function ColorCard({
             <label className="stack-color-palette">
               <span>Palette</span>
               <select
-                aria-label={`${target.target_name} narrowband palette`}
+                aria-label={`${target.target_name} narrowband${exposureLabel ? ` ${exposureLabel}` : custom ? ' custom' : ''} palette`}
                 value={palette}
                 disabled={busy}
                 onChange={(event) => onPaletteChange?.(event.target.value as StackNarrowbandPalette)}
@@ -202,7 +219,8 @@ function ColorCard({
                 ))}
               </select>
             </label>
-          ) : <span className="stack-preview-channel">{label}</span>}
+          ) : <span className="stack-preview-channel">{baseLabel}</span>}
+          {exposureLabel && <span className="stack-color-exposure">{exposureLabel}</span>}
           <label className="stack-color-crop">
             <span>Edges</span>
             <select
@@ -234,7 +252,7 @@ function ColorCard({
               className="stack-preview-card-action"
               href={apiClient.getStackColorFitsUrl(dbId, artifact.job_id, artifact.artifact_revision)}
               download
-              aria-label={label === 'RGB' ? 'Download RGB FITS' : `Download ${label} RGB FITS`}
+              aria-label={kind === 'rgb' ? `Download ${label} FITS` : `Download ${label} RGB FITS`}
             >
               FITS
             </a>
@@ -254,6 +272,7 @@ function ColorCard({
         </div>
       </header>
       {sourceControls}
+      {unavailableReason && <div className="stack-color-unavailable">{unavailableReason}</div>}
 
       {(artifact?.outdated || sourceStacksOutdated) && (
         <div className="stack-preview-outdated">
@@ -281,7 +300,7 @@ function ColorCard({
       ) : (
         <div className={`stack-preview-placeholder ${activeJob?.state === 'failed' ? 'error' : ''}`}>
           {activeJob?.error ?? (unavailable
-            ? 'The required channel stacks are not currently available.'
+            ? unavailableReason ? 'Not built' : 'The required channel stacks are not currently available.'
             : `Build an on-demand ${label} quick look from the channel stacks.`)}
         </div>
       )}
@@ -386,16 +405,17 @@ export default function StackColorPreviewPanel({
   projectId,
   sourceRevision,
   channelBuildRunning,
-  outdatedTargetIds,
+  outdatedSourceKeys,
   canCompute,
   onOpenImage,
 }: StackColorPreviewPanelProps) {
   const queryClient = useQueryClient();
   const [watchedJobIds, setWatchedJobIds] = useState<string[]>([]);
-  const [paletteByTarget, setPaletteByTarget] = useState<Record<number, StackNarrowbandPalette>>({});
+  const [paletteByCard, setPaletteByCard] = useState<Record<string, StackNarrowbandPalette>>({});
   const [cropByCard, setCropByCard] = useState<Record<string, StackColorCrop>>({});
   const [sourcesByCard, setSourcesByCard] = useState<Record<string, Partial<Record<StackColorRole, string>>>>({});
   const [savedByCard, setSavedByCard] = useState<Record<string, string>>({});
+  const [pendingCardKeys, setPendingCardKeys] = useState<ReadonlySet<string>>(new Set());
   const [inspector, setInspector] = useState<StackColorJob | null>(null);
 
   const catalog = useQuery({
@@ -405,12 +425,10 @@ export default function StackColorPreviewPanel({
 
   const {
     mutate: startColor,
-    isPending: startPending,
-    variables: startVariables,
     error: startError,
     reset: resetStart,
   } = useMutation({
-    mutationFn: (operation: ColorOperation) => apiClient.startStackColor(dbId, projectId, {
+    mutationFn: (operation: ColorOperation) => apiClient.startStackColor(operation.dbId, operation.projectId, {
       target_id: operation.targetId,
       kind: operation.kind,
       palette: operation.palette,
@@ -419,22 +437,29 @@ export default function StackColorPreviewPanel({
       processing: operation.processing,
       ...(operation.inputSources ? { input_sources: operation.inputSources } : {}),
     }),
+    onMutate: (operation) => setPendingCardKeys((current) => new Set(current).add(operation.cardKey)),
+    onSettled: (_data, _error, operation) => setPendingCardKeys((current) => {
+      const next = new Set(current);
+      next.delete(operation.cardKey);
+      return next;
+    }),
     onSuccess: (job, operation) => {
-      setSavedByCard((current) => {
-        const next = { ...current };
-        delete next[operationKey(operation.targetId, operation.kind, operation.palette)];
-        return next;
-      });
-      queryClient.setQueryData(jobQueryKey(dbId, projectId, job.job_id), job);
-      setWatchedJobIds((current) =>
-        current.includes(job.job_id) ? current : [...current, job.job_id]
-      );
+      queryClient.setQueryData(jobQueryKey(operation.dbId, operation.projectId, job.job_id), job);
       queryClient.invalidateQueries({ queryKey: STACK_ACTIVITY_QUERY_KEY });
       if (terminalStates.has(job.state)) {
         queryClient.invalidateQueries({
-          queryKey: catalogQueryKey(dbId, projectId, sourceRevision),
+          queryKey: ['db', operation.dbId, 'project', operation.projectId, 'stack-color', 'catalog'],
         });
       }
+      if (operation.dbId !== dbId || operation.projectId !== projectId) return;
+      setSavedByCard((current) => {
+        const next = { ...current };
+        delete next[operation.cardKey];
+        return next;
+      });
+      setWatchedJobIds((current) =>
+        current.includes(job.job_id) ? current : [...current, job.job_id]
+      );
     },
   });
 
@@ -467,10 +492,11 @@ export default function StackColorPreviewPanel({
 
   useEffect(() => {
     setWatchedJobIds([]);
-    setPaletteByTarget({});
+    setPaletteByCard({});
     setCropByCard({});
     setSourcesByCard({});
     setSavedByCard({});
+    setPendingCardKeys(new Set());
     setInspector(null);
     resetStart();
   }, [dbId, projectId, resetStart]);
@@ -498,13 +524,15 @@ export default function StackColorPreviewPanel({
   }, [adoptableIds]);
 
   const targets = useMemo(() => {
+    const jobs = [...(catalog.data?.jobs ?? []), ...watchedJobs];
     const byId = new Map((catalog.data?.targets ?? []).map((target) => [target.target_id, target]));
-    for (const job of catalog.data?.jobs ?? []) {
+    for (const job of jobs) {
       if (!byId.has(job.target_id)) {
         byId.set(job.target_id, {
           target_id: job.target_id,
           target_name: job.target_name,
           available_roles: [],
+          source_candidates: [],
           ambiguous_roles: [],
           unmapped_filters: [],
           rgb_available: false,
@@ -515,9 +543,10 @@ export default function StackColorPreviewPanel({
     }
     return [...byId.values()].filter((target) =>
       target.rgb_available || target.lrgb_available || target.narrowband_palettes.length > 0 ||
-      (catalog.data?.jobs ?? []).some((job) => job.target_id === target.target_id)
+      target.source_candidates?.some((source) => source.exposure_group) ||
+      jobs.some((job) => job.target_id === target.target_id)
     );
-  }, [catalog.data]);
+  }, [catalog.data, watchedJobs]);
 
   if (targets.length === 0 && !catalog.error) return null;
 
@@ -537,21 +566,30 @@ export default function StackColorPreviewPanel({
     return mine[mine.length - 1];
   };
 
-  const sourceSelection = (target: StackColorTargetAvailability, kind: StackColorKind, palette?: StackNarrowbandPalette) => {
-    const key = operationKey(target.target_id, kind, palette);
+  const sourceSelection = (
+    target: StackColorTargetAvailability,
+    kind: StackColorKind,
+    palette?: StackNarrowbandPalette,
+    exposureSet?: ExposureCardSet,
+  ) => {
+    const key = dbId + ':' + projectId + ':' + operationKey(target.target_id, kind, palette)
+      + (exposureSet ? `:exposure:${exposureSet.key}` : '');
     const roles = requiredRoles(kind, palette);
-    const candidates = target.source_candidates ?? [];
+    const candidates = (target.source_candidates ?? []).filter((source) => !exposureSet
+      || exposureSet.candidates.some((member) => sameColorSourceFamily(source, member)));
     const aware = target.source_candidates !== undefined;
-    const resolved = resolveColorSources(candidates, roles, sourcesByCard[key] ?? {});
+    const resolved = resolveColorSources(candidates, roles, exposureSet ? {} : sourcesByCard[key] ?? {});
+    const family = exposureSet ? resolveColorSources(exposureSet.candidates, roles, {}) : resolved;
     const saved = (catalog.data?.jobs ?? []).filter((job) => jobMatches(job, target.target_id, kind, palette));
-    const selectedSaved = saved.find((job) => job.job_id === savedByCard[key]);
-    const matchesFamily = (job: StackColorJob) => !aware || (resolved.complete
+    const selectedSaved = exposureSet ? undefined : saved.find((job) => job.job_id === savedByCard[key]);
+    const matchesFamily = (job: StackColorJob) => (!exposureSet && (!aware
+      || (candidates.length === 0 && (!selectedSaved || selectedSaved.job_id === job.job_id)))) || (family.complete
       && job.sources.length === roles.length
-      && resolved.sources.every((source) => job.sources.some((previous) => sameColorSourceFamily(source, previous))));
-    const showChoices = candidates.some((source) => source.exposure_group)
+      && family.sources.every((source) => job.sources.some((previous) => sameColorSourceFamily(source, previous))));
+    const showChoices = !exposureSet && (candidates.some((source) => source.exposure_group)
       || target.ambiguous_roles.some((role) => roles.includes(role))
       || (!resolved.complete && roles.some((role) => sourcesByCard[key]?.[role] !== undefined))
-      || saved.length > 1;
+      || saved.length > 1);
     const resetCrop = () => setCropByCard((current) => {
       const next = { ...current };
       delete next[key];
@@ -606,14 +644,94 @@ export default function StackColorPreviewPanel({
         })}
       </div>
     ) : undefined;
+    const missing = roles.filter((role) => !candidates.some((source) => source.role === role));
+    const ambiguous = roles.filter((role) => candidates.filter((source) => source.role === role).length > 1);
     return {
-      complete: !aware || resolved.complete,
-      inputSources: showChoices && resolved.complete ? resolved.inputSources : undefined,
+      key,
+      complete: (!aware || resolved.complete) && (!exposureSet || (exposureSet.known && !exposureSet.retained)),
+      inputSources: (exposureSet || showChoices) && resolved.complete ? resolved.inputSources : undefined,
       matchesFamily,
       remembered: selectedSaved ?? saved.find(matchesFamily)
-        ?? (candidates.length === 0 ? saved[0] : undefined),
+        ?? (!exposureSet && candidates.length === 0 ? saved[0] : undefined),
       controls,
+      sources: resolved.sources,
+      unavailableReason: !exposureSet ? undefined : exposureSet.retained ? 'Previous source set is no longer available'
+        : !exposureSet.known ? 'Exposure duration unavailable'
+        : [missing.length ? `Missing ${missing.map((role) => roleLabels[role]).join(', ')}` : '',
+          ambiguous.length ? `Multiple ${ambiguous.map((role) => roleLabels[role]).join(', ')} stacks` : '']
+          .filter(Boolean).join(' · ') || undefined,
     };
+  };
+
+  const renderCard = (
+    target: StackColorTargetAvailability,
+    kind: StackColorKind,
+    available: boolean,
+    exposureSet?: ExposureCardSet,
+    palette?: StackNarrowbandPalette,
+    paletteChoices: StackNarrowbandPalette[] = [],
+    paletteStateKey?: string,
+    custom = false,
+  ) => {
+    const sources = sourceSelection(target, kind, palette, exposureSet);
+    const watched = newestWatched(target.target_id, kind, palette, sources.matchesFamily);
+    const artifact = completedColorArtifact(watched, catalog.data?.jobs ?? [], sources.remembered);
+    if (!available && !artifact && !watched && !exposureSet) return null;
+    const key = sources.key;
+    const crop = cropByCard[key] ?? artifact?.crop ?? 'none';
+    const operationPending = pendingCardKeys.has(key);
+    const cardBusy = operationPending || (watched !== undefined && !terminalStates.has(watched.state));
+    const card = (
+      <ColorCard
+        key={key}
+        dbId={dbId}
+        target={target}
+        kind={kind}
+        palette={palette}
+        paletteChoices={paletteChoices}
+        crop={crop}
+        artifact={artifact}
+        activeJob={watched?.state === 'completed' ? undefined : watched}
+        busy={cardBusy}
+        operationPending={operationPending}
+        unavailable={(!exposureSet && !available) || !sources.complete}
+        unavailableReason={sources.unavailableReason}
+        sourceControls={sources.controls}
+        exposureSetKey={exposureSet?.key}
+        exposureLabel={exposureSet ? (exposureSet.retained ? 'Previous ' : '') + exposureSet.label : undefined}
+        custom={custom}
+        sourceStacksOutdated={[...sources.sources, ...(artifact?.sources ?? [])]
+          .some((source) => outdatedSourceKeys.has(colorSourceKey(source)))}
+        canCompute={canCompute}
+        onPaletteChange={paletteStateKey ? (next) => setPaletteByCard((current) => ({
+          ...current, [paletteStateKey]: next,
+        })) : undefined}
+        onCropChange={(next) => setCropByCard((current) => ({ ...current, [key]: next }))}
+        onBuild={() => startColor({
+          dbId, projectId,
+          targetId: target.target_id, kind, palette,
+          force: Boolean(artifact && !artifact.outdated),
+          operationKey: key, cardKey: key, crop,
+          processing: processingForColorBuild(artifact, requiredRoles(kind, palette)),
+          inputSources: sources.inputSources,
+        })}
+        onInspect={setInspector}
+        onProcessingApply={(processing) => startColor({
+          dbId, projectId,
+          targetId: target.target_id, kind, palette, force: false,
+          operationKey: key + ':processing', cardKey: key, crop, processing,
+          inputSources: sources.inputSources,
+        })}
+      />
+    );
+    return custom ? (
+      <details key={key + ':custom'} className="stack-color-custom"
+        data-color-kind={kind} data-target-id={target.target_id}
+        aria-label={target.target_name + ' ' + kind.toUpperCase() + ' custom combination'}>
+        <summary><span>Custom combination</span><small>{target.target_name} · {kind.toUpperCase()}</small></summary>
+        <div className="stack-color-grid">{card}</div>
+      </details>
+    ) : card;
   };
 
   return (
@@ -634,133 +752,63 @@ export default function StackColorPreviewPanel({
       <div className="stack-color-grid">
         {targets.flatMap((target) => {
           const targetJobs = (catalog.data?.jobs ?? []).filter((job) => job.target_id === target.target_id);
-          const cards = [];
-          const broadbandKinds: Array<{ kind: 'rgb' | 'lrgb'; available: boolean }> = [
-            { kind: 'rgb', available: target.rgb_available },
-            { kind: 'lrgb', available: target.lrgb_available },
-          ];
-          for (const { kind, available } of broadbandKinds) {
-            const sources = sourceSelection(target, kind);
-            const watched = newestWatched(target.target_id, kind, undefined, sources.matchesFamily);
-            const artifact = completedColorArtifact(watched, catalog.data?.jobs ?? [], sources.remembered);
-            const cardActive = watched?.state === 'completed' ? undefined : watched;
-            if (available || artifact) {
-              const key = operationKey(target.target_id, kind);
-              const crop = cropByCard[key] ?? artifact?.crop ?? 'none';
-              const operationPending = startPending &&
-                (startVariables?.operationKey === key ||
-                  startVariables?.operationKey === `${key}:processing`);
-              const cardBusy = operationPending ||
-                (watched !== undefined && !terminalStates.has(watched.state));
-              cards.push(
-                <ColorCard
-                  key={key}
-                  dbId={dbId}
-                  target={target}
-                  kind={kind}
-                  paletteChoices={[]}
-                  crop={crop}
-                  artifact={artifact}
-                  activeJob={cardActive}
-                  busy={cardBusy}
-                  operationPending={operationPending}
-                  unavailable={!available || !sources.complete}
-                  sourceControls={sources.controls}
-                  sourceStacksOutdated={outdatedTargetIds.has(target.target_id)}
-                  canCompute={canCompute}
-                  onCropChange={(next) => setCropByCard((current) => ({
-                    ...current, [key]: next,
-                  }))}
-                  onBuild={() => startColor({
-                    targetId: target.target_id,
-                    kind,
-                    force: Boolean(artifact && !artifact.outdated),
-                    operationKey: key,
-                    crop,
-                    processing: processingForColorBuild(artifact, requiredRoles(kind)),
-                    inputSources: sources.inputSources,
-                  })}
-                  onInspect={setInspector}
-                  onProcessingApply={(processing) => startColor({
-                    targetId: target.target_id,
-                    kind,
-                    force: false,
-                    operationKey: `${key}:processing`,
-                    crop,
-                    processing,
-                    inputSources: sources.inputSources,
-                  })}
-                />
-              );
-            }
+          const jobs = [...targetJobs, ...watchedJobs.filter((job) => job.target_id === target.target_id)];
+          const candidates = target.source_candidates ?? [];
+          const exposureMode = candidates.length > 0
+            ? candidates.some((source) => source.exposure_group)
+            : jobs.some((job) => job.sources.some((source) => source.exposure_group));
+          const cards: ReactNode[] = [];
+          for (const kind of ['rgb', 'lrgb'] as const) {
+            const available = kind === 'rgb' ? target.rgb_available : target.lrgb_available;
+            // RGB-only targets do not need a permanently missing LRGB card.
+            if (kind === 'lrgb' && !available
+              && !candidates.some((source) => source.role === 'luminance')
+              && !jobs.some((job) => job.kind === kind)) continue;
+            const roles = requiredRoles(kind);
+            const sets = exposureMode ? withRetainedColorExposureSets(
+              buildColorExposureSets(candidates, roles),
+              jobs.filter((job) => job.kind === kind), roles,
+            ) : [];
+            for (const set of sets) cards.push(renderCard(target, kind, available, set));
+            cards.push(renderCard(target, kind, available, undefined, undefined, [], undefined,
+              exposureMode && (sets.length > 0 || jobs.some((job) => job.kind === kind))));
           }
 
+          const narrowbandRoles: StackColorRole[] = ['ha', 'oiii', 'sii'];
+          const narrowbandJobs = jobs.filter((job) => job.kind === 'narrowband');
           const paletteChoices = paletteOrder.filter((palette) =>
-            target.narrowband_palettes.includes(palette) ||
-            targetJobs.some((job) => job.kind === 'narrowband' && job.palette === palette)
+            target.narrowband_palettes.includes(palette)
+            || narrowbandJobs.some((job) => job.palette === palette)
           );
-          const palette = paletteByTarget[target.target_id] ?? defaultPalette(paletteChoices);
-          if (palette) {
-            const sources = sourceSelection(target, 'narrowband', palette);
-            const watched = newestWatched(target.target_id, 'narrowband', palette, sources.matchesFamily);
-            const artifact = completedColorArtifact(watched, catalog.data?.jobs ?? [], sources.remembered);
-            const cardActive = watched?.state === 'completed' ? undefined : watched;
-            const key = operationKey(target.target_id, 'narrowband', palette);
-            const crop = cropByCard[key] ?? artifact?.crop ?? 'none';
-            const operationPending = startPending &&
-              (startVariables?.operationKey === key ||
-                startVariables?.operationKey === `${key}:processing`);
-            const cardBusy = operationPending ||
-              (watched !== undefined && !terminalStates.has(watched.state));
-            cards.push(
-              <ColorCard
-                key={`${target.target_id}:narrowband`}
-                dbId={dbId}
-                target={target}
-                kind="narrowband"
-                palette={palette}
-                paletteChoices={paletteChoices}
-                crop={crop}
-                artifact={artifact}
-                activeJob={cardActive}
-                busy={cardBusy}
-                operationPending={operationPending}
-                unavailable={!target.narrowband_palettes.includes(palette) || !sources.complete}
-                sourceControls={sources.controls}
-                sourceStacksOutdated={outdatedTargetIds.has(target.target_id)}
-                canCompute={canCompute}
-                onPaletteChange={(next) => setPaletteByTarget((current) => ({
-                  ...current, [target.target_id]: next,
-                }))}
-                onCropChange={(next) => setCropByCard((current) => ({
-                  ...current, [key]: next,
-                }))}
-                onBuild={() => startColor({
-                  targetId: target.target_id,
-                  kind: 'narrowband',
-                  palette,
-                  force: Boolean(artifact && !artifact.outdated),
-                  operationKey: key,
-                  crop,
-                  processing: processingForColorBuild(
-                    artifact, requiredRoles('narrowband', palette)
-                  ),
-                  inputSources: sources.inputSources,
-                })}
-                onInspect={setInspector}
-                onProcessingApply={(processing) => startColor({
-                  targetId: target.target_id,
-                  kind: 'narrowband',
-                  palette,
-                  force: false,
-                  operationKey: `${key}:processing`,
-                  crop,
-                  processing,
-                  inputSources: sources.inputSources,
-                })}
-              />
-            );
+          if (exposureMode && paletteChoices.length === 0
+            && candidates.some((source) => narrowbandRoles.includes(source.role))) {
+            paletteChoices.push(candidates.some((source) => source.role === 'sii') ? 'sho' : 'hoo');
           }
+          const sets = exposureMode ? withRetainedColorExposureSets(
+            buildColorExposureSets(candidates, narrowbandRoles), narrowbandJobs, narrowbandRoles,
+          ) : [];
+          for (const set of sets) {
+            const paletteKey = target.target_id + ':narrowband:' + set.key;
+            const localPalettes = paletteChoices.filter((choice) =>
+              resolveColorSources(set.candidates, requiredRoles('narrowband', choice), {}).complete);
+            const rememberedPalette = [...narrowbandJobs]
+              .sort((left, right) => Number(!terminalStates.has(right.state)) - Number(!terminalStates.has(left.state))
+                || right.created_unix_seconds - left.created_unix_seconds)
+              .find((job) => job.palette && job.sources.every((previous) => {
+                const matching = set.candidates.filter((source) => source.role === previous.role);
+                return matching.length === 1 && sameColorSourceFamily(matching[0], previous);
+              }))?.palette;
+            const palette = paletteByCard[paletteKey]
+              ?? rememberedPalette
+              ?? defaultPalette(localPalettes.length ? localPalettes : paletteChoices);
+            if (palette) cards.push(renderCard(target, 'narrowband',
+              target.narrowband_palettes.includes(palette), set, palette, paletteChoices, paletteKey));
+          }
+          const paletteKey = target.target_id + ':narrowband:custom';
+          const palette = paletteByCard[paletteKey] ?? defaultPalette(paletteChoices);
+          if (palette) cards.push(renderCard(target, 'narrowband',
+            target.narrowband_palettes.includes(palette), undefined, palette, paletteChoices,
+            paletteKey, exposureMode));
           return cards;
         })}
       </div>

--- a/static/src/components/StackColorSources.css
+++ b/static/src/components/StackColorSources.css
@@ -31,3 +31,35 @@
   font-size: 0.85rem;
   white-space: nowrap;
 }
+
+.stack-color-exposure {
+  flex-shrink: 0;
+  white-space: nowrap;
+  font-size: 0.85rem;
+}
+
+.stack-color-card[data-exposure-set] > header > div:first-child {
+  flex-wrap: wrap;
+}
+
+.stack-color-unavailable {
+  padding: 0.4rem 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.stack-color-custom {
+  grid-column: 1 / -1;
+  min-width: 0;
+  border-top: 1px solid var(--border-color);
+}
+
+.stack-color-custom > summary {
+  cursor: pointer;
+  padding: 0.65rem 0;
+}
+
+.stack-color-custom > summary small {
+  margin-left: 0.75rem;
+  color: var(--text-secondary);
+}

--- a/static/src/components/StackColorSources.css
+++ b/static/src/components/StackColorSources.css
@@ -1,0 +1,33 @@
+.stack-color-source-selectors {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 170px), 1fr));
+  gap: 0.6rem;
+  margin: 0.6rem 0;
+}
+
+.stack-color-source-selectors label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  font-size: 0.8rem;
+}
+
+.stack-color-source-selectors select {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  padding: 0.35rem;
+  border-radius: 4px;
+  color: inherit;
+  background: var(--bg-secondary, #222);
+  border: 1px solid var(--border-color, #444);
+}
+
+.stack-preview-exposure {
+  display: inline-block;
+  flex-shrink: 0;
+  margin-left: 0.5rem;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -18,6 +18,7 @@ import StackPreviewInspector from './StackPreviewInspector';
 import CalibrationMasterButton from './CalibrationMasterInspector';
 import StackSnrCurve from './StackSnrCurve';
 import StackColorPreviewPanel from './StackColorPreviewPanel';
+import { colorSourceKey } from './stackColorSources';
 import StackStretchControls from './StackStretchControls';
 import { isSkyOriented } from './stackOrientation';
 import { useAccess } from '../auth/access';
@@ -649,8 +650,8 @@ export default function StackPreviewPanel({
         ) !== null
       : false;
   }).length;
-  const outdatedTargetIds = useMemo(() => {
-    const targetIds = new Set<number>();
+  const outdatedSourceKeys = useMemo(() => {
+    const sourceKeys = new Set<string>();
     for (const entry of latest.data?.groups ?? []) {
       const key = channelKey(entry.group.target_id, entry.group.filter_name, entry.group.exposure_group);
       if (
@@ -667,10 +668,14 @@ export default function StackPreviewPanel({
           currentScoring
         )
       ) {
-        targetIds.add(entry.group.target_id);
+        sourceKeys.add(colorSourceKey({
+          job_id: entry.job_id,
+          group_index: entry.group.index,
+          artifact_revision: entry.artifact_revision,
+        }));
       }
     }
-    return targetIds;
+    return sourceKeys;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- effectiveCalibration reads calibrationMode and overrides, listed below.
   }, [
     acceptedOnly,
@@ -840,7 +845,7 @@ export default function StackPreviewPanel({
           projectId={projectId}
           sourceRevision={colorSourceRevision}
           channelBuildRunning={running}
-          outdatedTargetIds={outdatedTargetIds}
+          outdatedSourceKeys={outdatedSourceKeys}
           canCompute={canCompute}
           onOpenImage={onOpenImage}
         />

--- a/static/src/components/StackPreviewPanel.tsx
+++ b/static/src/components/StackPreviewPanel.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/rea
 import { apiClient } from '../api/client';
 import type {
   CalibrationMode,
+  ExposureGroup,
   Image,
   LatestStackPreviewGroup,
   StackFrameDecision,
@@ -31,7 +32,7 @@ import {
 
 type StackCandidateImage = Pick<
   Image,
-  'id' | 'target_id' | 'target_name' | 'filter_name' | 'grading_status'
+  'id' | 'target_id' | 'target_name' | 'filter_name' | 'grading_status' | 'exposure_group'
 >;
 
 interface StackPreviewPanelProps {
@@ -58,6 +59,7 @@ interface ChannelInput {
   targetId: number;
   targetName: string;
   filterName: string;
+  exposureGroup?: ExposureGroup | null;
   images: StackCandidateImage[];
 }
 
@@ -180,8 +182,14 @@ function latestStackQueryKey(dbId: string, projectId: number) {
   return ['db', dbId, 'project', projectId, 'stack-preview', 'latest'] as const;
 }
 
-function channelKey(targetId: number, filterName: string | null) {
-  return `${targetId}:${filterName ?? ''}`;
+function channelKey(targetId: number, filterName: string | null, exposure?: ExposureGroup | null) {
+  return exposure
+    ? JSON.stringify([targetId, filterName ?? '', exposure.key])
+    : `${targetId}:${filterName ?? ''}`;
+}
+
+function channelLabel(filterName: string | null, exposure?: ExposureGroup | null) {
+  return [filterName || 'No filter', exposure?.label].filter(Boolean).join(' · ');
 }
 
 function artifactStretchKey(artifact: StackArtifact) {
@@ -360,7 +368,7 @@ export default function StackPreviewPanel({
   const currentChannels = useMemo(() => {
     const channels = new Map<string, ChannelInput>();
     for (const image of images) {
-      const key = channelKey(image.target_id, image.filter_name);
+      const key = channelKey(image.target_id, image.filter_name, image.exposure_group);
       const existing = channels.get(key);
       if (existing) {
         existing.images.push(image);
@@ -370,6 +378,7 @@ export default function StackPreviewPanel({
           targetId: image.target_id,
           targetName: image.target_name,
           filterName: image.filter_name ?? '',
+          exposureGroup: image.exposure_group,
           images: [image],
         });
       }
@@ -417,6 +426,7 @@ export default function StackPreviewPanel({
           .map((channel) => ({
             target_id: channel.targetId,
             filter_name: channel.filterName,
+            exposure_group_key: channel.exposureGroup?.key,
             calibration: channelOverride(channel.key)!,
           })),
       }),
@@ -512,7 +522,7 @@ export default function StackPreviewPanel({
     () =>
       new Map(
         (latest.data?.groups ?? []).map((entry) => [
-          channelKey(entry.group.target_id, entry.group.filter_name),
+          channelKey(entry.group.target_id, entry.group.filter_name, entry.group.exposure_group),
           entry,
         ])
       ),
@@ -522,7 +532,7 @@ export default function StackPreviewPanel({
     const merged = new Map<string, { job: StackPreviewJob; group: StackPreviewJob['groups'][number] }>();
     for (const job of watchedJobs) {
       for (const group of job.groups) {
-        const key = channelKey(group.target_id, group.filter_name);
+        const key = channelKey(group.target_id, group.filter_name, group.exposure_group);
         const existing = merged.get(key);
         // A build still holding the channel outranks a settled one; among
         // equals the newer request wins, matching iteration order.
@@ -642,7 +652,7 @@ export default function StackPreviewPanel({
   const outdatedTargetIds = useMemo(() => {
     const targetIds = new Set<number>();
     for (const entry of latest.data?.groups ?? []) {
-      const key = channelKey(entry.group.target_id, entry.group.filter_name);
+      const key = channelKey(entry.group.target_id, entry.group.filter_name, entry.group.exposure_group);
       if (
         staleReason(
           currentChannels.get(key),
@@ -867,6 +877,7 @@ export default function StackPreviewPanel({
                 const group = artifact?.group ?? activeGroup;
                 const targetName = current?.targetName ?? group?.target_name ?? 'Unknown target';
                 const filterName = current?.filterName ?? group?.filter_name ?? '';
+                const exposureGroup = current?.exposureGroup ?? group?.exposure_group;
                 const outdated = artifact
                   ? staleReason(
                       current,
@@ -935,12 +946,14 @@ export default function StackPreviewPanel({
                   <article
                     className={`stack-preview-card ${outdated ? 'outdated' : ''}`}
                     data-outdated={outdated ? 'true' : 'false'}
+                    data-exposure-group={exposureGroup?.key}
                     key={key}
                   >
                     <header>
                       <div className="stack-preview-card-title">
                         <h3>{targetName}</h3>
                         <span className="stack-preview-channel">{filterName || 'No filter'}</span>
+                        {exposureGroup && <span className="stack-preview-exposure">{exposureGroup.label}</span>}
                       </div>
                       <div className="stack-preview-card-actions">
                         <span className={`stack-group-state ${activeGroup?.state ?? group?.state ?? 'not-built'}`}>
@@ -951,10 +964,11 @@ export default function StackPreviewPanel({
                           title={
                             'Calibration for this channel only. "Project" follows the ' +
                             'panel-wide Calibration choice; the other options override it ' +
-                            'for this target and filter, and are remembered.'
+                            'for this target, filter, and exposure group, and are remembered.'
                           }
                         >
                           <select
+                            aria-label={`${targetName} ${channelLabel(filterName, exposureGroup)} calibration`}
                             value={channelOverride(key) ?? ''}
                             disabled={running}
                             onChange={(event) =>
@@ -1031,7 +1045,7 @@ export default function StackPreviewPanel({
                             || apiClient.getStackPreviewUrl(
                               dbId, artifact.jobId, artifact.group.index, artifact.artifactRevision
                             )}
-                          alt={`${targetName} ${filterName} stack preview`}
+                          alt={`${targetName} ${channelLabel(filterName, exposureGroup)} stack preview`}
                         />
                         {isSkyOriented(artifact.group.sky_orientation) && (
                           <span className="stack-preview-orientation">N ↑ · E ←</span>
@@ -1074,7 +1088,7 @@ export default function StackPreviewPanel({
                       )}
                       <StackStretchControls
                         key={stretchKey}
-                        label={`${targetName} ${filterName || 'no filter'}`}
+                        label={`${targetName} ${channelLabel(filterName, exposureGroup)}`}
                         channels={artifact.group.output_channels === 3 ? 3 : 1}
                         disabled={!canCompute || running || processingQuery?.isPending || !!processingQuery?.error}
                         applied={appliedStretch}
@@ -1143,7 +1157,7 @@ export default function StackPreviewPanel({
                       <div
                         className="stack-preview-progress-track"
                         role="progressbar"
-                        aria-label={`${targetName} ${filterName || 'no filter'} stack progress`}
+                        aria-label={`${targetName} ${channelLabel(filterName, exposureGroup)} stack progress`}
                         aria-valuemin={0}
                         aria-valuemax={eligibleFrames}
                         aria-valuenow={processedFrames}
@@ -1164,7 +1178,7 @@ export default function StackPreviewPanel({
                     {artifactCurve && (
                       <StackSnrCurve
                         curve={artifactCurve}
-                        label={`${targetName} ${filterName || 'no filter'} completed stack`}
+                        label={`${targetName} ${channelLabel(filterName, exposureGroup)} completed stack`}
                         open={snrCurveOpen}
                         onOpenChange={chooseSnrCurveOpen}
                       />
@@ -1174,7 +1188,7 @@ export default function StackPreviewPanel({
                         <strong>{artifact ? 'Live rebuild progress' : 'Live build progress'}</strong>
                         <StackSnrCurve
                           curve={liveCurve}
-                          label={`${targetName} ${filterName || 'no filter'} live build`}
+                          label={`${targetName} ${channelLabel(filterName, exposureGroup)} live build`}
                           open={snrCurveOpen}
                           onOpenChange={chooseSnrCurveOpen}
                         />
@@ -1213,7 +1227,7 @@ export default function StackPreviewPanel({
                             dbId={dbId}
                             source={{ kind: 'mono', jobId: artifact.jobId, groupIndex: artifact.group.index, artifactRevision: artifact.artifactRevision }}
                             title={artifact.group.target_name}
-                            label={artifact.group.filter_name || 'No filter'}
+                            label={channelLabel(artifact.group.filter_name, artifact.group.exposure_group)}
                           />
                         </div>
                         <details className="stack-preview-details">
@@ -1248,7 +1262,7 @@ export default function StackPreviewPanel({
         <StackPreviewInspector
           eyebrow="Full-resolution integration"
           title={inspector.group.target_name}
-          label={inspector.group.filter_name || 'No filter'}
+          label={channelLabel(inspector.group.filter_name, inspector.group.exposure_group)}
           summary={[
             `${inspector.group.accepted_frames} frames`,
             `${Math.round(inspector.group.total_exposure_seconds)} s`,
@@ -1271,7 +1285,7 @@ export default function StackPreviewPanel({
               inspector.group.index,
               inspector.artifactRevision
             )}
-          imageAlt={`Full-resolution stack for ${inspector.group.target_name} ${inspector.group.filter_name || 'No filter'}`}
+          imageAlt={`Full-resolution stack for ${inspector.group.target_name} ${channelLabel(inspector.group.filter_name, inspector.group.exposure_group)}`}
           downloadLabel={stretches[artifactStretchKey(inspector)]?.fits_url
             ? 'Download deconvolved linear FITS'
             : 'Download linear FITS'}

--- a/static/src/components/__tests__/ProjectExposureGrouping.test.tsx
+++ b/static/src/components/__tests__/ProjectExposureGrouping.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import ProjectExposureGrouping from '../ProjectExposureGrouping';
+
+function mount(canManage = true) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  const mounted = render(<QueryClientProvider client={queryClient}>
+    <ProjectExposureGrouping dbId="test" projectId={1} canManage={canManage} />
+  </QueryClientProvider>);
+  return { ...mounted, queryClient };
+}
+
+describe('project exposure grouping', () => {
+  it('saves the project setting and restores it on reload', async () => {
+    let enabled = false;
+    server.use(
+      http.get('/api/db/test/projects/1/processing-settings', () => HttpResponse.json({
+        success: true, data: { split_exposure_groups: enabled },
+      })),
+      http.put('/api/db/test/projects/1/processing-settings', async ({ request }) => {
+        enabled = (await request.json() as { split_exposure_groups: boolean }).split_exposure_groups;
+        return HttpResponse.json({ success: true, data: { split_exposure_groups: enabled } });
+      }),
+    );
+    const first = mount();
+    const toggle = screen.getByRole('checkbox', { name: 'Separate exposure groups' });
+    await waitFor(() => expect(toggle).toBeEnabled());
+    expect(toggle).not.toBeChecked();
+    await userEvent.click(toggle);
+    await waitFor(() => expect(toggle).toBeChecked());
+    expect(enabled).toBe(true);
+    first.unmount();
+    mount();
+    await waitFor(() => expect(screen.getByRole('checkbox')).toBeChecked());
+  });
+
+  it('retains the server value and shows a save failure', async () => {
+    server.use(
+      http.get('/api/db/test/projects/1/processing-settings', () => HttpResponse.json({
+        success: true, data: { split_exposure_groups: false },
+      })),
+      http.put('/api/db/test/projects/1/processing-settings', () => HttpResponse.json(
+        { error: 'Database is read-only' }, { status: 403 }
+      )),
+    );
+    mount();
+    const toggle = screen.getByRole('checkbox');
+    await waitFor(() => expect(toggle).toBeEnabled());
+    await userEvent.click(toggle);
+    expect(await screen.findByRole('alert')).toHaveTextContent('Database is read-only');
+    expect(toggle).not.toBeChecked();
+    expect(toggle).toBeEnabled();
+  });
+
+  it('exposes the persisted state without allowing a viewer to change it', async () => {
+    server.use(http.get('/api/db/test/projects/1/processing-settings', () => HttpResponse.json({
+      success: true, data: { split_exposure_groups: true },
+    })));
+    mount(false);
+    await waitFor(() => expect(screen.getByRole('checkbox')).toBeChecked());
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+  });
+});

--- a/static/src/components/__tests__/StackColorPreviewPanel.exposures.test.tsx
+++ b/static/src/components/__tests__/StackColorPreviewPanel.exposures.test.tsx
@@ -1,127 +1,266 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../test/msw-server';
-import type { StackColorRole, StackColorSource } from '../../api/types';
+import type { StackColorInputSources, StackColorJob, StackColorProcessing, StackColorRole, StackColorSource } from '../../api/types';
 import StackColorPreviewPanel from '../StackColorPreviewPanel';
 import { colorSourceKey } from '../stackColorSources';
+
+vi.mock('../StackColorProcessingControls', () => ({
+  default: ({ label, applied, disabled, onApply }: {
+    label: string; applied: StackColorProcessing | null; disabled: boolean;
+    onApply: (processing: StackColorProcessing) => void;
+  }) => <button type="button" disabled={disabled} data-applied={JSON.stringify(applied)}
+    onClick={() => onApply({ background_extraction: null, input_deconvolutions: {}, input_stretches: {},
+      output_stretches: [{ model: { type: 'linear', black: 0, white: 0.7 }, color_strategy: 'linked' }] })}>
+    Apply processing {label}
+  </button>,
+}));
 
 const ok = (data: unknown) => HttpResponse.json({ success: true, data, error: null });
 const roles: StackColorRole[] = ['red', 'green', 'blue'];
 const candidates: StackColorSource[] = roles.flatMap((role, index) => [30, 300].map((seconds) => ({
   role, filter_name: role, label: `${role} (${seconds} s)`,
-  exposure_group: { key: `${seconds}`, label: `${seconds} s`, min_seconds: seconds, max_seconds: seconds },
+  exposure_group: { key: `${role}-${seconds}`, label: `${seconds} s`, min_seconds: seconds, max_seconds: seconds },
   job_id: `${role}-${seconds}`, group_index: index, artifact_revision: 'rev', accepted_frames: 4,
   reference_image_id: 1, sky_orientation: null, registration_transform: null,
 })));
+const atSeconds = (seconds: number) => candidates.filter((source) => source.exposure_group?.min_seconds === seconds);
+const references = (sources: StackColorSource[]) => Object.fromEntries(sources.map((source) => [source.role, {
+  job_id: source.job_id, group_index: source.group_index, artifact_revision: source.artifact_revision,
+}]));
 
-const target = {
-  target_id: 42, target_name: 'M31', available_roles: [], source_candidates: candidates,
-  ambiguous_roles: roles, unmapped_filters: [], rgb_available: true, lrgb_available: false, narrowband_palettes: [],
-};
+function job(sources: StackColorSource[], overrides: Partial<StackColorJob> = {}): StackColorJob {
+  return {
+    schema_version: 1, job_id: 'color', database_id: 'test', project_id: 1,
+    target_id: 42, target_name: 'M31', kind: 'rgb', palette: null, label: 'RGB',
+    state: 'completed', phase: 'Ready', sources, source_family_key: sources.map((source) => source.job_id).join(':'),
+    created_unix_seconds: 1, artifact_revision: 'color-rev', processed_channels: 3, total_channels: 3,
+    progress: { completed_units: 3, total_units: 3, active_phase: null, current_role: null, current_stage: null, stage_count: null, phases: [] },
+    cache_version: 12, stacking_version: 'test', background_version: 'test', deconvolution_version: '',
+    linear_input_id: null, crop: 'none', crop_report: null, processing: null,
+    resolved_input_stretches: {}, resolved_input_deconvolutions: {}, resolved_output_stretches: [],
+    resolved_backgrounds: {}, resolved_background_protection: {}, background_protection_fallbacks: {},
+    preview_url: '/preview', fits_url: '/fits', outdated: false, outdated_reason: null, error: null,
+    ...overrides,
+  };
+}
 
-describe('color exposure source selection', () => {
-  it('keeps stale explicit selectors visible after exposure grouping is disabled', async () => {
-    let currentCandidates = candidates;
-    server.use(
-      http.get('/api/stack-activity', () => ok({ active: [] })),
-      http.get('/api/db/test/projects/1/stack-previews/color', () => ok({
-        targets: [{ ...target, source_candidates: currentCandidates,
-          ambiguous_roles: currentCandidates.length > roles.length ? roles : [] }], jobs: [],
-      })),
-    );
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
-    const panel = (revision: string) => <QueryClientProvider client={queryClient}>
-      <StackColorPreviewPanel dbId="test" projectId={1} sourceRevision={revision}
-        channelBuildRunning={false} outdatedTargetIds={new Set()} canCompute onOpenImage={() => undefined} />
-    </QueryClientProvider>;
-    const rendered = render(panel('split'));
-    const selector = (role: StackColorRole) => screen.getByRole('combobox', {
-      name: `M31 rgb ${role[0].toUpperCase()} source stack`,
-    });
-    await screen.findByRole('button', { name: 'Build RGB color preview' });
-    for (const role of roles) {
-      const source = candidates.find((candidate) => candidate.role === role && candidate.exposure_group?.key === '300')!;
-      await userEvent.selectOptions(selector(role), colorSourceKey(source));
+interface BuildRequest {
+  input_sources?: StackColorInputSources;
+  crop: string;
+  processing: StackColorProcessing;
+  force: boolean;
+}
+
+function mount(options: {
+  sources?: StackColorSource[]; jobs?: StackColorJob[]; legacy?: boolean;
+  omitTarget?: boolean;
+  outdated?: ReadonlySet<string>; response?: (sources: StackColorSource[]) => Partial<StackColorJob>;
+} = {}) {
+  const catalog = { sources: options.sources ?? candidates, jobs: options.jobs ?? [], legacy: options.legacy ?? false };
+  const submissions: BuildRequest[] = [];
+  const posted = new Map<string, StackColorJob>();
+  server.use(
+    http.get('/api/stack-activity', () => ok({ active: [] })),
+    http.get('/api/db/test/projects/1/stack-previews/color', () => ok({ targets: options.omitTarget ? [] : [{
+      target_id: 42, target_name: 'M31', available_roles: roles.map((role) => ({ role, filter_name: role })),
+      ...(catalog.legacy ? {} : { source_candidates: catalog.sources }),
+      ambiguous_roles: roles.filter((role) => catalog.sources.filter((source) => source.role === role).length > 1),
+      unmapped_filters: [], rgb_available: roles.every((role) => catalog.sources.some((source) => source.role === role)),
+      lrgb_available: false, narrowband_palettes: [],
+    }], jobs: catalog.jobs })),
+    http.post('/api/db/test/projects/1/stack-previews/color', async ({ request }) => {
+      const body = await request.json() as BuildRequest;
+      submissions.push(body);
+      const selected = body.input_sources ? catalog.sources.filter((source) => {
+        const reference = body.input_sources?.[source.role];
+        return reference?.job_id === source.job_id && reference.group_index === source.group_index
+          && reference.artifact_revision === source.artifact_revision;
+      }) : catalog.sources;
+      const response = job(selected, { job_id: `posted-${submissions.length}`, state: 'queued', phase: 'Waiting',
+        created_unix_seconds: submissions.length + 10, processed_channels: 0, ...options.response?.(selected) });
+      posted.set(response.job_id, response);
+      return ok(response);
+    }),
+    http.get('/api/db/test/projects/1/stack-previews/color/:jobId', ({ params }) => ok(posted.get(String(params.jobId)))),
+  );
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  const panel = (revision: string, outdated = options.outdated ?? new Set<string>()) => <QueryClientProvider client={client}>
+    <StackColorPreviewPanel dbId="test" projectId={1} sourceRevision={revision}
+      channelBuildRunning={false} outdatedSourceKeys={outdated} canCompute onOpenImage={() => undefined} />
+  </QueryClientProvider>;
+  const rendered = render(panel('initial'));
+  return { catalog, submissions, rerender: (revision: string, outdated?: ReadonlySet<string>) => rendered.rerender(panel(revision, outdated)) };
+}
+
+function cardFor(button: HTMLElement) {
+  const article = button.closest('article');
+  if (!article) throw new Error('Color action is not inside its card');
+  return article;
+}
+
+const selector = (role: StackColorRole) => screen.getByRole('combobox', {
+  name: `M31 rgb ${role[0].toUpperCase()} source stack`,
+});
+
+describe('automatic color exposure cards', () => {
+  it('offers independent short and long builds without manual source choices', async () => {
+    mount();
+    const short = await screen.findByRole('button', { name: 'Build RGB 30 s color preview' });
+    const long = screen.getByRole('button', { name: 'Build RGB 300 s color preview' });
+    expect(short).toBeEnabled();
+    expect(long).toBeEnabled();
+    expect(cardFor(short)).not.toBe(cardFor(long));
+    expect(within(cardFor(short)).queryByRole('combobox', { name: /source stack/ })).not.toBeInTheDocument();
+    expect(within(cardFor(long)).queryByRole('combobox', { name: /source stack/ })).not.toBeInTheDocument();
+    expect(screen.getByText('Custom combination').closest('details')).not.toHaveAttribute('open');
+  });
+
+  it.each([30, 300])('submits exact source references from the %i s card', async (seconds) => {
+    const { submissions } = mount();
+    await userEvent.click(await screen.findByRole('button', { name: `Build RGB ${seconds} s color preview` }));
+    await waitFor(() => expect(submissions[0]?.input_sources).toEqual(references(atSeconds(seconds))));
+    const active = screen.getByRole('button', { name: `Build RGB ${seconds} s color preview` });
+    expect(within(cardFor(active)).getByRole('status')).toHaveTextContent('Waiting');
+    expect(screen.getByRole('button', { name: `Build RGB ${seconds === 30 ? 300 : 30} s color preview` })).toBeEnabled();
+  });
+
+  it('disables only the incomplete long set when its blue stack is missing', async () => {
+    mount({ sources: candidates.filter((source) => source.job_id !== 'blue-300') });
+    const short = await screen.findByRole('button', { name: 'Build RGB 30 s color preview' });
+    const long = screen.getByRole('button', { name: 'Build RGB 300 s color preview' });
+    expect(short).toBeEnabled();
+    expect(long).toBeDisabled();
+    expect(within(cardFor(long)).getByText('Missing B')).toBeVisible();
+    expect(within(cardFor(short)).queryByText('Missing B')).not.toBeInTheDocument();
+  });
+
+  it('keeps duplicate same-role sources ambiguous until a custom choice is made', async () => {
+    const duplicate = { ...atSeconds(30)[0], filter_name: 'Other red', job_id: 'other-red',
+      exposure_group: { ...atSeconds(30)[0].exposure_group!, key: 'other-red-family' } };
+    const { submissions } = mount({ sources: [...candidates, duplicate] });
+    const short = await screen.findByRole('button', { name: 'Build RGB 30 s color preview' });
+    expect(short).toBeDisabled();
+    expect(within(cardFor(short)).getByText('Multiple R stacks')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Build RGB 300 s color preview' })).toBeEnabled();
+    await userEvent.click(screen.getByText('Custom combination'));
+    for (const source of atSeconds(30)) await userEvent.selectOptions(selector(source.role), colorSourceKey(source));
+    await userEvent.click(screen.getByRole('button', { name: 'Build RGB custom color preview' }));
+    await waitFor(() => expect(submissions[0]?.input_sources).toEqual(references(atSeconds(30))));
+  });
+
+  it('allows deliberate mixed exposure sources only through Custom combination', async () => {
+    const { submissions } = mount();
+    await userEvent.click(await screen.findByText('Custom combination'));
+    const mixed = [atSeconds(30)[0], ...atSeconds(300).slice(1)];
+    for (const source of mixed) await userEvent.selectOptions(selector(source.role), colorSourceKey(source));
+    await userEvent.click(screen.getByRole('button', { name: 'Build RGB custom color preview' }));
+    await waitFor(() => expect(submissions[0]?.input_sources).toEqual(references(mixed)));
+    expect(screen.getByRole('button', { name: 'Build RGB 30 s color preview' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Build RGB 300 s color preview' })).toBeEnabled();
+  });
+
+  it('keeps saved short and long artifacts independently inspectable', async () => {
+    mount({ jobs: [job(atSeconds(30), { job_id: 'color-short' }), job(atSeconds(300), { job_id: 'color-long' })] });
+    const short = await screen.findByRole('button', { name: 'Inspect RGB 30 s full size' });
+    const long = screen.getByRole('button', { name: 'Inspect RGB 300 s full size' });
+    expect(within(cardFor(short)).getByRole('img')).toHaveAttribute('src', expect.stringContaining('color-short'));
+    expect(within(cardFor(long)).getByRole('img')).toHaveAttribute('src', expect.stringContaining('color-long'));
+    await userEvent.click(long);
+    expect(within(screen.getByRole('dialog')).getByText('red (300 s), green (300 s), blue (300 s)')).toBeVisible();
+  });
+
+  it('scopes a failed queued build to its exposure card', async () => {
+    const { submissions } = mount({ response: () => ({ state: 'failed', phase: 'Failed', error: 'Long channel registration failed' }) });
+    await userEvent.click(await screen.findByRole('button', { name: 'Build RGB 300 s color preview' }));
+    await waitFor(() => expect(submissions).toHaveLength(1));
+    const long = cardFor(screen.getByRole('button', { name: 'Build RGB 300 s color preview' }));
+    await waitFor(() => expect(within(long).getByText('Long channel registration failed')).toBeVisible());
+    const short = cardFor(screen.getByRole('button', { name: 'Build RGB 30 s color preview' }));
+    expect(within(short).queryByText('Long channel registration failed')).not.toBeInTheDocument();
+    expect(within(short).getByRole('status')).toHaveTextContent('Not built');
+  });
+
+  it('retains separate historical-only previews without enabling builds from missing sources', async () => {
+    mount({ omitTarget: true, sources: [], jobs: [
+      job(atSeconds(30), { job_id: 'history-short', outdated: true }),
+      job(atSeconds(300), { job_id: 'history-long', outdated: true }),
+    ] });
+    const short = cardFor(await screen.findByRole('button', { name: 'Inspect RGB Previous 30 s full size' }));
+    const long = cardFor(screen.getByRole('button', { name: 'Inspect RGB Previous 300 s full size' }));
+    expect(within(short).getByRole('img')).toHaveAttribute('src', expect.stringContaining('history-short'));
+    expect(within(long).getByRole('img')).toHaveAttribute('src', expect.stringContaining('history-long'));
+    expect(within(short).getByRole('button', { name: 'Rebuild RGB Previous 30 s color preview' })).toBeDisabled();
+    expect(within(long).getByRole('button', { name: 'Rebuild RGB Previous 300 s color preview' })).toBeDisabled();
+    for (const build of screen.getAllByRole('button', { name: /^(Build|Rebuild) RGB .*color preview$/ })) {
+      expect(build).toBeDisabled();
     }
-    expect(screen.getByRole('button', { name: 'Build RGB color preview' })).toBeEnabled();
-    currentCandidates = roles.map((role) => ({
-      ...candidates.find((candidate) => candidate.role === role)!,
-      job_id: `${role}-unsplit`, exposure_group: null, label: role,
-    }));
-    rendered.rerender(panel('unsplit'));
+  });
+
+  it('isolates saved processing and crop changes between exposure cards', async () => {
+    const shortProcessing: StackColorProcessing = { background_extraction: null, input_deconvolutions: {}, input_stretches: {},
+      output_stretches: [{ model: { type: 'identity' }, color_strategy: 'linked' }] };
+    const longProcessing: StackColorProcessing = { ...shortProcessing, output_stretches: [] };
+    const { submissions } = mount({ jobs: [
+      job(atSeconds(30), { job_id: 'color-short', crop: 'bounds', processing: shortProcessing }),
+      job(atSeconds(300), { job_id: 'color-long', crop: 'inscribed', processing: longProcessing }),
+    ] });
+    const shortCrop = await screen.findByRole('combobox', { name: 'M31 RGB 30 s edge crop' });
+    const longCrop = screen.getByRole('combobox', { name: 'M31 RGB 300 s edge crop' });
+    expect(shortCrop).toHaveValue('bounds');
+    expect(longCrop).toHaveValue('inscribed');
+    expect(screen.getByRole('button', { name: 'Apply processing M31 RGB 30 s' })).toHaveAttribute('data-applied', JSON.stringify(shortProcessing));
+    expect(screen.getByRole('button', { name: 'Apply processing M31 RGB 300 s' })).toHaveAttribute('data-applied', JSON.stringify(longProcessing));
+    await userEvent.selectOptions(shortCrop, 'none');
+    expect(longCrop).toHaveValue('inscribed');
+    await userEvent.click(screen.getByRole('button', { name: 'Apply processing M31 RGB 300 s' }));
+    await waitFor(() => expect(submissions[0]?.input_sources).toEqual(references(atSeconds(300))));
+    expect(submissions[0].crop).toBe('inscribed');
+    expect(submissions[0].processing.output_stretches).toEqual([{ model: { type: 'linear', black: 0, white: 0.7 }, color_strategy: 'linked' }]);
+    expect(shortCrop).toHaveValue('none');
+  });
+
+  it('marks only the card containing an exact stale source reference', async () => {
+    const longRed = atSeconds(300)[0];
+    const { rerender } = mount({ outdated: new Set([colorSourceKey({ ...longRed, artifact_revision: 'other-revision' })]) });
+    const short = cardFor(await screen.findByRole('button', { name: 'Build RGB 30 s color preview' }));
+    const long = cardFor(screen.getByRole('button', { name: 'Build RGB 300 s color preview' }));
+    expect(short).not.toHaveClass('outdated');
+    expect(long).not.toHaveClass('outdated');
+    rerender('current', new Set([colorSourceKey(longRed)]));
+    await waitFor(() => expect(cardFor(screen.getByRole('button', { name: 'Build RGB 300 s color preview' }))).toHaveClass('outdated'));
+    expect(cardFor(screen.getByRole('button', { name: 'Build RGB 30 s color preview' }))).not.toHaveClass('outdated');
+  });
+
+  it.each([false, true])('preserves unsplit single-source behavior (legacy catalog: %s)', async (legacy) => {
+    const unsplit = atSeconds(30).map((source) => ({ ...source, exposure_group: null }));
+    const { submissions } = mount({ sources: unsplit, legacy });
+    const build = await screen.findByRole('button', { name: 'Build RGB color preview' });
+    expect(build).toBeEnabled();
+    expect(screen.queryByText('Custom combination')).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /source stack/ })).not.toBeInTheDocument();
+    await userEvent.click(build);
+    await waitFor(() => expect(submissions).toHaveLength(1));
+    expect(submissions[0].input_sources).toBeUndefined();
+  });
+
+  it('keeps custom stale-source selectors recoverable after grouping is disabled', async () => {
+    const { catalog, rerender } = mount();
+    await userEvent.click(await screen.findByText('Custom combination'));
+    for (const source of atSeconds(300)) await userEvent.selectOptions(selector(source.role), colorSourceKey(source));
+    expect(screen.getByRole('button', { name: 'Build RGB custom color preview' })).toBeEnabled();
+    catalog.sources = atSeconds(30).map((source) => ({ ...source, job_id: `${source.role}-unsplit`, exposure_group: null }));
+    rerender('unsplit');
     await waitFor(() => expect(selector('red')).toHaveValue(''));
-    expect(screen.getByRole('button', { name: 'Build RGB color preview' })).toBeDisabled();
-    for (const source of currentCandidates) {
+    const build = screen.getByRole('button', { name: 'Build RGB color preview' });
+    expect(build).toBeDisabled();
+    for (const source of catalog.sources) {
       expect(selector(source.role)).toBeVisible();
       await userEvent.selectOptions(selector(source.role), colorSourceKey(source));
     }
-    expect(screen.getByRole('button', { name: 'Build RGB color preview' })).toBeEnabled();
-  });
-
-  it('identifies the saved exposure sources in the full-size inspector', async () => {
-    const sources = candidates.filter((source) => source.exposure_group?.key === '300');
-    const job = {
-      schema_version: 1, job_id: 'color-long', database_id: 'test', project_id: 1,
-      target_id: 42, target_name: 'M31', kind: 'rgb', palette: null, label: 'RGB',
-      state: 'completed', phase: 'Ready', sources,
-      created_unix_seconds: 1, artifact_revision: 'color-rev', processed_channels: 3, total_channels: 3,
-      preview_url: '/preview', fits_url: '/fits', outdated: false,
-    };
-    server.use(
-      http.get('/api/stack-activity', () => ok({ active: [] })),
-      http.get('/api/db/test/projects/1/stack-previews/color', () => ok({
-        targets: [{ ...target, source_candidates: sources, ambiguous_roles: [] }], jobs: [job],
-      })),
-    );
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
-    render(<QueryClientProvider client={queryClient}>
-      <StackColorPreviewPanel dbId="test" projectId={1} sourceRevision="test"
-        channelBuildRunning={false} outdatedTargetIds={new Set()} canCompute onOpenImage={() => undefined} />
-    </QueryClientProvider>);
-    await userEvent.click(await screen.findByRole('button', { name: 'Inspect RGB full size' }));
-    const inspector = screen.getByRole('dialog');
-    expect(within(inspector).getByText('red (300 s), green (300 s), blue (300 s)')).toBeVisible();
-  });
-
-  it('requires explicit ambiguous choices and submits the selected artifact identities', async () => {
-    let submitted: Record<string, unknown> | undefined;
-    const job = {
-      schema_version: 1, job_id: 'color', database_id: 'test', project_id: 1,
-      target_id: 42, target_name: 'M31', kind: 'rgb', palette: null, label: 'RGB',
-      state: 'queued', phase: 'Waiting', sources: candidates.filter((source) => source.exposure_group?.key === '300'),
-      created_unix_seconds: 1, artifact_revision: 'color-rev', processed_channels: 0, total_channels: 3,
-      preview_url: '/preview', fits_url: '/fits', outdated: false,
-    };
-    server.use(
-      http.get('/api/stack-activity', () => ok({ active: [] })),
-      http.get('/api/db/test/projects/1/stack-previews/color', () => ok({ targets: [target], jobs: [] })),
-      http.post('/api/db/test/projects/1/stack-previews/color', async ({ request }) => {
-        submitted = await request.json() as Record<string, unknown>;
-        return ok(job);
-      }),
-      http.get('/api/db/test/projects/1/stack-previews/color/color', () => ok(job)),
-    );
-    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
-    render(<QueryClientProvider client={queryClient}>
-      <StackColorPreviewPanel dbId="test" projectId={1} sourceRevision="test"
-        channelBuildRunning={false} outdatedTargetIds={new Set()} canCompute onOpenImage={() => undefined} />
-    </QueryClientProvider>);
-    const build = await screen.findByRole('button', { name: 'Build RGB color preview' });
-    expect(build).toBeDisabled();
-    for (const role of roles) {
-      const source = candidates.find((candidate) => candidate.role === role && candidate.exposure_group?.key === '300')!;
-      await userEvent.selectOptions(screen.getByRole('combobox', {
-        name: `M31 rgb ${role[0].toUpperCase()} source stack`,
-      }), colorSourceKey(source));
-    }
     expect(build).toBeEnabled();
-    await userEvent.click(build);
-    await waitFor(() => expect(submitted?.input_sources).toEqual(Object.fromEntries(roles.map((role, index) => [role, {
-      job_id: `${role}-300`, group_index: index, artifact_revision: 'rev',
-    }]))));
-    expect(screen.getByRole('status')).toHaveTextContent('Waiting');
   });
 });

--- a/static/src/components/__tests__/StackColorPreviewPanel.exposures.test.tsx
+++ b/static/src/components/__tests__/StackColorPreviewPanel.exposures.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/msw-server';
+import type { StackColorRole, StackColorSource } from '../../api/types';
+import StackColorPreviewPanel from '../StackColorPreviewPanel';
+import { colorSourceKey } from '../stackColorSources';
+
+const ok = (data: unknown) => HttpResponse.json({ success: true, data, error: null });
+const roles: StackColorRole[] = ['red', 'green', 'blue'];
+const candidates: StackColorSource[] = roles.flatMap((role, index) => [30, 300].map((seconds) => ({
+  role, filter_name: role, label: `${role} (${seconds} s)`,
+  exposure_group: { key: `${seconds}`, label: `${seconds} s`, min_seconds: seconds, max_seconds: seconds },
+  job_id: `${role}-${seconds}`, group_index: index, artifact_revision: 'rev', accepted_frames: 4,
+  reference_image_id: 1, sky_orientation: null, registration_transform: null,
+})));
+
+const target = {
+  target_id: 42, target_name: 'M31', available_roles: [], source_candidates: candidates,
+  ambiguous_roles: roles, unmapped_filters: [], rgb_available: true, lrgb_available: false, narrowband_palettes: [],
+};
+
+describe('color exposure source selection', () => {
+  it('keeps stale explicit selectors visible after exposure grouping is disabled', async () => {
+    let currentCandidates = candidates;
+    server.use(
+      http.get('/api/stack-activity', () => ok({ active: [] })),
+      http.get('/api/db/test/projects/1/stack-previews/color', () => ok({
+        targets: [{ ...target, source_candidates: currentCandidates,
+          ambiguous_roles: currentCandidates.length > roles.length ? roles : [] }], jobs: [],
+      })),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+    const panel = (revision: string) => <QueryClientProvider client={queryClient}>
+      <StackColorPreviewPanel dbId="test" projectId={1} sourceRevision={revision}
+        channelBuildRunning={false} outdatedTargetIds={new Set()} canCompute onOpenImage={() => undefined} />
+    </QueryClientProvider>;
+    const rendered = render(panel('split'));
+    const selector = (role: StackColorRole) => screen.getByRole('combobox', {
+      name: `M31 rgb ${role[0].toUpperCase()} source stack`,
+    });
+    await screen.findByRole('button', { name: 'Build RGB color preview' });
+    for (const role of roles) {
+      const source = candidates.find((candidate) => candidate.role === role && candidate.exposure_group?.key === '300')!;
+      await userEvent.selectOptions(selector(role), colorSourceKey(source));
+    }
+    expect(screen.getByRole('button', { name: 'Build RGB color preview' })).toBeEnabled();
+    currentCandidates = roles.map((role) => ({
+      ...candidates.find((candidate) => candidate.role === role)!,
+      job_id: `${role}-unsplit`, exposure_group: null, label: role,
+    }));
+    rendered.rerender(panel('unsplit'));
+    await waitFor(() => expect(selector('red')).toHaveValue(''));
+    expect(screen.getByRole('button', { name: 'Build RGB color preview' })).toBeDisabled();
+    for (const source of currentCandidates) {
+      expect(selector(source.role)).toBeVisible();
+      await userEvent.selectOptions(selector(source.role), colorSourceKey(source));
+    }
+    expect(screen.getByRole('button', { name: 'Build RGB color preview' })).toBeEnabled();
+  });
+
+  it('identifies the saved exposure sources in the full-size inspector', async () => {
+    const sources = candidates.filter((source) => source.exposure_group?.key === '300');
+    const job = {
+      schema_version: 1, job_id: 'color-long', database_id: 'test', project_id: 1,
+      target_id: 42, target_name: 'M31', kind: 'rgb', palette: null, label: 'RGB',
+      state: 'completed', phase: 'Ready', sources,
+      created_unix_seconds: 1, artifact_revision: 'color-rev', processed_channels: 3, total_channels: 3,
+      preview_url: '/preview', fits_url: '/fits', outdated: false,
+    };
+    server.use(
+      http.get('/api/stack-activity', () => ok({ active: [] })),
+      http.get('/api/db/test/projects/1/stack-previews/color', () => ok({
+        targets: [{ ...target, source_candidates: sources, ambiguous_roles: [] }], jobs: [job],
+      })),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+    render(<QueryClientProvider client={queryClient}>
+      <StackColorPreviewPanel dbId="test" projectId={1} sourceRevision="test"
+        channelBuildRunning={false} outdatedTargetIds={new Set()} canCompute onOpenImage={() => undefined} />
+    </QueryClientProvider>);
+    await userEvent.click(await screen.findByRole('button', { name: 'Inspect RGB full size' }));
+    const inspector = screen.getByRole('dialog');
+    expect(within(inspector).getByText('red (300 s), green (300 s), blue (300 s)')).toBeVisible();
+  });
+
+  it('requires explicit ambiguous choices and submits the selected artifact identities', async () => {
+    let submitted: Record<string, unknown> | undefined;
+    const job = {
+      schema_version: 1, job_id: 'color', database_id: 'test', project_id: 1,
+      target_id: 42, target_name: 'M31', kind: 'rgb', palette: null, label: 'RGB',
+      state: 'queued', phase: 'Waiting', sources: candidates.filter((source) => source.exposure_group?.key === '300'),
+      created_unix_seconds: 1, artifact_revision: 'color-rev', processed_channels: 0, total_channels: 3,
+      preview_url: '/preview', fits_url: '/fits', outdated: false,
+    };
+    server.use(
+      http.get('/api/stack-activity', () => ok({ active: [] })),
+      http.get('/api/db/test/projects/1/stack-previews/color', () => ok({ targets: [target], jobs: [] })),
+      http.post('/api/db/test/projects/1/stack-previews/color', async ({ request }) => {
+        submitted = await request.json() as Record<string, unknown>;
+        return ok(job);
+      }),
+      http.get('/api/db/test/projects/1/stack-previews/color/color', () => ok(job)),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+    render(<QueryClientProvider client={queryClient}>
+      <StackColorPreviewPanel dbId="test" projectId={1} sourceRevision="test"
+        channelBuildRunning={false} outdatedTargetIds={new Set()} canCompute onOpenImage={() => undefined} />
+    </QueryClientProvider>);
+    const build = await screen.findByRole('button', { name: 'Build RGB color preview' });
+    expect(build).toBeDisabled();
+    for (const role of roles) {
+      const source = candidates.find((candidate) => candidate.role === role && candidate.exposure_group?.key === '300')!;
+      await userEvent.selectOptions(screen.getByRole('combobox', {
+        name: `M31 rgb ${role[0].toUpperCase()} source stack`,
+      }), colorSourceKey(source));
+    }
+    expect(build).toBeEnabled();
+    await userEvent.click(build);
+    await waitFor(() => expect(submitted?.input_sources).toEqual(Object.fromEntries(roles.map((role, index) => [role, {
+      job_id: `${role}-300`, group_index: index, artifact_revision: 'rev',
+    }]))));
+    expect(screen.getByRole('status')).toHaveTextContent('Waiting');
+  });
+});

--- a/static/src/components/__tests__/StackPreviewPanel.queue.test.tsx
+++ b/static/src/components/__tests__/StackPreviewPanel.queue.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -77,6 +77,44 @@ function job(jobId: string, created: number, state: string, groups: unknown[]) {
     error: null,
   };
 }
+
+describe('StackPreviewPanel exposure groups', () => {
+  it('keeps same-filter cards, progress, and calibration overrides independent', async () => {
+    const short = { key: 'short', label: '30 s', min_seconds: 30, max_seconds: 30 };
+    const long = { key: 'long', label: '300 s', min_seconds: 300, max_seconds: 300 };
+    const inputs = images.map((image, index) => ({
+      ...image, filter_name: 'Ha', exposure_group: index < 2 ? short : long,
+    }));
+    let submitted: Record<string, unknown> | undefined;
+    const started = job('split', 100, 'running', [
+      { ...group(0, 'Ha', 'running', [1, 2]), exposure_group: short },
+      { ...group(1, 'Ha', 'queued', [3, 4]), exposure_group: long },
+    ]);
+    server.use(
+      http.get('/api/stack-activity', () => ok({ schema_version: 1, active: [] })),
+      http.get('/api/db/test/projects/1/stack-previews/latest', () => ok({ groups: [] })),
+      http.get('/api/db/test/projects/1/stack-previews/color', () => ok({ targets: [], jobs: [] })),
+      http.post('/api/db/test/projects/1/stack-previews', async ({ request }) => {
+        submitted = await request.json() as Record<string, unknown>;
+        return ok(started);
+      }),
+      http.get('/api/db/test/projects/1/stack-previews/split', () => ok(started)),
+    );
+    const view = render(<StackPreviewPanel dbId="test" projectId={1} images={inputs}
+      selectionSource="visible" onOpenImage={() => undefined} />, { wrapper: wrapper() });
+    expect(await screen.findAllByRole('button', { name: 'Build channel' })).toHaveLength(2);
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Sh2 86 Ha · 30 s calibration' }), 'off');
+    expect(screen.getByRole('combobox', { name: 'Sh2 86 Ha · 300 s calibration' })).toHaveValue('');
+    await userEvent.click(screen.getByRole('button', { name: 'Build stack previews' }));
+    await waitFor(() => expect(submitted?.calibration_overrides).toEqual([
+      { target_id: 42, filter_name: 'Ha', exposure_group_key: 'short', calibration: 'off' },
+    ]));
+    await waitFor(() => expect(view.container.querySelectorAll('.stack-preview-card')).toHaveLength(2));
+    expect(view.container.querySelector('[data-exposure-group="short"]')).toHaveTextContent('running');
+    expect(view.container.querySelector('[data-exposure-group="long"]')).toHaveTextContent('queued');
+    window.localStorage.removeItem('psf-guard.stack-calibration-overrides');
+  });
+});
 
 describe('StackPreviewPanel manual queue', () => {
   it('keeps other channels buildable and shows both queued builds', async () => {

--- a/static/src/components/__tests__/colorExposureCards.test.ts
+++ b/static/src/components/__tests__/colorExposureCards.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { StackColorKind, StackColorRole, StackColorSource, StackNarrowbandPalette } from '../../api/types';
+import { buildColorExposureSets } from '../stackColorSources';
+import { withRetainedColorExposureSets } from '../colorExposureCards';
+
+const rgb: StackColorRole[] = ['red', 'green', 'blue'];
+
+function source(role: StackColorRole, seconds: number, key = `${role}-${seconds}`): StackColorSource {
+  return {
+    role, filter_name: role, label: `${role} (${seconds} s)`,
+    exposure_group: { key, label: `${seconds} s`, min_seconds: seconds, max_seconds: seconds },
+    job_id: `${role}-${key}`, group_index: 0, artifact_revision: 'current', accepted_frames: 2,
+    reference_image_id: null, sky_orientation: null, registration_transform: null,
+  };
+}
+
+function recorded(
+  sources: StackColorSource[], jobId = 'saved', created = 1,
+  kind: StackColorKind = 'rgb', palette: StackNarrowbandPalette | null = null,
+) {
+  return { job_id: jobId, created_unix_seconds: created, sources, kind, palette };
+}
+
+describe('retained automatic color exposure cards', () => {
+  it('fills missing family descriptors without duplicating rebuilt current roles', () => {
+    const saved = rgb.map((role) => source(role, 30));
+    const current = [{ ...saved[0], job_id: 'rebuilt', artifact_revision: 'new' }, saved[1]];
+    const result = withRetainedColorExposureSets(buildColorExposureSets(current, rgb), [recorded(saved)], rgb);
+    expect(result).toHaveLength(1);
+    expect(result[0].retained).toBe(false);
+    expect(result[0].candidates).toHaveLength(3);
+    expect(result[0].candidates.find((entry) => entry.role === 'red')?.job_id).toBe('rebuilt');
+    expect(result[0].key).toBe(buildColorExposureSets(saved, rgb)[0].key);
+    expect(current).toHaveLength(2);
+  });
+
+  it('keeps a conflicting previous family separate instead of substituting the available channel', () => {
+    const saved = rgb.map((role) => source(role, 30));
+    const current = [source('red', 30, 'different-red'), source('green', 30), source('blue', 300)];
+    const result = withRetainedColorExposureSets(buildColorExposureSets(current, rgb), [recorded(saved)], rgb);
+    const retained = result.filter((set) => set.retained);
+    expect(retained).toHaveLength(1);
+    expect(retained[0].candidates).toEqual(buildColorExposureSets(saved, rgb)[0].candidates);
+    expect(result.filter((set) => !set.retained)).toHaveLength(2);
+  });
+
+  it('uses current ranges for missing families that now live in another band', () => {
+    const saved = rgb.map((role) => source(role, 30));
+    const changedBlue = source('blue', 300, saved[2].exposure_group!.key);
+    const current = buildColorExposureSets([saved[0], saved[1], changedBlue], rgb);
+    const result = withRetainedColorExposureSets(current, [recorded(saved)], rgb);
+    expect(result).toHaveLength(3);
+    expect(result.filter((set) => !set.retained).map((set) => set.candidates.length)).toEqual([2, 1]);
+    expect(result[2].retained).toBe(true);
+  });
+
+  it('keeps mixed-length and unknown custom combinations out of automatic sets', () => {
+    const mixed = [source('red', 30), source('green', 300), source('blue', 300)];
+    const unknown = rgb.map((role) => ({ ...source(role, 30), exposure_group: null }));
+    expect(withRetainedColorExposureSets([], [recorded(mixed), recorded(unknown)], rgb)).toEqual([]);
+    expect(withRetainedColorExposureSets([], [recorded(mixed.slice(0, 2))], rgb)).toEqual([]);
+  });
+
+  it('retains one card per family across saved and active revisions', () => {
+    const saved = rgb.map((role) => source(role, 30));
+    const rebuilt = saved.map((entry) => ({ ...entry, job_id: 'new', artifact_revision: 'new' }));
+    const result = withRetainedColorExposureSets([], [recorded(saved), recorded(rebuilt, 'active', 2)], rgb);
+    expect(result).toHaveLength(1);
+    expect(result[0].retained).toBe(true);
+    expect(result[0].candidates.every((entry) => entry.job_id === 'new')).toBe(true);
+  });
+
+  it('does not resolve duplicate-role ambiguity with an older saved selection', () => {
+    const saved = rgb.map((role) => source(role, 30));
+    const current = buildColorExposureSets([saved[0], source('red', 30, 'other-red'), saved[1]], rgb);
+    const result = withRetainedColorExposureSets(current, [recorded(saved)], rgb);
+    expect(result).toHaveLength(2);
+    expect(result[0].candidates).toHaveLength(3);
+    expect(result[1].retained).toBe(true);
+  });
+
+  it('requires each saved recipe to be complete and within the allowed role pool', () => {
+    const lrgb: StackColorRole[] = ['luminance', ...rgb];
+    const sho: StackColorRole[] = ['ha', 'oiii', 'sii'];
+    const incompleteLrgb = recorded(rgb.map((role) => source(role, 30)), 'lrgb', 1, 'lrgb');
+    const incompleteSho = recorded([source('ha', 30), source('oiii', 30)], 'sho', 1, 'narrowband', 'sho');
+    const completeLrgb = recorded(lrgb.map((role) => source(role, 30)), 'lrgb', 1, 'lrgb');
+    const completeSho = recorded(sho.map((role) => source(role, 30)), 'sho', 1, 'narrowband', 'sho');
+    expect(withRetainedColorExposureSets([], [incompleteLrgb], lrgb)).toEqual([]);
+    expect(withRetainedColorExposureSets([], [incompleteSho], sho)).toEqual([]);
+    expect(withRetainedColorExposureSets([], [completeLrgb], lrgb)).toHaveLength(1);
+    expect(withRetainedColorExposureSets([], [completeSho], sho)).toHaveLength(1);
+    expect(withRetainedColorExposureSets([], [completeLrgb], rgb)).toEqual([]);
+  });
+
+  it('retains complete HOO jobs without requiring SII in the allowed narrowband pool', () => {
+    const roles: StackColorRole[] = ['ha', 'oiii', 'sii'];
+    const sources = [source('ha', 30), source('oiii', 30)];
+    const jobs = [recorded(sources, 'hoo', 1, 'narrowband', 'hoo')];
+    const retained = withRetainedColorExposureSets([], jobs, roles);
+    expect(retained).toHaveLength(1);
+    expect(retained[0].retained).toBe(true);
+    expect(retained[0].candidates).toHaveLength(2);
+    const augmented = withRetainedColorExposureSets(buildColorExposureSets([sources[0]], roles), jobs, roles);
+    expect(augmented).toHaveLength(1);
+    expect(augmented[0].retained).toBe(false);
+    expect(augmented[0].candidates).toHaveLength(2);
+  });
+
+  it('preserves current SII while restoring a missing HOO family', () => {
+    const roles: StackColorRole[] = ['ha', 'oiii', 'sii'];
+    const saved = [source('ha', 30), source('oiii', 30)];
+    const sii = source('sii', 40);
+    const result = withRetainedColorExposureSets(
+      buildColorExposureSets([saved[0], sii], roles),
+      [recorded(saved, 'hoo', 1, 'narrowband', 'foraxx-hoo')], roles,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].retained).toBe(false);
+    expect(result[0].candidates).toContain(sii);
+    expect(result[0].candidates).toHaveLength(3);
+    expect(result[0].maxSeconds).toBe(40);
+  });
+
+  it('deduplicates HOO jobs already represented by a current three-role narrowband set', () => {
+    const roles: StackColorRole[] = ['ha', 'oiii', 'sii'];
+    const saved = [source('ha', 30), source('oiii', 30)];
+    const current = buildColorExposureSets([...saved, source('sii', 30)], roles);
+    const result = withRetainedColorExposureSets(current, [recorded(saved, 'hoo', 1, 'narrowband', 'hoo')], roles);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe(current[0].key);
+  });
+
+  it('includes optional current SII in the full range test before restoring a HOO family', () => {
+    const roles: StackColorRole[] = ['ha', 'oiii', 'sii'];
+    const saved = [source('ha', 30), source('oiii', 50)];
+    const current = buildColorExposureSets([saved[0], source('sii', 20)], roles);
+    const result = withRetainedColorExposureSets(current, [recorded(saved, 'hoo', 1, 'narrowband', 'hoo')], roles);
+    expect(result).toHaveLength(2);
+    expect(result[0].candidates).toHaveLength(2);
+    expect(result[1].retained).toBe(true);
+  });
+});

--- a/static/src/components/__tests__/stackColorSources.test.ts
+++ b/static/src/components/__tests__/stackColorSources.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { StackColorJob, StackColorSource } from '../../api/types';
+import { colorSourceKey, colorSourcesLabel, completedColorArtifact, resolveColorSources, sameColorSourceFamily } from '../stackColorSources';
+
+const source = (key: string, revision = 'revision'): StackColorSource => ({
+  role: 'red', filter_name: 'R', job_id: key, group_index: 0, artifact_revision: revision,
+  label: `R (${key})`, exposure_group: { key, label: key, min_seconds: 30, max_seconds: 30 },
+  accepted_frames: 10, reference_image_id: 1, sky_orientation: null, registration_transform: null,
+});
+
+describe('color source selection', () => {
+  it('auto-selects only a unique candidate', () => {
+    expect(resolveColorSources([source('short')], ['red'], {}).complete).toBe(true);
+    expect(resolveColorSources([source('short'), source('long')], ['red'], {}).complete).toBe(false);
+  });
+
+  it('sends the exact selected immutable source reference', () => {
+    const long = source('long');
+    const result = resolveColorSources([source('short'), long], ['red'], { red: colorSourceKey(long) });
+    expect(result.complete).toBe(true);
+    expect(result.inputSources).toEqual({ red: { job_id: 'long', group_index: 0, artifact_revision: 'revision' } });
+  });
+
+  it('does not silently replace an explicit source whose artifact revision changed', () => {
+    const original = source('short');
+    const result = resolveColorSources([source('short', 'new')], ['red'], { red: colorSourceKey(original) });
+    expect(result.complete).toBe(false);
+    expect(result.inputSources).toEqual({});
+  });
+
+  it('matches saved families by role, raw filter, and group, not current revision or label', () => {
+    expect(sameColorSourceFamily(source('short'), source('short', 'new'))).toBe(true);
+    expect(sameColorSourceFamily(source('short'), source('long'))).toBe(false);
+    expect(sameColorSourceFamily(source('short'), { ...source('short'), filter_name: 'Ha' })).toBe(false);
+    expect(sameColorSourceFamily(source('short'), { ...source('short'), role: 'green' })).toBe(false);
+  });
+
+  it('shows raw filters for legacy saved sources with an empty label', () => {
+    expect(colorSourcesLabel([{ ...source('short'), label: '', exposure_group: null }])).toBe('R');
+    expect(colorSourcesLabel([{ ...source('short'), label: '' }])).toBe('R · short');
+  });
+
+  it('uses refreshed catalog staleness after a watched color job completes', () => {
+    const watched = { job_id: 'color', state: 'completed', outdated: false } as StackColorJob;
+    const refreshed = { ...watched, outdated: true, outdated_reason: 'Exposure grouping changed' };
+    expect(completedColorArtifact(watched, [refreshed], undefined)).toBe(refreshed);
+    expect(completedColorArtifact(watched, [], undefined)).toBe(watched);
+  });
+});

--- a/static/src/components/__tests__/stackColorSources.test.ts
+++ b/static/src/components/__tests__/stackColorSources.test.ts
@@ -1,11 +1,122 @@
 import { describe, expect, it } from 'vitest';
-import type { StackColorJob, StackColorSource } from '../../api/types';
-import { colorSourceKey, colorSourcesLabel, completedColorArtifact, resolveColorSources, sameColorSourceFamily } from '../stackColorSources';
+import type { StackColorJob, StackColorRole, StackColorSource } from '../../api/types';
+import { buildColorExposureSets, colorSourceKey, colorSourcesLabel, completedColorArtifact, resolveColorSources, sameColorSourceFamily } from '../stackColorSources';
 
 const source = (key: string, revision = 'revision'): StackColorSource => ({
   role: 'red', filter_name: 'R', job_id: key, group_index: 0, artifact_revision: revision,
   label: `R (${key})`, exposure_group: { key, label: key, min_seconds: 30, max_seconds: 30 },
   accepted_frames: 10, reference_image_id: 1, sky_orientation: null, registration_transform: null,
+});
+
+const rgb: StackColorRole[] = ['red', 'green', 'blue'];
+const interval = (
+  role: StackColorRole, min: number | null, max: number | null = min, key = `${role}-${min}`,
+): StackColorSource => ({
+  ...source(key), role, filter_name: role,
+  exposure_group: { key, label: 'Display label', min_seconds: min, max_seconds: max },
+});
+
+describe('automatic color exposure sets', () => {
+  it('matches actual seconds across unrelated filter-local family keys', () => {
+    const candidates = [interval('red', 30, 30, 'exposure-12'), interval('green', 30, 30, 'unrelated'), interval('blue', 30, 30, 'third')];
+    const sets = buildColorExposureSets(candidates, rgb);
+    expect(sets).toHaveLength(1);
+    expect(sets[0]).toMatchObject({ known: true, label: '30 s', minSeconds: 30, maxSeconds: 30 });
+    expect(resolveColorSources(sets[0].candidates, rgb, {}).complete).toBe(true);
+  });
+
+  it('tolerates exposure jitter but separates short and long templates', () => {
+    const candidates = [interval('red', 30), interval('green', 30.1), interval('blue', 29.9),
+      interval('red', 300), interval('green', 300.1), interval('blue', 299.9)];
+    const sets = buildColorExposureSets(candidates, rgb);
+    expect(sets).toHaveLength(2);
+    expect(sets.map((set) => set.candidates.length)).toEqual([3, 3]);
+    expect(sets.map((set) => set.label)).toEqual(['29.9 s - 30.1 s', '299.9 s - 300.1 s']);
+  });
+
+  it('separates exactly twofold exposure differences', () => {
+    const sets = buildColorExposureSets([interval('red', 30), interval('green', 60), interval('blue', 119.9)], rgb);
+    expect(sets.map((set) => [set.minSeconds, set.maxSeconds])).toEqual([[30, 30], [60, 119.9]]);
+  });
+
+  it('retains three independently usable exposure tiers', () => {
+    const sets = buildColorExposureSets([10, 100, 1000].flatMap((seconds) => rgb.map((role) => interval(role, seconds))), rgb);
+    expect(sets.map((set) => set.label)).toEqual(['10 s', '100 s', '1000 s']);
+    expect(sets.every((set) => resolveColorSources(set.candidates, rgb, {}).complete)).toBe(true);
+  });
+
+  it('does not chain adjacent exposure gaps into a wide group', () => {
+    const sets = buildColorExposureSets([interval('red', 10), interval('green', 15), interval('blue', 25)], rgb);
+    expect(sets.map((set) => [set.minSeconds, set.maxSeconds])).toEqual([[10, 15], [25, 25]]);
+    expect(sets.every((set) => resolveColorSources(set.candidates, rgb, {}).complete)).toBe(false);
+  });
+
+  it('requires the entire candidate interval to fit the full band', () => {
+    const sets = buildColorExposureSets([interval('red', 30, 50), interval('green', 31, 61), interval('blue', 32, 60)], rgb);
+    expect(sets.map((set) => [set.minSeconds, set.maxSeconds])).toEqual([[30, 50], [31, 61]]);
+    expect(sets[0].candidates.map((candidate) => candidate.role)).toEqual(['red']);
+    expect(sets[1].candidates).toHaveLength(2);
+  });
+
+  it('keeps incomplete bands and duplicate roles without selecting an arbitrary candidate', () => {
+    const candidates = [interval('red', 30, 30, 'one'), interval('red', 30, 30, 'two'), interval('green', 30), interval('blue', 300)];
+    const sets = buildColorExposureSets(candidates, rgb);
+    expect(sets.map((set) => set.candidates.length)).toEqual([3, 1]);
+    const short = resolveColorSources(sets[0].candidates, rgb, {});
+    expect(short.complete).toBe(false);
+    expect(short.inputSources.red).toBeUndefined();
+    expect(short.inputSources.green).toBeDefined();
+  });
+
+  it('separates unknown and invalid bounds from known bands', () => {
+    const unknown = [
+      interval('red', null), interval('green', 0), interval('blue', -1),
+      interval('red', 30, null), interval('green', 30, Infinity), interval('blue', NaN),
+      interval('red', 40, 30), { ...interval('green', 30), exposure_group: null },
+    ];
+    const sets = buildColorExposureSets([interval('red', 30), ...unknown], rgb);
+    expect(sets).toHaveLength(2);
+    expect(sets[0]).toMatchObject({ known: true, label: '30 s' });
+    expect(sets[1]).toMatchObject({ known: false, label: 'Unknown exposure', minSeconds: null, maxSeconds: null });
+    expect(sets[1].candidates).toHaveLength(unknown.length);
+  });
+
+  it('never marks an individually twofold or wider interval as safe to compose', () => {
+    const sets = buildColorExposureSets([interval('red', 30, 60), interval('green', 10, 300), interval('blue', 30)], rgb);
+    expect(sets).toHaveLength(2);
+    expect(sets[1]).toMatchObject({ known: false, label: 'Mixed exposure', minSeconds: 10, maxSeconds: 300 });
+    expect(sets[1].candidates).toHaveLength(2);
+  });
+
+  it('filters unused roles before constructing bands', () => {
+    const sets = buildColorExposureSets([interval('ha', 1), ...rgb.map((role) => interval(role, 30))], rgb);
+    expect(sets).toHaveLength(1);
+    expect(sets[0].candidates).toHaveLength(3);
+    expect(buildColorExposureSets([interval('ha', 30)], rgb)).toEqual([]);
+    expect(buildColorExposureSets([interval('red', 30)], [])).toEqual([]);
+  });
+
+  it('keeps set identities across artifact rebuilds and display-duration changes', () => {
+    const candidates = rgb.map((role) => interval(role, 30));
+    const first = buildColorExposureSets(candidates, rgb)[0];
+    const rebuilt = candidates.map((candidate) => ({
+      ...candidate, job_id: `new-${candidate.job_id}`, group_index: 7, artifact_revision: 'new-revision',
+      label: 'Changed display', exposure_group: { ...candidate.exposure_group!, label: 'Changed display', min_seconds: 30.1, max_seconds: 30.2 },
+    }));
+    const next = buildColorExposureSets(rebuilt, rgb)[0];
+    expect(next.key).toBe(first.key);
+    expect(next.label).not.toBe(first.label);
+    expect(buildColorExposureSets([{ ...candidates[0], filter_name: 'Different red' }, ...candidates.slice(1)], rgb)[0].key).not.toBe(first.key);
+    expect(buildColorExposureSets([{ ...candidates[0], exposure_group: { ...candidates[0].exposure_group!, key: 'new-family' } }, ...candidates.slice(1)], rgb)[0].key).not.toBe(first.key);
+  });
+
+  it('is deterministic under candidate and role input order without mutating inputs', () => {
+    const candidates = [interval('red', 30), interval('blue', 300), interval('green', 30.1), interval('blue', 30)];
+    const original = [...candidates];
+    const expected = buildColorExposureSets(candidates, rgb);
+    expect(buildColorExposureSets([...candidates].reverse(), [...rgb].reverse())).toEqual(expected);
+    expect(candidates).toEqual(original);
+  });
 });
 
 describe('color source selection', () => {

--- a/static/src/components/colorExposureCards.ts
+++ b/static/src/components/colorExposureCards.ts
@@ -1,0 +1,84 @@
+import type { StackColorJob, StackColorRole, StackColorSource } from '../api/types';
+import { buildColorExposureSets, sameColorSourceFamily, type ColorExposureSet } from './stackColorSources';
+
+export interface ColorExposureCardSet extends ColorExposureSet {
+  /** A historical set which must remain inspectable, not an automatic build source. */
+  retained: boolean;
+}
+
+type RecordedColorSources = Pick<StackColorJob, 'job_id' | 'created_unix_seconds' | 'sources' | 'kind' | 'palette'>;
+
+function recipeRoles(job: RecordedColorSources): StackColorRole[] {
+  if (job.kind === 'rgb') return ['red', 'green', 'blue'];
+  if (job.kind === 'lrgb') return ['luminance', 'red', 'green', 'blue'];
+  if (job.palette === 'hoo' || job.palette === 'foraxx-hoo') return ['ha', 'oiii'];
+  return job.palette ? ['ha', 'oiii', 'sii'] : [];
+}
+
+function represents(set: ColorExposureSet, saved: ColorExposureSet): boolean {
+  return set.known && saved.candidates.every((previous) => {
+    const current = set.candidates.filter((source) => source.role === previous.role);
+    return current.length === 1 && sameColorSourceFamily(current[0], previous);
+  });
+}
+
+function completeKnownSet(sources: StackColorSource[], roles: StackColorRole[]): ColorExposureSet | undefined {
+  if (sources.length !== roles.length || !roles.every((role) => sources.filter((source) => source.role === role).length === 1)) {
+    return undefined;
+  }
+  const sets = buildColorExposureSets(sources, roles);
+  return sets.length === 1 && sets[0].known ? sets[0] : undefined;
+}
+
+/**
+ * Retain family descriptors when a saved or active combination loses an input.
+ * Callers must resolve build refs against the current catalog, never these
+ * historical candidates. Mixed-duration and unknown combinations stay custom.
+ */
+export function withRetainedColorExposureSets(
+  currentSets: ColorExposureSet[],
+  jobs: RecordedColorSources[],
+  roles: StackColorRole[],
+): ColorExposureCardSet[] {
+  const result = currentSets.map((set) => ({ ...set, candidates: [...set.candidates], retained: false }));
+  const currentSources = currentSets.flatMap((set) => set.candidates);
+  const recorded = [...jobs].sort((left, right) => right.created_unix_seconds - left.created_unix_seconds
+    || left.job_id.localeCompare(right.job_id));
+  for (const job of recorded) {
+    const requiredRoles = recipeRoles(job);
+    if (requiredRoles.length === 0 || !requiredRoles.every((role) => roles.includes(role))) continue;
+    const saved = completeKnownSet(job.sources, requiredRoles);
+    if (!saved || result.some((set) => represents(set, saved))) continue;
+    const compatible = result.map((set, index) => ({ set, index }))
+      .filter(({ set }) => !set.retained && set.known && set.candidates.length > 0
+        && requiredRoles.every((role) => set.candidates.filter((source) => source.role === role).length <= 1)
+        && set.candidates.some((current) => saved.candidates.some((previous) => sameColorSourceFamily(current, previous)))
+        && set.candidates.filter((current) => requiredRoles.includes(current.role))
+          .every((current) => saved.candidates.some((previous) => sameColorSourceFamily(current, previous))))
+      .sort((left, right) => right.set.candidates.length - left.set.candidates.length || left.index - right.index);
+    let merged = false;
+    for (const { set, index } of compatible) {
+      const combined = [...set.candidates];
+      let ambiguous = false;
+      for (const previous of saved.candidates) {
+        if (combined.some((source) => source.role === previous.role)) continue;
+        const current = currentSources.filter((source) => sameColorSourceFamily(source, previous));
+        if (current.length > 1) {
+          ambiguous = true;
+          break;
+        }
+        // An anchor can survive an exposure edit. Its current range wins even
+        // if the candidate moved to another band, so old metadata cannot bridge tiers.
+        combined.push(current[0] ?? previous);
+      }
+      const extendedSets = ambiguous ? [] : buildColorExposureSets(combined, roles);
+      const extended = extendedSets.length === 1 && extendedSets[0].known ? extendedSets[0] : undefined;
+      if (!extended) continue;
+      result[index] = { ...extended, retained: false };
+      merged = true;
+      break;
+    }
+    if (!merged) result.push({ ...saved, retained: true });
+  }
+  return result;
+}

--- a/static/src/components/stackColorSources.ts
+++ b/static/src/components/stackColorSources.ts
@@ -1,5 +1,87 @@
 import type { StackColorInputSources, StackColorJob, StackColorRole, StackColorSource } from '../api/types';
 
+export interface ColorExposureSet {
+  key: string;
+  label: string;
+  candidates: StackColorSource[];
+  known: boolean;
+  minSeconds: number | null;
+  maxSeconds: number | null;
+}
+
+function sourceFamilyIdentity(source: StackColorSource): string {
+  return JSON.stringify([source.role, source.filter_name, source.exposure_group?.key ?? null]);
+}
+
+function compareSourceFamilies(left: StackColorSource, right: StackColorSource): number {
+  const family = sourceFamilyIdentity(left).localeCompare(sourceFamilyIdentity(right));
+  return family || colorSourceKey(left).localeCompare(colorSourceKey(right));
+}
+
+function makeExposureSet(
+  candidates: StackColorSource[],
+  kind: 'known' | 'mixed' | 'unknown',
+  minSeconds: number | null,
+  maxSeconds: number | null,
+): ColorExposureSet {
+  const ordered = [...candidates].sort(compareSourceFamilies);
+  const key = JSON.stringify(['exposure-set', kind, ordered.map(sourceFamilyIdentity).sort()]);
+  let label = kind === 'mixed' ? 'Mixed exposure' : 'Unknown exposure';
+  if (kind === 'known' && minSeconds !== null && maxSeconds !== null) {
+    const minimum = `${Number(minSeconds.toPrecision(6))} s`;
+    const maximum = `${Number(maxSeconds.toPrecision(6))} s`;
+    label = minimum === maximum ? minimum : `${minimum} - ${maximum}`;
+  }
+  return { key, label, candidates: ordered, known: kind === 'known', minSeconds, maxSeconds };
+}
+
+/** Match physical exposure ranges; filter-local family keys only identify the resulting set. */
+export function buildColorExposureSets(
+  candidates: StackColorSource[],
+  roles: StackColorRole[],
+): ColorExposureSet[] {
+  const required = new Set(roles);
+  const intervals: Array<{ source: StackColorSource; min: number; max: number }> = [];
+  const unknown: StackColorSource[] = [];
+  const mixed: Array<{ source: StackColorSource; min: number; max: number }> = [];
+  for (const source of candidates) {
+    if (!required.has(source.role)) continue;
+    const min = source.exposure_group?.min_seconds;
+    const max = source.exposure_group?.max_seconds;
+    if (typeof min !== 'number' || typeof max !== 'number'
+      || !Number.isFinite(min) || !Number.isFinite(max) || min <= 0 || max < min) {
+      unknown.push(source);
+    } else if (max / min >= 2) {
+      mixed.push({ source, min, max });
+    } else {
+      intervals.push({ source, min, max });
+    }
+  }
+  intervals.sort((left, right) => left.min - right.min || left.max - right.max
+    || compareSourceFamilies(left.source, right.source));
+  const sets: ColorExposureSet[] = [];
+  let start = 0;
+  while (start < intervals.length) {
+    const minimum = intervals[start].min;
+    let maximum = intervals[start].max;
+    let end = start + 1;
+    // Bound the full union so overlapping or adjacent ranges cannot bridge tiers.
+    while (end < intervals.length && Math.max(maximum, intervals[end].max) / minimum < 2) {
+      maximum = Math.max(maximum, intervals[end].max);
+      end += 1;
+    }
+    sets.push(makeExposureSet(intervals.slice(start, end).map((entry) => entry.source), 'known', minimum, maximum));
+    start = end;
+  }
+  if (mixed.length > 0) {
+    sets.push(makeExposureSet(mixed.map((entry) => entry.source), 'mixed',
+      mixed.reduce((minimum, entry) => Math.min(minimum, entry.min), Infinity),
+      mixed.reduce((maximum, entry) => Math.max(maximum, entry.max), 0)));
+  }
+  if (unknown.length > 0) sets.push(makeExposureSet(unknown, 'unknown', null, null));
+  return sets;
+}
+
 export function completedColorArtifact(
   watched: StackColorJob | undefined,
   catalog: StackColorJob[],

--- a/static/src/components/stackColorSources.ts
+++ b/static/src/components/stackColorSources.ts
@@ -1,0 +1,50 @@
+import type { StackColorInputSources, StackColorJob, StackColorRole, StackColorSource } from '../api/types';
+
+export function completedColorArtifact(
+  watched: StackColorJob | undefined,
+  catalog: StackColorJob[],
+  remembered: StackColorJob | undefined,
+): StackColorJob | undefined {
+  if (watched?.state !== 'completed') return remembered;
+  // Only the catalog recomputes whether a completed artifact is still current.
+  return catalog.find((job) => job.job_id === watched.job_id) ?? watched;
+}
+
+export function colorSourceKey(source: Pick<StackColorSource, 'job_id' | 'group_index' | 'artifact_revision'>): string {
+  return JSON.stringify([source.job_id, source.group_index, source.artifact_revision]);
+}
+
+export function sameColorSourceFamily(left: StackColorSource, right: StackColorSource): boolean {
+  return left.role === right.role && left.filter_name === right.filter_name
+    && (left.exposure_group?.key ?? null) === (right.exposure_group?.key ?? null);
+}
+
+export function resolveColorSources(
+  candidates: StackColorSource[],
+  roles: StackColorRole[],
+  selected: Partial<Record<StackColorRole, string>>,
+): { sources: StackColorSource[]; complete: boolean; inputSources: StackColorInputSources } {
+  const sources: StackColorSource[] = [];
+  for (const role of roles) {
+    const matching = candidates.filter((source) => source.role === role);
+    const key = selected[role];
+    const source = key === undefined
+      ? matching.length === 1 ? matching[0] : undefined
+      : matching.find((candidate) => colorSourceKey(candidate) === key);
+    if (source) sources.push(source);
+  }
+  return {
+    sources,
+    complete: sources.length === roles.length,
+    inputSources: Object.fromEntries(sources.map((source) => [source.role, {
+      job_id: source.job_id,
+      group_index: source.group_index,
+      artifact_revision: source.artifact_revision,
+    }])),
+  };
+}
+
+export function colorSourcesLabel(sources: StackColorSource[]): string {
+  return sources.map((source) => source.label || [source.filter_name, source.exposure_group?.label]
+    .filter(Boolean).join(' · ')).join(', ');
+}

--- a/static/src/test/msw-handlers.ts
+++ b/static/src/test/msw-handlers.ts
@@ -52,6 +52,9 @@ const idleSpatialScan = {
 };
 
 export const handlers = [
+  http.get('/api/db/:dbId/projects/:projectId/processing-settings', () => HttpResponse.json({
+    success: true, data: { split_exposure_groups: false }, error: null,
+  })),
   http.get('/api/tools/rc-astro', () => HttpResponse.json({
     success: true, data: { available: false, tools: [] }, error: null,
   })),

--- a/static/src/utils/__tests__/imageGrouping.test.ts
+++ b/static/src/utils/__tests__/imageGrouping.test.ts
@@ -4,6 +4,8 @@ import {
   groupImagesBySession,
   NO_EXPANDED_GROUPS,
   resolveExpandedGroups,
+  splitImageGroupsByExposure,
+  imageGroupKey,
 } from '../imageGrouping';
 
 function image(id: number, acquiredDate: number, filter = 'HA'): Image {
@@ -56,5 +58,72 @@ describe('session image grouping', () => {
 
     expect(after.key).toBe(before.key);
     expect(after.filterName).not.toBe(before.filterName);
+  });
+});
+
+describe('server exposure partitions', () => {
+  const short = { key: 'short', label: '30 s', min_seconds: 30, max_seconds: 30 };
+  const long = { key: 'long', label: '300 s', min_seconds: 300, max_seconds: 300 };
+
+  it('preserves disabled groups and only uses server group identities', () => {
+    const unsplit = { filterName: 'HA', images: [image(1, 1), image(2, 2)] };
+    expect(splitImageGroupsByExposure([unsplit])[0]).toBe(unsplit);
+    const grouped = splitImageGroupsByExposure([{ ...unsplit, images: [
+      { ...image(1, 1), exposure_group: short },
+      { ...image(2, 2), exposure_group: long },
+      { ...image(3, 3), exposure_group: short, metadata: { ExposureTime: 9999 } },
+    ] }]);
+    expect(grouped.map((group) => group.images.map((entry) => entry.id))).toEqual([[1, 3], [2]]);
+    expect(grouped.map((group) => group.filterName)).toEqual(['HA · 30 s', 'HA · 300 s']);
+    expect(imageGroupKey(grouped[0])).not.toBe(imageGroupKey(grouped[1]));
+  });
+
+  it('keeps identities across filters of the visible population and changed labels', () => {
+    const before = splitImageGroupsByExposure([{ filterName: 'HA', images: [
+      { ...image(1, 1), exposure_group: short }, { ...image(2, 2), exposure_group: long },
+    ] }]);
+    const after = splitImageGroupsByExposure([{ filterName: 'HA', images: [
+      { ...image(1, 1), exposure_group: { ...short, label: '25–30 s', min_seconds: 25 } },
+    ] }]);
+    expect(imageGroupKey(after[0])).toBe(imageGroupKey(before[0]));
+  });
+
+  it('isolates enabled projects with the same exposure key and keeps disabled projects unsplit', () => {
+    const groups = splitImageGroupsByExposure([{ filterName: 'All', images: [
+      { ...image(1, 1), exposure_group: short },
+      { ...image(2, 2), project_id: 2, exposure_group: short },
+      { ...image(3, 3), project_id: 3 },
+      { ...image(4, 4), project_id: 3 },
+    ] }]);
+    expect(groups.map((group) => group.images.map((entry) => entry.id))).toEqual([[1], [2], [3, 4]]);
+  });
+
+  it('preserves expanded groups through toggling and opens all bands of the newest session', () => {
+    const base = [{ key: 'session', filterName: 'Session', images: [
+      { ...image(1, 1), exposure_group: short }, { ...image(2, 2), exposure_group: long },
+    ] }];
+    const split = splitImageGroupsByExposure(base);
+    expect(resolveExpandedGroups(split, 'filter', new Set(['session'])).size).toBe(2);
+    expect(resolveExpandedGroups(split, 'session', new Set()).size).toBe(2);
+    expect([...resolveExpandedGroups(base, 'filter', new Set(split.map(imageGroupKey)))]).toEqual(['session']);
+    expect(resolveExpandedGroups(split, 'session', new Set([NO_EXPANDED_GROUPS])).size).toBe(0);
+  });
+
+  it('separates equal anchors for different targets and identifies their different ranges', () => {
+    const groups = splitImageGroupsByExposure([{ filterName: 'R', images: [
+      { ...image(1, 1, 'R'), target_name: 'M31', exposure_group: { ...short, key: '10', label: '10–11 s' } },
+      { ...image(2, 2, 'R'), target_id: 2, target_name: 'M42', exposure_group: { ...short, key: '10', label: '10–18 s' } },
+    ] }]);
+    expect(groups.map((group) => group.filterName)).toEqual(['R · M31 · 10–11 s', 'R · M42 · 10–18 s']);
+    expect(new Set(groups.map(imageGroupKey)).size).toBe(2);
+  });
+
+  it('splits date groups by their exact filter and includes the filter in the heading', () => {
+    const groups = splitImageGroupsByExposure([{ filterName: '2026-09-11', images: [
+      { ...image(1, 1, 'R'), exposure_group: short },
+      { ...image(2, 2, 'G'), exposure_group: short },
+    ] }]);
+    expect(groups.map((group) => group.filterName)).toEqual(['2026-09-11 · R · 30 s', '2026-09-11 · G · 30 s']);
+    expect(new Set(groups.map(imageGroupKey)).size).toBe(2);
   });
 });

--- a/static/src/utils/imageGrouping.ts
+++ b/static/src/utils/imageGrouping.ts
@@ -4,8 +4,41 @@ import type { GroupingMode } from '../types/grouping';
 export interface ImageGroup {
   /** Stable identity for React and URL state. The label may change as a live session grows. */
   key?: string;
+  baseKey?: string;
   filterName: string;
   images: Image[];
+}
+
+/** Use the project's server-assigned partition, never a filtered subset's durations. */
+export function splitImageGroupsByExposure(groups: ImageGroup[]): ImageGroup[] {
+  return groups.flatMap((group) => {
+    if (!group.images.some((image) => image.exposure_group)) return [group];
+    const multipleTargets = new Set(group.images.map((image) => image.target_id)).size > 1;
+    const multipleFilters = new Set(group.images.map((image) => image.filter_name ?? '')).size > 1;
+    const partitions = new Map<string, ImageGroup>();
+    for (const image of group.images) {
+      const exposure = image.exposure_group;
+      const baseKey = imageGroupKey(group);
+      const key = exposure
+        ? JSON.stringify(['exposure', baseKey, image.project_id, image.target_id, image.filter_name ?? '', exposure.key])
+        : baseKey;
+      let partition = partitions.get(key);
+      if (!partition) {
+        partition = {
+          key,
+          baseKey,
+          filterName: exposure ? [group.filterName,
+            multipleTargets ? image.target_name : null,
+            multipleFilters ? image.filter_name || 'No Filter' : null,
+            exposure.label].filter(Boolean).join(' · ') : group.filterName,
+          images: [],
+        };
+        partitions.set(key, partition);
+      }
+      partition.images.push(image);
+    }
+    return [...partitions.values()];
+  });
 }
 
 export const NO_EXPANDED_GROUPS = '__none__';
@@ -73,9 +106,27 @@ export function resolveExpandedGroups(
   expandedGroups: ReadonlySet<string>,
 ): ReadonlySet<string> {
   if (expandedGroups.has(NO_EXPANDED_GROUPS)) return new Set();
-  if (expandedGroups.size > 0) return expandedGroups;
+  if (expandedGroups.size > 0) {
+    const previousBaseKeys = new Set<string>();
+    for (const key of expandedGroups) {
+      try {
+        const parts = JSON.parse(key);
+        if (Array.isArray(parts) && parts[0] === 'exposure' && typeof parts[1] === 'string') {
+          previousBaseKeys.add(parts[1]);
+        }
+      } catch { /* Existing filter/session keys are plain strings. */ }
+    }
+    return new Set(imageGroups.filter((group) => {
+      const key = imageGroupKey(group);
+      return expandedGroups.has(key)
+        || (group.baseKey !== undefined && expandedGroups.has(group.baseKey))
+        || (group.baseKey === undefined && previousBaseKeys.has(key));
+    }).map(imageGroupKey));
+  }
 
-  const initialGroups = groupingMode === 'session' ? imageGroups.slice(0, 1) : imageGroups;
+  const newestBase = imageGroups[0]?.baseKey;
+  const initialGroups = groupingMode !== 'session' ? imageGroups
+    : newestBase ? imageGroups.filter((group) => group.baseKey === newestBase) : imageGroups.slice(0, 1);
   return new Set(initialGroups.map(imageGroupKey));
 }
 

--- a/tests/integration_project_processing.rs
+++ b/tests/integration_project_processing.rs
@@ -1,0 +1,112 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::get,
+    Router,
+};
+use http_body_util::BodyExt;
+use psf_guard::server::{exposure_groups, state::AppState};
+use rusqlite::Connection;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn app() -> Router {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE project(Id INTEGER PRIMARY KEY,guid TEXT);
+        INSERT INTO project VALUES(1,'first'),(2,'second');",
+    )
+    .unwrap();
+    let state = Arc::new(AppState::new_for_test(conn));
+    state.set_allow_database_management(true);
+    Router::new()
+        .route(
+            "/api/db/{db_id}/projects/{project_id}/processing-settings",
+            get(exposure_groups::get_project_settings)
+                .put(exposure_groups::update_project_settings),
+        )
+        .with_state(state)
+}
+
+async fn request(app: &Router, project: i32, body: Option<Value>) -> (StatusCode, Value) {
+    let mut request = Request::builder().uri(format!(
+        "/api/db/test/projects/{project}/processing-settings"
+    ));
+    let body = match body {
+        Some(body) => {
+            request = request
+                .method("PUT")
+                .header("content-type", "application/json");
+            Body::from(body.to_string())
+        }
+        None => Body::empty(),
+    };
+    let response = app
+        .clone()
+        .oneshot(request.body(body).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    (
+        status,
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+    )
+}
+
+#[tokio::test]
+async fn project_setting_round_trip_is_isolated_and_reversible() {
+    let app = app();
+    let (status, initial) = request(&app, 1, None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(initial["data"]["split_exposure_groups"], false);
+    let (status, saved) = request(&app, 1, Some(json!({"split_exposure_groups":true}))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(saved["data"]["split_exposure_groups"], true);
+    assert_eq!(
+        request(&app, 1, None).await.1["data"]["split_exposure_groups"],
+        true
+    );
+    assert_eq!(
+        request(&app, 2, None).await.1["data"]["split_exposure_groups"],
+        false
+    );
+    assert_eq!(
+        request(&app, 1, Some(json!({"split_exposure_groups":false})))
+            .await
+            .0,
+        StatusCode::OK
+    );
+    assert_eq!(
+        request(&app, 1, None).await.1["data"]["split_exposure_groups"],
+        false
+    );
+}
+
+#[tokio::test]
+async fn project_setting_rejects_missing_projects_and_invalid_payloads() {
+    let app = app();
+    assert_eq!(request(&app, 999, None).await.0, StatusCode::NOT_FOUND);
+    assert_eq!(
+        request(&app, 999, Some(json!({"split_exposure_groups":true})))
+            .await
+            .0,
+        StatusCode::NOT_FOUND
+    );
+    for body in [
+        json!({}),
+        json!({"split_exposure_groups":"true"}),
+        json!({"split_exposure_groups":true,"project_id":2}),
+    ] {
+        assert_eq!(
+            request(&app, 1, Some(body)).await.0,
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+    assert_eq!(
+        request(&app, 1, None).await.1["data"]["split_exposure_groups"],
+        false
+    );
+}

--- a/tests/integration_server_auth.rs
+++ b/tests/integration_server_auth.rs
@@ -14,7 +14,7 @@ use psf_guard::{
     config::ServerAuthConfig,
     server::{
         auth::{self, ServerAuth},
-        flat_history, handlers, organization,
+        exposure_groups, flat_history, handlers, organization,
         stack_preview::calibration_masters,
         state::AppState,
         user_admin,
@@ -79,6 +79,11 @@ fn app_with_management(config: ServerAuthConfig, allow_management: bool) -> Rout
             post(organization::preview),
         )
         .route("/db/{db_id}/organization/apply", post(organization::apply))
+        .route(
+            "/db/{db_id}/projects/{project_id}/processing-settings",
+            get(exposure_groups::get_project_settings)
+                .put(exposure_groups::update_project_settings),
+        )
         .route(
             "/db/{db_id}/flat-history/invalidate",
             post(flat_history::invalidate),
@@ -176,6 +181,26 @@ fn user_management_app(directory: &tempfile::TempDir) -> Router {
         ))
         .with_state(state);
     Router::new().nest("/api", api)
+}
+
+#[tokio::test]
+async fn project_processing_settings_require_an_editor_and_database_management() {
+    for (allow_management, username, password) in [
+        (true, "viewer", "viewer-secret"),
+        (false, "editor", "editor-secret"),
+    ] {
+        let app = app_with_management(auth_config(), allow_management);
+        let (_, cookie, _) = login(&app, username, password).await;
+        let request = Request::builder()
+            .method(Method::PUT)
+            .uri("/api/db/test/projects/1/processing-settings")
+            .header(COOKIE, &cookie)
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"split_exposure_groups":true}"#))
+            .unwrap();
+        let (status, _, _) = json(&app, request).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Add **Separate exposure groups** as a persistent per-project setting, off by default. Short and long integrations can now serve different stacking purposes without changing Target Scheduler templates or existing grades.

- Group recorded exposures within each exact target/filter. Start a new family at 2x the shortest exposure in the current family; keep invalid or missing durations in an Unknown exposure group.
- Compute families from the full project catalog, then apply them consistently to image grouping, mono stack jobs, calibration overrides, latest results, and resume checkpoints.
- Show automatic color cards for compatible exposure sets, such as RGB 30 s and RGB 300 s. Match actual duration ranges across filters without borrowing missing channels from another set; disable incomplete or ambiguous combinations.
- Keep manual channel selectors under **Custom combination**. Retain inspectable saved combinations when inputs disappear, with crop, processing, palette, progress, and stale-source state scoped to each card.
- Keep legacy unsplit caches and requests compatible. Revalidate queued color sources and prevent incompatible queued mono results from becoming latest after a setting/catalog change.
- Cache catalog grouping by SQLite revision, persist project settings by stable GUID where available, and enforce editor/database-management access for changes.
- Improve narrow-screen stack controls and keep the project toggle and group count readable.

This does not add automatic HDR blending or saturated-pixel replacement. No Seiza or NINA plugin changes are required.

## Review

Independent backend and frontend reviews completed. Addressed cache invalidation/reopen handling, stable family identity, stale queued results, source-selection recovery after disabling grouping, and mobile overflow. Follow-up reviews covered duration-band boundaries, missing/ambiguous inputs, retained saved variants, exact per-source stale indicators, and independent card job/processing state. Updated the focused stacking guide and unreleased notes.

## Validation

Local checks on Windows:

- `cargo fmt -- --check`
- `cargo clippy --locked --all-targets --all-features -j2 -- -D warnings`
- `cargo test --locked -j2 --quiet`: 937 unit tests and 131 integration tests passed; five existing tests ignored.
- `cargo build --locked --bin psf-guard -j2`
- `npm run lint`
- `npx vitest run`: 450 tests passed across 87 files.
- `npm run build`
- `npx playwright test exposure-groups.spec.ts stack-preview.spec.ts image-grid.spec.ts --workers=1`: all eight passed against the rebuilt server, including a real three-frame Seiza stack, color composition, calibration inspection, project-setting persistence, automatic exposure cards, custom channel mixing, missing-channel isolation, and desktop/mobile layout checks.
- `git diff --check`

Rust formatting, Clippy, and tests ran for the initial implementation; Rust sources are unchanged in the color-card follow-up. The binary was rebuilt with the final frontend. Frontend checks and all eight browser tests were rerun after the follow-up.

The new exposure UI fixture uses synthetic cached mono pixels with real settings, catalog, and saved-processing endpoints. Existing browser regression tests exercise actual FITS stacking and color composition. All test catalogs and registries are isolated from live user data. Hosted CI results are separate from these local checks.